### PR TITLE
remove old category slicing

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -202,8 +202,8 @@ func summaryTopFailingTestsWithoutBug(topFailingTestsWithoutBug []sippyprocessin
 func summaryJobPassRatesByJobName(report, reportPrev sippyprocessingv1.TestReport, endDay, jobTestCount int) []sippyv1.PassRatesByJobName {
 	var passRatesSlice []sippyv1.PassRatesByJobName
 
-	for _, v := range report.JobResults {
-		prev := util.GetJobResultForJobName(v.Name, reportPrev.JobResults)
+	for _, v := range report.FrequentJobResults {
+		prev := util.GetJobResultForJobName(v.Name, reportPrev.FrequentJobResults)
 
 		var newJobPassRate sippyv1.PassRatesByJobName
 

--- a/pkg/apis/sippyprocessing/v1/types.go
+++ b/pkg/apis/sippyprocessing/v1/types.go
@@ -10,25 +10,30 @@ import (
 
 // TestReport is a type that lives in service of producing the html rendering for sippy.
 type TestReport struct {
-	Release string                                `json:"release"`
-	All     map[string]SortedAggregateTestsResult `json:"all"`
-	ByJob   map[string]SortedAggregateTestsResult `json:"byJob`
-	BySig   map[string]SortedAggregateTestsResult `json:"bySig`
+	Release   string    `json:"release"`
+	Timestamp time.Time `json:"timestamp"`
+
+	// TODO this appears to be used to reference all tests, but instead we could simply provide an list of tests sorted by pass/fail
+	All map[string]SortedAggregateTestsResult `json:"all"`
 
 	// ByPlatform organizes jobs and tests by platform, sorted by job pass rate from low to high
 	ByPlatform []PlatformResults `json:"byPlatform`
 
 	FailureGroups []JobRunResult `json:"failureGroups"`
 
-	// JobResults are jobresults for jobs that run more than 1.5 times per day
-	JobResults []JobResult `json:"jobResults"`
+	// FrequentJobResults are jobresults for jobs that run more than 1.5 times per day
+	FrequentJobResults []JobResult `json:"frequentJobResults"`
 	// InfrequentJobResults are jobresults for jobs that run less than 1.5 times per day
 	InfrequentJobResults []JobResult `json:"infrequentJobResults"`
 
-	Timestamp                 time.Time           `json:"timestamp"`
-	TopFailingTestsWithBug    []FailingTestResult `json:"topFailingTestsWithBug"`
+	// TopFailingTestsWithBug holds the top 50 failing tests that have bugs, sorted from low to high pass rate
+	TopFailingTestsWithBug []FailingTestResult `json:"topFailingTestsWithBug"`
+	// TopFailingTestsWithoutBug holds the top 50 failing tests that do not have bugs, sorted from low to high pass rate
 	TopFailingTestsWithoutBug []FailingTestResult `json:"topFailingTestsWithoutBug"`
-	BugsByFailureCount        []bugsv1.Bug        `json:"bugsByFailureCount"`
+
+	// BugsByFailureCount lists the bugs by the most frequently failed
+	// TODO add information about which FailingTestResult they reference and provide expansion links to tests and jobs
+	BugsByFailureCount []bugsv1.Bug `json:"bugsByFailureCount"`
 
 	// JobFailuresByBugzillaComponent are keyed by bugzilla components
 	JobFailuresByBugzillaComponent map[string]SortedBugzillaComponentResult `json:"jobFailuresByBugzillaComponent"`

--- a/pkg/html/html.go
+++ b/pkg/html/html.go
@@ -208,8 +208,8 @@ func summaryJobPassRatesByJobName(report, reportPrev sippyprocessingv1.TestRepor
 		</tr>
 	`, endDay)
 
-	for _, currJobResult := range report.JobResults {
-		prevJobResult := util.GetJobResultForJobName(currJobResult.Name, reportPrev.JobResults)
+	for _, currJobResult := range report.FrequentJobResults {
+		prevJobResult := util.GetJobResultForJobName(currJobResult.Name, reportPrev.FrequentJobResults)
 		jobHTML := newJobResultRenderer("by-job-name", currJobResult, release).
 			withMaxTestResultsToShow(jobTestCount).
 			withPrevious(prevJobResult).
@@ -438,7 +438,6 @@ func summaryJobsFailuresByBugzillaComponent(report, reportPrev sippyprocessingv1
 		safeBZJob = strings.ReplaceAll(safeBZJob, ".", "")
 		safeBZJob = strings.ReplaceAll(safeBZJob, " ", "")
 
-		prev := util.GetPrevBugzillaJobFailures(v.Name, failuresByBugzillaComponentPrev)
 		highestFailPercentage := v.JobsFailed[0].FailPercentage
 		lowestPassPercentage := 100 - highestFailPercentage
 		rowColor := ""
@@ -453,6 +452,7 @@ func summaryJobsFailuresByBugzillaComponent(report, reportPrev sippyprocessingv1
 			rowColor = "error"
 		}
 
+		prev := util.GetPrevBugzillaJobFailures(v.Name, failuresByBugzillaComponentPrev)
 		if prev != nil && len(prev.JobsFailed) > 0 {
 			previousHighestFailPercentage := prev.JobsFailed[0].FailPercentage
 			previousLowestPassPercentage := 100 - previousHighestFailPercentage
@@ -491,7 +491,10 @@ func summaryJobsFailuresByBugzillaComponent(report, reportPrev sippyprocessingv1
 			bzJobTuple = strings.ReplaceAll(bzJobTuple, " ", "")
 
 			// given the name, we can actually look up the original JobResult.  There aren't that many, just iterate.
-			fullJobResult := util.GetJobResultForJobName(failingJob.JobName, report.JobResults)
+			fullJobResult := util.GetJobResultForJobName(failingJob.JobName, report.FrequentJobResults)
+			if fullJobResult == nil { // if it wasn't in the first, look in the second
+				fullJobResult = util.GetJobResultForJobName(failingJob.JobName, report.InfrequentJobResults)
+			}
 
 			// create the synthetic JobResult for display purposes.
 			// TODO with another refactor, we'll be able to tighten this up later.

--- a/pkg/testgridanalysis/testgridanalysisapi/types.go
+++ b/pkg/testgridanalysis/testgridanalysisapi/types.go
@@ -8,8 +8,6 @@ package testgridanalysisapi
 
 type RawData struct {
 	ByAll map[string]AggregateTestsResult
-	ByJob map[string]AggregateTestsResult
-	BySig map[string]AggregateTestsResult
 
 	// JobResults is a map keyed by job name to results for all runs of a job
 	JobResults map[string]RawJobResult

--- a/pkg/testgridanalysis/testreportconversion/by_component.go
+++ b/pkg/testgridanalysis/testreportconversion/by_component.go
@@ -13,17 +13,25 @@ import (
 )
 
 func generateAllJobFailuresByBugzillaComponent(
-	allJobResults map[string]testgridanalysisapi.RawJobResult,
-	jobToTestResults map[string]sippyprocessingv1.SortedAggregateTestsResult,
+	rawJobResults map[string]testgridanalysisapi.RawJobResult,
+	jobResults []sippyprocessingv1.JobResult,
 ) map[string]sippyprocessingv1.SortedBugzillaComponentResult {
 
 	bzComponentToBZJobResults := map[string][]sippyprocessingv1.BugzillaJobResult{}
-	for job, jobResult := range allJobResults {
-		curr := generateJobFailuresByBugzillaComponent(job, jobResult.JobRunResults, jobToTestResults[job].TestResults)
-		// each job will be distinct, so we merely need to append
-		for bzComponent, bzJobResult := range curr {
-			bzComponentToBZJobResults[bzComponent] = append(bzComponentToBZJobResults[bzComponent], bzJobResult)
+	for job, rawJobResult := range rawJobResults {
+		for _, processedJobResult := range jobResults {
+			if processedJobResult.Name != rawJobResult.JobName {
+				continue
+			}
+
+			curr := generateJobFailuresByBugzillaComponent(job, rawJobResult.JobRunResults, processedJobResult.TestResults)
+			// each job will be distinct, so we merely need to append
+			for bzComponent, bzJobResult := range curr {
+				bzComponentToBZJobResults[bzComponent] = append(bzComponentToBZJobResults[bzComponent], bzJobResult)
+			}
+			break
 		}
+
 	}
 
 	sortedResults := map[string]sippyprocessingv1.SortedBugzillaComponentResult{}

--- a/pkg/testgridanalysis/testreportconversion/test_report.go
+++ b/pkg/testgridanalysis/testreportconversion/test_report.go
@@ -31,8 +31,6 @@ func PrepareTestReport(
 	standardTestResultFilterFn := standardTestResultFilter(minRuns, successThreshold)
 
 	byAll := summarizeTestResults(rawData.ByAll, bugCache, release, minRuns, successThreshold)
-	byJob := summarizeTestResults(rawData.ByJob, bugCache, release, minRuns, successThreshold)
-	bySig := summarizeTestResults(rawData.BySig, bugCache, release, minRuns, successThreshold)
 	byPlatform := convertRawDataToByPlatform(rawData.JobResults, bugCache, release, standardTestResultFilterFn)
 
 	filteredFailureGroups := filterFailureGroups(rawData.JobResults, bugCache, release, failureClusterThreshold)
@@ -40,16 +38,14 @@ func PrepareTestReport(
 	infrequentJobResults := filterPertinentInfrequentJobResults(allJobResults, endDay, standardTestResultFilterFn)
 
 	bugFailureCounts := generateSortedBugFailureCounts(rawData.JobResults, byAll, bugCache, release)
-	bugzillaComponentResults := generateAllJobFailuresByBugzillaComponent(rawData.JobResults, byJob)
+	bugzillaComponentResults := generateAllJobFailuresByBugzillaComponent(rawData.JobResults, allJobResults)
 
 	testReport := sippyprocessingv1.TestReport{
 		Release:                        release,
 		All:                            byAll,
 		ByPlatform:                     byPlatform,
-		ByJob:                          byJob,
-		BySig:                          bySig,
 		FailureGroups:                  filteredFailureGroups,
-		JobResults:                     frequentJobResults,
+		FrequentJobResults:             frequentJobResults,
 		InfrequentJobResults:           infrequentJobResults,
 		Timestamp:                      reportTimestamp,
 		BugsByFailureCount:             bugFailureCounts,


### PR DESCRIPTION
Removes by-sig, which we never reported in html.

Removes by-job, which is replaced by searching frequent and infrequent failures.  I'm open to combining them into a single categorization.

This is reducing duplicate accounting as we process testgrid and move us towards a pipeline that looks like:

1. parse testgrid into `job -> job run -> test results` (RawJobResult)
1. RawJobResult to processedJobResult by looking up bugzilla and doing frequency computation
1. RawJobResult to allTestResult (not done yet)
2. various filtering and sorting based on processedjobresults and alltest results.
2. display of the json.

