### PR TITLE
add test details page

### DIFF
--- a/pkg/html/generichtml/testresult.go
+++ b/pkg/html/generichtml/testresult.go
@@ -154,7 +154,7 @@ func (b *testResultRenderBuilder) ToHTML() string {
 
 	jobCollapseSectionName := MakeSafeForCollapseName("test-result---" + b.sectionBlock + "---" + b.currTestResult.displayName)
 	button := fmt.Sprintf(
-		`				<p><a href="/testdetails?release=%s&test=%v" target="_blank">Test Details by Platforms</a> `,
+		`				<p><a class="btn btn-primary btn-sm py-0" style="font-size: 0.8em" href="/testdetails?release=%s&test=%v" target="_blank" role="button">Test Details by Platforms</a> `,
 		b.release,
 		url.QueryEscape(b.currTestResult.displayName),
 	)

--- a/pkg/html/generichtml/testresult.go
+++ b/pkg/html/generichtml/testresult.go
@@ -153,9 +153,13 @@ func (b *testResultRenderBuilder) ToHTML() string {
 	}
 
 	jobCollapseSectionName := MakeSafeForCollapseName("test-result---" + b.sectionBlock + "---" + b.currTestResult.displayName)
-	button := ""
+	button := fmt.Sprintf(
+		`				<p><a href="/testdetails?release=%s&test=%v" target="_blank">Test Details by Platforms</a> `,
+		b.release,
+		url.QueryEscape(b.currTestResult.displayName),
+	)
 	if len(b.currTestResult.jobResults) > 0 {
-		button = "<p>" + GetButtonHTML(jobCollapseSectionName, "Expand Failing Jobs")
+		button += GetButtonHTML(jobCollapseSectionName, "Expand Failing Jobs")
 	}
 
 	// test name | bug | pass rate | higher/lower | pass rate

--- a/pkg/html/installhtml/test_detail.go
+++ b/pkg/html/installhtml/test_detail.go
@@ -1,0 +1,59 @@
+package installhtml
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/sippy/pkg/util/sets"
+
+	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+)
+
+func testDetailTests(curr, prev sippyprocessingv1.TestReport, testSubstrings []string) string {
+	dataForTestsByPlatform := getDataForTestsByPlatform(
+		curr, prev,
+		isTestDetailRelatedTest(testSubstrings),
+		neverMatch,
+	)
+
+	platforms := sets.String{}
+	for _, byPlatform := range dataForTestsByPlatform.testNameToPlatformToTestResult {
+		platforms.Insert(sets.StringKeySet(byPlatform).UnsortedList()...)
+	}
+
+	return dataForTestsByPlatform.getTableHTML("Details for Tests", "TestDetailByPlatform", "Test Details by Platform", platforms.List(), getOperatorFromTest)
+}
+
+func summaryTestDetailRelatedTests(curr, prev sippyprocessingv1.TestReport, testSubstrings []string, numDays int, release string) string {
+	// test name | test | pass rate | higher/lower | pass rate
+	s := fmt.Sprintf(`
+	<table class="table">
+		<tr>
+			<th colspan=5 class="text-center"><a class="text-dark" title="Tests, sorted by passing rate.  The link will prepopulate a BZ template to be filled out and submitted to report a test against the test." id="Tests" href="#Tests">Tests</a></th>
+		</tr>
+		<tr>
+			<th colspan=2/><th class="text-center">Latest %d Days</th><th/><th class="text-center">Previous 7 Days</th>
+		</tr>
+		<tr>
+			<th>Test Name</th><th>File a Test</th><th>Pass Rate</th><th/><th>Pass Rate</th>
+		</tr>
+	`, numDays)
+
+	s += failingTestsRows(curr.ByTest, prev.ByTest, release, isTestDetailRelatedTest(testSubstrings))
+
+	s = s + "</table>"
+
+	return s
+}
+
+func isTestDetailRelatedTest(testSubstrings []string) func(sippyprocessingv1.TestResult) bool {
+	return func(testResult sippyprocessingv1.TestResult) bool {
+		for _, testSubString := range testSubstrings {
+			if strings.Contains(testResult.Name, testSubString) {
+				return true
+			}
+		}
+
+		return false
+	}
+}

