### PR TITLE
resources/deploymentconfig: Add 4.6

### DIFF
--- a/resources/deploymentconfig.yaml
+++ b/resources/deploymentconfig.yaml
@@ -42,6 +42,8 @@ spec:
         - --local-data
         - /data
         - --release
+        - "4.6"
+        - --release
         - "4.5"
         - --release
         - "4.4"


### PR DESCRIPTION
4.5 has split off from master, which now tracks 4.6 (e.g. openshift/release#9417).  Have Sippy start indexing the 4.6 results to [avoid][2]:

> Invalid release identifier: 4.6

[2]: https://sippy-bparees.svc.ci.openshift.org/?release=4.6