### PR TITLE
add warning banner when bz lookups fail

### DIFF
--- a/main.go
+++ b/main.go
@@ -288,18 +288,24 @@ func (a *Analyzer) analyze() {
 		batchCount++
 
 		if batchCount > 50 {
-			r, _ := util.FindBugs(batchNames)
+			r, err := util.FindBugs(batchNames)
 			for k, v := range r {
 				util.TestBugCache[k] = v
+			}
+			if err != nil {
+				util.TestBugCacheErr = err
 			}
 			batchNames = []string{}
 			batchCount = 0
 		}
 	}
 	if batchCount > 0 {
-		r, _ := util.FindBugs(batchNames)
+		r, err := util.FindBugs(batchNames)
 		for k, v := range r {
 			util.TestBugCache[k] = v
+		}
+		if err != nil {
+			util.TestBugCacheErr = err
 		}
 	}
 	for runIdx, jobrun := range a.RawData.JobRuns {
@@ -696,6 +702,7 @@ type Server struct {
 func (s *Server) refresh(w http.ResponseWriter, req *http.Request) {
 	klog.Infof("Refreshing data")
 	util.TestBugCache = make(map[string][]util.Bug)
+	util.TestBugCacheErr = nil
 
 	for k, analyzer := range s.analyzers {
 		analyzer.RawData = RawData{

--- a/pkg/html/html.go
+++ b/pkg/html/html.go
@@ -70,6 +70,13 @@ Data current as of: %s
 </html>
 `
 
+	bugLookupWarning = `
+<div  style="background-color:pink" class="jumbotron">
+  <h1>Warning: Bugzilla Lookup Error</h1>
+  <p>At least one error was encountered looking up existing bugs for failing tests.  Some test failures may have
+  associated bugs that are not listed below. Lookup error: %s</p>
+</div>
+`
 	dashboardPageHtml = `
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 <style>
@@ -718,6 +725,9 @@ func PrintHtmlReport(w http.ResponseWriter, req *http.Request, report, prevRepor
 
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
 	fmt.Fprintf(w, htmlPageStart, "Release CI Health Dashboard")
+	if util.TestBugCacheErr != nil {
+		fmt.Fprintf(w, bugLookupWarning, util.TestBugCacheErr)
+	}
 
 	var dashboardPage = template.Must(template.New("dashboardPage").Funcs(
 		template.FuncMap{

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -39,7 +39,8 @@ var (
 	//	KnownIssueTestRegex *regexp.Regexp = regexp.MustCompile(`Application behind service load balancer with PDB is not disrupted|Kubernetes and OpenShift APIs remain available|Cluster frontend ingress remain available|OpenShift APIs remain available|Kubernetes APIs remain available|Cluster upgrade should maintain a functioning cluster`)
 
 	// TestBugCache is a map of test names to known bugs tied to those tests
-	TestBugCache map[string][]Bug = make(map[string][]Bug)
+	TestBugCache    map[string][]Bug = make(map[string][]Bug)
+	TestBugCacheErr error
 )
 
 type TestMeta struct {
@@ -320,6 +321,7 @@ func FindPlatform(name string) []string {
 	return platforms
 }
 
+/*
 func FindBug(testName string) ([]string, bool, error) {
 	testName = regexp.QuoteMeta(testName)
 	klog.V(4).Infof("Searching bugs for test name: %s\n", testName)
@@ -347,6 +349,7 @@ func FindBug(testName string) ([]string, bool, error) {
 	klog.V(2).Infof("Found bugs: %v", bugs)
 	return bugs, true, nil
 }
+*/
 
 // GET
 /*
@@ -403,15 +406,16 @@ func FindBugs(testNames []string) (map[string][]Bug, error) {
 		v.Add("search", testName)
 	}
 
-	//resp, err := http.PostForm("https://search.apps.build01.ci.devcluster.openshift.com/search", v)
-	resp, err := http.PostForm("https://search.ci.openshift.org/search", v)
+	//searchUrl:="https://search.apps.build01.ci.devcluster.openshift.com/search"
+	searchUrl := "https://search.ci.openshift.org/search"
+	resp, err := http.PostForm(searchUrl, v)
 	if err != nil {
-		e := fmt.Errorf("error during bug search: %v", err)
+		e := fmt.Errorf("error during bug search against %s: %s", searchUrl, err)
 		klog.Errorf(e.Error())
 		return searchResults, e
 	}
 	if resp.StatusCode != 200 {
-		e := fmt.Errorf("Non-200 response code during bug search: %v", resp)
+		e := fmt.Errorf("Non-200 response code during bug search against %s: %s", searchUrl, resp.Status)
 		klog.Errorf(e.Error())
 		return searchResults, e
 	}


### PR DESCRIPTION
adds banner like:
![image](https://user-images.githubusercontent.com/4974046/87050270-0899ae80-c1cc-11ea-9bba-3b13c6702ea3.png)


if any bz lookups failed on the latest refresh
