### PR TITLE
add final operator health tests

### DIFF
--- a/pkg/apis/sippyprocessing/v1/types.go
+++ b/pkg/apis/sippyprocessing/v1/types.go
@@ -65,6 +65,8 @@ type TopLevelIndicators struct {
 	// Upgrade indicates how successful we are with upgrading onto clusters that have already installed.
 	// Low Upgrade pass rates means clusters are not able to upgrade.  This should stop us from shipping the product.
 	Upgrade FailingTestResult
+	// FinalOperatorState indicates how often test runs finish with every operator healthy
+	FinalOperatorHealth FailingTestResult
 }
 
 // PlatformResults

--- a/pkg/html/installhtml/finalhealth_by_operators.go
+++ b/pkg/html/installhtml/finalhealth_by_operators.go
@@ -1,0 +1,83 @@
+package installhtml
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/sippy/pkg/util"
+
+	"github.com/openshift/sippy/pkg/util/sets"
+
+	"github.com/openshift/sippy/pkg/testgridanalysis/testgridanalysisapi"
+
+	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+)
+
+func operatorHealthTests(curr, prev sippyprocessingv1.TestReport) string {
+	dataForTestsByPlatform := getDataForTestsByPlatform(
+		curr, prev,
+		isOperatorHealthRelatedTest,
+		isOperatorHealthOverallTest,
+	)
+	// compute platform columns before we add the special "All" column
+	platformColumns := sets.StringKeySet(dataForTestsByPlatform.aggregationToOverallTestResult).List()
+
+	// we add an "All" column for all platforms. Fill in the aggregate data for that key
+	for _, testName := range sets.StringKeySet(dataForTestsByPlatform.aggregateResultByTestName).List() {
+		dataForTestsByPlatform.testNameToPlatformToTestResult[testName]["All"] = dataForTestsByPlatform.aggregateResultByTestName[testName].toCurrPrevTestResult()
+	}
+
+	// fill in the data for the first row's "All" column
+	var prevTestResult *sippyprocessingv1.TestResult
+	if installTest := util.FindFailedTestResult(testgridanalysisapi.FinalOperatorHealthTestName, prev.ByTest); installTest != nil {
+		prevTestResult = &installTest.TestResultAcrossAllJobs
+	}
+	dataForTestsByPlatform.aggregationToOverallTestResult["All"] = &currPrevTestResult{
+		curr: util.FindFailedTestResult(testgridanalysisapi.FinalOperatorHealthTestName, curr.ByTest).TestResultAcrossAllJobs,
+		prev: prevTestResult,
+	}
+
+	columnNames := append([]string{"All"}, platformColumns...)
+
+	return dataForTestsByPlatform.getTableHTML("Operator Health by Operator", "OperatorHealthByOperator", "Operator Health by Operator by Platform", columnNames, getOperatorFromTest)
+}
+
+func summaryOperatorHealthRelatedTests(curr, prev sippyprocessingv1.TestReport, numDays int, release string) string {
+	// test name | bug | pass rate | higher/lower | pass rate
+	s := fmt.Sprintf(`
+	<table class="table">
+		<tr>
+			<th colspan=5 class="text-center"><a class="text-dark" title="Operator health related tests, sorted by passing rate.  The link will prepopulate a BZ template to be filled out and submitted to report a bug against the test." id="InstallRelatedTests" href="#InstallRelatedTests">Install Related Tests</a></th>
+		</tr>
+		<tr>
+			<th colspan=2/><th class="text-center">Latest %d Days</th><th/><th class="text-center">Previous 7 Days</th>
+		</tr>
+		<tr>
+			<th>Test Name</th><th>File a Bug</th><th>Pass Rate</th><th/><th>Pass Rate</th>
+		</tr>
+	`, numDays)
+
+	s += failingTestsRows(curr.ByTest, prev.ByTest, release, isOperatorHealthRelatedTest)
+
+	s = s + "</table>"
+
+	return s
+}
+
+func isOperatorHealthRelatedTest(testResult sippyprocessingv1.TestResult) bool {
+	if strings.HasPrefix(testResult.Name, testgridanalysisapi.OperatorFinalHealthPrefix) {
+		return true
+	}
+
+	return false
+
+}
+
+func isOperatorHealthOverallTest(testResult sippyprocessingv1.TestResult) bool {
+	if strings.Contains(testResult.Name, testgridanalysisapi.FinalOperatorHealthTestName) {
+		return true
+	}
+
+	return false
+
+}

