### PR TITLE
Add metal-ipi as a potential platform

### DIFF
--- a/pkg/html/html.go
+++ b/pkg/html/html.go
@@ -104,16 +104,15 @@ Data current as of: %s
 
 	// 1 encoded job name
 	// 2 test name
-	// 3 job name
-	// 4 release
-	// 5 encoded test name
+	// 3 job name regex
+	// 4 encoded test name
 	testGroupTemplate = `
 		<tr class="collapse %s">
 			<td colspan=2>
 			%s
 			<p>
-			<a target="_blank" href="https://search.svc.ci.openshift.org/?maxAge=168h&context=1&type=junit&maxMatches=5&maxBytes=20971520&groupBy=job&name=%[3]s.*%[4]s&search=%[5]s">Job Search</a>
-			<a style="padding-left: 20px" target="_blank" href="https://search.svc.ci.openshift.org/?maxAge=168h&context=1&type=bug&maxMatches=5&maxBytes=20971520&groupBy=job&search=%[5]s">Bug Search</a>
+			<a target="_blank" href="https://search.svc.ci.openshift.org/?maxAge=168h&context=1&type=junit&maxMatches=5&maxBytes=20971520&groupBy=job&name=%[3]s&search=%[4]s">Job Search</a>
+			<a style="padding-left: 20px" target="_blank" href="https://search.svc.ci.openshift.org/?maxAge=168h&context=1&type=bug&maxMatches=5&maxBytes=20971520&groupBy=job&search=%[4]s">Bug Search</a>
 			</td>
 			<td>%0.2f%% <span class="text-nowrap">(%d runs)</span></td>
 		</tr>
@@ -291,8 +290,8 @@ func summaryJobsByPlatform(report, reportPrev util.TestReport, endDay, jobTestCo
 			count--
 
 			encodedTestName := url.QueryEscape(regexp.QuoteMeta(test.Name))
-
-			rows = rows + fmt.Sprintf(testGroupTemplate, strings.ReplaceAll(v.Platform, ".", ""), test.Name, v.Platform, report.Release, encodedTestName,
+			jobQuery := fmt.Sprintf("%s.*%s|%s.*%s", report.Release, v.Platform, v.Platform, report.Release)
+			rows = rows + fmt.Sprintf(testGroupTemplate, strings.ReplaceAll(v.Platform, ".", ""), test.Name, jobQuery, encodedTestName,
 				test.PassPercentage,
 				test.Successes+test.Failures,
 			)
@@ -547,7 +546,7 @@ func summaryJobPassRatesByJobName(report, reportPrev util.TestReport, endDay, jo
 			count--
 
 			encodedTestName := url.QueryEscape(regexp.QuoteMeta(test.Name))
-			rows = rows + fmt.Sprintf(testGroupTemplate, strings.ReplaceAll(v.Name, ".", ""), test.Name, v.Name, "", encodedTestName,
+			rows = rows + fmt.Sprintf(testGroupTemplate, strings.ReplaceAll(v.Name, ".", ""), test.Name, v.Name, encodedTestName,
 				test.PassPercentage,
 				test.Successes+test.Failures,
 			)

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -25,6 +25,7 @@ var (
 	gcpRegex       *regexp.Regexp = regexp.MustCompile(`(?i)-gcp-`)
 	openstackRegex *regexp.Regexp = regexp.MustCompile(`(?i)-openstack-`)
 	metalRegex     *regexp.Regexp = regexp.MustCompile(`(?i)-metal-`)
+	metalIPIRegex  *regexp.Regexp = regexp.MustCompile(`(?i)-metal-ipi`)
 	ovirtRegex     *regexp.Regexp = regexp.MustCompile(`(?i)-ovirt-`)
 	vsphereRegex   *regexp.Regexp = regexp.MustCompile(`(?i)-vsphere-`)
 	upgradeRegex   *regexp.Regexp = regexp.MustCompile(`(?i)-upgrade-`)
@@ -260,9 +261,17 @@ func FindPlatform(name string) []string {
 	if openstackRegex.MatchString(name) {
 		platforms = append(platforms, "openstack")
 	}
-	if metalRegex.MatchString(name) {
+
+	// Without support for negative lookbacks in the native
+	// regexp library, it's easiest to differentiate these
+	// two by seeing if it's metal-ipi, and then fall through
+	// to check if it's UPI metal.
+	if metalIPIRegex.MatchString(name) {
+		platforms = append(platforms, "metal-ipi")
+	} else if metalRegex.MatchString(name) {
 		platforms = append(platforms, "metal")
 	}
+
 	if ovirtRegex.MatchString(name) {
 		platforms = append(platforms, "ovirt")
 	}


### PR DESCRIPTION
Added to testgrids just now: https://github.com/kubernetes/test-infra/pull/17806

I think it makes sense to show metal and metal-ipi separately, since they're very different.