### PR TITLE
exclude never stable jobs from aggregrations for platforms or top level indicators

### DIFF
--- a/pkg/testgridanalysis/testidentification/platforms.go
+++ b/pkg/testgridanalysis/testidentification/platforms.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 
 	"github.com/openshift/sippy/pkg/util/sets"
-
 	"k8s.io/klog"
 )
 
@@ -40,6 +39,7 @@ var (
 		"gcp",
 		"metal-upi",
 		"metal-ipi",
+		"never-stable",
 		"openstack",
 		"ovirt",
 		"ovn",
@@ -49,7 +49,6 @@ var (
 		"realtime",
 		"s390x",
 		"serial",
-		"unassigned",
 		"upgrade",
 		"vsphere-ipi",
 		"vsphere-upi",
@@ -71,9 +70,6 @@ func FindPlatform(name string) []string {
 	platforms := []string{}
 
 	defer func() {
-		if len(platforms) == 0 {
-			platforms = append(platforms, "unassigned")
-		}
 		for _, platform := range platforms {
 			if !AllPlatforms.Has(platform) {
 				panic(fmt.Sprintf("coding error: missing platform: %q", platform))
@@ -82,7 +78,7 @@ func FindPlatform(name string) []string {
 	}()
 
 	if IsJobNeverStable(name) {
-		return platforms
+		return []string{"never-stable"}
 	}
 
 	// if it's a promotion job, it can't be a part of any other variant aggregation

--- a/pkg/testgridanalysis/testreportconversion/by_tests.go
+++ b/pkg/testgridanalysis/testreportconversion/by_tests.go
@@ -59,16 +59,13 @@ func getTestResultsByName(jobResults []sippyprocessingv1.JobResult) testResultsB
 
 				failingTestResult.TestResultAcrossAllJobs = combineTestResult(failingTestResult.TestResultAcrossAllJobs, testResult)
 
-				// if the job hasn't run at least 7 times, don't add it to the list
-				if testResult.Failures+testResult.Successes >= 7 && testResult.Failures > 0 {
-					failingTestResult.JobResults = append(failingTestResult.JobResults, sippyprocessingv1.FailingTestJobResult{
-						Name:           jobResult.Name,
-						TestFailures:   testResult.Failures,
-						TestSuccesses:  testResult.Successes,
-						PassPercentage: testResult.PassPercentage,
-						TestGridUrl:    jobResult.TestGridUrl,
-					})
-				}
+				failingTestResult.JobResults = append(failingTestResult.JobResults, sippyprocessingv1.FailingTestJobResult{
+					Name:           jobResult.Name,
+					TestFailures:   testResult.Failures,
+					TestSuccesses:  testResult.Successes,
+					PassPercentage: testResult.PassPercentage,
+					TestGridUrl:    jobResult.TestGridUrl,
+				})
 				break
 			}
 		}

--- a/pkg/testgridanalysis/testreportconversion/test_report.go
+++ b/pkg/testgridanalysis/testreportconversion/test_report.go
@@ -42,9 +42,10 @@ func PrepareTestReport(
 	topFailingTestsWithBug := getTopFailingTestsWithBug(allTestResultsByName, standardTestResultFilterFn)
 	topFailingTestsWithoutBug := getTopFailingTestsWithoutBug(allTestResultsByName, standardTestResultFilterFn)
 
-	infra := allTestResultsByName[testgridanalysisapi.InfrastructureTestName]
-	install := allTestResultsByName[testgridanalysisapi.InstallTestName]
-	upgrade := allTestResultsByName[testgridanalysisapi.UpgradeTestName]
+	// the top level indicators should exclude jobs that are not yet stable, because those failures are not informative
+	infra := excludeNeverStableJobs(allTestResultsByName[testgridanalysisapi.InfrastructureTestName])
+	install := excludeNeverStableJobs(allTestResultsByName[testgridanalysisapi.InstallTestName])
+	upgrade := excludeNeverStableJobs(allTestResultsByName[testgridanalysisapi.UpgradeTestName])
 
 	testReport := sippyprocessingv1.TestReport{
 		Release:   release,


### PR DESCRIPTION
ovirt upgrade has never worked.  Jobs which never worked should be visible in sippy so we can identify and address problems, but using them as indicators to aggregations like platforms and top level indicators pulls averages in unreasonable ways.

This creates a category of jobs called "never-stable" and displays them, but removes them from other aggregations.