### PR TITLE
allow a single BZ to be blamed for all job failures

### DIFF
--- a/pkg/sippyserver/analyzer.go
+++ b/pkg/sippyserver/analyzer.go
@@ -112,8 +112,11 @@ func updateBugCacheForJobResults(bugCache buganalysis.BugCache, rawJobResults te
 
 	// now that we have all the test failures (remember we added sythentics), use that to update the bugzilla cache
 	failedTestNamesAcrossAllJobRuns := getFailedTestNamesFromJobResults(rawJobResults.JobResults)
-	err := bugCache.UpdateForFailedTests(failedTestNamesAcrossAllJobRuns.List()...)
-	if err != nil {
+	if err := bugCache.UpdateForFailedTests(failedTestNamesAcrossAllJobRuns.List()...); err != nil {
+		klog.Error(err)
+		warnings = append(warnings, fmt.Sprintf("Bugzilla Lookup Error: an error was encountered looking up existing bugs for failing tests, some test failures may have associated bugs that are not listed below.  Lookup error: %v", err.Error()))
+	}
+	if err := bugCache.UpdateJobBlockers(sets.StringKeySet(rawJobResults.JobResults).List()...); err != nil {
 		klog.Error(err)
 		warnings = append(warnings, fmt.Sprintf("Bugzilla Lookup Error: an error was encountered looking up existing bugs for failing tests, some test failures may have associated bugs that are not listed below.  Lookup error: %v", err.Error()))
 	}

--- a/pkg/testgridanalysis/testreportconversion/jobresult.go
+++ b/pkg/testgridanalysis/testreportconversion/jobresult.go
@@ -86,7 +86,7 @@ func convertRawJobResultToProcessedJobResult(
 	job := sippyprocessingv1.JobResult{
 		Name:        rawJobResult.JobName,
 		TestGridUrl: rawJobResult.TestGridJobUrl,
-		TestResults: convertRawTestResultsToProcessedTestResults(rawJobResult.TestResults, bugCache, release),
+		TestResults: convertRawTestResultsToProcessedTestResults(rawJobResult.JobName, rawJobResult.TestResults, bugCache, release),
 	}
 
 	for _, rawJRR := range rawJobResult.JobRunResults {


### PR DESCRIPTION
This allows a job with environment containing "job=\<jobName\>=all" to accept blame for every failing test in the job.  This is more consistent than using platforms, while still keeping a list that is tractably long.

https://bugzilla.redhat.com/show_bug.cgi?id=1883693 is my practice bug

/hold  

Hold until I can see proof that this functions.  I think the ci search cache fills every hour or so.