### PR TITLE
show additional upgrade related tests

### DIFF
--- a/pkg/html/installhtml/upgrade_by_operators.go
+++ b/pkg/html/installhtml/upgrade_by_operators.go
@@ -68,24 +68,11 @@ func summaryUpgradeRelatedTests(curr, prev sippyprocessingv1.TestReport, numDays
 }
 
 func isUpgradeRelatedTest(testResult sippyprocessingv1.TestResult) bool {
-	if testidentification.IsUpgradeOperatorTest(testResult.Name) {
-		return true
-	}
-	if strings.Contains(testResult.Name, testgridanalysisapi.UpgradeTestName) {
-		return true
-	}
-	if strings.Contains(testResult.Name, `[sig-cluster-lifecycle] Cluster version operator acknowledges upgrade`) {
-		return true
-	}
-	if strings.Contains(testResult.Name, `[sig-cluster-lifecycle] cluster upgrade should be fast`) {
-		return true
-	}
-	if strings.Contains(testResult.Name, `APIs remain available`) {
-		return true
-	}
+	return testidentification.IsUpgradeRelatedTest(testResult.Name)
+}
 
+func neverMatch(testResult sippyprocessingv1.TestResult) bool {
 	return false
-
 }
 
 func summaryUpgradeRelatedJobs(report, reportPrev sippyprocessingv1.TestReport, numDays int, release string) string {

--- a/pkg/testgridanalysis/testidentification/test_identification.go
+++ b/pkg/testgridanalysis/testidentification/test_identification.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/openshift/sippy/pkg/testgridanalysis/testgridanalysisapi"
-
 	"github.com/openshift/sippy/pkg/util/sets"
 )
 
@@ -51,6 +50,7 @@ var curatedTestSubstrings = map[string][]string{
 		"pods should never transition back to pending",
 		"pods should successfully create sandboxes",
 		"upgrade should work",
+		"Cluster completes upgrade",
 	},
 }
 
@@ -96,9 +96,19 @@ func IsUpgradeRelatedTest(testName string) bool {
 		return true
 	}
 	if strings.Contains(testName, `[sig-cluster-lifecycle] Cluster version operator acknowledges upgrade`) {
+		// indicates that the CVO updated the clusterversion.status to indicate that it started work on a new payload
+		return true
+	}
+	if strings.Contains(testName, `[sig-cluster-lifecycle] Cluster completes upgrade`) {
+		// indicates every cluster operator upgraded successfully.  This does not include machine config pools
 		return true
 	}
 	if strings.Contains(testName, `[sig-cluster-lifecycle] cluster upgrade should be fast`) {
+		// indicates that every cluster operator upgraded withing X minutes (currently 75 as of today)
+		return true
+	}
+	if strings.Contains(testName, `[sig-mco] Machine config pools complete upgrade`) {
+		// indicates that all the machines restarted with new rhcos
 		return true
 	}
 	if strings.Contains(testName, `APIs remain available`) {


### PR DESCRIPTION
we were missing some that were added during 4.6 and refine "where did the upgrade fail".