### PR TITLE
filter the fastest moving jobs view for tests with few runs

### DIFF
--- a/pkg/testgridanalysis/testreportconversion/jobresult.go
+++ b/pkg/testgridanalysis/testreportconversion/jobresult.go
@@ -8,6 +8,23 @@ import (
 	"github.com/openshift/sippy/pkg/testgridanalysis/testgridanalysisapi"
 )
 
+func FilterJobResultTests(jobResult *sippyprocessingv1.JobResult, testFilterFn testResultFilterFunc) *sippyprocessingv1.JobResult {
+	if jobResult == nil {
+		return nil
+	}
+
+	out := *jobResult
+	testResults := []sippyprocessingv1.TestResult{}
+	for i := range out.TestResults {
+		testResult := out.TestResults[i]
+		if testFilterFn(testResult) {
+			testResults = append(testResults, testResult)
+		}
+	}
+	out.TestResults = testResults
+	return &out
+}
+
 func filterPertinentFrequentJobResults(
 	in []sippyprocessingv1.JobResult,
 	numberOfDaysOfData int, // number of days included in report.

--- a/pkg/testgridanalysis/testreportconversion/test_report.go
+++ b/pkg/testgridanalysis/testreportconversion/test_report.go
@@ -28,13 +28,14 @@ func PrepareTestReport(
 	allJobResults := convertRawJobResultsToProcessedJobResults(rawData.JobResults, bugCache, release)
 	allTestResultsByName := getTestResultsByName(allJobResults)
 
-	standardTestResultFilterFn := standardTestResultFilter(minRuns, successThreshold)
+	standardTestResultFilterFn := StandardTestResultFilter(minRuns, successThreshold)
+	infrequentJobsTestResultFilterFn := StandardTestResultFilter(2, successThreshold)
 
 	byPlatform := convertRawDataToByPlatform(allJobResults, standardTestResultFilterFn)
 
 	filteredFailureGroups := filterFailureGroups(rawData.JobResults, allTestResultsByName, failureClusterThreshold)
 	frequentJobResults := filterPertinentFrequentJobResults(allJobResults, numDays, standardTestResultFilterFn)
-	infrequentJobResults := filterPertinentInfrequentJobResults(allJobResults, numDays, standardTestResultFilterFn)
+	infrequentJobResults := filterPertinentInfrequentJobResults(allJobResults, numDays, infrequentJobsTestResultFilterFn)
 
 	bugFailureCounts := generateSortedBugFailureCounts(allTestResultsByName)
 	bugzillaComponentResults := generateAllJobFailuresByBugzillaComponent(rawData.JobResults, allJobResults)

--- a/pkg/testgridanalysis/testreportconversion/testresult.go
+++ b/pkg/testgridanalysis/testreportconversion/testresult.go
@@ -109,7 +109,7 @@ func acceptAllTests(testResult sippyprocessingv1.TestResult) bool {
 	return true
 }
 
-func filterSuccessfulTestResults(successThreshold float64 /*indicates an upper bound on how successful a test can be before it is excluded*/) testResultFilterFunc {
+func FilterSuccessfulTestResults(successThreshold float64 /*indicates an upper bound on how successful a test can be before it is excluded*/) testResultFilterFunc {
 	return func(testResult sippyprocessingv1.TestResult) bool {
 		if testResult.PassPercentage > successThreshold {
 			return false
@@ -118,14 +118,14 @@ func filterSuccessfulTestResults(successThreshold float64 /*indicates an upper b
 	}
 }
 
-func filterLowValueTestsByName(testResult sippyprocessingv1.TestResult) bool {
+func FilterLowValueTestsByName(testResult sippyprocessingv1.TestResult) bool {
 	if testResult.Name == "Overall" || testidentification.IsSetupContainerEquivalent(testResult.Name) {
 		return false
 	}
 	return true
 }
 
-func filterTooFewTestRuns(minRuns int /*indicates how many runs are required for a test is included in overall percentages*/) testResultFilterFunc {
+func FilterTooFewTestRuns(minRuns int /*indicates how many runs are required for a test is included in overall percentages*/) testResultFilterFunc {
 	return func(testResult sippyprocessingv1.TestResult) bool {
 		if testResult.Successes+testResult.Failures < minRuns {
 			return false
@@ -134,7 +134,7 @@ func filterTooFewTestRuns(minRuns int /*indicates how many runs are required for
 	}
 }
 
-func filterTestResultsByFilters(fns ...testResultFilterFunc) testResultFilterFunc {
+func FilterTestResultsByFilters(fns ...testResultFilterFunc) testResultFilterFunc {
 	return func(testResult sippyprocessingv1.TestResult) bool {
 		for _, fn := range fns {
 			if !fn(testResult) {
@@ -145,15 +145,15 @@ func filterTestResultsByFilters(fns ...testResultFilterFunc) testResultFilterFun
 	}
 }
 
-func standardTestResultFilter(
+func StandardTestResultFilter(
 	minRuns int, // indicates how many runs are required for a test is included in overall percentages
 	// TODO deads2k wants to eliminate the successThreshold
 	successThreshold float64, // indicates an upper bound on how successful a test can be before it is excluded
 ) testResultFilterFunc {
-	return filterTestResultsByFilters(
-		filterLowValueTestsByName,
-		filterTooFewTestRuns(minRuns),
-		filterSuccessfulTestResults(successThreshold),
+	return FilterTestResultsByFilters(
+		FilterLowValueTestsByName,
+		FilterTooFewTestRuns(minRuns),
+		FilterSuccessfulTestResults(successThreshold),
 	)
 }
 


### PR DESCRIPTION
This prevents lots of zero run tests from showing up on the job because of the way filtering works.