### PR TITLE
ovirt upgrade and three upgrade test have passed more than 50% of the time

### DIFF
--- a/pkg/testgridanalysis/testidentification/platforms.go
+++ b/pkg/testgridanalysis/testidentification/platforms.go
@@ -57,10 +57,7 @@ var (
 	// jobsNeverStableForPlatforms is a list of jobs that have never been stable (not were stable and broke)
 	// As we phase these jobs in, they should be excluded from "normal" variants.
 	// These jobs are still listed as jobs in total and when individual tests fail, they will still be listed with these jobs as causes.
-	jobsNeverStableForPlatforms = sets.NewString(
-		"release-openshift-ocp-installer-e2e-ovirt-upgrade-4.5-stable-to-4.6-ci",
-		"release-openshift-origin-installer-e2e-aws-upgrade-4.3-to-4.4-to-4.5-to-4.6-ci", // this job has never passed because timeouts are too short and cannot be changed
-	)
+	jobsNeverStableForPlatforms = sets.NewString()
 )
 
 func IsJobNeverStable(jobName string) bool {


### PR DESCRIPTION
The three day signal looks pretty good.  Opening this to be sure we recheck at the end of this week to see if we passed the bar for treating them as normal jobs.

/hold