### PR TITLE
client: add simple sippy api go client

### DIFF
--- a/pkg/apis/sippy/v1/types.go
+++ b/pkg/apis/sippy/v1/types.go
@@ -2,6 +2,23 @@ package v1
 
 import bugsv1 "github.com/openshift/sippy/pkg/apis/bugs/v1"
 
+// ReleaseReportsMap contain multiple reports per specified release.
+// Used for JSON serialization.
+type ReleaseReportsMap map[string]*Report
+
+// Report contain a single release report returned from Sippy API.
+type Report struct {
+	CanaryTestFailures             []CanaryTestFailInstance      `json:"canaryTestFailures"`
+	FailureGroupings               *FailureGroups                `json:"failureGroupings"`
+	JobPassRateByPlatform          []JobSummaryPlatform          `json:"jobPassRateByPlatform"`
+	JobPassRatesByName             []PassRatesByJobName          `json:"jobPassRatesByName"`
+	JobRunsWithFailureGroups       []FailureGroup                `json:"jobRunsWithFailureGroups"`
+	MinimumJobPassRatesByComponent []MinimumPassRatesByComponent `json:"minimumJobPassRatesByComponent"`
+	TestImpactingBugs              []bugsv1.Bug                  `json:"testImpactingBugs"`
+	TopFailingTestsWithoutBug      []FailingTestBug              `json:"topFailingTestsWithoutBug"`
+	TopFailingTestsWithBug         []FailingTestBug              `json:"topFailingTestsWithBug"`
+}
+
 // PassRate describes statistics on a pass rate
 type PassRate struct {
 	Percentage          float64 `json:"percentage"`

--- a/pkg/client/sippy/v1/sippy_client.go
+++ b/pkg/client/sippy/v1/sippy_client.go
@@ -1,0 +1,80 @@
+package v1
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	sippyv1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
+)
+
+const defaultSippyAPIEndpoint = "https://sippy.ci.openshift.org/json"
+
+type ReleaseReportClient interface {
+	Release(name string) ReleaseReportInterface
+}
+
+type ReleaseReportInterface interface {
+	Report(ctx context.Context) (*sippyv1.Report, error)
+	ReportAll(ctx context.Context) (sippyv1.ReleaseReportsMap, error)
+}
+
+type releaseReportClient struct {
+	http.Client
+}
+
+// New returns a new Sippy (https://sippy.ci.openshift.org/json) API client
+func New() ReleaseReportClient {
+	return &releaseReportClient{http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}}
+}
+
+// Release returns an interface that allow to fetch report for specific openshift release.
+// The name format is "4.6", "4.5", etc...
+func (c *releaseReportClient) Release(name string) ReleaseReportInterface {
+	releaseUrl, _ := url.Parse(defaultSippyAPIEndpoint)
+	releaseQuery := releaseUrl.Query()
+	releaseQuery.Add("release", name)
+	releaseUrl.RawQuery = releaseQuery.Encode()
+	return &releaseReportInterface{
+		releaseUrl:          *releaseUrl,
+		releaseName:         name,
+		releaseReportClient: c,
+	}
+}
+
+type releaseReportInterface struct {
+	releaseUrl  url.URL
+	releaseName string
+	*releaseReportClient
+}
+
+func (c *releaseReportInterface) ReportAll(ctx context.Context) (sippyv1.ReleaseReportsMap, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.releaseUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	report := sippyv1.ReleaseReportsMap{}
+	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
+		return nil, err
+	}
+	return report, nil
+}
+
+// Report returns a single release report or HTTP error.
+func (c *releaseReportInterface) Report(ctx context.Context) (*sippyv1.Report, error) {
+	result, err := c.ReportAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return result[c.releaseName], nil
+}

--- a/pkg/client/sippy/v1/sippy_client_test.go
+++ b/pkg/client/sippy/v1/sippy_client_test.go
@@ -1,0 +1,20 @@
+package v1
+
+import (
+	"context"
+	"testing"
+)
+
+func TestReleaseReportClient(t *testing.T) {
+	c := New()
+	report, err := c.Release("4.6").Report(context.TODO())
+	if err != nil {
+		t.Fatalf("unable to fetch 4.6 report: %v", err)
+	}
+	if c := len(report.CanaryTestFailures); c == 0 {
+		t.Errorf("expected some canary test failures, got %d", c)
+	}
+	if c := len(report.JobPassRateByPlatform); c == 0 {
+		t.Errorf("expected job pass rates by platform, got %d", c)
+	}
+}


### PR DESCRIPTION
This add very simple client that can be used to query the release reports from sippy API. It has minimal dependencies and can be used by third party integrations (slack, dashboards, etc.).