### PR TITLE
pkg/testgridanalysis/testidentification: Fix "not a valid bugzilla component" Errorf

### DIFF
--- a/pkg/testgridanalysis/testidentification/component.go
+++ b/pkg/testgridanalysis/testidentification/component.go
@@ -165,7 +165,7 @@ func GetBugzillaComponentForSig(sig string) string {
 
 func addOperatorMapping(operator, bugzillaComponent string) error {
 	if !ValidBugzillaComponents.Has(bugzillaComponent) {
-		return fmt.Errorf("%q is not a valid bugzilla component")
+		return fmt.Errorf("%q is not a valid bugzilla component", bugzillaComponent)
 	}
 	operatorToBugzillaComponent[operator] = bugzillaComponent
 	return nil
@@ -173,7 +173,7 @@ func addOperatorMapping(operator, bugzillaComponent string) error {
 
 func addSigMapping(sig, bugzillaComponent string) error {
 	if !ValidBugzillaComponents.Has(bugzillaComponent) {
-		return fmt.Errorf("%q is not a valid bugzilla component")
+		return fmt.Errorf("%q is not a valid bugzilla component", bugzillaComponent)
 	}
 	sigToBugzillaComponent[sig] = bugzillaComponent
 	return nil


### PR DESCRIPTION
Fixing a bug from 0ff36998d4 (#69) to avoid:

```console
$ go test ./...
pkg/testgridanalysis/testidentification/component.go:168:10: Errorf format %q reads arg #1, but call has 0 args
pkg/testgridanalysis/testidentification/component.go:176:10: Errorf format %q reads arg #1, but call has 0 args
...
```