--- a/pkg/html/installhtml/finalhealth_html.go
+++ b/pkg/html/installhtml/finalhealth_html.go
@@ -1,0 +1,57 @@
+package installhtml
+
+import (
+	"fmt"
+	"net/http"
+
+	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+	"github.com/openshift/sippy/pkg/html/generichtml"
+)
+
+var (
+	operatorHealthTopPageHtml = `
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+<style>
+#table td, #table th {
+	border:
+}
+</style>
+
+<h1 class=text-center>Release %s Install Dashboard</h1>
+
+<p class="small mb-3 text-nowrap">
+	Jump to: <a href="#OperatorHealthByOperator">Operator Health by Operator</a> | <a href="#OperatorHealthRelatedTests">Operator Health Related Tests</a>
+</p>
+
+`
+)
+
+func PrintOperatorHealthHtmlReport(w http.ResponseWriter, req *http.Request, report, prevReport sippyprocessingv1.TestReport, numDays int, release string) {
+	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
+	fmt.Fprintf(w, generichtml.HTMLPageStart, "Release "+release+" Install Dashboard")
+	if len(prevReport.AnalysisWarnings)+len(report.AnalysisWarnings) > 0 {
+		warningsHTML := ""
+		for _, analysisWarning := range prevReport.AnalysisWarnings {
+			warningsHTML += "<p>" + analysisWarning + "</p>\n"
+		}
+		for _, analysisWarning := range report.AnalysisWarnings {
+			warningsHTML += "<p>" + analysisWarning + "</p>\n"
+		}
+		fmt.Fprintf(w, generichtml.WarningHeader, warningsHTML)
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, operatorHealthTopPageHtml, release)
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w)
+	fmt.Fprint(w, operatorHealthTests(report, prevReport))
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w)
+	fmt.Fprint(w, summaryOperatorHealthRelatedTests(report, prevReport, numDays, release))
+	fmt.Fprintln(w)
+
+	//w.Write(result)
+	fmt.Fprintf(w, generichtml.HTMLPageEnd, report.Timestamp.Format("Jan 2 15:04 2006 MST"))
+}

