### PR TITLE
README: Add 4.6, drop 4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ A tool to process the job results from https://testgrid.k8s.io/
 Analyzes any job with a status of `FLAKY` or `FAILING` as reported on the following dashboards:
 
 ```
+https://testgrid.k8s.io/redhat-openshift-ocp-release-4.6-informing
 https://testgrid.k8s.io/redhat-openshift-ocp-release-4.5-informing
 https://testgrid.k8s.io/redhat-openshift-ocp-release-4.4-informing
 https://testgrid.k8s.io/redhat-openshift-ocp-release-4.3-informing
 https://testgrid.k8s.io/redhat-openshift-ocp-release-4.2-informing
-https://testgrid.k8s.io/redhat-openshift-ocp-release-4.1-informing
+https://testgrid.k8s.io/redhat-openshift-ocp-release-4.6-blocking
 https://testgrid.k8s.io/redhat-openshift-ocp-release-4.5-blocking
 https://testgrid.k8s.io/redhat-openshift-ocp-release-4.4-blocking
 https://testgrid.k8s.io/redhat-openshift-ocp-release-4.3-blocking
 https://testgrid.k8s.io/redhat-openshift-ocp-release-4.2-blocking
-https://testgrid.k8s.io/redhat-openshift-ocp-release-4.1-blocking
 ```
 
 Reports on which tests fail most frequently along different dimensions:


### PR DESCRIPTION
Catching up with 251c855266 (add 4.6 to dashboard view, 2020-06-02) and the subsequent 4.2 restoration from 6795065b0e (improve the readme, 2020-06-02).