### PR TITLE
replace byAll with ByTest which actually includes all tests

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -14,25 +14,6 @@ import (
 	"k8s.io/klog"
 )
 
-// summary across all job
-func summaryAcrossAllJobs(result, resultPrev map[string]sippyprocessingv1.SortedAggregateTestsResult, endDay int) *sippyv1.SummaryAcrossAllJobs {
-	all := result["all"]
-	allPrev := resultPrev["all"]
-
-	summary := sippyv1.SummaryAcrossAllJobs{
-		TestExecutions: map[string]int{
-			"latest": all.Successes + all.Failures,
-			"prev":   allPrev.Successes + allPrev.Failures,
-		},
-		TestPassPercentage: map[string]float64{
-			"latest": all.TestPassPercentage,
-			"prev":   allPrev.TestPassPercentage,
-		},
-	}
-
-	return &summary
-}
-
 // stats on failure groups
 func failureGroups(failureGroups, failureGroupsPrev []sippyprocessingv1.JobRunResult, endDay int) *sippyv1.FailureGroups {
 
@@ -98,17 +79,15 @@ func summaryJobsByPlatform(report, reportPrev sippyprocessingv1.TestReport, endD
 }
 
 // top failing tests with a bug
-func summaryTopFailingTestsWithBug(topFailingTestsWithBug []sippyprocessingv1.FailingTestResult, resultPrev map[string]sippyprocessingv1.SortedAggregateTestsResult, endDay int) []sippyv1.FailingTestBug {
+func summaryTopFailingTestsWithBug(topFailingTestsWithBug, prevTopFailingTestsWithBug []sippyprocessingv1.FailingTestResult) []sippyv1.FailingTestBug {
 
 	var topFailingTests []sippyv1.FailingTestBug
-
-	allPrev := resultPrev["all"]
 
 	for _, test := range topFailingTestsWithBug {
 		encodedTestName := url.QueryEscape(regexp.QuoteMeta(test.TestName))
 
 		testLink := fmt.Sprintf("%s%s", html.BugSearchUrl, encodedTestName)
-		testPrev := util.GetPrevTest(test.TestName, allPrev.TestResults)
+		testPrev := util.GetTestResult(test.TestName, prevTopFailingTestsWithBug)
 
 		var failedTestWithBug sippyv1.FailingTestBug
 
@@ -122,8 +101,8 @@ func summaryTopFailingTestsWithBug(topFailingTestsWithBug []sippyprocessingv1.Fa
 						Runs:       test.TestResultAcrossAllJobs.Successes + test.TestResultAcrossAllJobs.Failures,
 					},
 					"prev": sippyv1.PassRate{
-						Percentage: testPrev.PassPercentage,
-						Runs:       testPrev.Successes + test.TestResultAcrossAllJobs.Failures,
+						Percentage: testPrev.TestResultAcrossAllJobs.PassPercentage,
+						Runs:       testPrev.TestResultAcrossAllJobs.Successes + testPrev.TestResultAcrossAllJobs.Failures,
 					},
 				},
 				Bugs: test.TestResultAcrossAllJobs.BugList,
@@ -150,22 +129,18 @@ func summaryTopFailingTestsWithBug(topFailingTestsWithBug []sippyprocessingv1.Fa
 }
 
 // top failing tests without a bug
-func summaryTopFailingTestsWithoutBug(topFailingTestsWithoutBug []sippyprocessingv1.FailingTestResult, resultPrev map[string]sippyprocessingv1.SortedAggregateTestsResult, endDay int) []sippyv1.FailingTestBug {
-
-	allPrev := resultPrev["all"]
-
+func summaryTopFailingTestsWithoutBug(topFailingTestsWithoutBug, prevTopFailingTestsWithoutBug []sippyprocessingv1.FailingTestResult) []sippyv1.FailingTestBug {
 	var topFailingTests []sippyv1.FailingTestBug
 
 	for _, test := range topFailingTestsWithoutBug {
 		encodedTestName := url.QueryEscape(regexp.QuoteMeta(test.TestName))
 
 		testLink := fmt.Sprintf("%s%s", html.BugSearchUrl, encodedTestName)
-		testPrev := util.GetPrevTest(test.TestName, allPrev.TestResults)
+		testPrev := util.GetTestResult(test.TestName, prevTopFailingTestsWithoutBug)
 
 		var failedTestWithoutBug sippyv1.FailingTestBug
 
 		if testPrev != nil {
-
 			failedTestWithoutBug = sippyv1.FailingTestBug{
 				Name: test.TestName,
 				Url:  testLink,
@@ -175,8 +150,8 @@ func summaryTopFailingTestsWithoutBug(topFailingTestsWithoutBug []sippyprocessin
 						Runs:       test.TestResultAcrossAllJobs.Successes + test.TestResultAcrossAllJobs.Failures,
 					},
 					"prev": sippyv1.PassRate{
-						Percentage: testPrev.PassPercentage,
-						Runs:       testPrev.Successes + testPrev.Failures,
+						Percentage: testPrev.TestResultAcrossAllJobs.PassPercentage,
+						Runs:       testPrev.TestResultAcrossAllJobs.Successes + testPrev.TestResultAcrossAllJobs.Failures,
 					},
 				},
 			}
@@ -247,25 +222,31 @@ func summaryJobPassRatesByJobName(report, reportPrev sippyprocessingv1.TestRepor
 }
 
 // canaryTestFailures section
-func canaryTestFailures(result map[string]sippyprocessingv1.SortedAggregateTestsResult) []sippyv1.CanaryTestFailInstance {
-	all := result["all"].TestResults
-
+func canaryTestFailures(all []sippyprocessingv1.FailingTestResult) []sippyv1.CanaryTestFailInstance {
 	var canaryFailures []sippyv1.CanaryTestFailInstance
 
 	if len(all) <= 0 {
 		return nil
 	}
 
-	for i := len(all) - 1; i > len(all)-10; i-- {
+	foundCount := 0
+	for i := len(all) - 1; i >= 0; i-- {
 		test := all[i]
-		encodedTestName := url.QueryEscape(regexp.QuoteMeta(test.Name))
+		if test.TestResultAcrossAllJobs.Failures == 0 {
+			continue
+		}
+		foundCount++
+		if foundCount > 10 {
+			break
+		}
+		encodedTestName := url.QueryEscape(regexp.QuoteMeta(test.TestName))
 		canaryFailures = append(canaryFailures,
 			sippyv1.CanaryTestFailInstance{
-				Name: test.Name,
+				Name: test.TestName,
 				Url:  fmt.Sprintf("%s%s", html.BugSearchUrl, encodedTestName),
 				PassRate: sippyv1.PassRate{
-					Percentage: test.PassPercentage,
-					Runs:       test.Successes + test.Failures,
+					Percentage: test.TestResultAcrossAllJobs.PassPercentage,
+					Runs:       test.TestResultAcrossAllJobs.Successes + test.TestResultAcrossAllJobs.Failures,
 				},
 			})
 	}
@@ -295,13 +276,12 @@ func formatJSONReport(report, prevReport sippyprocessingv1.TestReport, endDay, j
 		Release:      report.Release}
 
 	jsonObject := map[string]interface{}{
-		"summaryAllJobs":            summaryAcrossAllJobs(data.Current.All, data.Prev.All, data.EndDay),
 		"failureGroupings":          failureGroups(data.Current.FailureGroups, data.Prev.FailureGroups, data.EndDay),
 		"jobPassRateByPlatform":     summaryJobsByPlatform(data.Current, data.Prev, data.EndDay, data.JobTestCount),
-		"topFailingTestsWithoutBug": summaryTopFailingTestsWithoutBug(data.Current.TopFailingTestsWithoutBug, data.Prev.All, data.EndDay),
-		"topFailingTestsWithBug":    summaryTopFailingTestsWithBug(data.Current.TopFailingTestsWithBug, data.Prev.All, data.EndDay),
+		"topFailingTestsWithoutBug": summaryTopFailingTestsWithoutBug(data.Current.TopFailingTestsWithoutBug, data.Prev.TopFailingTestsWithoutBug),
+		"topFailingTestsWithBug":    summaryTopFailingTestsWithBug(data.Current.TopFailingTestsWithBug, data.Prev.TopFailingTestsWithBug),
 		"jobPassRatesByName":        summaryJobPassRatesByJobName(data.Current, data.Prev, data.EndDay, data.JobTestCount),
-		"canaryTestFailures":        canaryTestFailures(data.Current.All),
+		"canaryTestFailures":        canaryTestFailures(data.Current.ByTest),
 		"jobRunsWithFailureGroups":  failureGroupList(data.Current),
 		"testImpactingBugs":         data.Current.BugsByFailureCount,
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -202,8 +202,8 @@ func summaryTopFailingTestsWithoutBug(topFailingTestsWithoutBug []sippyprocessin
 func summaryJobPassRatesByJobName(report, reportPrev sippyprocessingv1.TestReport, endDay, jobTestCount int) []sippyv1.PassRatesByJobName {
 	var passRatesSlice []sippyv1.PassRatesByJobName
 
-	for _, v := range report.JobResults {
-		prev := util.GetJobResultForJobName(v.Name, reportPrev.JobResults)
+	for _, v := range report.FrequentJobResults {
+		prev := util.GetJobResultForJobName(v.Name, reportPrev.FrequentJobResults)
 
 		var newJobPassRate sippyv1.PassRatesByJobName
 

--- a/pkg/apis/sippyprocessing/v1/types.go
+++ b/pkg/apis/sippyprocessing/v1/types.go
@@ -10,25 +10,30 @@ import (
 
 // TestReport is a type that lives in service of producing the html rendering for sippy.
 type TestReport struct {
-	Release string                                `json:"release"`
-	All     map[string]SortedAggregateTestsResult `json:"all"`
-	ByJob   map[string]SortedAggregateTestsResult `json:"byJob`
-	BySig   map[string]SortedAggregateTestsResult `json:"bySig`
+	Release   string    `json:"release"`
+	Timestamp time.Time `json:"timestamp"`
+
+	// TODO this appears to be used to reference all tests, but instead we could simply provide an list of tests sorted by pass/fail
+	All map[string]SortedAggregateTestsResult `json:"all"`
 
 	// ByPlatform organizes jobs and tests by platform, sorted by job pass rate from low to high
 	ByPlatform []PlatformResults `json:"byPlatform`
 
 	FailureGroups []JobRunResult `json:"failureGroups"`
 
-	// JobResults are jobresults for jobs that run more than 1.5 times per day
-	JobResults []JobResult `json:"jobResults"`
+	// FrequentJobResults are jobresults for jobs that run more than 1.5 times per day
+	FrequentJobResults []JobResult `json:"frequentJobResults"`
 	// InfrequentJobResults are jobresults for jobs that run less than 1.5 times per day
 	InfrequentJobResults []JobResult `json:"infrequentJobResults"`
 
-	Timestamp                 time.Time           `json:"timestamp"`
-	TopFailingTestsWithBug    []FailingTestResult `json:"topFailingTestsWithBug"`
+	// TopFailingTestsWithBug holds the top 50 failing tests that have bugs, sorted from low to high pass rate
+	TopFailingTestsWithBug []FailingTestResult `json:"topFailingTestsWithBug"`
+	// TopFailingTestsWithoutBug holds the top 50 failing tests that do not have bugs, sorted from low to high pass rate
 	TopFailingTestsWithoutBug []FailingTestResult `json:"topFailingTestsWithoutBug"`
-	BugsByFailureCount        []bugsv1.Bug        `json:"bugsByFailureCount"`
+
+	// BugsByFailureCount lists the bugs by the most frequently failed
+	// TODO add information about which FailingTestResult they reference and provide expansion links to tests and jobs
+	BugsByFailureCount []bugsv1.Bug `json:"bugsByFailureCount"`
 
 	// JobFailuresByBugzillaComponent are keyed by bugzilla components
 	JobFailuresByBugzillaComponent map[string]SortedBugzillaComponentResult `json:"jobFailuresByBugzillaComponent"`

--- a/pkg/apis/sippyprocessing/v1/types.go
+++ b/pkg/apis/sippyprocessing/v1/types.go
@@ -13,11 +13,11 @@ type TestReport struct {
 	Release   string    `json:"release"`
 	Timestamp time.Time `json:"timestamp"`
 
-	// TODO this appears to be used to reference all tests, but instead we could simply provide an list of tests sorted by pass/fail
-	All map[string]SortedAggregateTestsResult `json:"all"`
-
 	// ByPlatform organizes jobs and tests by platform, sorted by job pass rate from low to high
 	ByPlatform []PlatformResults `json:"byPlatform`
+
+	// ByTest organizes every test ordered by pass rate from low to high.
+	ByTest []FailingTestResult `json:"byTest"`
 
 	FailureGroups []JobRunResult `json:"failureGroups"`
 

--- a/pkg/html/html.go
+++ b/pkg/html/html.go
@@ -208,8 +208,8 @@ func summaryJobPassRatesByJobName(report, reportPrev sippyprocessingv1.TestRepor
 		</tr>
 	`, endDay)
 
-	for _, currJobResult := range report.JobResults {
-		prevJobResult := util.GetJobResultForJobName(currJobResult.Name, reportPrev.JobResults)
+	for _, currJobResult := range report.FrequentJobResults {
+		prevJobResult := util.GetJobResultForJobName(currJobResult.Name, reportPrev.FrequentJobResults)
 		jobHTML := newJobResultRenderer("by-job-name", currJobResult, release).
 			withMaxTestResultsToShow(jobTestCount).
 			withPrevious(prevJobResult).
@@ -438,7 +438,6 @@ func summaryJobsFailuresByBugzillaComponent(report, reportPrev sippyprocessingv1
 		safeBZJob = strings.ReplaceAll(safeBZJob, ".", "")
 		safeBZJob = strings.ReplaceAll(safeBZJob, " ", "")
 
-		prev := util.GetPrevBugzillaJobFailures(v.Name, failuresByBugzillaComponentPrev)
 		highestFailPercentage := v.JobsFailed[0].FailPercentage
 		lowestPassPercentage := 100 - highestFailPercentage
 		rowColor := ""
@@ -453,6 +452,7 @@ func summaryJobsFailuresByBugzillaComponent(report, reportPrev sippyprocessingv1
 			rowColor = "error"
 		}
 
+		prev := util.GetPrevBugzillaJobFailures(v.Name, failuresByBugzillaComponentPrev)
 		if prev != nil && len(prev.JobsFailed) > 0 {
 			previousHighestFailPercentage := prev.JobsFailed[0].FailPercentage
 			previousLowestPassPercentage := 100 - previousHighestFailPercentage
@@ -491,7 +491,10 @@ func summaryJobsFailuresByBugzillaComponent(report, reportPrev sippyprocessingv1
 			bzJobTuple = strings.ReplaceAll(bzJobTuple, " ", "")
 
 			// given the name, we can actually look up the original JobResult.  There aren't that many, just iterate.
-			fullJobResult := util.GetJobResultForJobName(failingJob.JobName, report.JobResults)
+			fullJobResult := util.GetJobResultForJobName(failingJob.JobName, report.FrequentJobResults)
+			if fullJobResult == nil { // if it wasn't in the first, look in the second
+				fullJobResult = util.GetJobResultForJobName(failingJob.JobName, report.InfrequentJobResults)
+			}
 
 			// create the synthetic JobResult for display purposes.
 			// TODO with another refactor, we'll be able to tighten this up later.

--- a/pkg/html/html.go
+++ b/pkg/html/html.go
@@ -96,9 +96,9 @@ Data current as of: %s
 
 {{ summaryJobsByPlatform .Current .Prev .EndDay .JobTestCount .Release }}
 
-{{ summaryTopFailingTestsWithoutBug .Current.TopFailingTestsWithoutBug .Prev.TopFailingTestsWithoutBug .EndDay .Release }}
+{{ summaryTopFailingTestsWithoutBug .Current.TopFailingTestsWithoutBug .Prev.ByTest .EndDay .Release }}
 
-{{ summaryTopFailingTestsWithBug .Current.TopFailingTestsWithBug .Prev.TopFailingTestsWithBug .EndDay .Release }}
+{{ summaryTopFailingTestsWithBug .Current.TopFailingTestsWithBug .Prev.ByTest .EndDay .Release }}
 
 {{ summaryJobPassRatesByJobName .Current .Prev .Release .EndDay .JobTestCount }}
 

--- a/pkg/testgridanalysis/testgridanalysisapi/types.go
+++ b/pkg/testgridanalysis/testgridanalysisapi/types.go
@@ -8,8 +8,6 @@ package testgridanalysisapi
 
 type RawData struct {
 	ByAll map[string]AggregateTestsResult
-	ByJob map[string]AggregateTestsResult
-	BySig map[string]AggregateTestsResult
 
 	// JobResults is a map keyed by job name to results for all runs of a job
 	JobResults map[string]RawJobResult

--- a/pkg/testgridanalysis/testgridanalysisapi/types.go
+++ b/pkg/testgridanalysis/testgridanalysisapi/types.go
@@ -7,8 +7,6 @@ package testgridanalysisapi
 // 3. JobRuns contain Tests.
 
 type RawData struct {
-	ByAll map[string]AggregateTestsResult
-
 	// JobResults is a map keyed by job name to results for all runs of a job
 	JobResults map[string]RawJobResult
 }

--- a/pkg/testgridanalysis/testreportconversion/by_component.go
+++ b/pkg/testgridanalysis/testreportconversion/by_component.go
@@ -13,17 +13,25 @@ import (
 )
 
 func generateAllJobFailuresByBugzillaComponent(
-	allJobResults map[string]testgridanalysisapi.RawJobResult,
-	jobToTestResults map[string]sippyprocessingv1.SortedAggregateTestsResult,
+	rawJobResults map[string]testgridanalysisapi.RawJobResult,
+	jobResults []sippyprocessingv1.JobResult,
 ) map[string]sippyprocessingv1.SortedBugzillaComponentResult {
 
 	bzComponentToBZJobResults := map[string][]sippyprocessingv1.BugzillaJobResult{}
-	for job, jobResult := range allJobResults {
-		curr := generateJobFailuresByBugzillaComponent(job, jobResult.JobRunResults, jobToTestResults[job].TestResults)
-		// each job will be distinct, so we merely need to append
-		for bzComponent, bzJobResult := range curr {
-			bzComponentToBZJobResults[bzComponent] = append(bzComponentToBZJobResults[bzComponent], bzJobResult)
+	for job, rawJobResult := range rawJobResults {
+		for _, processedJobResult := range jobResults {
+			if processedJobResult.Name != rawJobResult.JobName {
+				continue
+			}
+
+			curr := generateJobFailuresByBugzillaComponent(job, rawJobResult.JobRunResults, processedJobResult.TestResults)
+			// each job will be distinct, so we merely need to append
+			for bzComponent, bzJobResult := range curr {
+				bzComponentToBZJobResults[bzComponent] = append(bzComponentToBZJobResults[bzComponent], bzJobResult)
+			}
+			break
 		}
+
 	}
 
 	sortedResults := map[string]sippyprocessingv1.SortedBugzillaComponentResult{}

--- a/pkg/testgridanalysis/testreportconversion/by_tests.go
+++ b/pkg/testgridanalysis/testreportconversion/by_tests.go
@@ -2,78 +2,55 @@ package testreportconversion
 
 import (
 	"sort"
+	"strings"
+
+	"github.com/openshift/sippy/pkg/util/sets"
 
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 )
 
-func getTopFailingTestsWithBug(jobResults []sippyprocessingv1.JobResult, testResultFilterFn testResultFilterFunc) []sippyprocessingv1.FailingTestResult {
-	return getTopFailingTests(jobResults, func(testResult sippyprocessingv1.TestResult) bool {
+func getTopFailingTestsWithBug(testResultsByName testResultsByName, testResultFilterFn testResultFilterFunc) []sippyprocessingv1.FailingTestResult {
+	return getTopFailingTests(testResultsByName, func(testResult sippyprocessingv1.TestResult) bool {
 		return len(testResult.BugList) > 0
 	}, testResultFilterFn)
 }
 
-func getTopFailingTestsWithoutBug(jobResults []sippyprocessingv1.JobResult, testResultFilterFn testResultFilterFunc) []sippyprocessingv1.FailingTestResult {
-	return getTopFailingTests(jobResults, func(testResult sippyprocessingv1.TestResult) bool {
+func getTopFailingTestsWithoutBug(testResultsByName testResultsByName, testResultFilterFn testResultFilterFunc) []sippyprocessingv1.FailingTestResult {
+	return getTopFailingTests(testResultsByName, func(testResult sippyprocessingv1.TestResult) bool {
 		return len(testResult.BugList) == 0
 	}, testResultFilterFn)
 }
 
-type testFilterFunc func(sippyprocessingv1.TestResult) bool
+type testResultsByName map[string]sippyprocessingv1.FailingTestResult
 
-func getTopFailingTests(
-	jobResults []sippyprocessingv1.JobResult,
-	testFilterFn testFilterFunc,
-	testResultFilterFn testResultFilterFunc,
-) []sippyprocessingv1.FailingTestResult {
+func (a testResultsByName) toOrderedList() []sippyprocessingv1.FailingTestResult {
+	ret := []sippyprocessingv1.FailingTestResult{}
 
-	topTests := []sippyprocessingv1.FailingTestResult{}
-
-	type passFailPercent struct {
-		name            string
-		pass            int
-		fail            int
-		passFailPercent float64
+	for _, testResult := range a {
+		ret = append(ret, testResult)
 	}
-	testsToFailurePatterns := map[string]passFailPercent{}
 
+	sort.Stable(failingTestResultByPassPercentage(ret))
+	return ret
+}
+
+func getTestResultsByName(jobResults []sippyprocessingv1.JobResult) testResultsByName {
+	testsByName := testResultsByName{}
+
+	testNames := sets.NewString()
 	for _, jobResult := range jobResults {
 		for _, testResult := range jobResult.TestResults {
-			if !testFilterFn(testResult) {
-				continue
-			}
-			currPassFailPercent := testsToFailurePatterns[testResult.Name]
-			currPassFailPercent.name = testResult.Name
-			currPassFailPercent.pass += testResult.Successes
-			currPassFailPercent.fail += testResult.Failures
-			currPassFailPercent.passFailPercent = percent(currPassFailPercent.pass, currPassFailPercent.fail)
-			testsToFailurePatterns[testResult.Name] = currPassFailPercent
+			testNames.Insert(testResult.Name)
 		}
 	}
 
-	failingTests := []passFailPercent{}
-	for _, curr := range testsToFailurePatterns {
-		if curr.fail == 0 {
-			continue
-		}
-		if curr.fail+curr.pass < 10 {
-			continue
-		}
-		failingTests = append(failingTests, curr)
-	}
-	sort.SliceStable(failingTests, func(i, j int) bool {
-		return failingTests[i].passFailPercent < failingTests[j].passFailPercent
-	})
-
-	for _, failingTest := range failingTests {
-		if len(topTests) >= 50 {
-			break
-		}
-
+	for _, testName := range testNames.UnsortedList() {
 		failingTestResult := sippyprocessingv1.FailingTestResult{
-			TestName:                failingTest.name,
-			TestResultAcrossAllJobs: sippyprocessingv1.TestResult{Name: failingTest.name},
+			TestName:                testName,
+			TestResultAcrossAllJobs: sippyprocessingv1.TestResult{Name: testName},
 			JobResults:              nil,
 		}
+
 		for _, jobResult := range jobResults {
 			for _, testResult := range jobResult.TestResults {
 				if testResult.Name != failingTestResult.TestName {
@@ -95,17 +72,88 @@ func getTopFailingTests(
 				break
 			}
 		}
-		if !testResultFilterFn(failingTestResult.TestResultAcrossAllJobs) {
+
+		sort.Stable(failingTestJobResultByJobPassPercentage(failingTestResult.JobResults))
+
+		testsByName[testName] = failingTestResult
+	}
+
+	return testsByName
+}
+
+// failingTestJobResultByJobPassPercentage sorts from lowest to highest pass percentage
+type failingTestJobResultByJobPassPercentage []sippyprocessingv1.FailingTestJobResult
+
+func (a failingTestJobResultByJobPassPercentage) Len() int      { return len(a) }
+func (a failingTestJobResultByJobPassPercentage) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a failingTestJobResultByJobPassPercentage) Less(i, j int) bool {
+	if a[i].PassPercentage < a[j].PassPercentage {
+		return true
+	}
+	if a[i].PassPercentage > a[j].PassPercentage {
+		return false
+	}
+	if strings.Compare(a[i].Name, a[j].Name) < 0 {
+		return true
+	}
+	return false
+}
+
+// failingTestJobResultByJobPassPercentage sorts from lowest to highest pass percentage
+type failingTestResultByPassPercentage []sippyprocessingv1.FailingTestResult
+
+func (a failingTestResultByPassPercentage) Len() int      { return len(a) }
+func (a failingTestResultByPassPercentage) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a failingTestResultByPassPercentage) Less(i, j int) bool {
+	if a[i].TestResultAcrossAllJobs.PassPercentage < a[j].TestResultAcrossAllJobs.PassPercentage {
+		return true
+	}
+	if a[i].TestResultAcrossAllJobs.PassPercentage > a[j].TestResultAcrossAllJobs.PassPercentage {
+		return false
+	}
+	if strings.Compare(a[i].TestResultAcrossAllJobs.Name, a[j].TestResultAcrossAllJobs.Name) < 0 {
+		return true
+	}
+	return false
+}
+
+type testFilterFunc func(sippyprocessingv1.TestResult) bool
+
+func getTopFailingTests(
+	testResultsByName testResultsByName,
+	testFilterFn testFilterFunc,
+	testResultFilterFn testResultFilterFunc,
+) []sippyprocessingv1.FailingTestResult {
+
+	topTests := []sippyprocessingv1.FailingTestResult{}
+
+	for _, testResult := range testResultsByName {
+		if !testFilterFn(testResult.TestResultAcrossAllJobs) {
+			continue
+		}
+		if !testResultFilterFn(testResult.TestResultAcrossAllJobs) {
 			continue
 		}
 
-		// sort the jobResults by most failed first
-		sort.SliceStable(failingTestResult.JobResults, func(i, j int) bool {
-			return failingTestResult.JobResults[i].PassPercentage < failingTestResult.JobResults[j].PassPercentage
-		})
-
-		topTests = append(topTests, failingTestResult)
+		newInstance := sippyprocessingv1.FailingTestResult{
+			TestName:                testResult.TestName,
+			TestResultAcrossAllJobs: testResult.TestResultAcrossAllJobs,
+			JobResults:              nil,
+		}
+		for _, jobResult := range testResult.JobResults {
+			// if the job hasn't run at least 7 times, don't add it to the list
+			if jobResult.TestFailures+jobResult.TestSuccesses < 7 && jobResult.TestFailures == 0 {
+				continue
+			}
+			newInstance.JobResults = append(newInstance.JobResults, jobResult)
+		}
+		topTests = append(topTests, testResult)
 	}
 
-	return topTests
+	sort.Stable(failingTestResultByPassPercentage(topTests))
+
+	if len(topTests) < 50 {
+		return topTests
+	}
+	return topTests[:50]
 }

--- a/pkg/testgridanalysis/testreportconversion/test_report.go
+++ b/pkg/testgridanalysis/testreportconversion/test_report.go
@@ -31,8 +31,6 @@ func PrepareTestReport(
 	standardTestResultFilterFn := standardTestResultFilter(minRuns, successThreshold)
 
 	byAll := summarizeTestResults(rawData.ByAll, bugCache, release, minRuns, successThreshold)
-	byJob := summarizeTestResults(rawData.ByJob, bugCache, release, minRuns, successThreshold)
-	bySig := summarizeTestResults(rawData.BySig, bugCache, release, minRuns, successThreshold)
 	byPlatform := convertRawDataToByPlatform(rawData.JobResults, bugCache, release, standardTestResultFilterFn)
 
 	filteredFailureGroups := filterFailureGroups(rawData.JobResults, bugCache, release, failureClusterThreshold)
@@ -40,16 +38,14 @@ func PrepareTestReport(
 	infrequentJobResults := filterPertinentInfrequentJobResults(allJobResults, endDay, standardTestResultFilterFn)
 
 	bugFailureCounts := generateSortedBugFailureCounts(rawData.JobResults, byAll, bugCache, release)
-	bugzillaComponentResults := generateAllJobFailuresByBugzillaComponent(rawData.JobResults, byJob)
+	bugzillaComponentResults := generateAllJobFailuresByBugzillaComponent(rawData.JobResults, allJobResults)
 
 	testReport := sippyprocessingv1.TestReport{
 		Release:                        release,
 		All:                            byAll,
 		ByPlatform:                     byPlatform,
-		ByJob:                          byJob,
-		BySig:                          bySig,
 		FailureGroups:                  filteredFailureGroups,
-		JobResults:                     frequentJobResults,
+		FrequentJobResults:             frequentJobResults,
 		InfrequentJobResults:           infrequentJobResults,
 		Timestamp:                      reportTimestamp,
 		BugsByFailureCount:             bugFailureCounts,

--- a/pkg/testgridanalysis/testreportconversion/test_report.go
+++ b/pkg/testgridanalysis/testreportconversion/test_report.go
@@ -8,7 +8,6 @@ import (
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 	"github.com/openshift/sippy/pkg/buganalysis"
 	"github.com/openshift/sippy/pkg/testgridanalysis/testgridanalysisapi"
-	"github.com/openshift/sippy/pkg/util/sets"
 )
 
 func PrepareTestReport(
@@ -27,84 +26,43 @@ func PrepareTestReport(
 
 	// allJobResults holds all the job results with all the test results.  It contains complete frequency information and
 	allJobResults := convertRawJobResultsToProcessedJobResults(rawData.JobResults, bugCache, release)
+	allTestResultsByName := getTestResultsByName(allJobResults)
 
 	standardTestResultFilterFn := standardTestResultFilter(minRuns, successThreshold)
 
-	byAll := summarizeTestResults(rawData.ByAll, bugCache, release, minRuns, successThreshold)
 	byPlatform := convertRawDataToByPlatform(rawData.JobResults, bugCache, release, standardTestResultFilterFn)
 
 	filteredFailureGroups := filterFailureGroups(rawData.JobResults, bugCache, release, failureClusterThreshold)
 	frequentJobResults := filterPertinentFrequentJobResults(allJobResults, endDay, standardTestResultFilterFn)
 	infrequentJobResults := filterPertinentInfrequentJobResults(allJobResults, endDay, standardTestResultFilterFn)
 
-	bugFailureCounts := generateSortedBugFailureCounts(rawData.JobResults, byAll, bugCache, release)
+	bugFailureCounts := generateSortedBugFailureCounts(allTestResultsByName)
 	bugzillaComponentResults := generateAllJobFailuresByBugzillaComponent(rawData.JobResults, allJobResults)
 
+	topFailingTestsWithBug := getTopFailingTestsWithBug(allTestResultsByName, standardTestResultFilterFn)
+	topFailingTestsWithoutBug := getTopFailingTestsWithoutBug(allTestResultsByName, standardTestResultFilterFn)
+
 	testReport := sippyprocessingv1.TestReport{
-		Release:                        release,
-		All:                            byAll,
-		ByPlatform:                     byPlatform,
-		FailureGroups:                  filteredFailureGroups,
-		FrequentJobResults:             frequentJobResults,
-		InfrequentJobResults:           infrequentJobResults,
-		Timestamp:                      reportTimestamp,
+		Release:   release,
+		Timestamp: reportTimestamp,
+
+		ByTest:        allTestResultsByName.toOrderedList(),
+		ByPlatform:    byPlatform,
+		FailureGroups: filteredFailureGroups,
+
+		FrequentJobResults:   frequentJobResults,
+		InfrequentJobResults: infrequentJobResults,
+
 		BugsByFailureCount:             bugFailureCounts,
 		JobFailuresByBugzillaComponent: bugzillaComponentResults,
+
+		TopFailingTestsWithBug:    topFailingTestsWithBug,
+		TopFailingTestsWithoutBug: topFailingTestsWithoutBug,
 
 		AnalysisWarnings: analysisWarnings,
 	}
 
-	testReport.TopFailingTestsWithBug = getTopFailingTestsWithBug(allJobResults, standardTestResultFilterFn)
-	testReport.TopFailingTestsWithoutBug = getTopFailingTestsWithoutBug(allJobResults, standardTestResultFilterFn)
-
 	return testReport
-}
-
-func summarizeTestResults(
-	aggregateTestResult map[string]testgridanalysisapi.AggregateTestsResult,
-	bugCache buganalysis.BugCache, // required to associate tests with bug
-	release string, // required to limit bugs to those that apply to the release in question
-	minRuns int, // indicates how many runs are required for a test is included in overall percentages
-	// TODO deads2k wants to eliminate the successThreshold
-	successThreshold float64, // indicates an upper bound on how successful a test can be before it is excluded
-) map[string]sippyprocessingv1.SortedAggregateTestsResult {
-	sorted := make(map[string]sippyprocessingv1.SortedAggregateTestsResult)
-
-	for k, v := range aggregateTestResult {
-		sorted[k] = sippyprocessingv1.SortedAggregateTestsResult{}
-
-		passedCount := 0
-		failedCount := 0
-		for _, rawTestResult := range v.RawTestResults {
-			passPercentage := percent(rawTestResult.Successes, rawTestResult.Failures)
-
-			// strip out tests are more than N% successful
-			if passPercentage > successThreshold {
-				continue
-			}
-			// strip out tests that have less than N total runs
-			if rawTestResult.Successes+rawTestResult.Failures < minRuns {
-				continue
-			}
-
-			passedCount += rawTestResult.Successes
-			failedCount += rawTestResult.Failures
-
-			s := sorted[k]
-			s.TestResults = append(s.TestResults,
-				convertRawTestResultToProcessedTestResult(rawTestResult, bugCache, release))
-			sorted[k] = s
-		}
-
-		s := sorted[k]
-		s.Successes = passedCount
-		s.Failures = failedCount
-		s.TestPassPercentage = percent(passedCount, failedCount)
-		sorted[k] = s
-
-		sort.Stable(testResultsByPassPercentage(sorted[k].TestResults))
-	}
-	return sorted
 }
 
 func filterFailureGroups(
@@ -147,34 +105,21 @@ func filterFailureGroups(
 	return filteredJrr
 }
 
-func generateSortedBugFailureCounts(
-	allJobResults map[string]testgridanalysisapi.RawJobResult,
-	byAll map[string]sippyprocessingv1.SortedAggregateTestsResult,
-	bugCache buganalysis.BugCache, // required to associate tests with bug
-	release string, // required to limit bugs to those that apply to the release in question
-) []bugsv1.Bug {
+func generateSortedBugFailureCounts(allTestResultsByName testResultsByName) []bugsv1.Bug {
 	bugs := map[string]bugsv1.Bug{}
-
-	failedTestNamesAcrossAllJobRuns := sets.NewString()
-	for _, jobResult := range allJobResults {
-		for _, jobrun := range jobResult.JobRunResults {
-			failedTestNamesAcrossAllJobRuns.Insert(jobrun.FailedTestNames...)
-		}
-	}
 
 	// for every test that failed in some job run, look up the bug(s) associated w/ the test
 	// and attribute the number of times the test failed+flaked to that bug(s)
-	for _, testResult := range byAll["all"].TestResults {
-		testName := testResult.Name
-		bugList := bugCache.ListBugs(release, "", testName)
+	for _, testResult := range allTestResultsByName {
+		bugList := testResult.TestResultAcrossAllJobs.BugList
 		for _, bug := range bugList {
 			if b, found := bugs[bug.Url]; found {
-				b.FailureCount += testResult.Failures
-				b.FlakeCount += testResult.Flakes
+				b.FailureCount += testResult.TestResultAcrossAllJobs.Failures
+				b.FlakeCount += testResult.TestResultAcrossAllJobs.Flakes
 				bugs[bug.Url] = b
 			} else {
-				bug.FailureCount = testResult.Failures
-				bug.FlakeCount = testResult.Flakes
+				bug.FailureCount = testResult.TestResultAcrossAllJobs.Failures
+				bug.FlakeCount = testResult.TestResultAcrossAllJobs.Flakes
 				bugs[bug.Url] = bug
 			}
 		}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -16,9 +16,9 @@ var (
 	bugzillaRegex *regexp.Regexp = regexp.MustCompile(`(https://bugzilla.redhat.com/show_bug.cgi\?id=\d+)`)
 )
 
-func GetPrevTest(test string, testResults []sippyprocessingv1.TestResult) *sippyprocessingv1.TestResult {
+func GetTestResult(test string, testResults []sippyprocessingv1.FailingTestResult) *sippyprocessingv1.FailingTestResult {
 	for _, v := range testResults {
-		if v.Name == test {
+		if v.TestName == test {
 			return &v
 		}
 	}


### PR DESCRIPTION
ByAll was filtered and didn't include all the results.  The new ByTest does include them and uses the same datatype as the top failing test calculations.

This completes the main changes to the processing pipeline.  From here it is recutting an sorting.