### PR TITLE
add upgrade report

### DIFF
--- a/pkg/html/generichtml/bugs.go
+++ b/pkg/html/generichtml/bugs.go
@@ -1,8 +1,9 @@
-package releasehtml
+package generichtml
 
 import (
 	"fmt"
 	"net/url"
+	"regexp"
 
 	bugsv1 "github.com/openshift/sippy/pkg/apis/bugs/v1"
 )
@@ -49,4 +50,10 @@ FIXME: Provide a snippet of the test failure or error from the job log
 		release)
 
 	return bug
+}
+
+// testName is the non-encoded test.Name
+func testToSearchURL(testName string) string {
+	encodedTestName := url.QueryEscape(regexp.QuoteMeta(testName))
+	return fmt.Sprintf("https://search.ci.openshift.org/?maxAge=168h&context=1&type=bug%%2Bjunit&name=&maxMatches=5&maxBytes=20971520&groupBy=job&search=%s", encodedTestName)
 }

--- a/pkg/html/generichtml/jobaggregationresult.go
+++ b/pkg/html/generichtml/jobaggregationresult.go
@@ -1,9 +1,7 @@
-package releasehtml
+package generichtml
 
 import (
 	"fmt"
-
-	"github.com/openshift/sippy/pkg/html/generichtml"
 
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 )
@@ -67,18 +65,18 @@ type jobAggregationResultRenderBuilder struct {
 	release              string
 	maxTestResultsToShow int
 	maxJobResultsToShow  int
-	colors               generichtml.ColorizationCriteria
+	colors               ColorizationCriteria
 	collapsedAs          string
 }
 
