### PR TITLE
refine data for upgrades

### DIFF
--- a/pkg/html/installhtml/install_by_operators.go
+++ b/pkg/html/installhtml/install_by_operators.go
@@ -43,7 +43,7 @@ func installOperatorTests(curr, prev sippyprocessingv1.TestReport) string {
 
 	columnNames := append([]string{"All"}, platformColumns...)
 
-	return dataForTestsByPlatform.getTableHTML("Install Rates by Operator", "InstallRatesByOperator", "Install Rates by Operator by Platform", columnNames)
+	return dataForTestsByPlatform.getTableHTML("Install Rates by Operator", "InstallRatesByOperator", "Install Rates by Operator by Platform", columnNames, getOperatorFromTest)
 }
 
 func summaryInstallRelatedTests(curr, prev sippyprocessingv1.TestReport, numDays int, release string) string {

--- a/pkg/html/installhtml/upgrade_by_operators.go
+++ b/pkg/html/installhtml/upgrade_by_operators.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openshift/sippy/pkg/testgridanalysis/testidentification"
+
 	"github.com/openshift/sippy/pkg/html/generichtml"
 
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
@@ -15,9 +17,7 @@ import (
 func upgradeOperatorTests(curr, prev sippyprocessingv1.TestReport) string {
 	dataForTestsByPlatform := getDataForTestsByPlatform(
 		curr, prev,
-		func(testResult sippyprocessingv1.TestResult) bool {
-			return strings.HasPrefix(testResult.Name, testgridanalysisapi.OperatorUpgradePrefix)
-		},
+		isUpgradeRelatedTest,
 		func(testResult sippyprocessingv1.TestResult) bool {
 			return testResult.Name == testgridanalysisapi.UpgradeTestName
 		},
@@ -42,7 +42,7 @@ func upgradeOperatorTests(curr, prev sippyprocessingv1.TestReport) string {
 
 	columnNames := append([]string{"All"}, platformColumns...)
 
-	return dataForTestsByPlatform.getTableHTML("Upgrade Rates by Operator", "UpgradeRatesByOperator", "Upgrade Rates by Operator by Platform", columnNames)
+	return dataForTestsByPlatform.getTableHTML("Upgrade Rates by Operator", "UpgradeRatesByOperator", "Upgrade Rates by Operator by Platform", columnNames, getOperatorFromTest)
 }
 
 func summaryUpgradeRelatedTests(curr, prev sippyprocessingv1.TestReport, numDays int, release string) string {
@@ -68,7 +68,7 @@ func summaryUpgradeRelatedTests(curr, prev sippyprocessingv1.TestReport, numDays
 }
 
 func isUpgradeRelatedTest(testResult sippyprocessingv1.TestResult) bool {
-	if strings.HasPrefix(testResult.Name, testgridanalysisapi.OperatorUpgradePrefix) {
+	if testidentification.IsUpgradeOperatorTest(testResult.Name) {
 		return true
 	}
 	if strings.Contains(testResult.Name, testgridanalysisapi.UpgradeTestName) {

--- a/pkg/html/installhtml/upgrade_html.go
+++ b/pkg/html/installhtml/upgrade_html.go
@@ -17,7 +17,7 @@ var (
 }
 </style>
 
-<h1 class=text-center>Release %s upgrade Dashboard</h1>
+<h1 class=text-center>Release %s Upgrade Dashboard</h1>
 
 <p class="small mb-3 text-nowrap">
 	Jump to: <a href="#UpgradeRatesByOperator">Upgrade Rates by Operator</a> | <a href="#UpgradeRelatedTests">Upgrade Related Tests</a> | <a href="#UpgradeJobs">Upgrade Jobs</a> 

--- a/pkg/testgridanalysis/testgridconversion/synthentic_tests.go
+++ b/pkg/testgridanalysis/testgridconversion/synthentic_tests.go
@@ -33,8 +33,11 @@ func createSyntheticTests(rawJobResults testgridanalysisapi.RawData) []string {
 			syntheticTests := map[string]*synthenticTestResult{
 				testgridanalysisapi.InstallTestName:        &synthenticTestResult{name: testgridanalysisapi.InstallTestName},
 				testgridanalysisapi.InstallTimeoutTestName: &synthenticTestResult{name: testgridanalysisapi.InstallTestName},
-				testgridanalysisapi.UpgradeTestName:        &synthenticTestResult{name: testgridanalysisapi.UpgradeTestName},
 				testgridanalysisapi.InfrastructureTestName: &synthenticTestResult{name: testgridanalysisapi.InfrastructureTestName},
+			}
+			// upgrades should only be indicated on jobs that run upgrades
+			if isUpgrade {
+				syntheticTests[testgridanalysisapi.UpgradeTestName] = &synthenticTestResult{name: testgridanalysisapi.UpgradeTestName}
 			}
 
 			hasSomeOperatorResults := len(jrr.SadOperators) > 0

--- a/pkg/testgridanalysis/testgridconversion/to_raw_data.go
+++ b/pkg/testgridanalysis/testgridconversion/to_raw_data.go
@@ -124,16 +124,14 @@ func processTestToJobRunResults(jobResult testgridanalysisapi.RawJobResult, job 
 				switch {
 				case test.Name == "Overall":
 					jrr.Succeeded = true
-				case testgridanalysisapi.OperatorConditionsTestCaseName.MatchString(test.Name):
-					matches := testgridanalysisapi.OperatorConditionsTestCaseName.FindStringSubmatch(test.Name)
-					operatorIndex := testgridanalysisapi.OperatorConditionsTestCaseName.SubexpIndex("operator")
+				case testidentification.IsInstallOperatorTest(test.Name):
 					jrr.SadOperators = append(jrr.SadOperators, testgridanalysisapi.OperatorState{
-						Name:  matches[operatorIndex],
+						Name:  testidentification.GetOperatorFromInstallTest(test.Name),
 						State: testgridanalysisapi.Success,
 					})
-				case strings.HasPrefix(test.Name, testgridanalysisapi.OperatorUpgradePrefix):
+				case testidentification.IsUpgradeOperatorTest(test.Name):
 					jrr.UpgradeOperators = append(jrr.UpgradeOperators, testgridanalysisapi.OperatorState{
-						Name:  test.Name[len(testgridanalysisapi.OperatorUpgradePrefix):],
+						Name:  testidentification.GetOperatorFromUpgradeTest(test.Name),
 						State: testgridanalysisapi.Success,
 					})
 				case testidentification.IsSetupContainerEquivalent(test.Name):
@@ -162,16 +160,14 @@ func processTestToJobRunResults(jobResult testgridanalysisapi.RawJobResult, job 
 				switch {
 				case test.Name == "Overall":
 					jrr.Failed = true
-				case testgridanalysisapi.OperatorConditionsTestCaseName.MatchString(test.Name):
-					matches := testgridanalysisapi.OperatorConditionsTestCaseName.FindStringSubmatch(test.Name)
-					operatorIndex := testgridanalysisapi.OperatorConditionsTestCaseName.SubexpIndex("operator")
+				case testidentification.IsInstallOperatorTest(test.Name):
 					jrr.SadOperators = append(jrr.SadOperators, testgridanalysisapi.OperatorState{
-						Name:  matches[operatorIndex],
+						Name:  testidentification.GetOperatorFromInstallTest(test.Name),
 						State: testgridanalysisapi.Failure,
 					})
-				case strings.HasPrefix(test.Name, testgridanalysisapi.OperatorUpgradePrefix):
+				case testidentification.IsUpgradeOperatorTest(test.Name):
 					jrr.UpgradeOperators = append(jrr.UpgradeOperators, testgridanalysisapi.OperatorState{
-						Name:  test.Name[len(testgridanalysisapi.OperatorUpgradePrefix):],
+						Name:  testidentification.GetOperatorFromUpgradeTest(test.Name),
 						State: testgridanalysisapi.Failure,
 					})
 				case testidentification.IsSetupContainerEquivalent(test.Name):

--- a/pkg/testgridanalysis/testreportconversion/by_component.go
+++ b/pkg/testgridanalysis/testreportconversion/by_component.go
@@ -2,7 +2,6 @@ package testreportconversion
 
 import (
 	"sort"
-	"strings"
 
 	"github.com/openshift/sippy/pkg/testgridanalysis/testidentification"
 
@@ -133,14 +132,12 @@ func getBugzillaComponentsFromTestResult(testResult sippyprocessingv1.TestResult
 
 	// If we didn't have a bug, use the test name itself to identify a likely victim/blame
 	switch {
-	case testgridanalysisapi.OperatorConditionsTestCaseName.MatchString(testResult.Name):
-		matches := testgridanalysisapi.OperatorConditionsTestCaseName.FindStringSubmatch(testResult.Name)
-		operatorIndex := testgridanalysisapi.OperatorConditionsTestCaseName.SubexpIndex("operator")
-		operatorName := matches[operatorIndex]
+	case testidentification.IsInstallOperatorTest(testResult.Name):
+		operatorName := testidentification.GetOperatorFromInstallTest(testResult.Name)
 		return []string{testidentification.GetBugzillaComponentForOperator(operatorName)}
 
-	case strings.HasPrefix(testResult.Name, testgridanalysisapi.OperatorUpgradePrefix):
-		operatorName := testResult.Name[len(testgridanalysisapi.OperatorUpgradePrefix):]
+	case testidentification.IsUpgradeOperatorTest(testResult.Name):
+		operatorName := testidentification.GetOperatorFromUpgradeTest(testResult.Name)
 		return []string{testidentification.GetBugzillaComponentForOperator(operatorName)}
 
 	default:

--- a/pkg/testgridanalysis/testreportconversion/testresult.go
+++ b/pkg/testgridanalysis/testreportconversion/testresult.go
@@ -3,7 +3,6 @@ package testreportconversion
 import (
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/openshift/sippy/pkg/testgridanalysis/testidentification"
 
@@ -127,10 +126,10 @@ func FilterLowValueTestsByName(testResult sippyprocessingv1.TestResult) bool {
 }
 
 func IsHighValueTestsByName(testResult sippyprocessingv1.TestResult) bool {
-	if testgridanalysisapi.OperatorConditionsTestCaseName.MatchString(testResult.Name) {
+	if testidentification.IsInstallOperatorTest(testResult.Name) {
 		return true
 	}
-	if strings.HasPrefix(testResult.Name, testgridanalysisapi.OperatorUpgradePrefix) {
+	if testidentification.IsUpgradeRelatedTest(testResult.Name) {
 		return true
 	}
 	return false


### PR DESCRIPTION
adding more data to the grid for upgrades.  It has made several things really pop out
1. apiserver availability is very high on all platforms except Azure
1. apiserver availability suddenly dropped on azure
3. the "wait for SDN to be available" was extremely helpful, but we need to add it for oauth-apiserver
4. cluster upgrades suddenly  (in the past week) got much slower on azure 
5. upgrades on aws suddenly got less reliable this past week
6. upgrades on gcp suddenly got less reliable this past week.

![Screenshot from 2020-10-07 16-55-48](https://user-images.githubusercontent.com/8225098/95387154-53f05580-08be-11eb-8bbc-e3bdd5362311.png)
