### PR TITLE
use parens to indicate pass rate if infrastructure worked

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -189,12 +189,12 @@ func summaryJobPassRatesByJobName(report, reportPrev sippyprocessingv1.TestRepor
 				PassRates: map[string]sippyv1.PassRate{
 					"latest": sippyv1.PassRate{
 						Percentage:          v.PassPercentage,
-						ProjectedPercentage: v.PassPercentageWithKnownFailures,
+						ProjectedPercentage: v.PassPercentageWithoutInfrastructureFailures,
 						Runs:                v.Successes + v.Failures,
 					},
 					"prev": sippyv1.PassRate{
 						Percentage:          prev.PassPercentage,
-						ProjectedPercentage: prev.PassPercentageWithKnownFailures,
+						ProjectedPercentage: prev.PassPercentageWithoutInfrastructureFailures,
 						Runs:                prev.Successes + prev.Failures,
 					},
 				},
@@ -206,7 +206,7 @@ func summaryJobPassRatesByJobName(report, reportPrev sippyprocessingv1.TestRepor
 				PassRates: map[string]sippyv1.PassRate{
 					"latest": sippyv1.PassRate{
 						Percentage:          v.PassPercentage,
-						ProjectedPercentage: v.PassPercentageWithKnownFailures,
+						ProjectedPercentage: v.PassPercentageWithoutInfrastructureFailures,
 						Runs:                v.Successes + v.Failures,
 					},
 				},

--- a/pkg/apis/sippyprocessing/v1/types.go
+++ b/pkg/apis/sippyprocessing/v1/types.go
@@ -67,12 +67,14 @@ type TopLevelIndicators struct {
 
 // PlatformResults
 type PlatformResults struct {
-	PlatformName                          string  `json:"platformName"`
-	JobRunSuccesses                       int     `json:"jobRunSuccesses"`
-	JobRunFailures                        int     `json:"jobRunFailures"`
-	JobRunKnownFailures                   int     `json:"jobRunKnownFailures"`
-	JobRunPassPercentage                  float64 `json:"jobRunPassPercentage"`
-	JobRunPassPercentageWithKnownFailures float64 `json:"jobRunPassPercentageWithKnownFailures"`
+	PlatformName                                      string  `json:"platformName"`
+	JobRunSuccesses                                   int     `json:"jobRunSuccesses"`
+	JobRunFailures                                    int     `json:"jobRunFailures"`
+	JobRunKnownFailures                               int     `json:"jobRunKnownFailures"`
+	JobRunInfrastructureFailures                      int     `json:"jobRunInfrastructureFailures"`
+	JobRunPassPercentage                              float64 `json:"jobRunPassPercentage"`
+	JobRunPassPercentageWithKnownFailures             float64 `json:"jobRunPassPercentageWithKnownFailures"`
+	JobRunPassPercentageWithoutInfrastructureFailures float64 `json:"jobRunPassPercentageWithoutInfrastructureFailures"`
 
 	// JobResults for all jobs that match this platform, ordered by lowest PassPercentage to highest
 	JobResults []JobResult `json:"jobResults"`
@@ -126,14 +128,16 @@ type JobRunResult struct {
 }
 
 type JobResult struct {
-	Name                            string  `json:"name"`
-	Platform                        string  `json:"platform"`
-	Failures                        int     `json:"failures"`
-	KnownFailures                   int     `json:"knownFailures"`
-	Successes                       int     `json:"successes"`
-	PassPercentage                  float64 `json:"passPercentage"`
-	PassPercentageWithKnownFailures float64 `json:"passPercentageWithKnownFailures"`
-	TestGridUrl                     string  `json:"testGridUrl"`
+	Name                                        string  `json:"name"`
+	Platform                                    string  `json:"platform"`
+	Failures                                    int     `json:"failures"`
+	KnownFailures                               int     `json:"knownFailures"`
+	InfrastructureFailures                      int     `json:"infrastructureFailures"`
+	Successes                                   int     `json:"successes"`
+	PassPercentage                              float64 `json:"passPercentage"`
+	PassPercentageWithKnownFailures             float64 `json:"passPercentageWithKnownFailures"`
+	PassPercentageWithoutInfrastructureFailures float64 `json:"passPercentageWithoutInfrastructureFailures"`
+	TestGridUrl                                 string  `json:"testGridUrl"`
 
 	// TestResults holds entries for each test that is a part of this aggregation.  Each entry aggregates the results of all runs of a single test.  The array is sorted from lowest PassPercentage to highest PassPercentage
 	TestResults []TestResult `json:"results"`

--- a/pkg/html/html.go
+++ b/pkg/html/html.go
@@ -151,7 +151,7 @@ func summaryJobsByPlatform(report, reportPrev sippyprocessingv1.TestReport, numD
 	s := fmt.Sprintf(`
 	<table class="table">
 		<tr>
-			<th colspan=4 class="text-center"><a class="text-dark" title="Aggregation of all job runs for a given variant, sorted by passing rate percentage.  Variants at the top of this list have unreliable CI jobs or the product is unreliable in those variants.  The pass rate in parenthesis is the projected pass rate ignoring runs which failed only due to tests with associated bugs." id="JobPassRatesByVariant" href="#JobPassRatesByVariant">Job Pass Rates By Variant</a></th>
+			<th colspan=4 class="text-center"><a class="text-dark" title="Aggregation of all job runs for a given variant, sorted by passing rate percentage.  Variants at the top of this list have unreliable CI jobs or the product is unreliable in those variants.  The pass rate in parenthesis is the pass rate for jobs that started to run the installer and got at least the bootstrap kube-apiserver up and running." id="JobPassRatesByVariant" href="#JobPassRatesByVariant">Job Pass Rates By Variant</a></th>
 		</tr>
 		<tr>
 			<th>Variant</th><th>Latest %d days</th><th/><th>Previous 7 days</th>
@@ -181,7 +181,7 @@ func summaryFrequentJobPassRatesByJobName(report, reportPrev sippyprocessingv1.T
 	s := fmt.Sprintf(`
 	<table class="table">
 		<tr>
-			<th colspan=4 class="text-center"><a class="text-dark" title="Passing rate for each job definition, sorted by passing percentage.  Jobs at the top of this list are unreliable or represent environments where the product is not stable and should be investigated.  The pass rate in parenthesis is the projected pass rate ignoring runs which failed only due to tests with associated bugs." id="JobPassRatesByJobName" href="#JobPassRatesByJobName">Job Pass Rates By Job Name</a></th>
+			<th colspan=4 class="text-center"><a class="text-dark" title="Passing rate for each job definition, sorted by passing percentage.  Jobs at the top of this list are unreliable or represent environments where the product is not stable and should be investigated.  The pass rate in parenthesis is the pass rate for jobs that started to run the installer and got at least the bootstrap kube-apiserver up and running." id="JobPassRatesByJobName" href="#JobPassRatesByJobName">Job Pass Rates By Job Name</a></th>
 		</tr>
 		<tr>
 			<th>Name</th><th>Latest %d days</th><th/><th>Previous 7 days</th>
@@ -206,7 +206,7 @@ func summaryInfrequentJobPassRatesByJobName(report, reportPrev sippyprocessingv1
 	s := fmt.Sprintf(`
 	<table class="table">
 		<tr>
-			<th colspan=4 class="text-center"><a class="text-dark" title="Passing rate for each job infrequent definition, sorted by passing percentage.  Jobs at the top of this list are unreliable or represent environments where the product is not stable and should be investigated.  The pass rate in parenthesis is the projected pass rate ignoring runs which failed only due to tests with associated bugs." id="InfrequentJobPassRatesByJobName" href="#InfrequentJobPassRatesByJobName">Infrequent Job Pass Rates By Job Name</a></th>
+			<th colspan=4 class="text-center"><a class="text-dark" title="Passing rate for each job infrequent definition, sorted by passing percentage.  Jobs at the top of this list are unreliable or represent environments where the product is not stable and should be investigated.  The pass rate in parenthesis is the pass rate for jobs that started to run the installer and got at least the bootstrap kube-apiserver up and running." id="InfrequentJobPassRatesByJobName" href="#InfrequentJobPassRatesByJobName">Infrequent Job Pass Rates By Job Name</a></th>
 		</tr>
 		<tr>
 			<th>Name</th><th>Latest %d days</th><th/><th>Previous 7 days</th>

--- a/pkg/html/jobaggregationresult.go
+++ b/pkg/html/jobaggregationresult.go
@@ -11,12 +11,14 @@ import (
 
 // PlatformResults
 type jobAggregationResult struct {
-	AggregationName                             string
-	JobRunSuccesses                             int
-	JobRunFailures                              int
-	JobRunKnownJobRunFailures                   int
-	JobRunPassPercentage                        float64
-	JobRunPassPercentageWithKnownJobRunFailures float64
+	AggregationName                                   string
+	JobRunSuccesses                                   int
+	JobRunFailures                                    int
+	JobRunKnownJobRunFailures                         int
+	JobRunInfrastructureFailures                      int
+	JobRunPassPercentage                              float64
+	JobRunPassPercentageWithKnownJobRunFailures       float64
+	JobRunPassPercentageWithoutInfrastructureFailures float64
 
 	// JobResults for all jobs that match this platform, ordered by lowest JobRunPassPercentage to highest
 	JobResults []sippyprocessingv1.JobResult
@@ -30,14 +32,16 @@ func convertPlatformToAggregationResult(platformResult *sippyprocessingv1.Platfo
 		return nil
 	}
 	return &jobAggregationResult{
-		AggregationName:                             platformResult.PlatformName,
-		JobRunSuccesses:                             platformResult.JobRunSuccesses,
-		JobRunFailures:                              platformResult.JobRunFailures,
-		JobRunKnownJobRunFailures:                   platformResult.JobRunKnownFailures,
-		JobRunPassPercentage:                        platformResult.JobRunPassPercentage,
-		JobRunPassPercentageWithKnownJobRunFailures: platformResult.JobRunPassPercentageWithKnownFailures,
-		JobResults:                                  platformResult.JobResults,
-		AllTestResults:                              platformResult.AllTestResults,
+		AggregationName:                                   platformResult.PlatformName,
+		JobRunSuccesses:                                   platformResult.JobRunSuccesses,
+		JobRunFailures:                                    platformResult.JobRunFailures,
+		JobRunKnownJobRunFailures:                         platformResult.JobRunKnownFailures,
+		JobRunInfrastructureFailures:                      platformResult.JobRunInfrastructureFailures,
+		JobRunPassPercentage:                              platformResult.JobRunPassPercentage,
+		JobRunPassPercentageWithKnownJobRunFailures:       platformResult.JobRunPassPercentageWithKnownFailures,
+		JobRunPassPercentageWithoutInfrastructureFailures: platformResult.JobRunPassPercentageWithoutInfrastructureFailures,
+		JobResults:                                        platformResult.JobResults,
+		AllTestResults:                                    platformResult.AllTestResults,
 	}
 }
 
@@ -156,11 +160,11 @@ func (b *jobAggregationResultRenderBuilder) toHTML() string {
 			testsCollapseName,
 			jobsCollapseName,
 			b.currAggregationResult.JobRunPassPercentage,
-			b.currAggregationResult.JobRunPassPercentageWithKnownJobRunFailures,
+			b.currAggregationResult.JobRunPassPercentageWithoutInfrastructureFailures,
 			b.currAggregationResult.JobRunSuccesses+b.currAggregationResult.JobRunFailures,
 			arrow,
 			b.prevAggregationResult.JobRunPassPercentage,
-			b.prevAggregationResult.JobRunPassPercentageWithKnownJobRunFailures,
+			b.prevAggregationResult.JobRunPassPercentageWithoutInfrastructureFailures,
 			b.prevAggregationResult.JobRunSuccesses+b.prevAggregationResult.JobRunFailures,
 		)
 	} else {
@@ -170,7 +174,7 @@ func (b *jobAggregationResultRenderBuilder) toHTML() string {
 			testsCollapseName,
 			jobsCollapseName,
 			b.currAggregationResult.JobRunPassPercentage,
-			b.currAggregationResult.JobRunPassPercentageWithKnownJobRunFailures,
+			b.currAggregationResult.JobRunPassPercentageWithoutInfrastructureFailures,
 			b.currAggregationResult.JobRunSuccesses+b.currAggregationResult.JobRunFailures,
 		)
 	}

--- a/pkg/html/jobresult.go
+++ b/pkg/html/jobresult.go
@@ -117,11 +117,11 @@ func (b *jobResultRenderBuilder) toHTML() string {
 			class, b.baseIndentDepth*50+10,
 			b.currJobResult.TestGridUrl, b.currJobResult.Name, collapseName,
 			b.currJobResult.PassPercentage,
-			b.currJobResult.PassPercentageWithKnownFailures,
+			b.currJobResult.PassPercentageWithoutInfrastructureFailures,
 			b.currJobResult.Successes+b.currJobResult.Failures,
 			arrow,
 			b.prevJobResult.PassPercentage,
-			b.prevJobResult.PassPercentageWithKnownFailures,
+			b.prevJobResult.PassPercentageWithoutInfrastructureFailures,
 			b.prevJobResult.Successes+b.prevJobResult.Failures,
 		)
 	} else {
@@ -129,7 +129,7 @@ func (b *jobResultRenderBuilder) toHTML() string {
 			class, b.baseIndentDepth*50+10,
 			b.currJobResult.TestGridUrl, b.currJobResult.Name, collapseName,
 			b.currJobResult.PassPercentage,
-			b.currJobResult.PassPercentageWithKnownFailures,
+			b.currJobResult.PassPercentageWithoutInfrastructureFailures,
 			b.currJobResult.Successes+b.currJobResult.Failures,
 		)
 	}

--- a/pkg/testgridanalysis/testreportconversion/by_platform.go
+++ b/pkg/testgridanalysis/testreportconversion/by_platform.go
@@ -26,6 +26,7 @@ func convertRawDataToByPlatform(
 		successfulJobRuns := 0
 		failedJobRuns := 0
 		knownFailureJobRuns := 0
+		infraFailureJobRuns := 0
 
 		// do this the expensive way until we have a unit test.  This allows us to build the full platform result all at once.
 		// TODO if we are too slow, switch this to only build the job results once
@@ -38,6 +39,7 @@ func convertRawDataToByPlatform(
 			successfulJobRuns += jobResult.Successes
 			failedJobRuns += jobResult.Failures
 			knownFailureJobRuns += jobResult.KnownFailures
+			infraFailureJobRuns += jobResult.InfrastructureFailures
 
 			// combined the test results *before* we filter them
 			allPlatformTestResults = combineTestResults(jobResult.TestResults, allPlatformTestResults)
@@ -54,10 +56,12 @@ func convertRawDataToByPlatform(
 			JobRunSuccesses:                       successfulJobRuns,
 			JobRunFailures:                        failedJobRuns,
 			JobRunKnownFailures:                   knownFailureJobRuns,
+			JobRunInfrastructureFailures:          infraFailureJobRuns,
 			JobRunPassPercentage:                  percent(successfulJobRuns, failedJobRuns),
 			JobRunPassPercentageWithKnownFailures: percent(successfulJobRuns+knownFailureJobRuns, failedJobRuns-knownFailureJobRuns),
-			JobResults:                            jobResults,
-			AllTestResults:                        filteredPlatformTestResults,
+			JobRunPassPercentageWithoutInfrastructureFailures: percent(successfulJobRuns, failedJobRuns-infraFailureJobRuns),
+			JobResults:     jobResults,
+			AllTestResults: filteredPlatformTestResults,
 		})
 	}
 

--- a/pkg/testgridanalysis/testreportconversion/jobresult.go
+++ b/pkg/testgridanalysis/testreportconversion/jobresult.go
@@ -81,10 +81,14 @@ func convertRawJobResultToProcessedJobResult(
 		if rawJRR.Failed && areAllFailuresKnown(rawJRR, bugCache, release) {
 			job.KnownFailures++
 		}
+		if rawJRR.SetupStatus != testgridanalysisapi.Success {
+			job.InfrastructureFailures++
+		}
 	}
 
 	job.PassPercentage = percent(job.Successes, job.Failures)
 	job.PassPercentageWithKnownFailures = percent(job.Successes+job.KnownFailures, job.Failures-job.KnownFailures)
+	job.PassPercentageWithoutInfrastructureFailures = percent(job.Successes, job.Failures-job.InfrastructureFailures)
 
 	return job
 }


### PR DESCRIPTION
Updates the value in parens to indicate what the pass rate is for jobs that started to run the installer and got at least the bootstrap kube-apiserver up and running.  Given infrastructure failures between 10-15%, this has a meaningful impact on the pass rates of many platforms and jobs.  

We still separately track infrastructure/bootstrapping failures to drive them out, but the number in parens can be thought of as, "after a customer gets an install to start, what are the odds he will be successful".

The previous check was, "if all the tests that have bugs associated with them started passing, what would our pass rate be".  In order to be interpreted as "known failures that have been triaged and deferred" 
1. bugs associated with failing tests are mapped correctly
2. bugs associated with failing tests are the only reasons those tests are failing
3. the bugs have been properly assessed for impact to the product (this requires root causing in many cases) versus impact to the test results (this is easy and what most people do with frequency data and "not a regression" arguments)