-func newJobAggregationResultRenderer(sectionBlock string, currJobResult jobAggregationDisplay, release string) *jobAggregationResultRenderBuilder {
+func NewJobAggregationResultRenderer(sectionBlock string, currJobResult jobAggregationDisplay, release string) *jobAggregationResultRenderBuilder {
 	return &jobAggregationResultRenderBuilder{
 		sectionBlock:          sectionBlock,
 		currAggregationResult: currJobResult,
 		release:               release,
 		maxTestResultsToShow:  10, // just a default, can be overridden
 		maxJobResultsToShow:   10, // just a default, can be overridden
-		colors: generichtml.ColorizationCriteria{
+		colors: ColorizationCriteria{
 			MinRedPercent:    0,  // failure.  In this range, there is a systemic failure so severe that a reliable signal isn't available.
 			MinYellowPercent: 60, // at risk.  In this range, there is a systemic problem that needs to be addressed.
 			MinGreenPercent:  80, // no action required. This *should* be closer to 85%
@@ -86,20 +84,20 @@ func newJobAggregationResultRenderer(sectionBlock string, currJobResult jobAggre
 	}
 }
 
-func newJobAggregationResultRendererFromPlatformResults(sectionBlock string, curr sippyprocessingv1.PlatformResults, release string) *jobAggregationResultRenderBuilder {
-	return newJobAggregationResultRenderer(sectionBlock, platformResultToDisplay(curr), release)
+func NewJobAggregationResultRendererFromPlatformResults(sectionBlock string, curr sippyprocessingv1.PlatformResults, release string) *jobAggregationResultRenderBuilder {
+	return NewJobAggregationResultRenderer(sectionBlock, platformResultToDisplay(curr), release)
 }
 
-func newJobAggregationResultRendererFromBugzillaComponentResult(sectionBlock string, curr sippyprocessingv1.SortedBugzillaComponentResult, release string) *jobAggregationResultRenderBuilder {
-	return newJobAggregationResultRenderer(sectionBlock, bugzillaComponentReportToDisplay(curr), release)
+func NewJobAggregationResultRendererFromBugzillaComponentResult(sectionBlock string, curr sippyprocessingv1.SortedBugzillaComponentResult, release string) *jobAggregationResultRenderBuilder {
+	return NewJobAggregationResultRenderer(sectionBlock, bugzillaComponentReportToDisplay(curr), release)
 }
 
-func (b *jobAggregationResultRenderBuilder) withPrevious(prevJobResult *jobAggregationDisplay) *jobAggregationResultRenderBuilder {
+func (b *jobAggregationResultRenderBuilder) WithPrevious(prevJobResult *jobAggregationDisplay) *jobAggregationResultRenderBuilder {
 	b.prevAggregationResult = prevJobResult
 	return b
 }
 
-func (b *jobAggregationResultRenderBuilder) withPreviousPlatformResults(prev *sippyprocessingv1.PlatformResults) *jobAggregationResultRenderBuilder {
+func (b *jobAggregationResultRenderBuilder) WithPreviousPlatformResults(prev *sippyprocessingv1.PlatformResults) *jobAggregationResultRenderBuilder {
 	if prev == nil {
 		b.prevAggregationResult = nil
 		return b
@@ -109,7 +107,7 @@ func (b *jobAggregationResultRenderBuilder) withPreviousPlatformResults(prev *si
 	return b
 }
 
-func (b *jobAggregationResultRenderBuilder) withPreviousBugzillaComponentResult(prev *sippyprocessingv1.SortedBugzillaComponentResult) *jobAggregationResultRenderBuilder {
+func (b *jobAggregationResultRenderBuilder) WithPreviousBugzillaComponentResult(prev *sippyprocessingv1.SortedBugzillaComponentResult) *jobAggregationResultRenderBuilder {
 	if prev == nil {
 		b.prevAggregationResult = nil
 		return b
@@ -119,27 +117,27 @@ func (b *jobAggregationResultRenderBuilder) withPreviousBugzillaComponentResult(
 	return b
 }
 
-func (b *jobAggregationResultRenderBuilder) withMaxTestResultsToShow(maxTestResultsToShow int) *jobAggregationResultRenderBuilder {
+func (b *jobAggregationResultRenderBuilder) WithMaxTestResultsToShow(maxTestResultsToShow int) *jobAggregationResultRenderBuilder {
 	b.maxTestResultsToShow = maxTestResultsToShow
 	return b
 }
 
-func (b *jobAggregationResultRenderBuilder) withMaxJobResultsToShow(maxJobResultsToShow int) *jobAggregationResultRenderBuilder {
+func (b *jobAggregationResultRenderBuilder) WithMaxJobResultsToShow(maxJobResultsToShow int) *jobAggregationResultRenderBuilder {
 	b.maxJobResultsToShow = maxJobResultsToShow
 	return b
 }
 
-func (b *jobAggregationResultRenderBuilder) withColors(colors generichtml.ColorizationCriteria) *jobAggregationResultRenderBuilder {
+func (b *jobAggregationResultRenderBuilder) WithColors(colors ColorizationCriteria) *jobAggregationResultRenderBuilder {
 	b.colors = colors
 	return b
 }
 
-func (b *jobAggregationResultRenderBuilder) startCollapsedAs(collapsedAs string) *jobAggregationResultRenderBuilder {
+func (b *jobAggregationResultRenderBuilder) StartCollapsedAs(collapsedAs string) *jobAggregationResultRenderBuilder {
 	b.collapsedAs = collapsedAs
 	return b
 }
 
-func (b *jobAggregationResultRenderBuilder) toHTML() string {
+func (b *jobAggregationResultRenderBuilder) ToHTML() string {
 
 	s := ""
 
@@ -186,16 +184,16 @@ func (b *jobAggregationResultRenderBuilder) toHTML() string {
 		class += " collapse " + b.collapsedAs
 	}
 
-	testsCollapseName := generichtml.MakeSafeForCollapseName(b.sectionBlock + "---" + b.currAggregationResult.displayName + "---tests")
-	jobsCollapseName := generichtml.MakeSafeForCollapseName(b.sectionBlock + "---" + b.currAggregationResult.displayName + "---jobs")
+	testsCollapseName := MakeSafeForCollapseName(b.sectionBlock + "---" + b.currAggregationResult.displayName + "---tests")
+	jobsCollapseName := MakeSafeForCollapseName(b.sectionBlock + "---" + b.currAggregationResult.displayName + "---jobs")
 	button := ""
 	if len(b.currAggregationResult.testResults) > 0 { // add the button if we have tests to show
-		button += "					" + generichtml.GetButtonHTML(testsCollapseName, "Expand Failing Tests")
+		button += "					" + GetButtonHTML(testsCollapseName, "Expand Failing Tests")
 	}
-	button += "					" + generichtml.GetButtonHTML(jobsCollapseName, "Expand Failing Jobs")
+	button += "					" + GetButtonHTML(jobsCollapseName, "Expand Failing Jobs")
 
 	if b.prevAggregationResult != nil {
-		arrow := generichtml.GetArrow(b.currAggregationResult.totalJobRuns, b.currAggregationResult.displayPercentage, b.prevAggregationResult.displayPercentage)
+		arrow := GetArrow(b.currAggregationResult.totalJobRuns, b.currAggregationResult.displayPercentage, b.prevAggregationResult.displayPercentage)
 
 		s = s + fmt.Sprintf(template,
 			class,
@@ -242,12 +240,12 @@ func (b *jobAggregationResultRenderBuilder) toHTML() string {
 			}
 		}
 
-		jobRows = jobRows + newJobResultRenderer(jobsCollapseName, job, b.release).
-			withPrevious(prev).
-			withMaxTestResultsToShow(b.maxTestResultsToShow).
-			startCollapsed().
-			withIndent(1).
-			toHTML()
+		jobRows = jobRows + NewJobResultRenderer(jobsCollapseName, job, b.release).
+			WithPrevious(prev).
+			WithMaxTestResultsToShow(b.maxTestResultsToShow).
+			StartCollapsed().
+			WithIndent(1).
+			ToHTML()
 
 		jobRowCount++
 	}
@@ -289,11 +287,11 @@ func (b *jobAggregationResultRenderBuilder) toHTML() string {
 		}
 
 		testRows = testRows +
-			newTestResultRenderer(testsCollapseName, test, b.release).
-				withIndent(1).
-				withPrevious(prev).
-				startCollapsed().
-				toHTML()
+			NewTestResultRenderer(testsCollapseName, test, b.release).
+				WithIndent(1).
+				WithPrevious(prev).
+				StartCollapsed().
+				ToHTML()
 
 		testRowCount++
 	}

--- a/pkg/html/generichtml/jobresult.go
+++ b/pkg/html/generichtml/jobresult.go
@@ -1,9 +1,7 @@
-package releasehtml
+package generichtml
 
 import (
 	"fmt"
-
-	"github.com/openshift/sippy/pkg/html/generichtml"
 
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 )
@@ -28,7 +26,7 @@ type jobResultRenderBuilder struct {
 
 	release              string
 	maxTestResultsToShow int
-	colors               generichtml.ColorizationCriteria
+	colors               ColorizationCriteria
 	startCollapsedBool   bool
 	baseIndentDepth      int
 }
@@ -78,13 +76,13 @@ func failingJobResultToDisplay(in sippyprocessingv1.FailingTestJobResult) jobRes
 	return ret
 }
 
-func newJobResultRenderer(sectionBlock string, curr jobResultDisplay, release string) *jobResultRenderBuilder {
+func NewJobResultRenderer(sectionBlock string, curr jobResultDisplay, release string) *jobResultRenderBuilder {
 	return &jobResultRenderBuilder{
 		sectionBlock:         sectionBlock,
 		currJobResult:        curr,
 		release:              release,
 		maxTestResultsToShow: 10, // just a default, can be overridden
-		colors: generichtml.ColorizationCriteria{
+		colors: ColorizationCriteria{
 			MinRedPercent:    0,  // failure.  In this range, there is a systemic failure so severe that a reliable signal isn't available.
 			MinYellowPercent: 60, // at risk.  In this range, there is a systemic problem that needs to be addressed.
 			MinGreenPercent:  80, // no action required. This *should* be closer to 85%
@@ -92,46 +90,46 @@ func newJobResultRenderer(sectionBlock string, curr jobResultDisplay, release st
 	}
 }
 
-func newJobResultRendererFromJobResult(sectionBlock string, curr sippyprocessingv1.JobResult, release string) *jobResultRenderBuilder {
-	return newJobResultRenderer(sectionBlock, jobResultToDisplay(curr), release)
+func NewJobResultRendererFromJobResult(sectionBlock string, curr sippyprocessingv1.JobResult, release string) *jobResultRenderBuilder {
+	return NewJobResultRenderer(sectionBlock, jobResultToDisplay(curr), release)
 }
 
-func (b *jobResultRenderBuilder) withPrevious(prevJobResult *jobResultDisplay) *jobResultRenderBuilder {
+func (b *jobResultRenderBuilder) WithPrevious(prevJobResult *jobResultDisplay) *jobResultRenderBuilder {
 	b.prevJobResult = prevJobResult
 	return b
 }
 
-func (b *jobResultRenderBuilder) withPreviousJobResult(prevJobResult *sippyprocessingv1.JobResult) *jobResultRenderBuilder {
+func (b *jobResultRenderBuilder) WithPreviousJobResult(prevJobResult *sippyprocessingv1.JobResult) *jobResultRenderBuilder {
 	if prevJobResult == nil {
 		b.prevJobResult = nil
 		return b
 	}
 	t := jobResultToDisplay(*prevJobResult)
-	return b.withPrevious(&t)
+	return b.WithPrevious(&t)
 }
 
-func (b *jobResultRenderBuilder) withMaxTestResultsToShow(maxTestResultsToShow int) *jobResultRenderBuilder {
+func (b *jobResultRenderBuilder) WithMaxTestResultsToShow(maxTestResultsToShow int) *jobResultRenderBuilder {
 	b.maxTestResultsToShow = maxTestResultsToShow
 	return b
 }
 
-func (b *jobResultRenderBuilder) withColors(colors generichtml.ColorizationCriteria) *jobResultRenderBuilder {
+func (b *jobResultRenderBuilder) WithColors(colors ColorizationCriteria) *jobResultRenderBuilder {
 	b.colors = colors
 	return b
 }
 
-func (b *jobResultRenderBuilder) withIndent(depth int) *jobResultRenderBuilder {
+func (b *jobResultRenderBuilder) WithIndent(depth int) *jobResultRenderBuilder {
 	b.baseIndentDepth = depth
 	return b
 }
 
-func (b *jobResultRenderBuilder) startCollapsed() *jobResultRenderBuilder {
+func (b *jobResultRenderBuilder) StartCollapsed() *jobResultRenderBuilder {
 	b.startCollapsedBool = true
 	return b
 }
 
-func (b *jobResultRenderBuilder) toHTML() string {
-	testCollapseSectionName := generichtml.MakeSafeForCollapseName(b.sectionBlock + "---" + b.currJobResult.displayName + "---tests")
+func (b *jobResultRenderBuilder) ToHTML() string {
+	testCollapseSectionName := MakeSafeForCollapseName(b.sectionBlock + "---" + b.currJobResult.displayName + "---tests")
 
 	s := ""
 
@@ -178,11 +176,11 @@ func (b *jobResultRenderBuilder) toHTML() string {
 
 	button := ""
 	if len(b.currJobResult.testResults) > 0 {
-		button = "<p>" + generichtml.GetButtonHTML(testCollapseSectionName, "Expand Failing Tests")
+		button = "<p>" + GetButtonHTML(testCollapseSectionName, "Expand Failing Tests")
 	}
 
 	if b.prevJobResult != nil {
-		arrow := generichtml.GetArrow(b.currJobResult.totalRuns, b.currJobResult.displayPercent, b.prevJobResult.displayPercent)
+		arrow := GetArrow(b.currJobResult.totalRuns, b.currJobResult.displayPercent, b.prevJobResult.displayPercent)
 
 		s = s + fmt.Sprintf(template,
 			class, b.baseIndentDepth*50+10,
@@ -233,11 +231,11 @@ func (b *jobResultRenderBuilder) toHTML() string {
 		}
 
 		rows = rows +
-			newTestResultRenderer(testCollapseSectionName, test, b.release).
-				withIndent(b.baseIndentDepth+1).
-				withPrevious(prev).
-				startCollapsed().
-				toHTML()
+			NewTestResultRenderer(testCollapseSectionName, test, b.release).
+				WithIndent(b.baseIndentDepth+1).
+				WithPrevious(prev).
+				StartCollapsed().
+				ToHTML()
 
 		rowCount++
 	}

--- a/pkg/html/installhtml/install_by_operators.go
+++ b/pkg/html/installhtml/install_by_operators.go
@@ -4,11 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/openshift/sippy/pkg/html/generichtml"
-
 	"github.com/openshift/sippy/pkg/util"
-
-	"github.com/openshift/sippy/pkg/testgridanalysis/testidentification"
 
 	"github.com/openshift/sippy/pkg/util/sets"
 
@@ -17,147 +13,72 @@ import (
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 )
 
-var individualInstallUpgradeColor = generichtml.ColorizationCriteria{
-	MinRedPercent:    0,  // failure.  In this range, there is a systemic failure so severe that a reliable signal isn't available.
-	MinYellowPercent: 90, // at risk.  In this range, there is a systemic problem that needs to be addressed.
-	MinGreenPercent:  95, // no action required.
-}
-
-type currPrevTestResult struct {
-	curr sippyprocessingv1.TestResult
-	prev *sippyprocessingv1.TestResult
-}
-
-type currPrevFailedTestResult struct {
-	curr sippyprocessingv1.FailingTestResult
-	prev *sippyprocessingv1.FailingTestResult
-}
-
 func installOperatorTests(curr, prev sippyprocessingv1.TestReport) string {
+	dataForTestsByPlatform := getDataForTestsByPlatform(
+		curr, prev,
+		func(testResult sippyprocessingv1.TestResult) bool {
+			return strings.HasPrefix(testResult.Name, testgridanalysisapi.OperatorInstallPrefix)
+		},
+		func(testResult sippyprocessingv1.TestResult) bool {
+			return testResult.Name == testgridanalysisapi.InstallTestName
+		},
+	)
+	// compute platform columns before we add the special "All" column
+	platformColumns := sets.StringKeySet(dataForTestsByPlatform.aggregationToOverallTestResult).List()
+
+	// we add an "All" column for all platforms. Fill in the aggregate data for that key
+	for _, testName := range sets.StringKeySet(dataForTestsByPlatform.aggregateResultByTestName).List() {
+		dataForTestsByPlatform.testNameToPlatformToTestResult[testName]["All"] = dataForTestsByPlatform.aggregateResultByTestName[testName].toCurrPrevTestResult()
+	}
+
+	// fill in the data for the first row's "All" column
+	var prevTestResult *sippyprocessingv1.TestResult
+	if installTest := util.FindFailedTestResult(testgridanalysisapi.InstallTestName, prev.ByTest); installTest != nil {
+		prevTestResult = &installTest.TestResultAcrossAllJobs
+	}
+	dataForTestsByPlatform.aggregationToOverallTestResult["All"] = &currPrevTestResult{
+		curr: util.FindFailedTestResult(testgridanalysisapi.InstallTestName, curr.ByTest).TestResultAcrossAllJobs,
+		prev: prevTestResult,
+	}
+
+	columnNames := append([]string{"All"}, platformColumns...)
+
+	return dataForTestsByPlatform.getTableHTML("Install Rates by Operator", "InstallRatesByOperator", "Install Rates by Operator by Platform", columnNames)
+}
+
+func summaryInstallRelatedTests(curr, prev sippyprocessingv1.TestReport, numDays int, release string) string {
 	// test name | bug | pass rate | higher/lower | pass rate
 	s := fmt.Sprintf(`
 	<table class="table">
 		<tr>
-			<th colspan=%d class="text-center"><a class="text-dark" title="Operator installation, sorted by passing rate.  The link will prepopulate a BZ template to be filled out and submitted to report a bug against the test." id="InstallRatesByOperator" href="#InstallRatesByOperator">Install Rates by Operator</a></th>
+			<th colspan=5 class="text-center"><a class="text-dark" title="Install related tests, sorted by passing rate.  The link will prepopulate a BZ template to be filled out and submitted to report a bug against the test." id="InstallRelatedTests" href="#InstallRelatedTests">Install Related Tests</a></th>
 		</tr>
-	`,
-		len(curr.ByPlatform)+2)
+		<tr>
+			<th colspan=2/><th class="text-center">Latest %d Days</th><th/><th class="text-center">Previous 7 Days</th>
+		</tr>
+		<tr>
+			<th>Test Name</th><th>File a Bug</th><th>Pass Rate</th><th/><th>Pass Rate</th>
+		</tr>
+	`, numDays)
 
-	operatorTests := map[string]*currPrevFailedTestResult{}
-	for _, test := range curr.ByTest {
-		if strings.HasPrefix(test.TestName, testgridanalysisapi.OperatorInstallPrefix) && test.TestResultAcrossAllJobs.Failures > 0 {
-			operatorTests[test.TestName] = &currPrevFailedTestResult{curr: test}
-			if prevTestResult := util.FindFailedTestResult(test.TestName, prev.ByTest); prevTestResult != nil {
-				operatorTests[test.TestName].prev = prevTestResult
-			}
-		}
-	}
-
-	// now that we have the tests, let's run through all the platforms to pull the platform aggregation for each of the tests in question
-	operatorTestsToPlatformToTestResult := map[string]map[string]*currPrevTestResult{}
-	for testName := range operatorTests {
-		if _, ok := operatorTestsToPlatformToTestResult[testName]; !ok {
-			operatorTestsToPlatformToTestResult[testName] = map[string]*currPrevTestResult{}
-		}
-		for _, platform := range curr.ByPlatform {
-			for _, test := range platform.AllTestResults {
-				if test.Name != testName {
-					continue
-				}
-
-				operatorTestsToPlatformToTestResult[testName][platform.PlatformName] = &currPrevTestResult{curr: test}
-				if prevPlatform := util.FindPlatformResultsForName(platform.PlatformName, prev.ByPlatform); prevPlatform != nil {
-					if prevTestResult := util.FindTestResult(test.Name, prevPlatform.AllTestResults); prevTestResult != nil {
-						operatorTestsToPlatformToTestResult[testName][platform.PlatformName].prev = prevTestResult
-					}
-				}
-				break
-			}
-		}
-	}
-
-	platformToInstallTestResult := map[string]*currPrevTestResult{}
-	for _, platform := range curr.ByPlatform {
-		for _, test := range platform.AllTestResults {
-			if test.Name == testgridanalysisapi.InstallTestName {
-				platformToInstallTestResult[platform.PlatformName] = &currPrevTestResult{curr: test}
-
-				if prevPlatform := util.FindPlatformResultsForName(platform.PlatformName, prev.ByPlatform); prevPlatform != nil {
-					if prevTestResult := util.FindTestResult(test.Name, prevPlatform.AllTestResults); prevTestResult != nil {
-						platformToInstallTestResult[platform.PlatformName].prev = prevTestResult
-					}
-				}
-				break
-			}
-		}
-	}
-	// print platform column headers
-	s += "    <tr>"
-	s += "      <td nowrap=\"nowrap\"></td>\n"
-	s += "      <th nowrap=\"nowrap\" class=\"text-center\">All</th>\n"
-	for _, platformName := range testidentification.AllPlatforms.List() {
-		s += "      <th class=\"text-center\"><nobr>" + platformName + "</nobr></th>\n"
-	}
-	s += "		</tr>\n"
-
-	// now the overall install results by platform
-	s += "    <tr>"
-	s += "      <td>Overall</td>\n"
-	s += installCellHTMLFromFailedTestResult(&currPrevFailedTestResult{
-		curr: *util.FindFailedTestResult(testgridanalysisapi.InstallTestName, curr.ByTest),
-		prev: util.FindFailedTestResult(testgridanalysisapi.InstallTestName, prev.ByTest),
-	}, generichtml.OverallInstallUpgradeColors)
-	for _, platformName := range testidentification.AllPlatforms.List() {
-		s += installCellHTMLFromTestResult(platformToInstallTestResult[platformName], generichtml.OverallInstallUpgradeColors)
-	}
-	s += "		</tr>"
-
-	// now the main results by operator, by platform
-	for _, testName := range sets.StringKeySet(operatorTests).List() {
-		operatorName := strings.SplitN(testName, " ", 3)[2] // We happen to know the shape of this test name
-		s += "    <tr>"
-		s += "      <td class=\"\"><nobr>" + operatorName + "</nobr></td>\n"
-		s += installCellHTMLFromFailedTestResult(operatorTests[testName], individualInstallUpgradeColor)
-		platformResults := operatorTestsToPlatformToTestResult[testName]
-		for _, platformName := range testidentification.AllPlatforms.List() {
-			s += installCellHTMLFromTestResult(platformResults[platformName], individualInstallUpgradeColor)
-		}
-		s += "		</tr>"
-	}
+	s += failingTestsRows(curr.ByTest, prev.ByTest, release, isInstallRelatedTest)
 
 	s = s + "</table>"
 
 	return s
 }
 
-func installCellHTMLFromTestResult(cellResult *currPrevTestResult, colors generichtml.ColorizationCriteria) string {
-	if cellResult == nil {
-		// we filter out 100% passing results, so this almost certainly means we always pass.  We default to 100
-		passPercentage := 100.0
-		arrow := generichtml.Flat
-		color := colors.GetColor(passPercentage)
-		return fmt.Sprintf("      <td class=\"text-center %v\"><nobr>%0.2f%% %v NA</nobr></td>", color, passPercentage, arrow)
+func isInstallRelatedTest(testResult sippyprocessingv1.TestResult) bool {
+	if testgridanalysisapi.OperatorConditionsTestCaseName.MatchString(testResult.Name) {
+		return true
+	}
+	if strings.Contains(testResult.Name, testgridanalysisapi.InstallTestName) {
+		return true
+	}
+	if strings.Contains(testResult.Name, testgridanalysisapi.InstallTimeoutTestName) {
+		return true
 	}
 
-	// we filter out 100% passing results, so this almost certainly means we always pass.  We default to 100
-	passPercentage := cellResult.curr.PassPercentage
-	arrow := generichtml.GetArrowForTestResult(cellResult.curr, cellResult.prev)
-	color := colors.GetColor(passPercentage)
-	if cellResult.prev == nil {
-		return fmt.Sprintf("      <td class=\"text-center %v\"><nobr>%0.2f%% %v NA</nobr></td>", color, passPercentage, arrow)
-	}
+	return false
 
-	return fmt.Sprintf("      <td class=\"text-center %v\"><nobr>%0.2f%% %v %0.2f%% </nobr></td>", color, passPercentage, arrow, cellResult.prev.PassPercentage)
-}
-
-func installCellHTMLFromFailedTestResult(cellResult *currPrevFailedTestResult, colors generichtml.ColorizationCriteria) string {
-	var prevTestResult *sippyprocessingv1.TestResult
-	if cellResult.prev != nil {
-		prevTestResult = &cellResult.prev.TestResultAcrossAllJobs
-	}
-	testResultCell := currPrevTestResult{
-		curr: cellResult.curr.TestResultAcrossAllJobs,
-		prev: prevTestResult,
-	}
-	return installCellHTMLFromTestResult(&testResultCell, colors)
 }

--- a/pkg/html/installhtml/install_html.go
+++ b/pkg/html/installhtml/install_html.go
@@ -1,0 +1,57 @@
+package installhtml
+
+import (
+	"fmt"
+	"net/http"
+
+	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+	"github.com/openshift/sippy/pkg/html/generichtml"
+)
+
+var (
+	installTopPageHtml = `
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+<style>
+#table td, #table th {
+	border:
+}
+</style>
+
+<h1 class=text-center>Release %s Install Dashboard</h1>
+
+<p class="small mb-3 text-nowrap">
+	Jump to: <a href="#InstallRatesByOperator">Install Rates by Operator</a> | <a href="#InstallRelatedTests">Install Related Tests</a>
+</p>
+
+`
+)
+
+func PrintInstallHtmlReport(w http.ResponseWriter, req *http.Request, report, prevReport sippyprocessingv1.TestReport, numDays int, release string) {
+	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
+	fmt.Fprintf(w, generichtml.HTMLPageStart, "Release "+release+" Install Dashboard")
+	if len(prevReport.AnalysisWarnings)+len(report.AnalysisWarnings) > 0 {
+		warningsHTML := ""
+		for _, analysisWarning := range prevReport.AnalysisWarnings {
+			warningsHTML += "<p>" + analysisWarning + "</p>\n"
+		}
+		for _, analysisWarning := range report.AnalysisWarnings {
+			warningsHTML += "<p>" + analysisWarning + "</p>\n"
+		}
+		fmt.Fprintf(w, generichtml.WarningHeader, warningsHTML)
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, installTopPageHtml, release)
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w)
+	fmt.Fprint(w, installOperatorTests(report, prevReport))
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w)
+	fmt.Fprint(w, summaryInstallRelatedTests(report, prevReport, numDays, release))
+	fmt.Fprintln(w)
+
+	//w.Write(result)
+	fmt.Fprintf(w, generichtml.HTMLPageEnd, report.Timestamp.Format("Jan 2 15:04 2006 MST"))
+}

--- a/pkg/html/installhtml/upgrade_by_operators.go
+++ b/pkg/html/installhtml/upgrade_by_operators.go
@@ -1,0 +1,116 @@
+package installhtml
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/sippy/pkg/html/generichtml"
+
+	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+	"github.com/openshift/sippy/pkg/testgridanalysis/testgridanalysisapi"
+	"github.com/openshift/sippy/pkg/util"
+	"github.com/openshift/sippy/pkg/util/sets"
+)
+
+func upgradeOperatorTests(curr, prev sippyprocessingv1.TestReport) string {
+	dataForTestsByPlatform := getDataForTestsByPlatform(
+		curr, prev,
+		func(testResult sippyprocessingv1.TestResult) bool {
+			return strings.HasPrefix(testResult.Name, testgridanalysisapi.OperatorUpgradePrefix)
+		},
+		func(testResult sippyprocessingv1.TestResult) bool {
+			return testResult.Name == testgridanalysisapi.UpgradeTestName
+		},
+	)
+	// compute platform columns before we add the special "All" column
+	platformColumns := sets.StringKeySet(dataForTestsByPlatform.aggregationToOverallTestResult).List()
+
+	// we add an "All" column for all platforms. Fill in the aggregate data for that key
+	for _, testName := range sets.StringKeySet(dataForTestsByPlatform.aggregateResultByTestName).List() {
+		dataForTestsByPlatform.testNameToPlatformToTestResult[testName]["All"] = dataForTestsByPlatform.aggregateResultByTestName[testName].toCurrPrevTestResult()
+	}
+
+	// fill in the data for the first row's "All" column
+	var prevTestResult *sippyprocessingv1.TestResult
+	if installTest := util.FindFailedTestResult(testgridanalysisapi.UpgradeTestName, prev.ByTest); installTest != nil {
+		prevTestResult = &installTest.TestResultAcrossAllJobs
+	}
+	dataForTestsByPlatform.aggregationToOverallTestResult["All"] = &currPrevTestResult{
+		curr: util.FindFailedTestResult(testgridanalysisapi.UpgradeTestName, curr.ByTest).TestResultAcrossAllJobs,
+		prev: prevTestResult,
+	}
+
+	columnNames := append([]string{"All"}, platformColumns...)
+
+	return dataForTestsByPlatform.getTableHTML("Upgrade Rates by Operator", "UpgradeRatesByOperator", "Upgrade Rates by Operator by Platform", columnNames)
+}
+
+func summaryUpgradeRelatedTests(curr, prev sippyprocessingv1.TestReport, numDays int, release string) string {
+	// test name | bug | pass rate | higher/lower | pass rate
+	s := fmt.Sprintf(`
+	<table class="table">
+		<tr>
+			<th colspan=5 class="text-center"><a class="text-dark" title="Upgrade related tests, sorted by passing rate.  The link will prepopulate a BZ template to be filled out and submitted to report a bug against the test." id="UpgradeRelatedTests" href="#UpgradeRelatedTests">Upgrade Related Tests</a></th>
+		</tr>
+		<tr>
+			<th colspan=2/><th class="text-center">Latest %d Days</th><th/><th class="text-center">Previous 7 Days</th>
+		</tr>
+		<tr>
+			<th>Test Name</th><th>File a Bug</th><th>Pass Rate</th><th/><th>Pass Rate</th>
+		</tr>
+	`, numDays)
+
+	s += failingTestsRows(curr.ByTest, prev.ByTest, release, isUpgradeRelatedTest)
+
+	s = s + "</table>"
+
+	return s
+}
+
+func isUpgradeRelatedTest(testResult sippyprocessingv1.TestResult) bool {
+	if strings.HasPrefix(testResult.Name, testgridanalysisapi.OperatorUpgradePrefix) {
+		return true
+	}
+	if strings.Contains(testResult.Name, testgridanalysisapi.UpgradeTestName) {
+		return true
+	}
+	if strings.Contains(testResult.Name, `[sig-cluster-lifecycle] Cluster version operator acknowledges upgrade`) {
+		return true
+	}
+	if strings.Contains(testResult.Name, `[sig-cluster-lifecycle] cluster upgrade should be fast`) {
+		return true
+	}
+	if strings.Contains(testResult.Name, `APIs remain available`) {
+		return true
+	}
+
+	return false
+
+}
+
+func summaryUpgradeRelatedJobs(report, reportPrev sippyprocessingv1.TestReport, numDays int, release string) string {
+	s := fmt.Sprintf(`
+	<table class="table">
+		<tr>
+			<th colspan=4 class="text-center"><a class="text-dark" title="Passing rate for each job upgrade definition, sorted by passing percentage.  Jobs at the top of this list are unreliable or represent environments where the product is not stable and should be investigated.  The pass rate in parenthesis is the pass rate for jobs that started to run the installer and got at least the bootstrap kube-apiserver up and running." id="UpgradeJobs" href="#UpgradeJobs">Upgrade Jobs</a></th>
+		</tr>
+		<tr>
+			<th>Name</th><th>Latest %d days</th><th/><th>Previous 7 days</th>
+		</tr>
+	`, numDays)
+
+	for _, currJobResult := range report.ByJob {
+		if !strings.Contains(currJobResult.Name, "-upgrade-") {
+			continue
+		}
+		prevJobResult := util.FindJobResultForJobName(currJobResult.Name, reportPrev.InfrequentJobResults)
+		jobHTML := generichtml.NewJobResultRendererFromJobResult("by-infrequent-job-name", currJobResult, release).
+			WithPreviousJobResult(prevJobResult).
+			ToHTML()
+
+		s += jobHTML
+	}
+
+	s = s + "</table>"
+	return s
+}

--- a/pkg/html/installhtml/upgrade_html.go
+++ b/pkg/html/installhtml/upgrade_html.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	topPageHtml = `
+	upgradeTopPageHtml = `
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 <style>
 #table td, #table th {
@@ -17,18 +17,18 @@ var (
 }
 </style>
 
-<h1 class=text-center>Release %s Install Dashboard</h1>
+<h1 class=text-center>Release %s upgrade Dashboard</h1>
 
 <p class="small mb-3 text-nowrap">
-	Jump to: <a href="#InstallRatesByOperator">Install Rates by Operator</a>
+	Jump to: <a href="#UpgradeRatesByOperator">Upgrade Rates by Operator</a> | <a href="#UpgradeRelatedTests">Upgrade Related Tests</a> | <a href="#UpgradeJobs">Upgrade Jobs</a> 
 </p>
 
 `
 )
 
-func PrintInstallHtmlReport(w http.ResponseWriter, req *http.Request, report, prevReport sippyprocessingv1.TestReport, release string) {
+func PrintUpgradeHtmlReport(w http.ResponseWriter, req *http.Request, report, prevReport sippyprocessingv1.TestReport, numDays int, release string) {
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
-	fmt.Fprintf(w, generichtml.HTMLPageStart, "Release "+release+" Install Dashboard")
+	fmt.Fprintf(w, generichtml.HTMLPageStart, "Release "+release+" Upgrade Dashboard")
 	if len(prevReport.AnalysisWarnings)+len(report.AnalysisWarnings) > 0 {
 		warningsHTML := ""
 		for _, analysisWarning := range prevReport.AnalysisWarnings {
@@ -41,11 +41,19 @@ func PrintInstallHtmlReport(w http.ResponseWriter, req *http.Request, report, pr
 	}
 
 	fmt.Fprintln(w)
-	fmt.Fprintf(w, topPageHtml, release)
+	fmt.Fprintf(w, upgradeTopPageHtml, release)
 	fmt.Fprintln(w)
 
 	fmt.Fprintln(w)
-	fmt.Fprint(w, installOperatorTests(report, prevReport))
+	fmt.Fprint(w, upgradeOperatorTests(report, prevReport))
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w)
+	fmt.Fprint(w, summaryUpgradeRelatedTests(report, prevReport, numDays, release))
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w)
+	fmt.Fprint(w, summaryUpgradeRelatedJobs(report, prevReport, numDays, release))
 	fmt.Fprintln(w)
 
 	//w.Write(result)

--- a/pkg/html/installhtml/util.go
+++ b/pkg/html/installhtml/util.go
@@ -1,0 +1,197 @@
+package installhtml
+
+import (
+	"fmt"
+	"strings"
+
+	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+	"github.com/openshift/sippy/pkg/html/generichtml"
+	"github.com/openshift/sippy/pkg/testgridanalysis/testreportconversion"
+	"github.com/openshift/sippy/pkg/util"
+	"github.com/openshift/sippy/pkg/util/sets"
+)
+
+var individualInstallUpgradeColor = generichtml.ColorizationCriteria{
+	MinRedPercent:    0,  // failure.  In this range, there is a systemic failure so severe that a reliable signal isn't available.
+	MinYellowPercent: 90, // at risk.  In this range, there is a systemic problem that needs to be addressed.
+	MinGreenPercent:  95, // no action required.
+}
+
+type currPrevTestResult struct {
+	curr sippyprocessingv1.TestResult
+	prev *sippyprocessingv1.TestResult
+}
+
+func (c *currPrevFailedTestResult) toCurrPrevTestResult() *currPrevTestResult {
+	if c == nil {
+		return nil
+	}
+	if c.prev == nil {
+		return &currPrevTestResult{curr: c.curr.TestResultAcrossAllJobs}
+	}
+	return &currPrevTestResult{
+		curr: c.curr.TestResultAcrossAllJobs,
+		prev: &c.prev.TestResultAcrossAllJobs,
+	}
+}
+
+type currPrevFailedTestResult struct {
+	curr sippyprocessingv1.FailingTestResult
+	prev *sippyprocessingv1.FailingTestResult
+}
+
+type testsByPlatform struct {
+	aggregateResultByTestName      map[string]*currPrevFailedTestResult
+	testNameToPlatformToTestResult map[string]map[string]*currPrevTestResult // these are the other rows in the table.
+	aggregationToOverallTestResult map[string]*currPrevTestResult            // this is the first row of the table, summarizing all data.  If empty or nil, no summary is given.
+}
+
+func getDataForTestsByPlatform(curr, prev sippyprocessingv1.TestReport, isInterestingTest testreportconversion.TestResultFilterFunc, isAggregateTest testreportconversion.TestResultFilterFunc) testsByPlatform {
+	ret := testsByPlatform{
+		aggregateResultByTestName:      map[string]*currPrevFailedTestResult{},
+		testNameToPlatformToTestResult: map[string]map[string]*currPrevTestResult{},
+		aggregationToOverallTestResult: map[string]*currPrevTestResult{},
+	}
+
+	for _, test := range curr.ByTest {
+		if isInterestingTest(test.TestResultAcrossAllJobs) {
+			ret.aggregateResultByTestName[test.TestName] = &currPrevFailedTestResult{curr: test}
+			if prevTestResult := util.FindFailedTestResult(test.TestName, prev.ByTest); prevTestResult != nil {
+				ret.aggregateResultByTestName[test.TestName].prev = prevTestResult
+			}
+		}
+	}
+
+	// now that we have the tests, let's run through all the platforms to pull the platform aggregation for each of the tests in question
+	for testName := range ret.aggregateResultByTestName {
+		if _, ok := ret.testNameToPlatformToTestResult[testName]; !ok {
+			ret.testNameToPlatformToTestResult[testName] = map[string]*currPrevTestResult{}
+		}
+		for _, platform := range curr.ByPlatform {
+			for _, test := range platform.AllTestResults {
+				if test.Name != testName {
+					continue
+				}
+
+				ret.testNameToPlatformToTestResult[testName][platform.PlatformName] = &currPrevTestResult{curr: test}
+				if prevPlatform := util.FindPlatformResultsForName(platform.PlatformName, prev.ByPlatform); prevPlatform != nil {
+					if prevTestResult := util.FindTestResult(test.Name, prevPlatform.AllTestResults); prevTestResult != nil {
+						ret.testNameToPlatformToTestResult[testName][platform.PlatformName].prev = prevTestResult
+					}
+				}
+				break
+			}
+		}
+	}
+
+	for _, platform := range curr.ByPlatform {
+		for _, test := range platform.AllTestResults {
+			if isAggregateTest(test) {
+				ret.aggregationToOverallTestResult[platform.PlatformName] = &currPrevTestResult{curr: test}
+
+				if prevPlatform := util.FindPlatformResultsForName(platform.PlatformName, prev.ByPlatform); prevPlatform != nil {
+					if prevTestResult := util.FindTestResult(test.Name, prevPlatform.AllTestResults); prevTestResult != nil {
+						ret.aggregationToOverallTestResult[platform.PlatformName].prev = prevTestResult
+					}
+				}
+				break
+			}
+		}
+	}
+
+	return ret
+}
+
+func (a testsByPlatform) getTableHTML(
+	title string,
+	anchor string,
+	description string,
+	aggregationNames []string, // these are the columns
+) string {
+	// test name | bug | pass rate | higher/lower | pass rate
+	s := fmt.Sprintf(`
+	<table class="table">
+		<tr>
+			<th colspan=%d class="text-center"><a class="text-dark" title=%q id="%s" href="#%s">%s</a></th>
+		</tr>
+	`,
+		len(aggregationNames)+2,
+		description,
+		anchor,
+		anchor,
+		title,
+	)
+
+	// print platform column headers
+	s += "    <tr>"
+	s += "      <td nowrap=\"nowrap\"></td>\n"
+	for _, platformName := range aggregationNames {
+		s += "      <th class=\"text-center\"><nobr>" + platformName + "</nobr></th>\n"
+	}
+	s += "		</tr>\n"
+
+	// now the overall install results by platform
+	if len(a.aggregationToOverallTestResult) > 0 {
+		s += "    <tr>"
+		s += "      <td>Overall</td>\n"
+		for _, platformName := range aggregationNames {
+			s += installCellHTMLFromTestResult(a.aggregationToOverallTestResult[platformName], generichtml.OverallInstallUpgradeColors)
+		}
+		s += "		</tr>"
+	}
+
+	// now the main results by operator, by platform
+	for _, testName := range sets.StringKeySet(a.testNameToPlatformToTestResult).List() {
+		operatorName := strings.SplitN(testName, " ", 3)[2] // We happen to know the shape of this test name
+		s += "    <tr>"
+		s += "      <td class=\"\"><nobr>" + operatorName + "</nobr></td>\n"
+		platformResults := a.testNameToPlatformToTestResult[testName]
+		for _, platformName := range aggregationNames {
+			s += installCellHTMLFromTestResult(platformResults[platformName], individualInstallUpgradeColor)
+		}
+		s += "		</tr>"
+	}
+
+	s = s + "</table>"
+
+	return s
+}
+
+func installCellHTMLFromTestResult(cellResult *currPrevTestResult, colors generichtml.ColorizationCriteria) string {
+	if cellResult == nil {
+		// we filter out 100% passing results, so this almost certainly means we always pass.  We default to 100
+		passPercentage := 100.0
+		//arrow := generichtml.Flat
+		color := colors.GetColor(passPercentage)
+		return fmt.Sprintf("      <td class=\"text-center %v\"><nobr>no-data</nobr></td>", color)
+	}
+
+	// we filter out 100% passing results, so this almost certainly means we always pass.  We default to 100
+	passPercentage := cellResult.curr.PassPercentage
+	arrow := generichtml.GetArrowForTestResult(cellResult.curr, cellResult.prev)
+	color := colors.GetColor(passPercentage)
+	if cellResult.prev == nil {
+		return fmt.Sprintf("      <td class=\"text-center %v\"><nobr>%0.2f%% %v NA</nobr></td>", color, passPercentage, arrow)
+	}
+
+	return fmt.Sprintf("      <td class=\"text-center %v\"><nobr>%0.2f%% %v %0.2f%% </nobr></td>", color, passPercentage, arrow, cellResult.prev.PassPercentage)
+}
+
+type testFilterFunc func(testResult sippyprocessingv1.TestResult) bool
+
+func failingTestsRows(topFailingTests, prevTests []sippyprocessingv1.FailingTestResult, release string, testFilterFn testFilterFunc) string {
+	s := ""
+
+	for _, testResult := range topFailingTests {
+		if !testFilterFn(testResult.TestResultAcrossAllJobs) {
+			continue
+		}
+
+		s = s +
+			generichtml.NewTestResultRendererForFailedTestResult("", testResult, release).
+				WithPreviousFailedTestResult(util.FindFailedTestResult(testResult.TestName, prevTests)).
+				ToHTML()
+	}
+
+	return s
+}

--- a/pkg/html/releasehtml/failing_bzcomponents.go
+++ b/pkg/html/releasehtml/failing_bzcomponents.go
@@ -34,10 +34,10 @@ func summaryJobsFailuresByBugzillaComponent(report, reportPrev sippyprocessingv1
 	for _, bugzillaComponentResult := range failuresByBugzillaComponent {
 		prev := util.FindBugzillaJobFailures(bugzillaComponentResult.Name, failuresByBugzillaComponentPrev)
 
-		bugzillaComponentHTML := newJobAggregationResultRendererFromBugzillaComponentResult("by-bugzilla-component", bugzillaComponentResult, release).
-			withColors(colors).
-			withPreviousBugzillaComponentResult(prev).
-			toHTML()
+		bugzillaComponentHTML := generichtml.NewJobAggregationResultRendererFromBugzillaComponentResult("by-bugzilla-component", bugzillaComponentResult, release).
+			WithColors(colors).
+			WithPreviousBugzillaComponentResult(prev).
+			ToHTML()
 
 		s += bugzillaComponentHTML
 	}

--- a/pkg/html/releasehtml/failing_tests.go
+++ b/pkg/html/releasehtml/failing_tests.go
@@ -3,6 +3,8 @@ package releasehtml
 import (
 	"fmt"
 
+	"github.com/openshift/sippy/pkg/html/generichtml"
+
 	"github.com/openshift/sippy/pkg/util"
 
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
@@ -93,9 +95,9 @@ func topFailingTestsRows(topFailingTests, prevTests []sippyprocessingv1.FailingT
 		testPrev := util.FindFailedTestResult(testResult.TestName, prevTests)
 
 		s = s +
-			newTestResultRendererForFailedTestResult("", testResult, release).
-				withPreviousFailedTestResult(testPrev).
-				toHTML()
+			generichtml.NewTestResultRendererForFailedTestResult("", testResult, release).
+				WithPreviousFailedTestResult(testPrev).
+				ToHTML()
 	}
 
 	s = s + "</table>"

--- a/pkg/html/releasehtml/fastest_moving_jobs.go
+++ b/pkg/html/releasehtml/fastest_moving_jobs.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/openshift/sippy/pkg/html/generichtml"
+
 	"github.com/openshift/sippy/pkg/testgridanalysis/testreportconversion"
 
 	"github.com/openshift/sippy/pkg/util"
@@ -64,10 +66,10 @@ func summaryTopNegativelyMovingJobs(twoDaysJobs, prevJobs []sippyprocessingv1.Jo
 		currJobResult = testreportconversion.FilterJobResultTests(currJobResult, testFilterFn)
 		prevJobResult = testreportconversion.FilterJobResultTests(prevJobResult, testFilterFn)
 
-		jobHTML := newJobResultRendererFromJobResult("by-job-name", *currJobResult, release).
-			withMaxTestResultsToShow(jobTestCount).
-			withPreviousJobResult(prevJobResult).
-			toHTML()
+		jobHTML := generichtml.NewJobResultRendererFromJobResult("by-job-name", *currJobResult, release).
+			WithMaxTestResultsToShow(jobTestCount).
+			WithPreviousJobResult(prevJobResult).
+			ToHTML()
 
 		s += jobHTML
 	}

--- a/pkg/html/releasehtml/html.go
+++ b/pkg/html/releasehtml/html.go
@@ -119,22 +119,16 @@ func summaryJobsByPlatform(report, reportPrev sippyprocessingv1.TestReport, numD
 	`, numDays)
 
 	for _, currPlatform := range report.ByPlatform {
-		platformHTML := newJobAggregationResultRendererFromPlatformResults("by-variant", currPlatform, release).
-			withMaxTestResultsToShow(jobTestCount).
-			withPreviousPlatformResults(util.FindPlatformResultsForName(currPlatform.PlatformName, reportPrev.ByPlatform)).
-			toHTML()
+		platformHTML := generichtml.NewJobAggregationResultRendererFromPlatformResults("by-variant", currPlatform, release).
+			WithMaxTestResultsToShow(jobTestCount).
+			WithPreviousPlatformResults(util.FindPlatformResultsForName(currPlatform.PlatformName, reportPrev.ByPlatform)).
+			ToHTML()
 
 		s += platformHTML
 	}
 
 	s = s + "</table>"
 	return s
-}
-
-// testName is the non-encoded test.Name
-func testToSearchURL(testName string) string {
-	encodedTestName := url.QueryEscape(regexp.QuoteMeta(testName))
-	return fmt.Sprintf("https://search.ci.openshift.org/?maxAge=168h&context=1&type=bug%%2Bjunit&name=&maxMatches=5&maxBytes=20971520&groupBy=job&search=%s", encodedTestName)
 }
 
 func summaryFrequentJobPassRatesByJobName(report, reportPrev sippyprocessingv1.TestReport, release string, numDays, jobTestCount int) string {
@@ -150,10 +144,10 @@ func summaryFrequentJobPassRatesByJobName(report, reportPrev sippyprocessingv1.T
 
 	for _, currJobResult := range report.FrequentJobResults {
 		prevJobResult := util.FindJobResultForJobName(currJobResult.Name, reportPrev.FrequentJobResults)
-		jobHTML := newJobResultRendererFromJobResult("by-job-name", currJobResult, release).
-			withMaxTestResultsToShow(jobTestCount).
-			withPreviousJobResult(prevJobResult).
-			toHTML()
+		jobHTML := generichtml.NewJobResultRendererFromJobResult("by-job-name", currJobResult, release).
+			WithMaxTestResultsToShow(jobTestCount).
+			WithPreviousJobResult(prevJobResult).
+			ToHTML()
 
 		s += jobHTML
 	}
@@ -175,10 +169,10 @@ func summaryInfrequentJobPassRatesByJobName(report, reportPrev sippyprocessingv1
 
 	for _, currJobResult := range report.InfrequentJobResults {
 		prevJobResult := util.FindJobResultForJobName(currJobResult.Name, reportPrev.InfrequentJobResults)
-		jobHTML := newJobResultRendererFromJobResult("by-infrequent-job-name", currJobResult, release).
-			withMaxTestResultsToShow(jobTestCount).
-			withPreviousJobResult(prevJobResult).
-			toHTML()
+		jobHTML := generichtml.NewJobResultRendererFromJobResult("by-infrequent-job-name", currJobResult, release).
+			WithMaxTestResultsToShow(jobTestCount).
+			WithPreviousJobResult(prevJobResult).
+			ToHTML()
 
 		s += jobHTML
 	}

--- a/pkg/html/releasehtml/top_level_indicators.go
+++ b/pkg/html/releasehtml/top_level_indicators.go
@@ -17,7 +17,7 @@ func topLevelIndicators(report, reportPrev sippyprocessingv1.TestReport, release
 		<tr>
 			<th title="How often we get to the point of running the installer.  This is judged by whether a kube-apiserver is available, it's not perfect, but it's very close." class="text-center {{ .infraColor }}">Infrastructure</th>
 			<th title="How often the install completes successfully." class="text-center {{ .installColor }}"><a href="/install?release={{ .release }}">Install</a></th>
-			<th title="How often an upgrade that is started completes successfully." class="text-center {{ .upgradeColor }}">Upgrade</th>
+			<th title="How often an upgrade that is started completes successfully." class="text-center {{ .upgradeColor }}"><a href="/upgrade?release={{ .release }}">Upgrade</a></th>
 		</tr>
 		<tr>
 			<td class="text-center {{ .infraColor }}">{{ .infraHTML }}</td>

--- a/pkg/sippyserver/install_details.go
+++ b/pkg/sippyserver/install_details.go
@@ -15,6 +15,21 @@ func (s *Server) printInstallHtmlReport(w http.ResponseWriter, req *http.Request
 	installhtml.PrintInstallHtmlReport(w, req,
 		s.currTestReports[release].CurrentPeriodReport,
 		s.currTestReports[release].PreviousWeekReport,
+		s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.NumDays,
+		release,
+	)
+}
+
+func (s *Server) printUpgradeHtmlReport(w http.ResponseWriter, req *http.Request) {
+	release := req.URL.Query().Get("release")
+	if _, ok := s.currTestReports[release]; !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	installhtml.PrintUpgradeHtmlReport(w, req,
+		s.currTestReports[release].CurrentPeriodReport,
+		s.currTestReports[release].PreviousWeekReport,
+		s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.NumDays,
 		release,
 	)
 }

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -197,6 +197,7 @@ func (s *Server) detailed(w http.ResponseWriter, req *http.Request) {
 func (s *Server) Serve() {
 	http.DefaultServeMux.HandleFunc("/", s.printHtmlReport)
 	http.DefaultServeMux.HandleFunc("/install", s.printInstallHtmlReport)
+	http.DefaultServeMux.HandleFunc("/upgrade", s.printUpgradeHtmlReport)
 	http.DefaultServeMux.HandleFunc("/json", s.printJSONReport)
 	http.DefaultServeMux.HandleFunc("/detailed", s.detailed)
 	http.DefaultServeMux.HandleFunc("/refresh", s.refresh)

--- a/pkg/testgridanalysis/testreportconversion/by_platform.go
+++ b/pkg/testgridanalysis/testreportconversion/by_platform.go
@@ -11,7 +11,7 @@ import (
 // convertRawDataToByPlatform takes the raw data and produces a map of platform names to job and test results
 func convertRawDataToByPlatform(
 	allJobResults []sippyprocessingv1.JobResult,
-	testResultFilterFn testResultFilterFunc,
+	testResultFilterFn TestResultFilterFunc,
 ) []sippyprocessingv1.PlatformResults {
 
 	platformResults := []sippyprocessingv1.PlatformResults{}
@@ -41,7 +41,7 @@ func convertRawDataToByPlatform(
 			jobResults = append(jobResults, jobResult)
 		}
 
-		filteredPlatformTestResults := testResultFilterFn.filterTestResults(allPlatformTestResults)
+		filteredPlatformTestResults := testResultFilterFn.FilterTestResults(allPlatformTestResults)
 		sort.Stable(jobsByPassPercentage(jobResults))
 
 		platformResults = append(platformResults, sippyprocessingv1.PlatformResults{

--- a/pkg/testgridanalysis/testreportconversion/by_tests.go
+++ b/pkg/testgridanalysis/testreportconversion/by_tests.go
@@ -11,13 +11,13 @@ import (
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 )
 
-func getTopFailingTestsWithBug(testResultsByName testResultsByName, testResultFilterFn testResultFilterFunc) []sippyprocessingv1.FailingTestResult {
+func getTopFailingTestsWithBug(testResultsByName testResultsByName, testResultFilterFn TestResultFilterFunc) []sippyprocessingv1.FailingTestResult {
 	return getTopFailingTests(testResultsByName, func(testResult sippyprocessingv1.TestResult) bool {
 		return len(testResult.BugList) > 0
 	}, testResultFilterFn)
 }
 
-func getTopFailingTestsWithoutBug(testResultsByName testResultsByName, testResultFilterFn testResultFilterFunc) []sippyprocessingv1.FailingTestResult {
+func getTopFailingTestsWithoutBug(testResultsByName testResultsByName, testResultFilterFn TestResultFilterFunc) []sippyprocessingv1.FailingTestResult {
 	return getTopFailingTests(testResultsByName, func(testResult sippyprocessingv1.TestResult) bool {
 		return len(testResult.BugList) == 0
 	}, testResultFilterFn)
@@ -133,7 +133,7 @@ type testFilterFunc func(sippyprocessingv1.TestResult) bool
 func getTopFailingTests(
 	testResultsByName testResultsByName,
 	testFilterFn testFilterFunc,
-	testResultFilterFn testResultFilterFunc,
+	testResultFilterFn TestResultFilterFunc,
 ) []sippyprocessingv1.FailingTestResult {
 
 	topTests := []sippyprocessingv1.FailingTestResult{}

--- a/pkg/testgridanalysis/testreportconversion/jobresult.go
+++ b/pkg/testgridanalysis/testreportconversion/jobresult.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/sippy/pkg/testgridanalysis/testgridanalysisapi"
 )
 
-func FilterJobResultTests(jobResult *sippyprocessingv1.JobResult, testFilterFn testResultFilterFunc) *sippyprocessingv1.JobResult {
+func FilterJobResultTests(jobResult *sippyprocessingv1.JobResult, testFilterFn TestResultFilterFunc) *sippyprocessingv1.JobResult {
 	if jobResult == nil {
 		return nil
 	}
@@ -28,13 +28,13 @@ func FilterJobResultTests(jobResult *sippyprocessingv1.JobResult, testFilterFn t
 func filterPertinentFrequentJobResults(
 	in []sippyprocessingv1.JobResult,
 	numberOfDaysOfData int, // number of days included in report.
-	testResultFilterFn testResultFilterFunc,
+	testResultFilterFn TestResultFilterFunc,
 ) []sippyprocessingv1.JobResult {
 	filtered := []sippyprocessingv1.JobResult{}
 
 	for _, job := range in {
 		if job.Successes+job.Failures > numberOfDaysOfData*3/2 /*time 1.5*/ {
-			job.TestResults = testResultFilterFn.filterTestResults(job.TestResults)
+			job.TestResults = testResultFilterFn.FilterTestResults(job.TestResults)
 			filtered = append(filtered, job)
 		}
 	}
@@ -45,13 +45,13 @@ func filterPertinentFrequentJobResults(
 func filterPertinentInfrequentJobResults(
 	in []sippyprocessingv1.JobResult,
 	numberOfDaysOfData int, // number of days included in report.
-	testResultFilterFn testResultFilterFunc,
+	testResultFilterFn TestResultFilterFunc,
 ) []sippyprocessingv1.JobResult {
 	filtered := []sippyprocessingv1.JobResult{}
 
 	for _, job := range in {
 		if job.Successes+job.Failures <= numberOfDaysOfData*3/2 /*time 1.5*/ {
-			job.TestResults = testResultFilterFn.filterTestResults(job.TestResults)
+			job.TestResults = testResultFilterFn.FilterTestResults(job.TestResults)
 			filtered = append(filtered, job)
 		}
 	}


### PR DESCRIPTION
Adds an endpoint at /upgrades?release=4.6 to show an upgrade job table (like the install table) and includes upgrade related tests and upgrade jobs.  It's a nice view for targeting upgrades specifically.