### PR TITLE
some tests can be in testgrid and not run at all in the selected window

### DIFF
--- a/pkg/testgridanalysis/testgridconversion/to_raw_data.go
+++ b/pkg/testgridanalysis/testgridconversion/to_raw_data.go
@@ -181,6 +181,11 @@ func processTestToJobRunResults(jobResult testgridanalysisapi.RawJobResult, job 
 		col += remaining
 	}
 
+	// don't add results for tests that did not run
+	if passed+failed+flaked == 0 {
+		return
+	}
+
 	// we override some test names based on their type.  Historically we misnamed the install and upgrade tests
 	// what we really want is to call these the final state
 	// This prevents any real results with this junit from counting.  This should only be needed during our transition  and


### PR DESCRIPTION
Imagine cases where the content includes days you aren't going to analyze.  I found this because of all the "zero runs" showing up as zero percent.