--- a/pkg/html/installhtml/test_detail_html.go
+++ b/pkg/html/installhtml/test_detail_html.go
@@ -1,0 +1,57 @@
+package installhtml
+
+import (
+	"fmt"
+	"net/http"
+
+	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+	"github.com/openshift/sippy/pkg/html/generichtml"
+)
+
+var (
+	testDetailTopPageHtml = `
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+<style>
+#table td, #table th {
+	border:
+}
+</style>
+
+<h1 class=text-center>Test Detail Dashboard</h1>
+
+<p class="small mb-3 text-nowrap">
+	Jump to: <a href="#TestDetailByPlatform">Test Details by Platform</a> | <a href="#Tests">Tests</a> 
+</p>
+
+`
+)
+
+func PrintTestDetailHtmlReport(w http.ResponseWriter, req *http.Request, report, prevReport sippyprocessingv1.TestReport, testSubstrings []string, numDays int, release string) {
+	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
+	fmt.Fprintf(w, generichtml.HTMLPageStart, "Test Details")
+	if len(prevReport.AnalysisWarnings)+len(report.AnalysisWarnings) > 0 {
+		warningsHTML := ""
+		for _, analysisWarning := range prevReport.AnalysisWarnings {
+			warningsHTML += "<p>" + analysisWarning + "</p>\n"
+		}
+		for _, analysisWarning := range report.AnalysisWarnings {
+			warningsHTML += "<p>" + analysisWarning + "</p>\n"
+		}
+		fmt.Fprintf(w, generichtml.WarningHeader, warningsHTML)
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, testDetailTopPageHtml)
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w)
+	fmt.Fprint(w, testDetailTests(report, prevReport, testSubstrings))
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w)
+	fmt.Fprint(w, summaryTestDetailRelatedTests(report, prevReport, testSubstrings, numDays, release))
+	fmt.Fprintln(w)
+
+	//w.Write(result)
+	fmt.Fprintf(w, generichtml.HTMLPageEnd, report.Timestamp.Format("Jan 2 15:04 2006 MST"))
+}

--- a/pkg/sippyserver/install_details.go
+++ b/pkg/sippyserver/install_details.go
@@ -47,3 +47,18 @@ func (s *Server) printOperatorHealthHtmlReport(w http.ResponseWriter, req *http.
 		release,
 	)
 }
+
+func (s *Server) printTestDetailHtmlReport(w http.ResponseWriter, req *http.Request) {
+	release := req.URL.Query().Get("release")
+	if _, ok := s.currTestReports[release]; !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	installhtml.PrintTestDetailHtmlReport(w, req,
+		s.currTestReports[release].CurrentPeriodReport,
+		s.currTestReports[release].PreviousWeekReport,
+		req.URL.Query()["test"],
+		s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.NumDays,
+		release,
+	)
+}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -199,6 +199,7 @@ func (s *Server) Serve() {
 	http.DefaultServeMux.HandleFunc("/install", s.printInstallHtmlReport)
 	http.DefaultServeMux.HandleFunc("/upgrade", s.printUpgradeHtmlReport)
 	http.DefaultServeMux.HandleFunc("/operator-health", s.printOperatorHealthHtmlReport)
+	http.DefaultServeMux.HandleFunc("/testdetails", s.printTestDetailHtmlReport)
 	http.DefaultServeMux.HandleFunc("/json", s.printJSONReport)
 	http.DefaultServeMux.HandleFunc("/detailed", s.detailed)
 	http.DefaultServeMux.HandleFunc("/refresh", s.refresh)


### PR DESCRIPTION
Needs some UX help, but it provides a detail page that looks like this:

![Screenshot from 2020-10-12 17-44-48](https://user-images.githubusercontent.com/8225098/95793022-abbe0080-0cb2-11eb-88a1-777bfa779abf.png)


It allows multiple `testSubstrings`, so it could be used to show details of a list of a tests.  I like that idea best.  click to expand top 20 failures on this job against all platforms.