### PR TITLE
refine install, upgrade, infra

### DIFF
--- a/pkg/html/html.go
+++ b/pkg/html/html.go
@@ -73,7 +73,7 @@ Data current as of: %s
 	bugLookupWarning = `
 <div  style="background-color:pink" class="jumbotron">
   <h1>Warning: Analysis Error</h1>
-  <p>%s</p>
+  %s
 </div>
 `
 	dashboardPageHtml = `
@@ -392,11 +392,15 @@ func WriteLandingPage(w http.ResponseWriter, releases []string) {
 func PrintHtmlReport(w http.ResponseWriter, req *http.Request, report, twoDayReport, prevReport sippyprocessingv1.TestReport, endDay, jobTestCount int) {
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
 	fmt.Fprintf(w, htmlPageStart, "Release CI Health Dashboard")
-	for _, analysisWarning := range prevReport.AnalysisWarnings {
-		fmt.Fprintf(w, bugLookupWarning, analysisWarning)
-	}
-	for _, analysisWarning := range report.AnalysisWarnings {
-		fmt.Fprintf(w, bugLookupWarning, analysisWarning)
+	if len(prevReport.AnalysisWarnings)+len(report.AnalysisWarnings) > 0 {
+		warningsHTML := ""
+		for _, analysisWarning := range prevReport.AnalysisWarnings {
+			warningsHTML += "<p>" + analysisWarning + "</p>\n"
+		}
+		for _, analysisWarning := range report.AnalysisWarnings {
+			warningsHTML += "<p>" + analysisWarning + "</p>\n"
+		}
+		fmt.Fprintf(w, bugLookupWarning, warningsHTML)
 	}
 
 	var dashboardPage = template.Must(template.New("dashboardPage").Funcs(

--- a/pkg/sippyserver/analyzer.go
+++ b/pkg/sippyserver/analyzer.go
@@ -59,8 +59,11 @@ func (a *TestReportGeneratorConfig) PrepareTestReport(release string, bugCache b
 // prepareTestReportFromData should always remain private unless refactored. it's a convenient way to re-use the test grid data deserialized from disk.
 func (a *TestReportGeneratorConfig) prepareTestReportFromData(release string, bugCache buganalysis.BugCache, testGridJobDetails []testgridv1.JobDetails, lastUpdateTime time.Time) sippyprocessingv1.TestReport {
 	rawJobResultOptions := testgridconversion.ProcessingOptions{StartDay: a.RawJobResultsAnalysisConfig.StartDay, EndDay: a.RawJobResultsAnalysisConfig.EndDay}
-	rawJobResults := rawJobResultOptions.ProcessTestGridDataIntoRawJobResults(testGridJobDetails)
+	rawJobResults, processingWarnings := rawJobResultOptions.ProcessTestGridDataIntoRawJobResults(testGridJobDetails)
 	bugCacheWarnings := updateBugCacheForJobResults(bugCache, rawJobResults)
+	warnings := []string{}
+	warnings = append(warnings, processingWarnings...)
+	warnings = append(warnings, bugCacheWarnings...)
 
 	return testreportconversion.PrepareTestReport(
 		rawJobResults,
@@ -69,7 +72,7 @@ func (a *TestReportGeneratorConfig) prepareTestReportFromData(release string, bu
 		a.DisplayDataConfig.MinTestRuns,
 		a.DisplayDataConfig.TestSuccessThreshold,
 		a.RawJobResultsAnalysisConfig.EndDay,
-		bugCacheWarnings,
+		warnings,
 		lastUpdateTime,
 		a.DisplayDataConfig.FailureClusterThreshold,
 	)

--- a/pkg/testgridanalysis/testgridanalysisapi/types.go
+++ b/pkg/testgridanalysis/testgridanalysisapi/types.go
@@ -63,6 +63,7 @@ const (
 
 	InfrastructureTestName = `[sig-sippy] infrastructure should work`
 	InstallTestName        = `[sig-sippy] install should work`
+	InstallTimeoutTestName = `[sig-sippy] install should not timeout`
 	UpgradeTestName        = `[sig-sippy] upgrade should work`
 
 	Success = "Success"

--- a/pkg/testgridanalysis/testgridconversion/to_raw_data.go
+++ b/pkg/testgridanalysis/testgridconversion/to_raw_data.go
@@ -19,7 +19,8 @@ type ProcessingOptions struct {
 	EndDay   int
 }
 
-func (o ProcessingOptions) ProcessTestGridDataIntoRawJobResults(testGridJobInfo []testgridv1.JobDetails) testgridanalysisapi.RawData {
+// returns the raw data and a list of warnings encountered processing the data.
+func (o ProcessingOptions) ProcessTestGridDataIntoRawJobResults(testGridJobInfo []testgridv1.JobDetails) (testgridanalysisapi.RawData, []string) {
 	rawJobResults := testgridanalysisapi.RawData{JobResults: map[string]testgridanalysisapi.RawJobResult{}}
 
 	for _, jobDetails := range testGridJobInfo {
@@ -29,9 +30,9 @@ func (o ProcessingOptions) ProcessTestGridDataIntoRawJobResults(testGridJobInfo 
 	}
 
 	// now that we have all the JobRunResults, use them to create synthetic tests for install, upgrade, and infra
-	createSyntheticTests(rawJobResults)
+	warnings := createSyntheticTests(rawJobResults)
 
-	return rawJobResults
+	return rawJobResults, warnings
 }
 
 func processJobDetails(rawJobResults testgridanalysisapi.RawData, job testgridv1.JobDetails, startCol, endCol int) {

--- a/pkg/testgridanalysis/testidentification/test_identification.go
+++ b/pkg/testgridanalysis/testidentification/test_identification.go
@@ -1,0 +1,30 @@
+package testidentification
+
+import (
+	"strings"
+)
+
+// not all setup containers are called setup.  This is heavily dependent on the actual UPI jobs, but they turn out to be different.
+// When this needs updating,  it shows up as installs timing out in weird numbers
+func IsSetupContainerEquivalent(testName string) bool {
+	if strings.Contains(testName, "e2e-vsphere-upi-upi-install-vsphere") {
+		return true
+	}
+	if strings.Contains(testName, "e2e-vsphere-upi-serial-upi-install-vsphere") {
+		return true
+	}
+	if strings.Contains(testName, "e2e-vsphere-serial-ipi-install-vsphere") {
+		return true
+	}
+	if strings.Contains(testName, "e2e-vsphere-ipi-install-vsphere") {
+		return true
+	}
+	if strings.Contains(testName, "e2e-metal-ipi-baremetalds-devscripts-setup") {
+		return true
+	}
+	if strings.HasSuffix(testName, "container setup") {
+		return true
+	}
+
+	return false
+}

--- a/pkg/testgridanalysis/testidentification/test_identification.go
+++ b/pkg/testgridanalysis/testidentification/test_identification.go
@@ -2,26 +2,28 @@ package testidentification
 
 import (
 	"strings"
+
+	"github.com/openshift/sippy/pkg/util/sets"
+)
+
+var customJobSetupContainers = sets.NewString(
+	"e2e-metal-ipi-baremetalds-devscripts-setup",
+	"e2e-aws-proxy-ipi-install-install",
+	"e2e-vsphere-ipi-install-vsphere",
+	"e2e-vsphere-upi-upi-install-vsphere",
+	"e2e-vsphere-upi-serial-upi-install-vsphere",
+	"e2e-vsphere-serial-ipi-install-vsphere",
 )
 
 // not all setup containers are called setup.  This is heavily dependent on the actual UPI jobs, but they turn out to be different.
 // When this needs updating,  it shows up as installs timing out in weird numbers
 func IsSetupContainerEquivalent(testName string) bool {
-	if strings.Contains(testName, "e2e-vsphere-upi-upi-install-vsphere") {
-		return true
+	for setup := range customJobSetupContainers {
+		if strings.Contains(testName, setup) {
+			return true
+		}
 	}
-	if strings.Contains(testName, "e2e-vsphere-upi-serial-upi-install-vsphere") {
-		return true
-	}
-	if strings.Contains(testName, "e2e-vsphere-serial-ipi-install-vsphere") {
-		return true
-	}
-	if strings.Contains(testName, "e2e-vsphere-ipi-install-vsphere") {
-		return true
-	}
-	if strings.Contains(testName, "e2e-metal-ipi-baremetalds-devscripts-setup") {
-		return true
-	}
+
 	if strings.HasSuffix(testName, "container setup") {
 		return true
 	}

--- a/pkg/testgridanalysis/testreportconversion/testresult.go
+++ b/pkg/testgridanalysis/testreportconversion/testresult.go
@@ -3,7 +3,8 @@ package testreportconversion
 import (
 	"fmt"
 	"sort"
-	"strings"
+
+	"github.com/openshift/sippy/pkg/testgridanalysis/testidentification"
 
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 	"github.com/openshift/sippy/pkg/buganalysis"
@@ -114,7 +115,7 @@ func filterSuccessfulTestResults(successThreshold float64 /*indicates an upper b
 }
 
 func filterLowValueTestsByName(testResult sippyprocessingv1.TestResult) bool {
-	if testResult.Name == "Overall" || strings.HasSuffix(testResult.Name, "container setup") {
+	if testResult.Name == "Overall" || testidentification.IsSetupContainerEquivalent(testResult.Name) {
 		return false
 	}
 	return true


### PR DESCRIPTION
Makes the infra, install, upgrade calculation more clear. This uncovered calculation problems where certain platforms never had infra report success or failure.  This very slightly pushes the infra percentages, but makes a fairly  large shift in install (vsphere-upi and metal are installing quite well).  It's pushing upgrade down.


Not all containers are named setup anymore.  Some jobs are currently missing an install step.  That's weird.