### PR TITLE
convert to startday and offset

### DIFF
--- a/pkg/html/failing_bzcomponents.go
+++ b/pkg/html/failing_bzcomponents.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift/sippy/pkg/util"
 )
 
-func summaryJobsFailuresByBugzillaComponent(report, reportPrev sippyprocessingv1.TestReport, endDay int, release string) string {
+func summaryJobsFailuresByBugzillaComponent(report, reportPrev sippyprocessingv1.TestReport, numDays int, release string) string {
 	failuresByBugzillaComponent := summarizeJobsFailuresByBugzillaComponent(report)
 	failuresByBugzillaComponentPrev := summarizeJobsFailuresByBugzillaComponent(reportPrev)
 
@@ -21,7 +21,7 @@ func summaryJobsFailuresByBugzillaComponent(report, reportPrev sippyprocessingv1
 		<tr>
 			<th>Component</th><th>Latest %d days</th><th/><th>Previous 7 days</th>
 		</tr>
-	`, endDay)
+	`, numDays)
 
 	bzGroupTemplate := `
 		<tr class="%s">

--- a/pkg/html/failing_tests.go
+++ b/pkg/html/failing_tests.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/klog"
 )
 
-func summaryTopFailingTestsWithBug(topFailingTestsWithBug, allTests []sippyprocessingv1.FailingTestResult, endDay int, release string) string {
+func summaryTopFailingTestsWithBug(topFailingTestsWithBug, allTests []sippyprocessingv1.FailingTestResult, numDays int, release string) string {
 	// test name | bug | pass rate | higher/lower | pass rate
 	s := fmt.Sprintf(`
 	<table class="table">
@@ -24,7 +24,7 @@ func summaryTopFailingTestsWithBug(topFailingTestsWithBug, allTests []sippyproce
 		<tr>
 			<th>Test Name</th><th>File a Bug</th><th>Pass Rate</th><th/><th>Pass Rate</th>
 		</tr>
-	`, endDay)
+	`, numDays)
 
 	s += topFailingTestsRows(topFailingTestsWithBug, allTests, release)
 
@@ -33,7 +33,7 @@ func summaryTopFailingTestsWithBug(topFailingTestsWithBug, allTests []sippyproce
 	return s
 }
 
-func summaryTopFailingTestsWithoutBug(topFailingTestsWithBug, allTests []sippyprocessingv1.FailingTestResult, endDay int, release string) string {
+func summaryTopFailingTestsWithoutBug(topFailingTestsWithBug, allTests []sippyprocessingv1.FailingTestResult, numDays int, release string) string {
 	// test name | bug | pass rate | higher/lower | pass rate
 	s := fmt.Sprintf(`
 	<table class="table">
@@ -46,7 +46,7 @@ func summaryTopFailingTestsWithoutBug(topFailingTestsWithBug, allTests []sippypr
 		<tr>
 			<th>Test Name</th><th>File a Bug</th><th>Pass Rate</th><th/><th>Pass Rate</th>
 		</tr>
-	`, endDay)
+	`, numDays)
 
 	s += topFailingTestsRows(topFailingTestsWithBug, allTests, release)
 

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -77,7 +77,7 @@ func (s *Server) printHtmlReport(w http.ResponseWriter, req *http.Request) {
 		s.currTestReports[release].CurrentPeriodReport,
 		s.currTestReports[release].CurrentTwoDayReport,
 		s.currTestReports[release].PreviousWeekReport,
-		s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.EndDay,
+		s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.NumDays,
 		15)
 }
 
@@ -96,7 +96,7 @@ func (s *Server) printJSONReport(w http.ResponseWriter, req *http.Request) {
 				continue
 			}
 		}
-		api.PrintJSONReport(w, req, releaseReports, s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.EndDay, 15)
+		api.PrintJSONReport(w, req, releaseReports, s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.NumDays, 15)
 		return
 	} else if _, ok := s.currTestReports[release]; !ok {
 		// return a 404 error along with the list of available releases in the detail section
@@ -110,7 +110,7 @@ func (s *Server) printJSONReport(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	releaseReports[release] = []sippyprocessingv1.TestReport{s.currTestReports[release].CurrentPeriodReport, s.currTestReports[release].PreviousWeekReport}
-	api.PrintJSONReport(w, req, releaseReports, s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.EndDay, 15)
+	api.PrintJSONReport(w, req, releaseReports, s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.NumDays, 15)
 }
 
 func (s *Server) detailed(w http.ResponseWriter, req *http.Request) {
@@ -126,10 +126,11 @@ func (s *Server) detailed(w http.ResponseWriter, req *http.Request) {
 		startDay, _ = strconv.Atoi(t)
 	}
 
-	endDay := startDay + 7
+	numDays := 7
 	t = req.URL.Query().Get("endDay")
 	if t != "" {
-		endDay, _ = strconv.Atoi(t)
+		endDay, _ := strconv.Atoi(t)
+		numDays = endDay - startDay
 	}
 
 	testSuccessThreshold := 98.0
@@ -178,7 +179,7 @@ func (s *Server) detailed(w http.ResponseWriter, req *http.Request) {
 		},
 		RawJobResultsAnalysisConfig: RawJobResultsAnalysisConfig{
 			StartDay: startDay,
-			EndDay:   endDay,
+			NumDays:  numDays,
 		},
 		DisplayDataConfig: DisplayDataConfig{
 			MinTestRuns:             minTestRuns,
@@ -188,7 +189,7 @@ func (s *Server) detailed(w http.ResponseWriter, req *http.Request) {
 	}
 	testReports := testReportConfig.PrepareStandardTestReports(release, s.bugCache)
 
-	html.PrintHtmlReport(w, req, testReports.CurrentPeriodReport, testReports.CurrentTwoDayReport, testReports.PreviousWeekReport, endDay, jobTestCount)
+	html.PrintHtmlReport(w, req, testReports.CurrentPeriodReport, testReports.CurrentTwoDayReport, testReports.PreviousWeekReport, numDays, jobTestCount)
 
 }
 

--- a/pkg/testgridanalysis/testreportconversion/test_report.go
+++ b/pkg/testgridanalysis/testreportconversion/test_report.go
@@ -18,7 +18,7 @@ func PrepareTestReport(
 	minRuns int, // indicates how many runs are required for a test is included in overall percentages
 	// TODO deads2k wants to eliminate the successThreshold
 	successThreshold float64, // indicates an upper bound on how successful a test can be before it is excluded
-	endDay int, // indicates how many days of data to collect
+	numDays int, // indicates how many days of data to collect
 	analysisWarnings []string,
 	reportTimestamp time.Time, // TODO seems like we could derive this from our raw data
 	failureClusterThreshold int, // TODO I don't think we even display this anymore
@@ -33,8 +33,8 @@ func PrepareTestReport(
 	byPlatform := convertRawDataToByPlatform(rawData.JobResults, bugCache, release, standardTestResultFilterFn)
 
 	filteredFailureGroups := filterFailureGroups(rawData.JobResults, bugCache, release, failureClusterThreshold)
-	frequentJobResults := filterPertinentFrequentJobResults(allJobResults, endDay, standardTestResultFilterFn)
-	infrequentJobResults := filterPertinentInfrequentJobResults(allJobResults, endDay, standardTestResultFilterFn)
+	frequentJobResults := filterPertinentFrequentJobResults(allJobResults, numDays, standardTestResultFilterFn)
+	infrequentJobResults := filterPertinentInfrequentJobResults(allJobResults, numDays, standardTestResultFilterFn)
 
 	bugFailureCounts := generateSortedBugFailureCounts(allTestResultsByName)
 	bugzillaComponentResults := generateAllJobFailuresByBugzillaComponent(rawData.JobResults, allJobResults)


### PR DESCRIPTION
This makes -1 mean, "most recent available time" and uses an offset instead of endDay.  This allows `./sippy --local-data historical-data/4.5GA --release 4.5 --server --start-day=-1` to allow visiting http://localhost:8080/?release=4.5 to "just work", making these urls very easy to build.