### PR TITLE
refactor analyzer to support re-use across releases

### DIFF
--- a/pkg/sippyserver/analyzer.go
+++ b/pkg/sippyserver/analyzer.go
@@ -1,120 +1,101 @@
 package sippyserver
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"regexp"
-	"strings"
 	"time"
 
-	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 	testgridv1 "github.com/openshift/sippy/pkg/apis/testgrid/v1"
+
+	"github.com/openshift/sippy/pkg/testgridanalysis/testgridhelpers"
+
+	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 	"github.com/openshift/sippy/pkg/buganalysis"
 	"github.com/openshift/sippy/pkg/testgridanalysis/testgridanalysisapi"
 	"github.com/openshift/sippy/pkg/testgridanalysis/testgridconversion"
-	"github.com/openshift/sippy/pkg/testgridanalysis/testgridhelpers"
 	"github.com/openshift/sippy/pkg/testgridanalysis/testreportconversion"
-	"github.com/openshift/sippy/pkg/util"
 	"github.com/openshift/sippy/pkg/util/sets"
 	"k8s.io/klog"
 )
 
-// TODO I think many of these are dead/inappropriate
-type Options struct {
-	LocalData               string
-	Releases                []string
-	StartDay                int
-	EndDay                  int
-	TestSuccessThreshold    float64
-	JobFilter               string
+// TestGridLoadingOptions control the data which is loaded from disk into the testgrid structs
+type TestGridLoadingConfig struct {
+	// LocalData is the directory where the testgrid data is stored
+	LocalData string
+	// JobFilter is a regex run against job names. Only match names are loaded.
+	JobFilter *regexp.Regexp
+}
+
+// RawJobResultsAnalysisOptions control which subset of data from the testgrid data is analyzed into the rawJobResults
+type RawJobResultsAnalysisConfig struct {
+	StartDay int
+	EndDay   int
+}
+
+// DisplayDataOptions controls how the RawJobResults are processed and prepared for display
+type DisplayDataConfig struct {
 	MinTestRuns             int
-	Output                  string
+	TestSuccessThreshold    float64
 	FailureClusterThreshold int
-	FetchData               string
-	ListenAddr              string
-	Server                  bool
 }
 
-type Analyzer struct {
-	Options        Options
-	LastUpdateTime time.Time
-	Release        string
-
-	BugCache buganalysis.BugCache
+// TestReportGeneratorConfig is a static configuration that can be re-used across multiple invocations of PrepareTestReport with different versions
+type TestReportGeneratorConfig struct {
+	TestGridLoadingConfig       TestGridLoadingConfig
+	RawJobResultsAnalysisConfig RawJobResultsAnalysisConfig
+	DisplayDataConfig           DisplayDataConfig
 }
 
-func (a *Analyzer) getTestGridData(releases []string, storagePath string) []testgridv1.JobDetails {
-	testGridJobDetails := []testgridv1.JobDetails{}
-
-	var jobFilter *regexp.Regexp
-	if len(a.Options.JobFilter) > 0 {
-		jobFilter = regexp.MustCompile(a.Options.JobFilter)
-	}
-
-	for _, release := range releases {
-		dashboard := fmt.Sprintf(testgridhelpers.DashboardTemplate, release, "blocking")
-		blockingJobs, ts, err := testgridhelpers.LoadJobSummaries(dashboard, storagePath)
-		if err != nil {
-			klog.Errorf("Error loading dashboard page %s: %v\n", dashboard, err)
-			continue
-		}
-		a.LastUpdateTime = ts
-		for jobName, job := range blockingJobs {
-			if util.RelevantJob(jobName, job.OverallStatus, jobFilter) {
-				klog.V(4).Infof("Job %s has bad status %s\n", jobName, job.OverallStatus)
-				details, err := loadJobDetails(dashboard, jobName, storagePath)
-				if err != nil {
-					klog.Errorf("Error loading job details for %s: %v\n", jobName, err)
-				} else {
-					testGridJobDetails = append(testGridJobDetails, details)
-				}
-			}
-		}
-	}
-	for _, release := range releases {
-		dashboard := fmt.Sprintf(testgridhelpers.DashboardTemplate, release, "informing")
-		informingJobs, _, err := testgridhelpers.LoadJobSummaries(dashboard, storagePath)
-		if err != nil {
-			klog.Errorf("Error load dashboard page %s: %v\n", dashboard, err)
-			continue
-		}
-
-		for jobName, job := range informingJobs {
-			if util.RelevantJob(jobName, job.OverallStatus, jobFilter) {
-				klog.V(4).Infof("Job %s has bad status %s\n", jobName, job.OverallStatus)
-				details, err := loadJobDetails(dashboard, jobName, storagePath)
-				if err != nil {
-					klog.Errorf("Error loading job details for %s: %v\n", jobName, err)
-				} else {
-					testGridJobDetails = append(testGridJobDetails, details)
-				}
-			}
-		}
-	}
-
-	return testGridJobDetails
+// PrepareTestReport is expensive.  It
+//  1. gathers test grid data from disk
+//  2. proceses that data to produce RawJobResults which look more how humans read testgrid
+//  3. uses the RawJobResults to produce a bug cache of relevant bugs
+//  4. converts the result of that into a display API object.
+func (a *TestReportGeneratorConfig) PrepareTestReport(release string, bugCache buganalysis.BugCache) sippyprocessingv1.TestReport {
+	testGridJobDetails, lastUpdateTime := testgridhelpers.LoadTestGridDataFromDisk(a.TestGridLoadingConfig.LocalData, []string{release}, a.TestGridLoadingConfig.JobFilter)
+	return a.prepareTestReportFromData(release, bugCache, testGridJobDetails, lastUpdateTime)
 }
 
-// PrepareTestReport is expensive.  It gathers test grid data
-func (a *Analyzer) PrepareTestReport() sippyprocessingv1.TestReport {
-	testGridJobDetails := a.getTestGridData([]string{a.Release}, a.Options.LocalData)
-	rawJobResultOptions := testgridconversion.ProcessingOptions{StartDay: a.Options.StartDay, EndDay: a.Options.EndDay}
+// prepareTestReportFromData should always remain private unless refactored. it's a convenient way to re-use the test grid data deserialized from disk.
+func (a *TestReportGeneratorConfig) prepareTestReportFromData(release string, bugCache buganalysis.BugCache, testGridJobDetails []testgridv1.JobDetails, lastUpdateTime time.Time) sippyprocessingv1.TestReport {
+	rawJobResultOptions := testgridconversion.ProcessingOptions{StartDay: a.RawJobResultsAnalysisConfig.StartDay, EndDay: a.RawJobResultsAnalysisConfig.EndDay}
 	rawJobResults := rawJobResultOptions.ProcessTestGridDataIntoRawJobResults(testGridJobDetails)
-	bugCacheWarnings := updateBugCacheForJobResults(a.BugCache, rawJobResults)
+	bugCacheWarnings := updateBugCacheForJobResults(bugCache, rawJobResults)
 
 	return testreportconversion.PrepareTestReport(
 		rawJobResults,
-		a.BugCache,
-		a.Release,
-		a.Options.MinTestRuns,
-		a.Options.TestSuccessThreshold,
-		a.Options.EndDay,
+		bugCache,
+		release,
+		a.DisplayDataConfig.MinTestRuns,
+		a.DisplayDataConfig.TestSuccessThreshold,
+		a.RawJobResultsAnalysisConfig.EndDay,
 		bugCacheWarnings,
-		a.LastUpdateTime,
-		a.Options.FailureClusterThreshold,
+		lastUpdateTime,
+		a.DisplayDataConfig.FailureClusterThreshold,
 	)
+}
+
+// PrepareStandardTestReports returns the current period, current two day period, and the previous seven days period
+func (a TestReportGeneratorConfig) PrepareStandardTestReports(release string, bugCache buganalysis.BugCache) StandardReport {
+	testGridJobDetails, lastUpdateTime := testgridhelpers.LoadTestGridDataFromDisk(a.TestGridLoadingConfig.LocalData, []string{release}, a.TestGridLoadingConfig.JobFilter)
+
+	currTimePeriodConfig := a.deepCopy()
+	currentTimePeriodReport := currTimePeriodConfig.prepareTestReportFromData(release, bugCache, testGridJobDetails, lastUpdateTime)
+
+	currentTwoDayPeriodConfig := a.deepCopy()
+	currentTwoDayPeriodConfig.RawJobResultsAnalysisConfig.EndDay = a.RawJobResultsAnalysisConfig.StartDay + 2
+	currentTwoDayReport := currentTwoDayPeriodConfig.prepareTestReportFromData(release, bugCache, testGridJobDetails, lastUpdateTime)
+
+	previousSevenDayPeriodConfig := a.deepCopy()
+	previousSevenDayPeriodConfig.RawJobResultsAnalysisConfig.StartDay = a.RawJobResultsAnalysisConfig.EndDay
+	previousSevenDayPeriodConfig.RawJobResultsAnalysisConfig.EndDay = a.RawJobResultsAnalysisConfig.EndDay + 7
+	previousSevenDayReport := previousSevenDayPeriodConfig.prepareTestReportFromData(release, bugCache, testGridJobDetails, lastUpdateTime)
+
+	return StandardReport{
+		CurrentPeriodReport: currentTimePeriodReport,
+		CurrentTwoDayReport: currentTwoDayReport,
+		PreviousWeekReport:  previousSevenDayReport,
+	}
 }
 
 // updateBugCacheForJobResults looks up all the bugs related to every failing test in the jobResults and returns a list of
@@ -143,25 +124,24 @@ func getFailedTestNamesFromJobResults(jobResults map[string]testgridanalysisapi.
 	return failedTestNames
 }
 
-func loadJobDetails(dashboard, jobName, storagePath string) (testgridv1.JobDetails, error) {
-	details := testgridv1.JobDetails{
-		Name: jobName,
+func (a TestReportGeneratorConfig) deepCopy() TestReportGeneratorConfig {
+	ret := TestReportGeneratorConfig{
+		TestGridLoadingConfig: TestGridLoadingConfig{
+			LocalData: a.TestGridLoadingConfig.LocalData,
+		},
+		RawJobResultsAnalysisConfig: RawJobResultsAnalysisConfig{
+			StartDay: a.RawJobResultsAnalysisConfig.StartDay,
+			EndDay:   a.RawJobResultsAnalysisConfig.EndDay,
+		},
+		DisplayDataConfig: DisplayDataConfig{
+			MinTestRuns:             a.DisplayDataConfig.MinTestRuns,
+			TestSuccessThreshold:    a.DisplayDataConfig.TestSuccessThreshold,
+			FailureClusterThreshold: a.DisplayDataConfig.FailureClusterThreshold,
+		},
+	}
+	if a.TestGridLoadingConfig.JobFilter != nil {
+		ret.TestGridLoadingConfig.JobFilter = a.TestGridLoadingConfig.JobFilter.Copy()
 	}
 
-	url := fmt.Sprintf("https://testgrid.k8s.io/%s/table?&show-stale-tests=&tab=%s&grid=old", dashboard, jobName)
-
-	var buf *bytes.Buffer
-	filename := storagePath + "/" + "\"" + strings.ReplaceAll(url, "/", "-") + "\""
-	b, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return details, fmt.Errorf("Could not read local data file %s: %v", filename, err)
-	}
-	buf = bytes.NewBuffer(b)
-
-	err = json.NewDecoder(buf).Decode(&details)
-	if err != nil {
-		return details, err
-	}
-	details.TestGridUrl = fmt.Sprintf("https://testgrid.k8s.io/%s#%s", dashboard, jobName)
-	return details, nil
+	return ret
 }

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 
 	"github.com/openshift/sippy/pkg/api"
@@ -13,55 +14,41 @@ import (
 	"k8s.io/klog"
 )
 
-func NewServer(o Options) *Server {
+func NewServer(
+	testGridLoadingOptions TestGridLoadingConfig,
+	rawJobResultsAnalysisOptions RawJobResultsAnalysisConfig,
+	displayDataOptions DisplayDataConfig,
+	releases []string,
+	listenAddr string,
+) *Server {
 	server := &Server{
-		bugCache:                   buganalysis.NewBugCache(),
-		testReportGeneratorOptions: make(map[string]Analyzer),
-		currTestReports:            make(map[string]sippyprocessingv1.TestReport),
-		options:                    o,
-	}
-
-	for _, release := range o.Releases {
-		// most recent 7 day period (days 0-7)
-		analyzer := Analyzer{
-			Release:  release,
-			Options:  o,
-			BugCache: server.bugCache,
-		}
-
-		server.testReportGeneratorOptions[release] = analyzer
-
-		// most recent 2 day period (days 0-2)
-		optCopy := o
-		optCopy.EndDay = 2
-		optCopy.StartDay = 0
-		analyzer = Analyzer{
-			Release:  release,
-			Options:  o,
-			BugCache: server.bugCache,
-		}
-		server.testReportGeneratorOptions[release+"-days-2"] = analyzer
-
-		// prior 7 day period (days 7-14)
-		optCopy = o
-		optCopy.EndDay = 14
-		optCopy.StartDay = 7
-		analyzer = Analyzer{
-			Release:  release,
-			Options:  optCopy,
-			BugCache: server.bugCache,
-		}
-		server.testReportGeneratorOptions[release+"-prev"] = analyzer
+		listenAddr: listenAddr,
+		releases:   releases,
+		bugCache:   buganalysis.NewBugCache(),
+		testReportGeneratorConfig: TestReportGeneratorConfig{
+			TestGridLoadingConfig:       testGridLoadingOptions,
+			RawJobResultsAnalysisConfig: rawJobResultsAnalysisOptions,
+			DisplayDataConfig:           displayDataOptions,
+		},
+		currTestReports: map[string]StandardReport{},
 	}
 
 	return server
 }
 
 type Server struct {
-	bugCache                   buganalysis.BugCache
-	testReportGeneratorOptions map[string]Analyzer
-	currTestReports            map[string]sippyprocessingv1.TestReport
-	options                    Options
+	listenAddr string
+	releases   []string
+
+	bugCache                  buganalysis.BugCache
+	testReportGeneratorConfig TestReportGeneratorConfig
+	currTestReports           map[string]StandardReport
+}
+
+type StandardReport struct {
+	CurrentPeriodReport sippyprocessingv1.TestReport
+	CurrentTwoDayReport sippyprocessingv1.TestReport
+	PreviousWeekReport  sippyprocessingv1.TestReport
 }
 
 func (s *Server) refresh(w http.ResponseWriter, req *http.Request) {
@@ -74,8 +61,8 @@ func (s *Server) refresh(w http.ResponseWriter, req *http.Request) {
 func (s *Server) RefreshData() {
 	klog.Infof("Refreshing data")
 	s.bugCache.Clear()
-	for k, analyzer := range s.testReportGeneratorOptions {
-		s.currTestReports[k] = analyzer.PrepareTestReport()
+	for _, release := range s.releases {
+		s.currTestReports[release] = s.testReportGeneratorConfig.PrepareStandardTestReports(release, s.bugCache)
 	}
 	klog.Infof("Refresh complete")
 }
@@ -83,10 +70,15 @@ func (s *Server) RefreshData() {
 func (s *Server) printHtmlReport(w http.ResponseWriter, req *http.Request) {
 	release := req.URL.Query().Get("release")
 	if _, ok := s.currTestReports[release]; !ok {
-		html.WriteLandingPage(w, s.options.Releases)
+		html.WriteLandingPage(w, s.releases)
 		return
 	}
-	html.PrintHtmlReport(w, req, s.currTestReports[release], s.currTestReports[release+"-days-2"], s.currTestReports[release+"-prev"], s.options.EndDay, 15)
+	html.PrintHtmlReport(w, req,
+		s.currTestReports[release].CurrentPeriodReport,
+		s.currTestReports[release].CurrentTwoDayReport,
+		s.currTestReports[release].PreviousWeekReport,
+		s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.EndDay,
+		15)
 }
 
 func (s *Server) printJSONReport(w http.ResponseWriter, req *http.Request) {
@@ -96,33 +88,32 @@ func (s *Server) printJSONReport(w http.ResponseWriter, req *http.Request) {
 	if release == "all" {
 		// return all available json reports
 		// store [currentReport, prevReport] in a slice
-		for _, r := range s.options.Releases {
+		for _, r := range s.releases {
 			if _, ok := s.currTestReports[r]; ok {
-				releaseReports[r] = []sippyprocessingv1.TestReport{s.currTestReports[r], s.currTestReports[r+"-prev"]}
+				releaseReports[r] = []sippyprocessingv1.TestReport{s.currTestReports[r].CurrentPeriodReport, s.currTestReports[r].PreviousWeekReport}
 			} else {
 				klog.Errorf("unable to load test report for release version %s", r)
 				continue
 			}
 		}
-		api.PrintJSONReport(w, req, releaseReports, s.options.EndDay, 15)
+		api.PrintJSONReport(w, req, releaseReports, s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.EndDay, 15)
 		return
 	} else if _, ok := s.currTestReports[release]; !ok {
 		// return a 404 error along with the list of available releases in the detail section
 		errMsg := map[string]interface{}{
 			"code":   "404",
-			"detail": fmt.Sprintf("No valid release specified, valid releases are: %v", s.options.Releases),
+			"detail": fmt.Sprintf("No valid release specified, valid releases are: %v", s.releases),
 		}
 		errMsgBytes, _ := json.Marshal(errMsg)
 		w.WriteHeader(http.StatusNotFound)
 		w.Write(errMsgBytes)
 		return
 	}
-	releaseReports[release] = []sippyprocessingv1.TestReport{s.currTestReports[release], s.currTestReports[release+"-prev"]}
-	api.PrintJSONReport(w, req, releaseReports, s.options.EndDay, 15)
+	releaseReports[release] = []sippyprocessingv1.TestReport{s.currTestReports[release].CurrentPeriodReport, s.currTestReports[release].PreviousWeekReport}
+	api.PrintJSONReport(w, req, releaseReports, s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.EndDay, 15)
 }
 
 func (s *Server) detailed(w http.ResponseWriter, req *http.Request) {
-
 	release := "4.5"
 	t := req.URL.Query().Get("release")
 	if t != "" {
@@ -147,10 +138,10 @@ func (s *Server) detailed(w http.ResponseWriter, req *http.Request) {
 		testSuccessThreshold, _ = strconv.ParseFloat(t, 64)
 	}
 
-	jobFilter := ""
+	jobFilterString := ""
 	t = req.URL.Query().Get("jobFilter")
 	if t != "" {
-		jobFilter = t
+		jobFilterString = t
 	}
 
 	minTestRuns := 10
@@ -159,10 +150,10 @@ func (s *Server) detailed(w http.ResponseWriter, req *http.Request) {
 		minTestRuns, _ = strconv.Atoi(t)
 	}
 
-	fct := 10
+	failureClusterThreshold := 10
 	t = req.URL.Query().Get("failureClusterThreshold")
 	if t != "" {
-		fct, _ = strconv.Atoi(t)
+		failureClusterThreshold, _ = strconv.Atoi(t)
 	}
 
 	jobTestCount := 10
@@ -171,45 +162,33 @@ func (s *Server) detailed(w http.ResponseWriter, req *http.Request) {
 		jobTestCount, _ = strconv.Atoi(t)
 	}
 
-	opt := Options{
-		StartDay:                startDay,
-		EndDay:                  endDay,
-		TestSuccessThreshold:    testSuccessThreshold,
-		JobFilter:               jobFilter,
-		MinTestRuns:             minTestRuns,
-		FailureClusterThreshold: fct,
-		LocalData:               s.options.LocalData,
+	var jobFilter *regexp.Regexp
+	if len(jobFilterString) > 0 {
+		var err error
+		jobFilter, err = regexp.Compile(jobFilterString)
+		if err != nil {
+			// TODO add warning
+		}
 	}
 
-	analyzer := Analyzer{
-		Release:  release,
-		Options:  opt,
-		BugCache: s.bugCache,
+	testReportConfig := TestReportGeneratorConfig{
+		TestGridLoadingConfig: TestGridLoadingConfig{
+			LocalData: s.testReportGeneratorConfig.TestGridLoadingConfig.LocalData,
+			JobFilter: jobFilter,
+		},
+		RawJobResultsAnalysisConfig: RawJobResultsAnalysisConfig{
+			StartDay: startDay,
+			EndDay:   endDay,
+		},
+		DisplayDataConfig: DisplayDataConfig{
+			MinTestRuns:             minTestRuns,
+			TestSuccessThreshold:    testSuccessThreshold,
+			FailureClusterThreshold: failureClusterThreshold,
+		},
 	}
-	currentReport := analyzer.PrepareTestReport()
+	testReports := testReportConfig.PrepareStandardTestReports(release, s.bugCache)
 
-	// current 2 day period
-	optCopy := opt
-	optCopy.EndDay = 2
-	twoDayAnalyzer := Analyzer{
-		Release:  release,
-		Options:  optCopy,
-		BugCache: s.bugCache,
-	}
-	twoDayReport := twoDayAnalyzer.PrepareTestReport()
-
-	// prior 7 day period
-	optCopy = opt
-	optCopy.StartDay = endDay + 1
-	optCopy.EndDay = endDay + 8
-	prevAnalyzer := Analyzer{
-		Release:  release,
-		Options:  optCopy,
-		BugCache: s.bugCache,
-	}
-	previousReport := prevAnalyzer.PrepareTestReport()
-
-	html.PrintHtmlReport(w, req, currentReport, twoDayReport, previousReport, opt.EndDay, jobTestCount)
+	html.PrintHtmlReport(w, req, testReports.CurrentPeriodReport, testReports.CurrentTwoDayReport, testReports.PreviousWeekReport, endDay, jobTestCount)
 
 }
 
@@ -219,8 +198,8 @@ func (s *Server) Serve() {
 	http.DefaultServeMux.HandleFunc("/detailed", s.detailed)
 	http.DefaultServeMux.HandleFunc("/refresh", s.refresh)
 	//go func() {
-	klog.Infof("Serving reports on %s ", s.options.ListenAddr)
-	if err := http.ListenAndServe(s.options.ListenAddr, nil); err != nil {
+	klog.Infof("Serving reports on %s ", s.listenAddr)
+	if err := http.ListenAndServe(s.listenAddr, nil); err != nil {
 		klog.Exitf("Server exited: %v", err)
 	}
 	//}()

--- a/pkg/testgridanalysis/testgridhelpers/testgridhelpers.go
+++ b/pkg/testgridanalysis/testgridhelpers/testgridhelpers.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	DashboardTemplate = "redhat-openshift-ocp-release-%s-%s"
+	dashboardTemplate = "redhat-openshift-ocp-release-%s-%s"
 )
 
 func DownloadData(releases []string, filter string, storagePath string) {
@@ -29,13 +29,13 @@ func DownloadData(releases []string, filter string, storagePath string) {
 
 	for _, release := range releases {
 
-		dashboard := fmt.Sprintf(DashboardTemplate, release, "blocking")
+		dashboard := fmt.Sprintf(dashboardTemplate, release, "blocking")
 		err := downloadJobSummaries(dashboard, storagePath)
 		if err != nil {
 			klog.Errorf("Error fetching dashboard page %s: %v\n", dashboard, err)
 			continue
 		}
-		blockingJobs, _, err := LoadJobSummaries(dashboard, storagePath)
+		blockingJobs, _, err := loadJobSummaries(dashboard, storagePath)
 		if err != nil {
 			klog.Errorf("Error loading dashboard page %s: %v\n", dashboard, err)
 			continue
@@ -54,13 +54,13 @@ func DownloadData(releases []string, filter string, storagePath string) {
 
 	for _, release := range releases {
 
-		dashboard := fmt.Sprintf(DashboardTemplate, release, "informing")
+		dashboard := fmt.Sprintf(dashboardTemplate, release, "informing")
 		err := downloadJobSummaries(dashboard, storagePath)
 		if err != nil {
 			klog.Errorf("Error fetching dashboard page %s: %v\n", dashboard, err)
 			continue
 		}
-		informingJobs, _, err := LoadJobSummaries(dashboard, storagePath)
+		informingJobs, _, err := loadJobSummaries(dashboard, storagePath)
 		if err != nil {
 			klog.Errorf("Error fetching dashboard page %s: %v\n", dashboard, err)
 			continue
@@ -78,7 +78,87 @@ func DownloadData(releases []string, filter string, storagePath string) {
 	}
 }
 
-func LoadJobSummaries(dashboard string, storagePath string) (map[string]testgridv1.JobSummary, time.Time, error) {
+// LoadTestGridDataFromDisk reads the requested testgrid data from disk and returns the details and the timestamp of the last
+// modification on disk
+func LoadTestGridDataFromDisk(storagePath string, releases []string, jobFilter *regexp.Regexp) ([]testgridv1.JobDetails, time.Time) {
+	testGridJobDetails := []testgridv1.JobDetails{}
+
+	lastUpdateTime := time.Time{}
+
+	for _, release := range releases {
+		dashboard := fmt.Sprintf(dashboardTemplate, release, "blocking")
+		blockingJobs, ts, err := loadJobSummaries(dashboard, storagePath)
+		if err != nil {
+			klog.Errorf("Error loading dashboard page %s: %v\n", dashboard, err)
+			continue
+		}
+		if ts.After(lastUpdateTime) {
+			lastUpdateTime = ts
+		}
+
+		for jobName, job := range blockingJobs {
+			if util.RelevantJob(jobName, job.OverallStatus, jobFilter) {
+				klog.V(4).Infof("Job %s has bad status %s\n", jobName, job.OverallStatus)
+				details, err := loadJobDetails(dashboard, jobName, storagePath)
+				if err != nil {
+					klog.Errorf("Error loading job details for %s: %v\n", jobName, err)
+				} else {
+					testGridJobDetails = append(testGridJobDetails, details)
+				}
+			}
+		}
+	}
+	for _, release := range releases {
+		dashboard := fmt.Sprintf(dashboardTemplate, release, "informing")
+		informingJobs, ts, err := loadJobSummaries(dashboard, storagePath)
+		if err != nil {
+			klog.Errorf("Error load dashboard page %s: %v\n", dashboard, err)
+			continue
+		}
+		if ts.After(lastUpdateTime) {
+			lastUpdateTime = ts
+		}
+
+		for jobName, job := range informingJobs {
+			if util.RelevantJob(jobName, job.OverallStatus, jobFilter) {
+				klog.V(4).Infof("Job %s has bad status %s\n", jobName, job.OverallStatus)
+				details, err := loadJobDetails(dashboard, jobName, storagePath)
+				if err != nil {
+					klog.Errorf("Error loading job details for %s: %v\n", jobName, err)
+				} else {
+					testGridJobDetails = append(testGridJobDetails, details)
+				}
+			}
+		}
+	}
+
+	return testGridJobDetails, lastUpdateTime
+}
+
+func loadJobDetails(dashboard, jobName, storagePath string) (testgridv1.JobDetails, error) {
+	details := testgridv1.JobDetails{
+		Name: jobName,
+	}
+
+	url := fmt.Sprintf("https://testgrid.k8s.io/%s/table?&show-stale-tests=&tab=%s&grid=old", dashboard, jobName)
+
+	var buf *bytes.Buffer
+	filename := storagePath + "/" + "\"" + strings.ReplaceAll(url, "/", "-") + "\""
+	b, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return details, fmt.Errorf("Could not read local data file %s: %v", filename, err)
+	}
+	buf = bytes.NewBuffer(b)
+
+	err = json.NewDecoder(buf).Decode(&details)
+	if err != nil {
+		return details, err
+	}
+	details.TestGridUrl = fmt.Sprintf("https://testgrid.k8s.io/%s#%s", dashboard, jobName)
+	return details, nil
+}
+
+func loadJobSummaries(dashboard string, storagePath string) (map[string]testgridv1.JobSummary, time.Time, error) {
 	jobs := make(map[string]testgridv1.JobSummary)
 	url := fmt.Sprintf("https://testgrid.k8s.io/%s/summary", dashboard)
 


### PR DESCRIPTION
The configuration itself doesn't vary today, but the release data does. Since it is fully independent, we can re-use the configuration and pass the data use to select the data itself. This will allow very easy parallelization in the future.

Also stop using maps for for release+variant to days and track variant days as a struct.