### PR TITLE
make colors relate to developer actions

### DIFF
--- a/pkg/html/jobresult.go
+++ b/pkg/html/jobresult.go
@@ -35,9 +35,9 @@ func newJobResultRenderer(sectionBlock string, currJobResult sippyprocessingv1.J
 		release:              release,
 		maxTestResultsToShow: 10, // just a default, can be overridden
 		colors: colorizationCriteria{
-			minRedPercent:    0,
-			minYellowPercent: 30,
-			minGreenPercent:  75,
+			minRedPercent:    0,  // failure.  In this range, there is a systemic failure so severe that a reliable signal isn't available.
+			minYellowPercent: 60, // at risk.  In this range, there is a systemic problem that needs to be addressed.
+			minGreenPercent:  80, // no action required. This *should* be closer to 85%
 		},
 	}
 }


### PR DESCRIPTION
a 30% pass rate is too low for reliable signal.  a 60% failure rate is still very frequent, but potentially good enough to consider reliable.