### PR TITLE
pkg/testgridanalysis: Generic handling for sad-operator test-case

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.10
+FROM golang:1.15.2
 #RUN INSTALL_PKGS="golang" && \
 #    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
 #    rpm -V $INSTALL_PKGS && \

--- a/pkg/testgridanalysis/testgridanalysisapi/types.go
+++ b/pkg/testgridanalysis/testgridanalysisapi/types.go
@@ -2,6 +2,10 @@
 // long term, I think these types become internal under this package.
 package testgridanalysisapi
 
+import (
+	"regexp"
+)
+
 // 1. TestGrid contains jobs
 // 2. Jobs contain JobRuns.  Jobs have associated variants/platforms.
 // 3. JobRuns contain Tests.
@@ -46,7 +50,7 @@ type RawJobRunResult struct {
 	// Used to create synthentic tests.
 	SetupStatus string
 	// Used to create synthentic tests.
-	InstallOperators []OperatorState
+	SadOperators []OperatorState
 	// Used to create synthentic tests.
 	UpgradeOperators []OperatorState
 }
@@ -58,7 +62,6 @@ type OperatorState struct {
 }
 
 const (
-	OperatorInstallPrefix = "operator install "
 	OperatorUpgradePrefix = "Operator upgrade "
 
 	InfrastructureTestName = `[sig-sippy] infrastructure should work`
@@ -68,4 +71,8 @@ const (
 
 	Success = "Success"
 	Failure = "Failure"
+)
+
+var (
+	OperatorConditionsTestCaseName = regexp.MustCompile("operator (install|conditions) (?P<operator>.*)")
 )

--- a/pkg/testgridanalysis/testgridconversion/synthentic_tests.go
+++ b/pkg/testgridanalysis/testgridconversion/synthentic_tests.go
@@ -37,9 +37,9 @@ func createSyntheticTests(rawJobResults testgridanalysisapi.RawData) []string {
 				testgridanalysisapi.InfrastructureTestName: &synthenticTestResult{name: testgridanalysisapi.InfrastructureTestName},
 			}
 
-			hasSomeOperatorResults := len(jrr.InstallOperators) > 0
+			hasSomeOperatorResults := len(jrr.SadOperators) > 0
 			allOperatorsSuccessfulAtEndOfRun := true
-			for _, operator := range jrr.InstallOperators {
+			for _, operator := range jrr.SadOperators {
 				if operator.State == testgridanalysisapi.Failure {
 					allOperatorsSuccessfulAtEndOfRun = false
 					break

--- a/pkg/testgridanalysis/testgridconversion/to_raw_data.go
+++ b/pkg/testgridanalysis/testgridconversion/to_raw_data.go
@@ -124,9 +124,11 @@ func processTestToJobRunResults(jobResult testgridanalysisapi.RawJobResult, job 
 				switch {
 				case test.Name == "Overall":
 					jrr.Succeeded = true
-				case strings.HasPrefix(test.Name, testgridanalysisapi.OperatorInstallPrefix):
-					jrr.InstallOperators = append(jrr.InstallOperators, testgridanalysisapi.OperatorState{
-						Name:  test.Name[len(testgridanalysisapi.OperatorInstallPrefix):],
+				case testgridanalysisapi.OperatorConditionsTestCaseName.MatchString(test.Name):
+					matches := testgridanalysisapi.OperatorConditionsTestCaseName.FindStringSubmatch(test.Name)
+					operatorIndex := testgridanalysisapi.OperatorConditionsTestCaseName.SubexpIndex("operator")
+					jrr.SadOperators = append(jrr.SadOperators, testgridanalysisapi.OperatorState{
+						Name:  matches[operatorIndex],
 						State: testgridanalysisapi.Success,
 					})
 				case strings.HasPrefix(test.Name, testgridanalysisapi.OperatorUpgradePrefix):
@@ -160,9 +162,11 @@ func processTestToJobRunResults(jobResult testgridanalysisapi.RawJobResult, job 
 				switch {
 				case test.Name == "Overall":
 					jrr.Failed = true
-				case strings.HasPrefix(test.Name, testgridanalysisapi.OperatorInstallPrefix):
-					jrr.InstallOperators = append(jrr.InstallOperators, testgridanalysisapi.OperatorState{
-						Name:  test.Name[len(testgridanalysisapi.OperatorInstallPrefix):],
+				case testgridanalysisapi.OperatorConditionsTestCaseName.MatchString(test.Name):
+					matches := testgridanalysisapi.OperatorConditionsTestCaseName.FindStringSubmatch(test.Name)
+					operatorIndex := testgridanalysisapi.OperatorConditionsTestCaseName.SubexpIndex("operator")
+					jrr.SadOperators = append(jrr.SadOperators, testgridanalysisapi.OperatorState{
+						Name:  matches[operatorIndex],
 						State: testgridanalysisapi.Failure,
 					})
 				case strings.HasPrefix(test.Name, testgridanalysisapi.OperatorUpgradePrefix):

--- a/pkg/testgridanalysis/testreportconversion/by_component.go
+++ b/pkg/testgridanalysis/testreportconversion/by_component.go
@@ -133,8 +133,10 @@ func getBugzillaComponentsFromTestResult(testResult sippyprocessingv1.TestResult
 
 	// If we didn't have a bug, use the test name itself to identify a likely victim/blame
 	switch {
-	case strings.HasPrefix(testResult.Name, testgridanalysisapi.OperatorInstallPrefix):
-		operatorName := testResult.Name[len(testgridanalysisapi.OperatorInstallPrefix):]
+	case testgridanalysisapi.OperatorConditionsTestCaseName.MatchString(testResult.Name):
+		matches := testgridanalysisapi.OperatorConditionsTestCaseName.FindStringSubmatch(testResult.Name)
+		operatorIndex := testgridanalysisapi.OperatorConditionsTestCaseName.SubexpIndex("operator")
+		operatorName := matches[operatorIndex]
 		return []string{testidentification.GetBugzillaComponentForOperator(operatorName)}
 
 	case strings.HasPrefix(testResult.Name, testgridanalysisapi.OperatorUpgradePrefix):


### PR DESCRIPTION
Per openshift/release#12298, the test-case is really about whether the operator has any sad conditions at gather-time, regardless of whether those gathers occured after a failed install or not.

[1]: https://github.com/openshift/release/pull/12298