### PR TITLE
only lookup bugs once and reuse the mapping afterwards

### DIFF
--- a/pkg/testgridanalysis/testreportconversion/by_platform.go
+++ b/pkg/testgridanalysis/testreportconversion/by_platform.go
@@ -4,17 +4,13 @@ import (
 	"sort"
 
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
-	"github.com/openshift/sippy/pkg/buganalysis"
-	"github.com/openshift/sippy/pkg/testgridanalysis/testgridanalysisapi"
 	"github.com/openshift/sippy/pkg/testgridanalysis/testidentification"
 	"github.com/openshift/sippy/pkg/util/sets"
 )
 
 // convertRawDataToByPlatform takes the raw data and produces a map of platform names to job and test results
 func convertRawDataToByPlatform(
-	rawJobResults map[string]testgridanalysisapi.RawJobResult,
-	bugCache buganalysis.BugCache, // required to associate tests with bug
-	release string, // required to limit bugs to those that apply to the release in question
+	allJobResults []sippyprocessingv1.JobResult,
 	testResultFilterFn testResultFilterFunc,
 ) []sippyprocessingv1.PlatformResults {
 
@@ -29,13 +25,11 @@ func convertRawDataToByPlatform(
 		infraFailureJobRuns := 0
 
 		// do this the expensive way until we have a unit test.  This allows us to build the full platform result all at once.
-		// TODO if we are too slow, switch this to only build the job results once
-		for _, rawJobResult := range rawJobResults {
-			if !sets.NewString(testidentification.FindPlatform(rawJobResult.JobName)...).Has(platform) {
+		for _, jobResult := range allJobResults {
+			if !sets.NewString(testidentification.FindPlatform(jobResult.Name)...).Has(platform) {
 				continue
 			}
 
-			jobResult := convertRawJobResultToProcessedJobResult(rawJobResult, bugCache, release)
 			successfulJobRuns += jobResult.Successes
 			failedJobRuns += jobResult.Failures
 			knownFailureJobRuns += jobResult.KnownFailures
@@ -44,7 +38,6 @@ func convertRawDataToByPlatform(
 			// combined the test results *before* we filter them
 			allPlatformTestResults = combineTestResults(jobResult.TestResults, allPlatformTestResults)
 
-			jobResult.TestResults = testResultFilterFn.filterTestResults(jobResult.TestResults)
 			jobResults = append(jobResults, jobResult)
 		}
 


### PR DESCRIPTION
This reduces the call sites for looking up bugs from the cache and instead forces a reference from a single source.