### PR TITLE
add synthetic junit tests for infra, install, and upgrade

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -99,6 +99,26 @@ type JobRunResult struct {
 	Failed             bool     `json:"failed"`
 	HasUnknownFailures bool     `json:"hasUnknownFailures"`
 	Succeeded          bool     `json:"succeeded"`
+
+	// SetupStatus can be "", "Success", "Failure"
+	SetupStatus      string          `json:"setupStatus"`
+	InstallOperators []OperatorState `json:"installOperators"`
+	UpgradeOperators []OperatorState `json:"upgradeOperators"`
+}
+
+const (
+	InfrastructureTestName = `[sig-sippy] infrastructure should work`
+	InstallTestName        = `[sig-sippy] install should work`
+	UpgradeTestName        = `[sig-sippy] upgrade should work`
+
+	Success = "Success"
+	Failure = "Failure"
+)
+
+type OperatorState struct {
+	Name string `json:"name"`
+	// OperatorState can be "", "Success", "Failure"
+	State string `json:"state"`
 }
 
 type JobResult struct {


### PR DESCRIPTION
This tracks the known install and upgrade junit tests and follows the know setup container junit to try to determine whether an install failed, whether the infra failed, or whether the upgrade failed.

It seems to be showing a tough set of infra problems on some platforms.