### PR TITLE
refactor display of tests to always show past results for tests

### DIFF
--- a/pkg/html/decorations.go
+++ b/pkg/html/decorations.go
@@ -3,6 +3,7 @@ package html
 import (
 	"fmt"
 	"regexp"
+	"text/template"
 )
 
 const (
@@ -59,4 +60,14 @@ var collapseNameRemoveRegex = regexp.MustCompile(`[. ,:\(\)\[\]]`)
 
 func makeSafeForCollapseName(in string) string {
 	return collapseNameRemoveRegex.ReplaceAllString(in, "")
+}
+
+func getButtonHTML(sectionName, buttonName string) string {
+	buttonHTML := `<button class="btn btn-primary btn-sm py-0" style="font-size: 0.8em" type="button" data-toggle="collapse" data-target=".{{ .sectionName }}" aria-expanded="false" aria-controls="{{ .sectionName }}">{{ .buttonName }}</button>`
+	buttonHTMLTemplate := template.Must(template.New("buttonHTML").Parse(buttonHTML))
+
+	return mustSubstitute(buttonHTMLTemplate, map[string]string{
+		"sectionName": sectionName,
+		"buttonName":  buttonName,
+	})
 }

--- a/pkg/html/failing_tests.go
+++ b/pkg/html/failing_tests.go
@@ -2,13 +2,10 @@ package html
 
 import (
 	"fmt"
-	"net/url"
-	"regexp"
 
 	"github.com/openshift/sippy/pkg/util"
 
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
-	"k8s.io/klog"
 )
 
 func summaryTopFailingTestsWithBug(topFailingTestsWithBug, allTests []sippyprocessingv1.FailingTestResult, numDays int, release string) string {
@@ -59,27 +56,6 @@ func topFailingTestsRows(topFailingTests, allTests []sippyprocessingv1.FailingTe
 	// test name | bug | pass rate | higher/lower | pass rate
 	s := ""
 
-	template := `
-		<tr>
-			<td>
-				%s
-				<p/>
-				<button class="btn btn-primary btn-sm py-0" style="font-size: 0.8em" type="button" data-toggle="collapse" data-target=".%[2]s" aria-expanded="false" aria-controls="%[2]s">Expand Failing Jobs</button>
-			</td>
-			<td>%s</td><td>%0.2f%% <span class="text-nowrap">(%d runs)</span></td><td>%s</td><td>%0.2f%% <span class="text-nowrap">(%d runs)</span></td>
-		</tr>
-	`
-	naTemplate := `
-		<tr>
-			<td>
-				%s
-				<p/>
-				<button class="btn btn-primary btn-sm py-0" style="font-size: 0.8em" type="button" data-toggle="collapse" data-target=".%[2]s" aria-expanded="false" aria-controls="%[2]s">Expand Failing Jobs</button>
-			</td>
-			<td>%s</td><td>%0.2f%% <span class="text-nowrap">(%d runs)</span></td><td/><td>NA</td>
-		</tr>
-	`
-
 	count := 0
 	for _, testResult := range topFailingTests {
 		// if we only have one failure, don't show it on the glass.  Keep it in the actual data so we can choose how to handle it,
@@ -92,122 +68,12 @@ func topFailingTestsRows(topFailingTests, allTests []sippyprocessingv1.FailingTe
 			break
 		}
 
-		encodedTestName := url.QueryEscape(regexp.QuoteMeta(testResult.TestName))
-
-		testLink := fmt.Sprintf("<a target=\"_blank\" href=\"https://search.ci.openshift.org/?maxAge=168h&context=1&type=bug%%2Bjunit&name=%s&maxMatches=5&maxBytes=20971520&groupBy=job&search=%s\">%s</a>", release, encodedTestName, testResult.TestName)
-
 		testPrev := util.FindFailedTestResult(testResult.TestName, allTests)
 
-		byJobCollapseName := makeSafeForCollapseName("test-result---" + testResult.TestName)
-
-		klog.V(2).Infof("processing top failing tests %s, bugs: %v", testResult.TestName, testResult.TestResultAcrossAllJobs.BugList)
-		bugHTML := bugHTMLForTest(testResult.TestResultAcrossAllJobs.BugList, release, "", testResult.TestResultAcrossAllJobs.Name)
-		if testPrev != nil {
-			arrow := getArrow(testResult.TestResultAcrossAllJobs.Successes+testResult.TestResultAcrossAllJobs.Failures, testResult.TestResultAcrossAllJobs.PassPercentage, testPrev.TestResultAcrossAllJobs.PassPercentage)
-
-			s += fmt.Sprintf(template, testLink, byJobCollapseName, bugHTML, testResult.TestResultAcrossAllJobs.PassPercentage, testResult.TestResultAcrossAllJobs.Successes+testResult.TestResultAcrossAllJobs.Failures, arrow, testPrev.TestResultAcrossAllJobs.PassPercentage, testPrev.TestResultAcrossAllJobs.Successes+testPrev.TestResultAcrossAllJobs.Failures)
-		} else {
-			s += fmt.Sprintf(naTemplate, testLink, byJobCollapseName, bugHTML, testResult.TestResultAcrossAllJobs.PassPercentage, testResult.TestResultAcrossAllJobs.Successes+testResult.TestResultAcrossAllJobs.Failures)
-		}
-
-		// 1 encoded job name
-		// 2 indent depth
-		// 3 test name
-		// 4 job name regex
-		// 5 encoded test name
-		// 6 bug list/bug search
-		// 7 pass rate
-		// 8 number of runs
-		const failingTestJobGroupTemplate = `
-			<tr class="collapse %s">
-				<td style="padding-left:%dpx">
-					<a target="_blank" href="%s">%s</a>
-				</td>
-				<td>
-					%0.2f%%<span class="text-nowrap">(%d runs)</span>
-				</td>
-				<td>
-					%s
-				</td>
-				<td>
-					%0.2f%%<span class="text-nowrap">(%d runs)</span>
-				</td>
-			</tr>
-	`
-		const failingTestJobGroupTemplateNA = `
-			<tr class="collapse %s">
-				<td style="padding-left:%dpx">
-					<a target="_blank" href="%s">%s</a>
-				</td>
-				<td>
-					%0.2f%%<span class="text-nowrap">(%d runs)</span>
-				</td>
-				<td></td>
-				<td>
-					NA
-				</td>
-			</tr>
-	`
-
-		jobIndentDepth := 50 + 10
-		count := 10
-		rowCount := 0
-		rows := ""
-		additionalMatches := 0
-		for _, failingTestJobResult := range testResult.JobResults {
-			if count == 0 {
-				additionalMatches++
-				continue
-			}
-			count--
-
-			var prevTestJobResult *sippyprocessingv1.FailingTestJobResult
-			if testPrev != nil {
-				for _, prevJobInstance := range testPrev.JobResults {
-					if prevJobInstance.Name == failingTestJobResult.Name {
-						prevTestJobResult = &prevJobInstance
-						break
-					}
-				}
-			}
-
-			if prevTestJobResult != nil {
-				arrow := getArrow(failingTestJobResult.TestSuccesses+failingTestJobResult.TestFailures, failingTestJobResult.PassPercentage, prevTestJobResult.PassPercentage)
-
-				rows = rows + fmt.Sprintf(failingTestJobGroupTemplate,
-					byJobCollapseName,
-					jobIndentDepth,
-					failingTestJobResult.TestGridUrl,
-					failingTestJobResult.Name,
-					failingTestJobResult.PassPercentage,
-					failingTestJobResult.TestSuccesses+failingTestJobResult.TestFailures,
-					arrow,
-					prevTestJobResult.PassPercentage,
-					prevTestJobResult.TestSuccesses+prevTestJobResult.TestFailures,
-				)
-			} else {
-				rows = rows + fmt.Sprintf(failingTestJobGroupTemplateNA,
-					byJobCollapseName,
-					jobIndentDepth,
-					failingTestJobResult.TestGridUrl,
-					failingTestJobResult.Name,
-					failingTestJobResult.PassPercentage,
-					failingTestJobResult.TestSuccesses+failingTestJobResult.TestFailures,
-				)
-			}
-			rowCount++
-		}
-
-		if additionalMatches > 0 {
-			rows += fmt.Sprintf(`<tr class="collapse %s"><td colspan=2 style="padding-left:%dpx">Plus %d more jobs</td></tr>`, byJobCollapseName, jobIndentDepth, additionalMatches)
-		}
-		if rowCount > 0 {
-			s = s + fmt.Sprintf(`<tr class="collapse %s"><td colspan=2 style="padding-left:%dpx" class="font-weight-bold">Job Name</td><td class="font-weight-bold">Job Pass Rate</td></tr>`, byJobCollapseName, jobIndentDepth)
-			s = s + rows
-			s = s + fmt.Sprintf(`<tr class="collapse %s"><td colspan=2 style="padding-left:60px" class="font-weight-bold"></td><td class="font-weight-bold"></td></tr>`, byJobCollapseName)
-		} else {
-			s = s + fmt.Sprintf(`<tr class="collapse %s"><td colspan=3 style="padding-left:%dpx" class="font-weight-bold">No Jobs Matched Filters</td></tr>`, byJobCollapseName, jobIndentDepth)
-		}
+		s = s +
+			newTestResultRendererForFailedTestResult("", testResult, release).
+				withPreviousFailedTestResult(testPrev).
+				toHTML()
 	}
 
 	s = s + "</table>"

--- a/pkg/html/fastest_moving_jobs.go
+++ b/pkg/html/fastest_moving_jobs.go
@@ -53,9 +53,9 @@ func summaryTopNegativelyMovingJobs(twoDaysJobs, prevJobs []sippyprocessingv1.Jo
 		}
 		currJobResult := util.FindJobResultForJobName(jobDetails.jobName, twoDaysJobs)
 		prevJobResult := util.FindJobResultForJobName(currJobResult.Name, prevJobs)
-		jobHTML := newJobResultRenderer("by-job-name", *currJobResult, release).
+		jobHTML := newJobResultRendererFromJobResult("by-job-name", *currJobResult, release).
 			withMaxTestResultsToShow(jobTestCount).
-			withPrevious(prevJobResult).
+			withPreviousJobResult(prevJobResult).
 			toHTML()
 
 		s += jobHTML

--- a/pkg/html/html.go
+++ b/pkg/html/html.go
@@ -190,9 +190,9 @@ func summaryFrequentJobPassRatesByJobName(report, reportPrev sippyprocessingv1.T
 
 	for _, currJobResult := range report.FrequentJobResults {
 		prevJobResult := util.FindJobResultForJobName(currJobResult.Name, reportPrev.FrequentJobResults)
-		jobHTML := newJobResultRenderer("by-job-name", currJobResult, release).
+		jobHTML := newJobResultRendererFromJobResult("by-job-name", currJobResult, release).
 			withMaxTestResultsToShow(jobTestCount).
-			withPrevious(prevJobResult).
+			withPreviousJobResult(prevJobResult).
 			toHTML()
 
 		s += jobHTML
@@ -215,9 +215,9 @@ func summaryInfrequentJobPassRatesByJobName(report, reportPrev sippyprocessingv1
 
 	for _, currJobResult := range report.InfrequentJobResults {
 		prevJobResult := util.FindJobResultForJobName(currJobResult.Name, reportPrev.InfrequentJobResults)
-		jobHTML := newJobResultRenderer("by-infrequent-job-name", currJobResult, release).
+		jobHTML := newJobResultRendererFromJobResult("by-infrequent-job-name", currJobResult, release).
 			withMaxTestResultsToShow(jobTestCount).
-			withPrevious(prevJobResult).
+			withPreviousJobResult(prevJobResult).
 			toHTML()
 
 		s += jobHTML

--- a/pkg/html/jobresult.go
+++ b/pkg/html/jobresult.go
@@ -2,31 +2,74 @@ package html
 
 import (
 	"fmt"
-	"net/url"
-	"regexp"
 
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 )
+
+type jobResultDisplay struct {
+	displayName                        string
+	testGridURL                        string
+	displayPercent                     float64
+	displayPercentWithoutInfraFailures float64
+	totalRuns                          int
+	successfulRuns                     int
+	failedRuns                         int
+
+	testResults []testResultDisplay
+}
 
 type jobResultRenderBuilder struct {
 	// sectionBlock needs to be unique for each part of the report.  It is used to uniquely name the collapse/expand
 	// sections so they open properly
 	sectionBlock string
 
-	currJobResult sippyprocessingv1.JobResult
-	prevJobResult *sippyprocessingv1.JobResult
+	currJobResult jobResultDisplay
+	prevJobResult *jobResultDisplay
 
 	release              string
 	maxTestResultsToShow int
 	colors               colorizationCriteria
-	collapsedAs          string
+	startCollapsedBool   bool
 	baseIndentDepth      int
 }
 
-func newJobResultRenderer(sectionBlock string, currJobResult sippyprocessingv1.JobResult, release string) *jobResultRenderBuilder {
+func jobResultToDisplay(in sippyprocessingv1.JobResult) jobResultDisplay {
+	ret := jobResultDisplay{
+		displayName:                        in.Name,
+		testGridURL:                        in.TestGridUrl,
+		displayPercent:                     in.PassPercentage,
+		displayPercentWithoutInfraFailures: in.PassPercentageWithoutInfrastructureFailures,
+		totalRuns:                          in.Successes + in.Failures,
+		successfulRuns:                     in.Successes,
+		failedRuns:                         in.Failures,
+	}
+
+	for _, testResult := range in.TestResults {
+		ret.testResults = append(ret.testResults, testResultToDisplay(testResult))
+	}
+
+	return ret
+}
+
+func failingJobResultToDisplay(in sippyprocessingv1.FailingTestJobResult) jobResultDisplay {
+	ret := jobResultDisplay{
+		displayName:    in.Name,
+		testGridURL:    in.TestGridUrl,
+		displayPercent: in.PassPercentage,
+		// TODO gather this info
+		//displayPercentWithoutInfraFailures: in.PassPercentageWithoutInfrastructureFailures,
+		totalRuns:      in.TestSuccesses + in.TestFailures,
+		successfulRuns: in.TestSuccesses,
+		failedRuns:     in.TestFailures,
+	}
+
+	return ret
+}
+
+func newJobResultRenderer(sectionBlock string, curr jobResultDisplay, release string) *jobResultRenderBuilder {
 	return &jobResultRenderBuilder{
 		sectionBlock:         sectionBlock,
-		currJobResult:        currJobResult,
+		currJobResult:        curr,
 		release:              release,
 		maxTestResultsToShow: 10, // just a default, can be overridden
 		colors: colorizationCriteria{
@@ -37,9 +80,22 @@ func newJobResultRenderer(sectionBlock string, currJobResult sippyprocessingv1.J
 	}
 }
 
-func (b *jobResultRenderBuilder) withPrevious(prevJobResult *sippyprocessingv1.JobResult) *jobResultRenderBuilder {
+func newJobResultRendererFromJobResult(sectionBlock string, curr sippyprocessingv1.JobResult, release string) *jobResultRenderBuilder {
+	return newJobResultRenderer(sectionBlock, jobResultToDisplay(curr), release)
+}
+
+func (b *jobResultRenderBuilder) withPrevious(prevJobResult *jobResultDisplay) *jobResultRenderBuilder {
 	b.prevJobResult = prevJobResult
 	return b
+}
+
+func (b *jobResultRenderBuilder) withPreviousJobResult(prevJobResult *sippyprocessingv1.JobResult) *jobResultRenderBuilder {
+	if prevJobResult == nil {
+		b.prevJobResult = nil
+		return b
+	}
+	t := jobResultToDisplay(*prevJobResult)
+	return b.withPrevious(&t)
 }
 
 func (b *jobResultRenderBuilder) withMaxTestResultsToShow(maxTestResultsToShow int) *jobResultRenderBuilder {
@@ -57,13 +113,13 @@ func (b *jobResultRenderBuilder) withIndent(depth int) *jobResultRenderBuilder {
 	return b
 }
 
-func (b *jobResultRenderBuilder) startCollapsedAs(collapsedAs string) *jobResultRenderBuilder {
-	b.collapsedAs = collapsedAs
+func (b *jobResultRenderBuilder) startCollapsed() *jobResultRenderBuilder {
+	b.startCollapsedBool = true
 	return b
 }
 
 func (b *jobResultRenderBuilder) toHTML() string {
-	collapseName := makeSafeForCollapseName(b.sectionBlock + "---" + b.currJobResult.Name + "---tests")
+	testCollapseSectionName := makeSafeForCollapseName(b.sectionBlock + "---" + b.currJobResult.displayName + "---tests")
 
 	s := ""
 
@@ -73,8 +129,7 @@ func (b *jobResultRenderBuilder) toHTML() string {
 			<tr class="%s">
 				<td style="padding-left:%dpx">
 					<a target="_blank" href="%s">%s</a>
-					<p>
-					<button class="btn btn-primary btn-sm py-0" style="font-size: 0.8em" type="button" data-toggle="collapse" data-target=".%[5]s" aria-expanded="false" aria-controls="%[5]s">Expand Failing Tests</button>
+					%s
 				</td>
 				<td>
 					%0.2f%% (%0.2f%%)<span class="text-nowrap">(%d runs)</span>
@@ -92,8 +147,7 @@ func (b *jobResultRenderBuilder) toHTML() string {
 			<tr class="%s">
 				<td style="padding-left:%dpx">
 					<a target="_blank" href="%s">%s</a>
-					<p>
-					<button class="btn btn-primary btn-sm py-0" style="font-size: 0.8em" type="button" data-toggle="collapse" data-target=".%[5]s" aria-expanded="false" aria-controls="%[5]s">Expand Failing Tests</button>
+					%s
 				</td>
 				<td>
 					%0.2f%% (%0.2f%%)<span class="text-nowrap">(%d runs)</span>
@@ -105,33 +159,43 @@ func (b *jobResultRenderBuilder) toHTML() string {
 			</tr>
 		`
 
-	class := b.colors.getColor(b.currJobResult.PassPercentage)
-	if len(b.collapsedAs) > 0 {
-		class += " collapse " + b.collapsedAs
+	class := b.colors.getColor(b.currJobResult.displayPercent)
+	if b.startCollapsedBool {
+		class += " collapse " + b.sectionBlock
+	}
+
+	button := ""
+	if len(b.currJobResult.testResults) > 0 {
+		button = "<p>" + getButtonHTML(testCollapseSectionName, "Expand Failing Tests")
 	}
 
 	if b.prevJobResult != nil {
-		arrow := getArrow(b.currJobResult.Successes+b.currJobResult.Failures, b.currJobResult.PassPercentage, b.prevJobResult.PassPercentage)
+		arrow := getArrow(b.currJobResult.totalRuns, b.currJobResult.displayPercent, b.prevJobResult.displayPercent)
 
 		s = s + fmt.Sprintf(template,
 			class, b.baseIndentDepth*50+10,
-			b.currJobResult.TestGridUrl, b.currJobResult.Name, collapseName,
-			b.currJobResult.PassPercentage,
-			b.currJobResult.PassPercentageWithoutInfrastructureFailures,
-			b.currJobResult.Successes+b.currJobResult.Failures,
+			b.currJobResult.testGridURL, b.currJobResult.displayName, button,
+			b.currJobResult.displayPercent,
+			b.currJobResult.displayPercentWithoutInfraFailures,
+			b.currJobResult.totalRuns,
 			arrow,
-			b.prevJobResult.PassPercentage,
-			b.prevJobResult.PassPercentageWithoutInfrastructureFailures,
-			b.prevJobResult.Successes+b.prevJobResult.Failures,
+			b.prevJobResult.displayPercent,
+			b.prevJobResult.displayPercentWithoutInfraFailures,
+			b.prevJobResult.totalRuns,
 		)
 	} else {
 		s = s + fmt.Sprintf(naTemplate,
 			class, b.baseIndentDepth*50+10,
-			b.currJobResult.TestGridUrl, b.currJobResult.Name, collapseName,
-			b.currJobResult.PassPercentage,
-			b.currJobResult.PassPercentageWithoutInfrastructureFailures,
-			b.currJobResult.Successes+b.currJobResult.Failures,
+			b.currJobResult.testGridURL, b.currJobResult.displayName, button,
+			b.currJobResult.displayPercent,
+			b.currJobResult.displayPercentWithoutInfraFailures,
+			b.currJobResult.totalRuns,
 		)
+	}
+
+	// if we have no test results, we're done
+	if len(b.currJobResult.testResults) == 0 {
+		return s
 	}
 
 	testIndentDepth := (b.baseIndentDepth+1)*50 + 10
@@ -139,38 +203,42 @@ func (b *jobResultRenderBuilder) toHTML() string {
 	rowCount := 0
 	rows := ""
 	additionalMatches := 0
-	for _, test := range b.currJobResult.TestResults {
+	for _, test := range b.currJobResult.testResults {
 		if count <= 0 {
 			additionalMatches++
 			continue
 		}
 		count--
 
-		encodedTestName := url.QueryEscape(regexp.QuoteMeta(test.Name))
-		bugHTML := bugHTMLForTest(test.BugList, b.release, "", test.Name)
+		var prev *testResultDisplay
+		if b.prevJobResult != nil {
+			for _, prevInstance := range b.prevJobResult.testResults {
+				if prevInstance.displayName == test.displayName {
+					prev = &prevInstance
+					break
+				}
+			}
+		}
 
-		rows = rows + fmt.Sprintf(testGroupTemplate,
-			collapseName,
-			testIndentDepth,
-			test.Name,
-			b.currJobResult.Name,
-			encodedTestName,
-			bugHTML,
-			test.PassPercentage,
-			test.Successes+test.Failures,
-		)
+		rows = rows +
+			newTestResultRenderer(testCollapseSectionName, test, b.release).
+				withIndent(b.baseIndentDepth+1).
+				withPrevious(prev).
+				startCollapsed().
+				toHTML()
+
 		rowCount++
 	}
 
 	if additionalMatches > 0 {
-		rows += fmt.Sprintf(`<tr class="collapse %s"><td colspan=2 style="padding-left:%dpx">Plus %d more tests</td></tr>`, collapseName, testIndentDepth, additionalMatches)
+		rows += fmt.Sprintf(`<tr class="collapse %s"><td colspan=2 style="padding-left:%dpx">Plus %d more tests</td></tr>`, testCollapseSectionName, testIndentDepth, additionalMatches)
 	}
 	if rowCount > 0 {
-		s = s + fmt.Sprintf(`<tr class="collapse %s"><td colspan=2 style="padding-left:%dpx" class="font-weight-bold">Test Name</td><td class="font-weight-bold">Test Pass Rate</td></tr>`, collapseName, testIndentDepth)
+		s = s + fmt.Sprintf(`<tr class="collapse %s"><td colspan=2 style="padding-left:%dpx" class="font-weight-bold">Test Name</td><td class="font-weight-bold">Test Pass Rate</td></tr>`, testCollapseSectionName, testIndentDepth)
 		s = s + rows
-		s = s + fmt.Sprintf(`<tr class="collapse %s"><td colspan=2 style="padding-left:60px" class="font-weight-bold"></td><td class="font-weight-bold"></td></tr>`, collapseName)
+		s = s + fmt.Sprintf(`<tr class="collapse %s"><td colspan=2 style="padding-left:60px" class="font-weight-bold"></td><td class="font-weight-bold"></td></tr>`, testCollapseSectionName)
 	} else {
-		s = s + fmt.Sprintf(`<tr class="collapse %s"><td colspan=3 style="padding-left:%dpx" class="font-weight-bold">No Tests Matched Filters</td></tr>`, collapseName, testIndentDepth)
+		s = s + fmt.Sprintf(`<tr class="collapse %s"><td colspan=3 style="padding-left:%dpx" class="font-weight-bold">No Tests Matched Filters</td></tr>`, testCollapseSectionName, testIndentDepth)
 	}
 
 	return s

--- a/pkg/html/testresult.go
+++ b/pkg/html/testresult.go
@@ -1,5 +1,16 @@
 package html
 
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+
+	bugsv1 "github.com/openshift/sippy/pkg/apis/bugs/v1"
+	"k8s.io/klog"
+
+	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+)
+
 // 1 encoded job name
 // 2 indent depth
 // 3 test name
@@ -19,3 +30,218 @@ const testGroupTemplate = `
 			<td>%0.2f%% <span class="text-nowrap">(%d runs)</span></td>
 		</tr>
 	`
+
+type testResultDisplay struct {
+	displayName    string
+	displayPercent float64
+	totalRuns      int
+	successfulRuns int
+	failedRuns     int
+	bugList        []bugsv1.Bug
+
+	jobResults []jobResultDisplay
+}
+
+func testResultToDisplay(in sippyprocessingv1.TestResult) testResultDisplay {
+	ret := testResultDisplay{
+		displayName:    in.Name,
+		displayPercent: in.PassPercentage,
+		totalRuns:      in.Successes + in.Failures,
+		successfulRuns: in.Successes,
+		failedRuns:     in.Failures,
+	}
+	for _, bug := range in.BugList {
+		ret.bugList = append(ret.bugList, bug)
+	}
+	return ret
+}
+
+func failedTestResultToDisplay(in sippyprocessingv1.FailingTestResult) testResultDisplay {
+	ret := testResultToDisplay(in.TestResultAcrossAllJobs)
+
+	for _, jobResult := range in.JobResults {
+		ret.jobResults = append(ret.jobResults, failingJobResultToDisplay(jobResult))
+	}
+	return ret
+}
+
+type testResultRenderBuilder struct {
+	// sectionBlock needs to be unique for each part of the report.  It is used to uniquely name the collapse/expand
+	// sections so they open properly
+	sectionBlock string
+
+	currTestResult testResultDisplay
+	prevTestResult *testResultDisplay
+
+	release             string
+	maxJobResultsToShow int
+	colors              colorizationCriteria
+	startCollapsedBool  bool
+	baseIndentDepth     int
+}
+
+func newTestResultRenderer(sectionBlock string, curr testResultDisplay, release string) *testResultRenderBuilder {
+	return &testResultRenderBuilder{
+		sectionBlock:        sectionBlock,
+		currTestResult:      curr,
+		release:             release,
+		maxJobResultsToShow: 10, // just a default, can be overridden
+		colors: colorizationCriteria{
+			minRedPercent:    0,  // failure.  In this range, there is a systemic failure so severe that a reliable signal isn't available.
+			minYellowPercent: 60, // at risk.  In this range, there is a systemic problem that needs to be addressed.
+			minGreenPercent:  80, // no action required. This *should* be closer to 85%
+		},
+	}
+}
+
+func newTestResultRendererForTestResult(sectionBlock string, curr sippyprocessingv1.TestResult, release string) *testResultRenderBuilder {
+	return newTestResultRenderer(sectionBlock, testResultToDisplay(curr), release)
+}
+
+func newTestResultRendererForFailedTestResult(sectionBlock string, curr sippyprocessingv1.FailingTestResult, release string) *testResultRenderBuilder {
+	return newTestResultRenderer(sectionBlock, failedTestResultToDisplay(curr), release)
+}
+
+func (b *testResultRenderBuilder) withPrevious(prev *testResultDisplay) *testResultRenderBuilder {
+	b.prevTestResult = prev
+	return b
+}
+
+func (b *testResultRenderBuilder) withPreviousTestResult(prev *sippyprocessingv1.TestResult) *testResultRenderBuilder {
+	if prev == nil {
+		b.prevTestResult = nil
+		return b
+	}
+	t := testResultToDisplay(*prev)
+	b.prevTestResult = &t
+	return b
+}
+
+func (b *testResultRenderBuilder) withPreviousFailedTestResult(prev *sippyprocessingv1.FailingTestResult) *testResultRenderBuilder {
+	if prev == nil {
+		b.prevTestResult = nil
+		return b
+	}
+	t := failedTestResultToDisplay(*prev)
+	b.prevTestResult = &t
+	return b
+}
+
+func (b *testResultRenderBuilder) withMaxJobResultsToShow(maxTestResultsToShow int) *testResultRenderBuilder {
+	b.maxJobResultsToShow = maxTestResultsToShow
+	return b
+}
+
+func (b *testResultRenderBuilder) withColors(colors colorizationCriteria) *testResultRenderBuilder {
+	b.colors = colors
+	return b
+}
+
+func (b *testResultRenderBuilder) withIndent(depth int) *testResultRenderBuilder {
+	b.baseIndentDepth = depth
+	return b
+}
+
+func (b *testResultRenderBuilder) startCollapsed() *testResultRenderBuilder {
+	b.startCollapsedBool = true
+	return b
+}
+
+func (b *testResultRenderBuilder) toHTML() string {
+	indentDepth := (b.baseIndentDepth)*50 + 10
+
+	template := `
+		<tr class="%s">
+			<td style="padding-left:%dpx">
+				%s
+				%s
+			</td>
+			<td>%s</td><td>%0.2f%% <span class="text-nowrap">(%d runs)</span></td><td>%s</td><td>%0.2f%% <span class="text-nowrap">(%d runs)</span></td>
+		</tr>
+	`
+	naTemplate := `
+		<tr class="%s">
+			<td style="padding-left:%dpx">
+				%s
+				%s
+			</td>
+			<td>%s</td><td>%0.2f%% <span class="text-nowrap">(%d runs)</span></td><td/><td>NA</td>
+		</tr>
+	`
+
+	class := ""
+	if b.startCollapsedBool {
+		class += "collapse " + b.sectionBlock
+	}
+
+	jobCollapseSectionName := makeSafeForCollapseName("test-result---" + b.sectionBlock + "---" + b.currTestResult.displayName)
+	button := ""
+	if len(b.currTestResult.jobResults) > 0 {
+		button = "<p>" + getButtonHTML(jobCollapseSectionName, "Expand Failing Jobs")
+	}
+
+	// test name | bug | pass rate | higher/lower | pass rate
+	s := ""
+
+	encodedTestName := url.QueryEscape(regexp.QuoteMeta(b.currTestResult.displayName))
+	testLink := fmt.Sprintf("<a target=\"_blank\" href=\"https://search.ci.openshift.org/?maxAge=168h&context=1&type=bug%%2Bjunit&name=%s&maxMatches=5&maxBytes=20971520&groupBy=job&search=%s\">%s</a>", b.release, encodedTestName, b.currTestResult.displayName)
+
+	klog.V(2).Infof("processing top failing tests %s, bugs: %v", b.currTestResult.displayName, b.currTestResult.bugList)
+	bugHTML := bugHTMLForTest(b.currTestResult.bugList, b.release, "", b.currTestResult.displayName)
+	if b.prevTestResult != nil {
+		arrow := getArrow(b.currTestResult.totalRuns, b.currTestResult.displayPercent, b.prevTestResult.displayPercent)
+
+		s += fmt.Sprintf(template, class, indentDepth, testLink, button, bugHTML, b.currTestResult.displayPercent, b.currTestResult.totalRuns, arrow, b.prevTestResult.displayPercent, b.prevTestResult.totalRuns)
+	} else {
+		s += fmt.Sprintf(naTemplate, class, indentDepth, testLink, button, bugHTML, b.currTestResult.displayPercent, b.currTestResult.totalRuns)
+	}
+
+	// if we have no jobresults we're done
+	if len(b.currTestResult.jobResults) == 0 {
+		return s
+	}
+
+	jobIndentDepth := 50 + 10
+	count := 10
+	rowCount := 0
+	rows := ""
+	additionalMatches := 0
+	for _, failingTestJobResult := range b.currTestResult.jobResults {
+		if count == 0 {
+			additionalMatches++
+			continue
+		}
+		count--
+
+		var prevTestJobResult *jobResultDisplay
+		if b.prevTestResult != nil {
+			for _, prevJobInstance := range b.prevTestResult.jobResults {
+				if prevJobInstance.displayName == failingTestJobResult.displayName {
+					prevTestJobResult = &prevJobInstance
+					break
+				}
+			}
+		}
+
+		rows = rows + newJobResultRenderer(jobCollapseSectionName, failingTestJobResult, b.release).
+			withIndent(b.baseIndentDepth+1).
+			withPrevious(prevTestJobResult).
+			startCollapsed().
+			toHTML()
+
+		rowCount++
+	}
+
+	if additionalMatches > 0 {
+		rows += fmt.Sprintf(`<tr class="collapse %s"><td colspan=2 style="padding-left:%dpx">Plus %d more jobs</td></tr>`, jobCollapseSectionName, jobIndentDepth, additionalMatches)
+	}
+	if rowCount > 0 {
+		s = s + fmt.Sprintf(`<tr class="collapse %s"><td colspan=2 style="padding-left:%dpx" class="font-weight-bold">Job Name</td><td class="font-weight-bold">Job Pass Rate</td></tr>`, jobCollapseSectionName, jobIndentDepth)
+		s = s + rows
+		s = s + fmt.Sprintf(`<tr class="collapse %s"><td colspan=2 style="padding-left:60px" class="font-weight-bold"></td><td class="font-weight-bold"></td></tr>`, jobCollapseSectionName)
+	} else {
+		s = s + fmt.Sprintf(`<tr class="collapse %s"><td colspan=3 style="padding-left:%dpx" class="font-weight-bold">No Jobs Matched Filters</td></tr>`, jobCollapseSectionName, jobIndentDepth)
+	}
+
+	return s
+}


### PR DESCRIPTION
Unifies display for tests so that we always get previous test data and if available we get the nested sections.