### PR TITLE
add ovn as a platform

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -25,6 +25,7 @@ var (
 	azureRegex     *regexp.Regexp = regexp.MustCompile(`(?i)-azure-`)
 	gcpRegex       *regexp.Regexp = regexp.MustCompile(`(?i)-gcp`)
 	openstackRegex *regexp.Regexp = regexp.MustCompile(`(?i)-openstack-`)
+	ovnRegex *regexp.Regexp = regexp.MustCompile(`(?i)-ovn-`)
 	metalRegex     *regexp.Regexp = regexp.MustCompile(`(?i)-metal-`)
 	metalIPIRegex  *regexp.Regexp = regexp.MustCompile(`(?i)-metal-ipi`)
 	ovirtRegex     *regexp.Regexp = regexp.MustCompile(`(?i)-ovirt-`)
@@ -372,6 +373,9 @@ func FindPlatform(name string) []string {
 	}
 	if serialRegex.MatchString(name) {
 		platforms = append(platforms, "serial")
+	}
+	if ovnRegex.MatchString(name) {
+		platforms = append(platforms, "ovn")
 	}
 	if ppc64leRegex.MatchString(name) {
 		platforms = append(platforms, "ppc64le")


### PR DESCRIPTION
I suspect that many ovn failures are specific to ovn.  Having a platform checks the general feature and classifies the top failures so we can quickly compare.