--- a/pkg/html/installhtml/util.go
+++ b/pkg/html/installhtml/util.go
@@ -164,14 +164,10 @@ func (a testsByPlatform) getTableHTML(
 }
 
 func getOperatorFromTest(testName string) string {
-	switch {
-	case testidentification.IsInstallOperatorTest(testName):
-		return testidentification.GetOperatorFromInstallTest(testName)
-	case testidentification.IsUpgradeOperatorTest(testName):
-		return testidentification.GetOperatorFromUpgradeTest(testName)
-	default:
-		return testName
+	if ret := testidentification.GetOperatorNameFromTest(testName); len(ret) > 0 {
+		return ret
 	}
+	return testName
 }
 
 func installCellHTMLFromTestResult(cellResult *currPrevTestResult, colors generichtml.ColorizationCriteria) string {

--- a/pkg/html/releasehtml/top_level_indicators.go
+++ b/pkg/html/releasehtml/top_level_indicators.go
@@ -18,11 +18,14 @@ func topLevelIndicators(report, reportPrev sippyprocessingv1.TestReport, release
 			<th title="How often we get to the point of running the installer.  This is judged by whether a kube-apiserver is available, it's not perfect, but it's very close." class="text-center {{ .infraColor }}">Infrastructure</th>
 			<th title="How often the install completes successfully." class="text-center {{ .installColor }}"><a href="/install?release={{ .release }}">Install</a></th>
 			<th title="How often an upgrade that is started completes successfully." class="text-center {{ .upgradeColor }}"><a href="/upgrade?release={{ .release }}">Upgrade</a></th>
+			<!-- Operator health at the end of a CI run provides information about how stable our operators actually are in use.  Operators can successfully install and subsequently go unhealthy.  This is a bad situation, but one that we are facing here at the end of 4.6. -->
+			<!-- <th title="How often CI job runs finish with all operators healthy." class="text-center {{ .finalColor }}"><a href="/operator-health?release={{ .release }}">Operator Health</a></th> -->
 		</tr>
 		<tr>
 			<td class="text-center {{ .infraColor }}">{{ .infraHTML }}</td>
 			<td class="text-center {{ .installColor }}">{{ .installHTML }}</td>
 			<td class="text-center {{ .upgradeColor }}">{{ .upgradeHTML }}</td>
+			<!-- <td class="text-center {{ .finalColor }}">{{ .finalHTML }}</td> -->
 		</tr>
 	</table>
 	`
@@ -31,19 +34,23 @@ func topLevelIndicators(report, reportPrev sippyprocessingv1.TestReport, release
 	infraColor := generichtml.OverallInstallUpgradeColors.GetColor(report.TopLevelIndicators.Infrastructure.TestResultAcrossAllJobs.PassPercentage)
 	installColor := generichtml.OverallInstallUpgradeColors.GetColor(report.TopLevelIndicators.Install.TestResultAcrossAllJobs.PassPercentage)
 	upgradeColor := generichtml.OverallInstallUpgradeColors.GetColor(report.TopLevelIndicators.Upgrade.TestResultAcrossAllJobs.PassPercentage)
+	finalColor := generichtml.OverallInstallUpgradeColors.GetColor(report.TopLevelIndicators.FinalOperatorHealth.TestResultAcrossAllJobs.PassPercentage)
 
 	infraHTML := getTopLevelIndicateFailedTestHTML(report.TopLevelIndicators.Infrastructure, &reportPrev.TopLevelIndicators.Infrastructure)
 	installHTML := getTopLevelIndicateFailedTestHTML(report.TopLevelIndicators.Install, &reportPrev.TopLevelIndicators.Install)
 	upgradeHTML := getTopLevelIndicateFailedTestHTML(report.TopLevelIndicators.Upgrade, &reportPrev.TopLevelIndicators.Upgrade)
+	finalHTML := getTopLevelIndicateFailedTestHTML(report.TopLevelIndicators.FinalOperatorHealth, &reportPrev.TopLevelIndicators.FinalOperatorHealth)
 
 	return generichtml.MustSubstitute(tableHTMLTemplate, map[string]string{
 		"release":      release,
 		"infraColor":   infraColor,
 		"installColor": installColor,
 		"upgradeColor": upgradeColor,
+		"finalColor":   finalColor,
 		"infraHTML":    infraHTML,
 		"installHTML":  installHTML,
 		"upgradeHTML":  upgradeHTML,
+		"finalHTML":    finalHTML,
 	})
 }
 

--- a/pkg/sippyserver/install_details.go
+++ b/pkg/sippyserver/install_details.go
@@ -33,3 +33,17 @@ func (s *Server) printUpgradeHtmlReport(w http.ResponseWriter, req *http.Request
 		release,
 	)
 }
+
+func (s *Server) printOperatorHealthHtmlReport(w http.ResponseWriter, req *http.Request) {
+	release := req.URL.Query().Get("release")
+	if _, ok := s.currTestReports[release]; !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	installhtml.PrintOperatorHealthHtmlReport(w, req,
+		s.currTestReports[release].CurrentPeriodReport,
+		s.currTestReports[release].PreviousWeekReport,
+		s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.NumDays,
+		release,
+	)
+}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -198,6 +198,7 @@ func (s *Server) Serve() {
 	http.DefaultServeMux.HandleFunc("/", s.printHtmlReport)
 	http.DefaultServeMux.HandleFunc("/install", s.printInstallHtmlReport)
 	http.DefaultServeMux.HandleFunc("/upgrade", s.printUpgradeHtmlReport)
+	http.DefaultServeMux.HandleFunc("/operator-health", s.printOperatorHealthHtmlReport)
 	http.DefaultServeMux.HandleFunc("/json", s.printJSONReport)
 	http.DefaultServeMux.HandleFunc("/detailed", s.detailed)
 	http.DefaultServeMux.HandleFunc("/refresh", s.refresh)

--- a/pkg/testgridanalysis/testgridanalysisapi/types.go
+++ b/pkg/testgridanalysis/testgridanalysisapi/types.go
@@ -48,11 +48,8 @@ type RawJobRunResult struct {
 
 	// SetupStatus can be "", "Success", "Failure"
 	// Used to create synthentic tests.
-	SetupStatus string
-	// Used to create synthentic tests.
-	SadOperators []OperatorState
-	// Used to create synthentic tests.
-	UpgradeOperators []OperatorState
+	SetupStatus         string
+	FinalOperatorStates []OperatorState
 
 	// UpgradeStarted is true if the test attempted to start an upgrade based on the CVO succeeding (or failing) to acknowledge a request
 	UpgradeStarted bool
@@ -69,7 +66,9 @@ type OperatorState struct {
 }
 
 const (
-	OperatorUpgradePrefix = "Operator upgrade "
+	OperatorUpgradePrefix       = "Operator upgrade "
+	OperatorFinalHealthPrefix   = "operator conditions "
+	FinalOperatorHealthTestName = `[sig-sippy] tests should finish with healthy operators`
 
 	InfrastructureTestName = `[sig-sippy] infrastructure should work`
 	InstallTestName        = `[sig-sippy] install should work`
@@ -82,5 +81,5 @@ const (
 
 var (
 	OperatorInstallPrefix          = "operator install "
-	OperatorConditionsTestCaseName = regexp.MustCompile("operator (install|conditions) (?P<operator>.*)")
+	OperatorConditionsTestCaseName = regexp.MustCompile("operator install (?P<operator>.*)")
 )

--- a/pkg/testgridanalysis/testidentification/test_identification.go
+++ b/pkg/testgridanalysis/testidentification/test_identification.go
@@ -69,12 +69,12 @@ func IsCuratedTest(release, testName string) bool {
 	return false
 }
 
-func IsInstallOperatorTest(testName string) bool {
+func IsOldInstallOperatorTest(testName string) bool {
 	return testgridanalysisapi.OperatorConditionsTestCaseName.MatchString(testName)
 }
 
 func GetOperatorFromInstallTest(testName string) string {
-	if !IsInstallOperatorTest(testName) {
+	if !IsOldInstallOperatorTest(testName) {
 		return "NOT-AN-INSTALL-TEST-" + testName
 	}
 	matches := testgridanalysisapi.OperatorConditionsTestCaseName.FindStringSubmatch(testName)
@@ -82,8 +82,21 @@ func GetOperatorFromInstallTest(testName string) string {
 	return matches[operatorIndex]
 }
 
-func IsUpgradeOperatorTest(testName string) bool {
+func IsOldUpgradeOperatorTest(testName string) bool {
 	return strings.HasPrefix(testName, testgridanalysisapi.OperatorUpgradePrefix)
+}
+
+func IsOperatorHealthTest(testName string) bool {
+	if strings.HasPrefix(testName, testgridanalysisapi.OperatorUpgradePrefix) {
+		return true
+	}
+	if testgridanalysisapi.OperatorConditionsTestCaseName.MatchString(testName) {
+		return true
+	}
+	if strings.HasPrefix(testName, testgridanalysisapi.OperatorFinalHealthPrefix) {
+		return true
+	}
+	return false
 }
 
 func IsUpgradeStartedTest(testName string) bool {
@@ -99,15 +112,28 @@ func IsMachineConfigPoolsUpgradedTest(testName string) bool {
 }
 
 func GetOperatorFromUpgradeTest(testName string) string {
-	if !IsUpgradeOperatorTest(testName) {
+	if !IsOldUpgradeOperatorTest(testName) {
 		return "NOT-AN-UPGRADE-TEST-" + testName
 	}
 	return testName[len(testgridanalysisapi.OperatorUpgradePrefix):]
 }
 
+func GetOperatorNameFromTest(testName string) string {
+	if IsOldUpgradeOperatorTest(testName) {
+		return GetOperatorFromUpgradeTest(testName)
+	}
+	if IsOldInstallOperatorTest(testName) {
+		return GetOperatorFromInstallTest(testName)
+	}
+	if strings.HasPrefix(testName, testgridanalysisapi.OperatorFinalHealthPrefix) {
+		return testName[len(testgridanalysisapi.OperatorFinalHealthPrefix):]
+	}
+	return ""
+}
+
 // IsUpgradeRelatedTest is a filter function for identifying tests that are valuable to track for upgrade diagnosis.
 func IsUpgradeRelatedTest(testName string) bool {
-	if IsUpgradeOperatorTest(testName) {
+	if IsOldUpgradeOperatorTest(testName) {
 		return true
 	}
 	if strings.Contains(testName, testgridanalysisapi.UpgradeTestName) {

--- a/pkg/testgridanalysis/testreportconversion/by_component.go
+++ b/pkg/testgridanalysis/testreportconversion/by_component.go
@@ -132,11 +132,11 @@ func getBugzillaComponentsFromTestResult(testResult sippyprocessingv1.TestResult
 
 	// If we didn't have a bug, use the test name itself to identify a likely victim/blame
 	switch {
-	case testidentification.IsInstallOperatorTest(testResult.Name):
+	case testidentification.IsOldInstallOperatorTest(testResult.Name):
 		operatorName := testidentification.GetOperatorFromInstallTest(testResult.Name)
 		return []string{testidentification.GetBugzillaComponentForOperator(operatorName)}
 
-	case testidentification.IsUpgradeOperatorTest(testResult.Name):
+	case testidentification.IsOldUpgradeOperatorTest(testResult.Name):
 		operatorName := testidentification.GetOperatorFromUpgradeTest(testResult.Name)
 		return []string{testidentification.GetBugzillaComponentForOperator(operatorName)}
 

--- a/pkg/testgridanalysis/testreportconversion/test_report.go
+++ b/pkg/testgridanalysis/testreportconversion/test_report.go
@@ -48,14 +48,16 @@ func PrepareTestReport(
 	infra := excludeNeverStableJobs(allTestResultsByName[testgridanalysisapi.InfrastructureTestName])
 	install := excludeNeverStableJobs(allTestResultsByName[testgridanalysisapi.InstallTestName])
 	upgrade := excludeNeverStableJobs(allTestResultsByName[testgridanalysisapi.UpgradeTestName])
+	finalOperatorHealth := excludeNeverStableJobs(allTestResultsByName[testgridanalysisapi.FinalOperatorHealthTestName])
 
 	testReport := sippyprocessingv1.TestReport{
 		Release:   release,
 		Timestamp: reportTimestamp,
 		TopLevelIndicators: sippyprocessingv1.TopLevelIndicators{
-			Infrastructure: infra,
-			Install:        install,
-			Upgrade:        upgrade,
+			Infrastructure:      infra,
+			Install:             install,
+			Upgrade:             upgrade,
+			FinalOperatorHealth: finalOperatorHealth,
 		},
 
 		ByTest:        allTestResultsByName.toOrderedList(),

--- a/pkg/testgridanalysis/testreportconversion/testresult.go
+++ b/pkg/testgridanalysis/testreportconversion/testresult.go
@@ -153,10 +153,13 @@ func FilterLowValueTestsByName(testResult sippyprocessingv1.TestResult) bool {
 }
 
 func IsHighValueTestsByName(testResult sippyprocessingv1.TestResult) bool {
-	if testidentification.IsInstallOperatorTest(testResult.Name) {
+	if testidentification.IsOldInstallOperatorTest(testResult.Name) {
 		return true
 	}
 	if testidentification.IsUpgradeRelatedTest(testResult.Name) {
+		return true
+	}
+	if testidentification.IsOperatorHealthTest(testResult.Name) {
 		return true
 	}
 	return false


### PR DESCRIPTION
Adds final operator health as a top level indicator and corrects the virtual vs real tests for install and upgrade on consumption.