### PR TITLE
remove dead fields

### DIFF
--- a/main.go
+++ b/main.go
@@ -591,14 +591,10 @@ func (a *Analyzer) printJsonReport() {
 }
 
 func (a *Analyzer) printDashboardReport() {
-	fmt.Println("================== Summary Across All Jobs ==================")
-	all := a.Report.All["all"]
-	fmt.Printf("Passing test runs: %d\n", all.Successes)
-	fmt.Printf("Failing test runs: %d\n", all.Failures)
-	fmt.Printf("Test Pass Percentage: %0.2f\n", all.TestPassPercentage)
 
 	fmt.Println("\n\n================== Top 10 Most Frequently Failing Tests ==================")
 	count := 0
+	all := a.Report.All["all"]
 	for i := 0; count < 10 && i < len(all.TestResults); i++ {
 		test := all.TestResults[i]
 		if (test.Successes + test.Failures) > a.Options.MinTestRuns {
@@ -649,30 +645,9 @@ func (a *Analyzer) printDashboardReport() {
 }
 
 func (a *Analyzer) printTextReport() {
-	fmt.Println("================== Test Summary Across All Jobs ==================")
-	all := a.Report.All["all"]
-	fmt.Printf("Passing test runs: %d\n", all.Successes)
-	fmt.Printf("Failing test runs: %d\n", all.Failures)
-	fmt.Printf("Test Pass Percentage: %0.2f\n", all.TestPassPercentage)
-	testCount := 0
-	testSuccesses := 0
-	testFailures := 0
-	for _, test := range all.TestResults {
-		fmt.Printf("\tTest Name: %s\n", test.Name)
-		fmt.Printf("\tPassed: %d\n", test.Successes)
-		fmt.Printf("\tFailed: %d\n", test.Failures)
-		fmt.Printf("\tTest Pass Percentage: %0.2f\n\n", test.PassPercentage)
-		testCount++
-		testSuccesses += test.Successes
-		testFailures += test.Failures
-	}
-
 	fmt.Println("\n\n\n================== Test Summary By Platform ==================")
 	for key, by := range a.Report.ByPlatform {
 		fmt.Printf("Platform: %s\n", key)
-		//		fmt.Printf("Passing test runs: %d\n", platform.Successes)
-		//		fmt.Printf("Failing test runs: %d\n", platform.Failures)
-		fmt.Printf("Test Pass Percentage: %0.2f\n", by.TestPassPercentage)
 		for _, test := range by.TestResults {
 			fmt.Printf("\tTest Name: %s\n", test.Name)
 			fmt.Printf("\tPassed: %d\n", test.Successes)
@@ -685,9 +660,6 @@ func (a *Analyzer) printTextReport() {
 	fmt.Println("\n\n\n================== Test Summary By Job ==================")
 	for key, by := range a.Report.ByJob {
 		fmt.Printf("Job: %s\n", key)
-		//		fmt.Printf("Passing test runs: %d\n", platform.Successes)
-		//		fmt.Printf("Failing test runs: %d\n", platform.Failures)
-		fmt.Printf("Test Pass Percentage: %0.2f\n", by.TestPassPercentage)
 		for _, test := range by.TestResults {
 			fmt.Printf("\tTest Name: %s\n", test.Name)
 			fmt.Printf("\tPassed: %d\n", test.Successes)
@@ -700,9 +672,6 @@ func (a *Analyzer) printTextReport() {
 	fmt.Println("\n\n\n================== Test Summary By Sig ==================")
 	for key, by := range a.Report.BySig {
 		fmt.Printf("\nSig: %s\n", key)
-		//		fmt.Printf("Passing test runs: %d\n", platform.Successes)
-		//		fmt.Printf("Failing test runs: %d\n", platform.Failures)
-		fmt.Printf("Test Pass Percentage: %0.2f\n", by.TestPassPercentage)
 		for _, test := range by.TestResults {
 			fmt.Printf("\tTest Name: %s\n", test.Name)
 			//			fmt.Printf("\tPassed: %d\n", test.Successes)
@@ -753,11 +722,6 @@ func (a *Analyzer) printTextReport() {
 	fmt.Printf("Total Job Successes: %d\n", jobSuccesses)
 	fmt.Printf("Total Job Failures: %d\n", jobFailures)
 	fmt.Printf("Total Job Pass Percentage: %0.2f\n\n", util.Percent(jobSuccesses, jobFailures))
-
-	fmt.Printf("Total Tests: %d\n", testCount)
-	fmt.Printf("Total Test Successes: %d\n", testSuccesses)
-	fmt.Printf("Total Test Failures: %d\n", testFailures)
-	fmt.Printf("Total Test Pass Percentage: %0.2f\n", util.Percent(testSuccesses, testFailures))
 }
 
 type Server struct {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -16,25 +16,6 @@ import (
 	"k8s.io/klog"
 )
 
-// summary across all job
-func summaryAcrossAllJobs(result, resultPrev map[string]v12.SortedAggregateTestsResult, endDay int) *v1.SummaryAcrossAllJobs {
-	all := result["all"]
-	allPrev := resultPrev["all"]
-
-	summary := v1.SummaryAcrossAllJobs{
-		TestExecutions: map[string]int{
-			"latest": all.Successes + all.Failures,
-			"prev":   allPrev.Successes + allPrev.Failures,
-		},
-		TestPassPercentage: map[string]float64{
-			"latest": all.TestPassPercentage,
-			"prev":   allPrev.TestPassPercentage,
-		},
-	}
-
-	return &summary
-}
-
 // stats on failure groups
 func failureGroups(failureGroups, failureGroupsPrev []v12.JobRunResult, endDay int) *v1.FailureGroups {
 
@@ -300,7 +281,6 @@ func formatJSONReport(report, prevReport v12.TestReport, endDay, jobTestCount in
 		Release:      report.Release}
 
 	jsonObject := map[string]interface{}{
-		"summaryAllJobs":            summaryAcrossAllJobs(data.Current.All, data.Prev.All, data.EndDay),
 		"failureGroupings":          failureGroups(data.Current.FailureGroups, data.Prev.FailureGroups, data.EndDay),
 		"jobPassRateByPlatform":     summaryJobsByPlatform(data.Current, data.Prev, data.EndDay, data.JobTestCount),
 		"topFailingTestsWithoutBug": summaryTopFailingTestsWithoutBug(data.Current.TopFailingTestsWithoutBug, data.Prev.All, data.EndDay),

--- a/pkg/apis/sippyprocessing/v1/types.go
+++ b/pkg/apis/sippyprocessing/v1/types.go
@@ -37,9 +37,6 @@ type TestReport struct {
 
 // SortedAggregateTestsResult
 type SortedAggregateTestsResult struct {
-	Successes          int     `json:"successes"`
-	Failures           int     `json:"failures"`
-	TestPassPercentage float64 `json:"testPassPercentage"`
 	// TestResults holds entries for each test that is a part of this aggregation.  Each entry aggregates the results of all runs of a single test.  The array is sorted from lowest PassPercentage to highest PassPercentage
 	TestResults []TestResult `json:"results"`
 }

--- a/pkg/html/html.go
+++ b/pkg/html/html.go
@@ -139,30 +139,6 @@ Data current as of: %s
 	`
 )
 
-func summaryAcrossAllJobs(result, resultPrev map[string]sippyprocessingv1.SortedAggregateTestsResult, endDay int) string {
-
-	all := result["all"]
-	allPrev := resultPrev["all"]
-
-	summary := `
-	<table class="table">
-		<tr>
-			<th colspan=3 class="text-center"><a class="text-dark" id="SummaryAcrossAllJobs" href="#SummaryAcrossAllJobs">Summary Across All Jobs</a></th>			
-		</tr>
-		<tr>
-			<th/><th>Latest %d days</th><th>Previous 7 days</th>
-		</tr>
-		<tr>
-			<td>Test executions: </td><td>%d</td><td>%d</td>
-		</tr>
-		<tr>
-			<td>Test Pass Percentage: </td><td>%0.2f</td><td>%0.2f</td>
-		</tr>
-	</table>`
-	s := fmt.Sprintf(summary, endDay, all.Successes+all.Failures, allPrev.Successes+allPrev.Failures, all.TestPassPercentage, allPrev.TestPassPercentage)
-	return s
-}
-
 func failureGroups(failureGroups, failureGroupsPrev []sippyprocessingv1.JobRunResult, endDay int) string {
 
 	_, _, median, medianPrev, avg, avgPrev := util.ComputeFailureGroupStats(failureGroups, failureGroupsPrev)
@@ -740,7 +716,6 @@ func PrintHtmlReport(w http.ResponseWriter, req *http.Request, report, prevRepor
 
 	var dashboardPage = template.Must(template.New("dashboardPage").Funcs(
 		template.FuncMap{
-			"summaryAcrossAllJobs":                   summaryAcrossAllJobs,
 			"failureGroups":                          failureGroups,
 			"summaryJobsByPlatform":                  summaryJobsByPlatform,
 			"summaryTopFailingTests":                 summaryTopFailingTests,

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -149,9 +149,6 @@ func SummarizeTestResults(
 		}
 
 		s := sorted[k]
-		s.Successes = passedCount
-		s.Failures = failedCount
-		s.TestPassPercentage = Percent(passedCount, failedCount)
 		sorted[k] = s
 
 		// sort from lowest to highest


### PR DESCRIPTION
success, failure, and passpercentage in the sorted aggregate fields are not used and are deceptive.  In fact, several spots explicitly avoid reporting the value, the overall summary was removed, and even the spots showing a pass percentage (questionable value) didn't report success and failure.

this makes the print report consistent with the html one and removes the dead fields.