### PR TITLE
separate infrequent jobs into a different table section

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -207,8 +207,8 @@ func summaryTopFailingTestsWithoutBug(topFailingTestsWithoutBug []*v12.TestResul
 func summaryJobPassRatesByJobName(report, reportPrev v12.TestReport, endDay, jobTestCount int) []v1.PassRatesByJobName {
 	var passRatesSlice []v1.PassRatesByJobName
 
-	for _, v := range report.JobPassRate {
-		prev := util.GetJobResultForJobName(v.Name, reportPrev.JobPassRate)
+	for _, v := range report.JobResults {
+		prev := util.GetJobResultForJobName(v.Name, reportPrev.JobResults)
 
 		var newJobPassRate v1.PassRatesByJobName
 

--- a/pkg/apis/sippyprocessing/v1/types.go
+++ b/pkg/apis/sippyprocessing/v1/types.go
@@ -16,12 +16,17 @@ type TestReport struct {
 	ByJob      map[string]SortedAggregateTestsResult `json:"byJob`
 	BySig      map[string]SortedAggregateTestsResult `json:"bySig`
 
-	FailureGroups             []JobRunResult `json:"failureGroups"`
-	JobPassRate               []JobResult    `json:"jobPassRate"`
-	Timestamp                 time.Time      `json:"timestamp"`
-	TopFailingTestsWithBug    []*TestResult  `json:"topFailingTestsWithBug"`
-	TopFailingTestsWithoutBug []*TestResult  `json:"topFailingTestsWithoutBug"`
-	BugsByFailureCount        []bugsv1.Bug   `json:"bugsByFailureCount"`
+	FailureGroups []JobRunResult `json:"failureGroups"`
+
+	// JobResults are jobresults for jobs that run more than 1.5 times per day
+	JobResults []JobResult `json:"jobResults"`
+	// InfrequentJobResults are jobresults for jobs that run less than 1.5 times per day
+	InfrequentJobResults []JobResult `json:"infrequentJobResults"`
+
+	Timestamp                 time.Time     `json:"timestamp"`
+	TopFailingTestsWithBug    []*TestResult `json:"topFailingTestsWithBug"`
+	TopFailingTestsWithoutBug []*TestResult `json:"topFailingTestsWithoutBug"`
+	BugsByFailureCount        []bugsv1.Bug  `json:"bugsByFailureCount"`
 
 	// JobFailuresByBugzillaComponent are keyed by bugzilla components
 	JobFailuresByBugzillaComponent map[string]SortedBugzillaComponentResult `json:"jobFailuresByBugzillaComponent"`


### PR DESCRIPTION
We can create different coloriziation rules too. I'm biased towards making infrequent jobs more forgiving in terms of going yellow or red since an off day has a bigger impact.