### PR TITLE
Refactor to make it easier to tie webserver hits to results produced.

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -40,7 +40,7 @@ func summaryJobsByPlatform(report, reportPrev sippyprocessingv1.TestReport, endD
 	var jobSummariesByPlatform []sippyv1.JobSummaryPlatform
 
 	for _, v := range report.ByPlatform {
-		prev := util.GetPlatform(v.PlatformName, reportPrev.ByPlatform)
+		prev := util.FindPlatformResultsForName(v.PlatformName, reportPrev.ByPlatform)
 
 		var jobSummaryPlatform sippyv1.JobSummaryPlatform
 
@@ -87,7 +87,7 @@ func summaryTopFailingTestsWithBug(topFailingTestsWithBug, prevTestResults []sip
 		encodedTestName := url.QueryEscape(regexp.QuoteMeta(test.TestName))
 
 		testLink := fmt.Sprintf("%s%s", html.BugSearchUrl, encodedTestName)
-		testPrev := util.GetTestResult(test.TestName, prevTestResults)
+		testPrev := util.FindTestResult(test.TestName, prevTestResults)
 
 		var failedTestWithBug sippyv1.FailingTestBug
 
@@ -136,7 +136,7 @@ func summaryTopFailingTestsWithoutBug(topFailingTestsWithoutBug, prevTopFailingT
 		encodedTestName := url.QueryEscape(regexp.QuoteMeta(test.TestName))
 
 		testLink := fmt.Sprintf("%s%s", html.BugSearchUrl, encodedTestName)
-		testPrev := util.GetTestResult(test.TestName, prevTopFailingTestsWithoutBug)
+		testPrev := util.FindTestResult(test.TestName, prevTopFailingTestsWithoutBug)
 
 		var failedTestWithoutBug sippyv1.FailingTestBug
 
@@ -178,7 +178,7 @@ func summaryJobPassRatesByJobName(report, reportPrev sippyprocessingv1.TestRepor
 	var passRatesSlice []sippyv1.PassRatesByJobName
 
 	for _, v := range report.FrequentJobResults {
-		prev := util.GetJobResultForJobName(v.Name, reportPrev.FrequentJobResults)
+		prev := util.FindJobResultForJobName(v.Name, reportPrev.FrequentJobResults)
 
 		var newJobPassRate sippyv1.PassRatesByJobName
 

--- a/pkg/html/failing_tests.go
+++ b/pkg/html/failing_tests.go
@@ -96,7 +96,7 @@ func topFailingTestsRows(topFailingTests, allTests []sippyprocessingv1.FailingTe
 
 		testLink := fmt.Sprintf("<a target=\"_blank\" href=\"https://search.ci.openshift.org/?maxAge=168h&context=1&type=bug%%2Bjunit&name=%s&maxMatches=5&maxBytes=20971520&groupBy=job&search=%s\">%s</a>", release, encodedTestName, testResult.TestName)
 
-		testPrev := util.GetTestResult(testResult.TestName, allTests)
+		testPrev := util.FindTestResult(testResult.TestName, allTests)
 
 		byJobCollapseName := makeSafeForCollapseName("test-result---" + testResult.TestName)
 

--- a/pkg/html/fastest_moving_jobs.go
+++ b/pkg/html/fastest_moving_jobs.go
@@ -17,7 +17,7 @@ func summaryTopNegativelyMovingJobs(twoDaysJobs, prevJobs []sippyprocessingv1.Jo
 	jobPassChanges := []jobPassChange{}
 
 	for _, job := range twoDaysJobs {
-		prevJob := util.GetJobResultForJobName(job.Name, prevJobs)
+		prevJob := util.FindJobResultForJobName(job.Name, prevJobs)
 		if prevJob == nil {
 			continue
 		}
@@ -51,8 +51,8 @@ func summaryTopNegativelyMovingJobs(twoDaysJobs, prevJobs []sippyprocessingv1.Jo
 		if jobDetails.passPercentageChange > -10 {
 			break
 		}
-		currJobResult := util.GetJobResultForJobName(jobDetails.jobName, twoDaysJobs)
-		prevJobResult := util.GetJobResultForJobName(currJobResult.Name, prevJobs)
+		currJobResult := util.FindJobResultForJobName(jobDetails.jobName, twoDaysJobs)
+		prevJobResult := util.FindJobResultForJobName(currJobResult.Name, prevJobs)
 		jobHTML := newJobResultRenderer("by-job-name", *currJobResult, release).
 			withMaxTestResultsToShow(jobTestCount).
 			withPrevious(prevJobResult).

--- a/pkg/html/html.go
+++ b/pkg/html/html.go
@@ -159,7 +159,7 @@ func summaryJobsByPlatform(report, reportPrev sippyprocessingv1.TestReport, endD
 	for _, currPlatform := range report.ByPlatform {
 		jobHTML := newJobAggregationResultRenderer("by-variant", *convertPlatformToAggregationResult(&currPlatform), release).
 			withMaxTestResultsToShow(jobTestCount).
-			withPrevious(convertPlatformToAggregationResult(util.GetPlatform(currPlatform.PlatformName, reportPrev.ByPlatform))).
+			withPrevious(convertPlatformToAggregationResult(util.FindPlatformResultsForName(currPlatform.PlatformName, reportPrev.ByPlatform))).
 			toHTML()
 
 		s += jobHTML
@@ -187,7 +187,7 @@ func summaryFrequentJobPassRatesByJobName(report, reportPrev sippyprocessingv1.T
 	`, endDay)
 
 	for _, currJobResult := range report.FrequentJobResults {
-		prevJobResult := util.GetJobResultForJobName(currJobResult.Name, reportPrev.FrequentJobResults)
+		prevJobResult := util.FindJobResultForJobName(currJobResult.Name, reportPrev.FrequentJobResults)
 		jobHTML := newJobResultRenderer("by-job-name", currJobResult, release).
 			withMaxTestResultsToShow(jobTestCount).
 			withPrevious(prevJobResult).
@@ -212,7 +212,7 @@ func summaryInfrequentJobPassRatesByJobName(report, reportPrev sippyprocessingv1
 	`, endDay)
 
 	for _, currJobResult := range report.InfrequentJobResults {
-		prevJobResult := util.GetJobResultForJobName(currJobResult.Name, reportPrev.InfrequentJobResults)
+		prevJobResult := util.FindJobResultForJobName(currJobResult.Name, reportPrev.InfrequentJobResults)
 		jobHTML := newJobResultRenderer("by-infrequent-job-name", currJobResult, release).
 			withMaxTestResultsToShow(jobTestCount).
 			withPrevious(prevJobResult).
@@ -255,7 +255,7 @@ func canaryTestFailures(all, prevAll []sippyprocessingv1.FailingTestResult) stri
 		}
 
 		// TODO use a standard presentation for the failed test
-		util.GetTestResult(test.TestName, prevAll)
+		util.FindTestResult(test.TestName, prevAll)
 
 		encodedTestName := url.QueryEscape(regexp.QuoteMeta(test.TestName))
 
@@ -439,7 +439,7 @@ func summaryJobsFailuresByBugzillaComponent(report, reportPrev sippyprocessingv1
 			rowColor = "error"
 		}
 
-		prev := util.GetPrevBugzillaJobFailures(v.Name, failuresByBugzillaComponentPrev)
+		prev := util.FindPrevBugzillaJobFailures(v.Name, failuresByBugzillaComponentPrev)
 		if prev != nil && len(prev.JobsFailed) > 0 {
 			previousHighestFailPercentage := prev.JobsFailed[0].FailPercentage
 			previousLowestPassPercentage := 100 - previousHighestFailPercentage
@@ -476,7 +476,7 @@ func summaryJobsFailuresByBugzillaComponent(report, reportPrev sippyprocessingv1
 			bzJobTuple := makeSafeForCollapseName(fmt.Sprintf("%s---%s", v.Name, failingJob.JobName))
 
 			// given the name, we can actually look up the original JobResult.  There aren't that many, just iterate.
-			fullJobResult := util.GetJobResultForJobName(failingJob.JobName, report.ByJob)
+			fullJobResult := util.FindJobResultForJobName(failingJob.JobName, report.ByJob)
 
 			// create the synthetic JobResult for display purposes.
 			// TODO with another refactor, we'll be able to tighten this up later.

--- a/pkg/html/jobaggregationresult.go
+++ b/pkg/html/jobaggregationresult.go
@@ -189,7 +189,7 @@ func (b *jobAggregationResultRenderBuilder) toHTML() string {
 
 		var prevJob *sippyprocessingv1.JobResult
 		if b.prevAggregationResult != nil {
-			prevJob = util.GetJobResultForJobName(job.Name, b.prevAggregationResult.JobResults)
+			prevJob = util.FindJobResultForJobName(job.Name, b.prevAggregationResult.JobResults)
 		}
 
 		jobRows = jobRows + newJobResultRenderer(jobsCollapseName, job, b.release).

--- a/pkg/testgridanalysis/testgridanalysisapi/types.go
+++ b/pkg/testgridanalysis/testgridanalysisapi/types.go
@@ -22,14 +22,6 @@ type RawJobResult struct {
 	TestResults map[string]RawTestResult
 }
 
-// AggregateTestsResult is an intermediate datatype that may not have complete or consistent data when interrogated.
-// It holds data about many different tests, not just one.
-// It is used to build up a set of TestResults (details about individual tests).
-type AggregateTestsResult struct {
-	// TestResults is a map from test.Name to the aggregated results for each run of that test.
-	RawTestResults map[string]RawTestResult
-}
-
 // RawTestResult is an intermediate datatype that may not have complete or consistent data when interrogated.
 // It holds data about an individual test that may have happened in may different jobs and job runs.
 // It is used to build up a complete set of successes and failure, but until all the testgrid results have been checked, it will be incomplete

--- a/pkg/testgridanalysis/testgridconversion/doc.go
+++ b/pkg/testgridanalysis/testgridconversion/doc.go
@@ -1,0 +1,3 @@
+// testgridconversion takes testgridv1 data and processes it to produce testgridanalysisapi data that is easier for
+// humans to understand before undergoing further filtering and transformation.
+package testgridconversion

--- a/pkg/testgridanalysis/testgridconversion/synthentic_tests.go
+++ b/pkg/testgridanalysis/testgridconversion/synthentic_tests.go
@@ -1,0 +1,82 @@
+package testgridconversion
+
+import (
+	"strings"
+
+	"github.com/openshift/sippy/pkg/testgridanalysis/testgridanalysisapi"
+	"github.com/openshift/sippy/pkg/util"
+)
+
+// createSyntheticTests takes the JobRunResult information and produces some pre-analysis by interpreting different types of failures
+// and potentially producing synthentic test results and aggregations to better inform sippy.
+// This needs to be called after all the JobDetails have been processed.
+func createSyntheticTests(rawJobResults testgridanalysisapi.RawData) {
+	// make a pass to fill in install, upgrade, and infra synthentic tests.
+	type synthenticTestResult struct {
+		name string
+		pass int
+		fail int
+	}
+
+	for jobName, jobResults := range rawJobResults.JobResults {
+		for jrrKey, jrr := range jobResults.JobRunResults {
+			isUpgrade := strings.Contains(jrr.Job, "upgrade")
+
+			syntheticTests := map[string]*synthenticTestResult{
+				testgridanalysisapi.InstallTestName:        &synthenticTestResult{name: testgridanalysisapi.InstallTestName},
+				testgridanalysisapi.UpgradeTestName:        &synthenticTestResult{name: testgridanalysisapi.UpgradeTestName},
+				testgridanalysisapi.InfrastructureTestName: &synthenticTestResult{name: testgridanalysisapi.InfrastructureTestName},
+			}
+
+			installFailed := false
+			for _, operator := range jrr.InstallOperators {
+				if operator.State == testgridanalysisapi.Failure {
+					installFailed = true
+					break
+				}
+			}
+			upgradeFailed := false
+			for _, operator := range jrr.UpgradeOperators {
+				if operator.State == testgridanalysisapi.Failure {
+					upgradeFailed = true
+					break
+				}
+			}
+			setupFailed := jrr.SetupStatus != testgridanalysisapi.Success
+
+			if installFailed {
+				jrr.TestFailures++
+				jrr.FailedTestNames = append(jrr.FailedTestNames, testgridanalysisapi.InstallTestName)
+				syntheticTests[testgridanalysisapi.InstallTestName].fail = 1
+			} else {
+				if !setupFailed { // this will be an undercount, but we only want to count installs that actually worked.
+					syntheticTests[testgridanalysisapi.InstallTestName].pass = 1
+				}
+			}
+			if setupFailed && len(jrr.InstallOperators) == 0 { // we only want to count it as an infra issue if the install did not start
+				jrr.TestFailures++
+				jrr.FailedTestNames = append(jrr.FailedTestNames, testgridanalysisapi.InfrastructureTestName)
+				syntheticTests[testgridanalysisapi.InfrastructureTestName].fail = 1
+			} else {
+				syntheticTests[testgridanalysisapi.InfrastructureTestName].pass = 1
+			}
+			if isUpgrade && !setupFailed && !installFailed { // only record upgrade status if we were able to attempt the upgrade
+				if upgradeFailed || len(jrr.UpgradeOperators) == 0 {
+					jrr.TestFailures++
+					jrr.FailedTestNames = append(jrr.FailedTestNames, testgridanalysisapi.UpgradeTestName)
+					syntheticTests[testgridanalysisapi.UpgradeTestName].fail = 1
+				} else {
+					syntheticTests[testgridanalysisapi.UpgradeTestName].pass = 1
+				}
+			}
+
+			for testName, result := range syntheticTests {
+				util.AddTestResult(jobResults.TestResults, testName, result.pass, result.fail, 0)
+			}
+
+			jobResults.JobRunResults[jrrKey] = jrr
+		}
+
+		rawJobResults.JobResults[jobName] = jobResults
+	}
+}

--- a/pkg/testgridanalysis/testgridconversion/to_raw_data.go
+++ b/pkg/testgridanalysis/testgridconversion/to_raw_data.go
@@ -1,0 +1,196 @@
+package testgridconversion
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
+	"time"
+
+	testgridv1 "github.com/openshift/sippy/pkg/apis/testgrid/v1"
+	"github.com/openshift/sippy/pkg/testgridanalysis/testgridanalysisapi"
+	"github.com/openshift/sippy/pkg/util"
+	"k8s.io/klog"
+)
+
+type ProcessingOptions struct {
+	StartDay int
+	EndDay   int
+}
+
+func (o ProcessingOptions) ProcessTestGridDataIntoRawJobResults(testGridJobInfo []testgridv1.JobDetails) testgridanalysisapi.RawData {
+	rawJobResults := testgridanalysisapi.RawData{JobResults: map[string]testgridanalysisapi.RawJobResult{}}
+
+	for _, jobDetails := range testGridJobInfo {
+		klog.V(2).Infof("processing test details for job %s\n", jobDetails.Name)
+		startCol, endCol := computeLookback(o.StartDay, o.EndDay, jobDetails.Timestamps)
+		processJobDetails(rawJobResults, jobDetails, startCol, endCol)
+	}
+
+	// now that we have all the JobRunResults, use them to create synthetic tests for install, upgrade, and infra
+	createSyntheticTests(rawJobResults)
+
+	return rawJobResults
+}
+
+func processJobDetails(rawJobResults testgridanalysisapi.RawData, job testgridv1.JobDetails, startCol, endCol int) {
+	for i, test := range job.Tests {
+		klog.V(4).Infof("Analyzing results from %d to %d from job %s for test %s\n", startCol, endCol, job.Name, test.Name)
+
+		test.Name = strings.TrimSpace(tagStripRegex.ReplaceAllString(test.Name, ""))
+		job.Tests[i] = test
+
+		processTest(rawJobResults, job, test, startCol, endCol)
+	}
+}
+
+func computeLookback(startday, lookback int, timestamps []int) (int, int) {
+	stopTs := time.Now().Add(time.Duration(-1*lookback*24)*time.Hour).Unix() * 1000
+	startTs := time.Now().Add(time.Duration(-1*startday*24)*time.Hour).Unix() * 1000
+	klog.V(2).Infof("starttime: %d\nendtime: %d\n", startTs, stopTs)
+	start := math.MaxInt32 // start is an int64 so leave overhead for wrapping to negative in case this gets incremented(it does).
+	for i, t := range timestamps {
+		if int64(t) < startTs && i < start {
+			start = i
+		}
+		if int64(t) < stopTs {
+			return start, i
+		}
+	}
+	return start, len(timestamps)
+}
+
+// tagStripRegex removes test markers deemed unhelpful at one point in time.
+// TODO relitigate the value of doing this.  Without these markers, I don't think it is possible to run the failing test back through `openshift-tests run-test <foo>`
+var tagStripRegex = regexp.MustCompile(`\[Skipped:.*?\]|\[Suite:.*\]`)
+
+// ignoreTestRegex is used to strip o ut tests that don't have predictive or diagnostic value.  We don't want to show these in our data.
+var ignoreTestRegex = regexp.MustCompile(`Run multi-stage test|operator.Import the release payload|operator.Import a release payload|operator.Run template|operator.Build image|Monitor cluster while tests execute|Overall|job.initialize|\[sig-arch\]\[Feature:ClusterUpgrade\] Cluster should remain functional during upgrade`)
+
+// processTestToJobRunResults adds the tests to the provided jobresult to the provided JobResult and returns the passed, failed, flaked for the test
+func processTestToJobRunResults(jobResult testgridanalysisapi.RawJobResult, job testgridv1.JobDetails, test testgridv1.Test, startCol, endCol int) (passed int, failed int, flaked int) {
+	col := 0
+	for _, result := range test.Statuses {
+		if col > endCol {
+			break
+		}
+
+		// the test results are run length encoded(e.g. "6 passes, 5 failures, 7 passes"), but since we are searching for a test result
+		// from a specific time period, it's possible a particular run of results overlaps the start-point
+		// for the time period we care about.  So we need to iterate each encoded run until we get to the column
+		// we care about(a column which falls within the timestamp range we care about, then start the analysis with the remaining
+		// columns in the run.
+		remaining := result.Count
+		if col < startCol {
+			for i := 0; i < result.Count && col < startCol; i++ {
+				col++
+				remaining--
+			}
+		}
+		// if after iterating above we still aren't within the column range we care about, don't do any analysis
+		// on this run of results.
+		if col < startCol {
+			continue
+		}
+		switch result.Value {
+		case 1, 13: // success, flake(failed one or more times but ultimately succeeded)
+			for i := col; i < col+remaining && i < endCol; i++ {
+				passed++
+				if result.Value == 13 {
+					flaked++
+				}
+				joburl := fmt.Sprintf("https://prow.svc.ci.openshift.org/view/gcs/%s/%s", job.Query, job.ChangeLists[i])
+				jrr, ok := jobResult.JobRunResults[joburl]
+				if !ok {
+					jrr = testgridanalysisapi.RawJobRunResult{
+						Job:       job.Name,
+						JobRunURL: joburl,
+					}
+				}
+				switch {
+				case test.Name == "Overall":
+					jrr.Succeeded = true
+				case strings.HasPrefix(test.Name, testgridanalysisapi.OperatorInstallPrefix):
+					jrr.InstallOperators = append(jrr.InstallOperators, testgridanalysisapi.OperatorState{
+						Name:  test.Name[len(testgridanalysisapi.OperatorInstallPrefix):],
+						State: testgridanalysisapi.Success,
+					})
+				case strings.HasPrefix(test.Name, testgridanalysisapi.OperatorUpgradePrefix):
+					jrr.UpgradeOperators = append(jrr.UpgradeOperators, testgridanalysisapi.OperatorState{
+						Name:  test.Name[len(testgridanalysisapi.OperatorUpgradePrefix):],
+						State: testgridanalysisapi.Success,
+					})
+				case strings.HasSuffix(test.Name, "container setup"):
+					jrr.SetupStatus = testgridanalysisapi.Success
+				}
+				jobResult.JobRunResults[joburl] = jrr
+			}
+		case 12: // failure
+			for i := col; i < col+remaining && i < endCol; i++ {
+				failed++
+				joburl := fmt.Sprintf("https://prow.svc.ci.openshift.org/view/gcs/%s/%s", job.Query, job.ChangeLists[i])
+				jrr, ok := jobResult.JobRunResults[joburl]
+				if !ok {
+					jrr = testgridanalysisapi.RawJobRunResult{
+						Job:       job.Name,
+						JobRunURL: joburl,
+					}
+				}
+				// only add the failing test and name if it has predictive value.  We excluded all the non-predictive ones above except for these
+				// which we use to set various JobRunResult markers
+				if test.Name != "Overall" && !strings.HasSuffix(test.Name, "container setup") {
+					jrr.FailedTestNames = append(jrr.FailedTestNames, test.Name)
+					jrr.TestFailures++
+				}
+
+				switch {
+				case test.Name == "Overall":
+					jrr.Failed = true
+				case strings.HasPrefix(test.Name, testgridanalysisapi.OperatorInstallPrefix):
+					jrr.InstallOperators = append(jrr.InstallOperators, testgridanalysisapi.OperatorState{
+						Name:  test.Name[len(testgridanalysisapi.OperatorInstallPrefix):],
+						State: testgridanalysisapi.Failure,
+					})
+				case strings.HasPrefix(test.Name, testgridanalysisapi.OperatorUpgradePrefix):
+					jrr.UpgradeOperators = append(jrr.UpgradeOperators, testgridanalysisapi.OperatorState{
+						Name:  test.Name[len(testgridanalysisapi.OperatorUpgradePrefix):],
+						State: testgridanalysisapi.Failure,
+					})
+				case strings.HasSuffix(test.Name, "container setup"):
+					jrr.SetupStatus = testgridanalysisapi.Failure
+				}
+				jobResult.JobRunResults[joburl] = jrr
+			}
+		}
+		col += remaining
+	}
+
+	util.AddTestResult(jobResult.TestResults, test.Name, passed, failed, flaked)
+
+	return
+}
+
+func processTest(rawJobResults testgridanalysisapi.RawData, job testgridv1.JobDetails, test testgridv1.Test, startCol, endCol int) {
+	// strip out tests that don't have predictive or diagnostic value
+	// we have to know about overall to be able to set the global success or failure.
+	// we have to know about container setup to be able to set infra failures
+	// TODO stop doing this so we can avoid any filtering. We can filter when preparing to create the data for display
+	if test.Name != "Overall" && !strings.HasSuffix(test.Name, "container setup") && ignoreTestRegex.MatchString(test.Name) {
+		return
+	}
+
+	jobResult, ok := rawJobResults.JobResults[job.Name]
+	if !ok {
+		jobResult = testgridanalysisapi.RawJobResult{
+			JobName:        job.Name,
+			TestGridJobUrl: job.TestGridUrl,
+			JobRunResults:  map[string]testgridanalysisapi.RawJobRunResult{},
+			TestResults:    map[string]testgridanalysisapi.RawTestResult{},
+		}
+	}
+
+	processTestToJobRunResults(jobResult, job, test, startCol, endCol)
+
+	// we have mutated, so assign back to our intermediate value
+	rawJobResults.JobResults[job.Name] = jobResult
+}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,15 +1,12 @@
 package util
 
 import (
-	"math"
 	"regexp"
 	"sort"
 	"strings"
-	"time"
 
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 	"github.com/openshift/sippy/pkg/testgridanalysis/testgridanalysisapi"
-	"k8s.io/klog"
 )
 
 func FindTestResult(test string, testResults []sippyprocessingv1.FailingTestResult) *sippyprocessingv1.FailingTestResult {
@@ -81,23 +78,6 @@ func RelevantJob(jobName, status string, filter *regexp.Regexp) bool {
 		}
 		return false
 	*/
-}
-
-func ComputeLookback(startday, lookback int, timestamps []int) (int, int) {
-
-	stopTs := time.Now().Add(time.Duration(-1*lookback*24)*time.Hour).Unix() * 1000
-	startTs := time.Now().Add(time.Duration(-1*startday*24)*time.Hour).Unix() * 1000
-	klog.V(2).Infof("starttime: %d\nendtime: %d\n", startTs, stopTs)
-	start := math.MaxInt32 // start is an int64 so leave overhead for wrapping to negative in case this gets incremented(it does).
-	for i, t := range timestamps {
-		if int64(t) < startTs && i < start {
-			start = i
-		}
-		if int64(t) < stopTs {
-			return start, i
-		}
-	}
-	return start, len(timestamps)
 }
 
 func AddTestResult(testResults map[string]testgridanalysisapi.RawTestResult, testName string, passed, failed, flaked int) {


### PR DESCRIPTION
This separates the data from a particular run from the configuration used to produce data on a repeating cycle.