### PR TITLE
Test details for test sections

### DIFF
--- a/pkg/html/generichtml/decorations.go
+++ b/pkg/html/generichtml/decorations.go
@@ -2,6 +2,7 @@ package generichtml
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 	"text/template"
 
@@ -84,12 +85,27 @@ func MakeSafeForCollapseName(in string) string {
 	return collapseNameRemoveRegex.ReplaceAllString(in, "")
 }
 
-func GetButtonHTML(sectionName, buttonName string) string {
+func GetExpandingButtonHTML(sectionName, buttonName string) string {
 	buttonHTML := `<button class="btn btn-primary btn-sm py-0" style="font-size: 0.8em" type="button" data-toggle="collapse" data-target=".{{ .sectionName }}" aria-expanded="false" aria-controls="{{ .sectionName }}">{{ .buttonName }}</button>`
 	buttonHTMLTemplate := template.Must(template.New("buttonHTML").Parse(buttonHTML))
 
 	return MustSubstitute(buttonHTMLTemplate, map[string]string{
 		"sectionName": sectionName,
 		"buttonName":  buttonName,
+	})
+}
+
+func GetTestDetailsButtonHTML(release string, testNames ...string) string {
+	testDetailsButtonHTML := `<a class="btn btn-primary btn-sm py-0" style="font-size: 0.8em" href="/testdetails?release={{ .release }}{{range .testNames}}&test={{ . }}{{end}}" target="_blank" role="button">Test Details by Platforms</a>`
+	buttonHTMLTemplate := template.Must(template.New("testDetailsButtonHTML").Parse(testDetailsButtonHTML))
+
+	escapedTestNames := []string{}
+	for _, curr := range testNames {
+		escapedTestNames = append(escapedTestNames, url.QueryEscape(curr))
+	}
+
+	return MustSubstitute(buttonHTMLTemplate, map[string]interface{}{
+		"release":   release,
+		"testNames": escapedTestNames,
 	})
 }

--- a/pkg/html/generichtml/decorations.go
+++ b/pkg/html/generichtml/decorations.go
@@ -96,7 +96,7 @@ func GetExpandingButtonHTML(sectionName, buttonName string) string {
 }
 
 func GetTestDetailsButtonHTML(release string, testNames ...string) string {
-	testDetailsButtonHTML := `<a class="btn btn-primary btn-sm py-0" style="font-size: 0.8em" href="/testdetails?release={{ .release }}{{range .testNames}}&test={{ . }}{{end}}" target="_blank" role="button">Test Details by Platforms</a>`
+	testDetailsButtonHTML := `<a class="btn btn-primary btn-sm py-0" style="font-size: 0.8em" href="/testdetails?release={{ .release }}{{range .testNames}}&test={{ . }}{{end}}" target="_blank" role="button">Test Details by Variants</a>`
 	buttonHTMLTemplate := template.Must(template.New("testDetailsButtonHTML").Parse(testDetailsButtonHTML))
 
 	escapedTestNames := []string{}

--- a/pkg/html/generichtml/jobaggregationresult.go
+++ b/pkg/html/generichtml/jobaggregationresult.go
@@ -193,7 +193,7 @@ func (b *jobAggregationResultRenderBuilder) ToHTML() string {
 	jobsCollapseName := MakeSafeForCollapseName(b.sectionBlock + "---" + b.currAggregationResult.displayName + "---jobs")
 	testRows, displayedTests := getTestRowHTML(b.release, testCollapseSectionName, b.currAggregationResult.testResults, prevTestResults, b.maxTestResultsToShow)
 	button := "					" + GetExpandingButtonHTML(jobsCollapseName, "Expand Failing Jobs")
-	if len(b.currAggregationResult.testResults) > 0 { // add the button if we have tests to show
+	if len(displayedTests) > 0 { // add the button if we have tests to show
 		button += " " + GetExpandingButtonHTML(testCollapseSectionName, "Expand Failing Tests")
 		button += " " + GetTestDetailsButtonHTML(b.release, displayedTests...)
 	}

--- a/pkg/html/generichtml/jobresult.go
+++ b/pkg/html/generichtml/jobresult.go
@@ -182,7 +182,7 @@ func (b *jobResultRenderBuilder) ToHTML() string {
 	testRows, displayedTests := getTestRowHTML(b.release, testCollapseSectionName, b.currJobResult.testResults, prevTestResults, b.maxTestResultsToShow)
 
 	button := ""
-	if len(b.currJobResult.testResults) > 0 {
+	if len(displayedTests) > 0 {
 		button = "<p>" + GetExpandingButtonHTML(testCollapseSectionName, "Expand Failing Tests") + " " + GetTestDetailsButtonHTML(b.release, displayedTests...)
 	}
 

--- a/pkg/html/generichtml/jobresult.go
+++ b/pkg/html/generichtml/jobresult.go
@@ -174,9 +174,11 @@ func (b *jobResultRenderBuilder) ToHTML() string {
 		class += " collapse " + b.sectionBlock
 	}
 
+	testRows, displayedTests := b.getTestRowHTML(testCollapseSectionName)
+
 	button := ""
 	if len(b.currJobResult.testResults) > 0 {
-		button = "<p>" + GetButtonHTML(testCollapseSectionName, "Expand Failing Tests")
+		button = "<p>" + GetExpandingButtonHTML(testCollapseSectionName, "Expand Failing Tests") + " " + GetTestDetailsButtonHTML(b.release, displayedTests...)
 	}
 
 	if b.prevJobResult != nil {
@@ -207,6 +209,15 @@ func (b *jobResultRenderBuilder) ToHTML() string {
 	if len(b.currJobResult.testResults) == 0 {
 		return s
 	}
+	s += testRows
+
+	return s
+}
+
+// returns the table row html and a list of tests displayed
+func (b *jobResultRenderBuilder) getTestRowHTML(testCollapseSectionName string) (string, []string) {
+	s := ""
+	testNames := []string{}
 
 	testIndentDepth := (b.baseIndentDepth+1)*50 + 10
 	count := b.maxTestResultsToShow
@@ -219,6 +230,7 @@ func (b *jobResultRenderBuilder) ToHTML() string {
 			continue
 		}
 		count--
+		testNames = append(testNames, test.displayName)
 
 		var prev *testResultDisplay
 		if b.prevJobResult != nil {
@@ -251,5 +263,5 @@ func (b *jobResultRenderBuilder) ToHTML() string {
 		s = s + fmt.Sprintf(`<tr class="collapse %s"><td colspan=3 style="padding-left:%dpx" class="font-weight-bold">No Tests Matched Filters</td></tr>`, testCollapseSectionName, testIndentDepth)
 	}
 
-	return s
+	return s, testNames
 }

--- a/pkg/html/generichtml/testresult.go
+++ b/pkg/html/generichtml/testresult.go
@@ -154,7 +154,7 @@ func (b *testResultRenderBuilder) ToHTML() string {
 
 	jobCollapseSectionName := MakeSafeForCollapseName("test-result---" + b.sectionBlock + "---" + b.currTestResult.displayName)
 	button := fmt.Sprintf(
-		`				<p><a href="/testdetails?release=%s&test=%v" target="_blank">Test Details by Platforms</a> `,
+		`				<p><a class="btn btn-primary btn-sm py-0" style="font-size: 0.8em" href="/testdetails?release=%s&test=%v" target="_blank" role="button">Test Details by Platforms</a> `,
 		b.release,
 		url.QueryEscape(b.currTestResult.displayName),
 	)

--- a/pkg/html/generichtml/testresult.go
+++ b/pkg/html/generichtml/testresult.go
@@ -224,3 +224,55 @@ func (b *testResultRenderBuilder) ToHTML() string {
 
 	return s
 }
+
+// returns the table row html and a list of tests displayed
+func getTestRowHTML(release, testsCollapseName string, currTestResults, prevTestResults []testResultDisplay, maxTestResultsToShow int) (string, []string) {
+	s := ""
+	testNames := []string{}
+
+	testCount := maxTestResultsToShow
+	testRowCount := 0
+	testRows := ""
+	for _, test := range currTestResults {
+		if testCount <= 0 {
+			break
+		}
+		// if the test isn't failing and isn't flaking, skip it. We do want to see the flakes, so keep iterating.
+		if test.displayPercent > 99.99 && test.flakedRuns == 0 {
+			continue
+		}
+		testCount--
+		testNames = append(testNames, test.displayName)
+
+		var prev *testResultDisplay
+		for _, prevInstance := range prevTestResults {
+			if prevInstance.displayName == test.displayName {
+				prev = &prevInstance
+				break
+			}
+		}
+
+		testRows = testRows +
+			NewTestResultRenderer(testsCollapseName, test, release).
+				WithIndent(1).
+				WithPrevious(prev).
+				StartCollapsed().
+				ToHTML()
+
+		testRowCount++
+	}
+	additionalMatches := len(currTestResults) - len(testNames)
+
+	if additionalMatches > 0 {
+		testRows += fmt.Sprintf(`<tr class="collapse %s"><td colspan=2 style="padding-left:60px">Plus %d more tests</td></tr>`, testsCollapseName, additionalMatches)
+	}
+	if testRowCount > 0 {
+		s = s + fmt.Sprintf(`<tr class="collapse %s"><td colspan=2 style="padding-left:60px" class="font-weight-bold">Test Name</td><td class="font-weight-bold">Test Pass Rate</td></tr>`, testsCollapseName)
+		s = s + testRows
+		s = s + fmt.Sprintf(`<tr class="collapse %s"><td colspan=2 style="padding-left:60px" class="font-weight-bold"></td><td class="font-weight-bold"></td></tr>`, testsCollapseName)
+	} else {
+		s = s + fmt.Sprintf(`<tr class="collapse %s"><td colspan=3 style="padding-left:60px" class="font-weight-bold">No Tests Matched Filters</td></tr>`, testsCollapseName)
+	}
+
+	return s, testNames
+}

--- a/pkg/html/generichtml/testresult.go
+++ b/pkg/html/generichtml/testresult.go
@@ -153,9 +153,13 @@ func (b *testResultRenderBuilder) ToHTML() string {
 	}
 
 	jobCollapseSectionName := MakeSafeForCollapseName("test-result---" + b.sectionBlock + "---" + b.currTestResult.displayName)
-	button := ""
+	button := fmt.Sprintf(
+		`				<p><a href="/testdetails?release=%s&test=%v" target="_blank">Test Details by Platforms</a> `,
+		b.release,
+		url.QueryEscape(b.currTestResult.displayName),
+	)
 	if len(b.currTestResult.jobResults) > 0 {
-		button = "<p>" + GetButtonHTML(jobCollapseSectionName, "Expand Failing Jobs")
+		button += GetButtonHTML(jobCollapseSectionName, "Expand Failing Jobs")
 	}
 
 	// test name | bug | pass rate | higher/lower | pass rate

--- a/pkg/html/generichtml/testresult.go
+++ b/pkg/html/generichtml/testresult.go
@@ -153,16 +153,13 @@ func (b *testResultRenderBuilder) ToHTML() string {
 	}
 
 	jobCollapseSectionName := MakeSafeForCollapseName("test-result---" + b.sectionBlock + "---" + b.currTestResult.displayName)
-	button := fmt.Sprintf(
-		`				<p><a class="btn btn-primary btn-sm py-0" style="font-size: 0.8em" href="/testdetails?release=%s&test=%v" target="_blank" role="button">Test Details by Platforms</a> `,
-		b.release,
-		url.QueryEscape(b.currTestResult.displayName),
-	)
+	button := ""
 	if len(b.currTestResult.jobResults) > 0 {
-		button += GetButtonHTML(jobCollapseSectionName, "Expand Failing Jobs")
+		button += `				<p>` + GetExpandingButtonHTML(jobCollapseSectionName, "Expand Failing Jobs") + " " + GetTestDetailsButtonHTML(b.release, b.currTestResult.displayName)
+	} else {
+		button += `				<p>` + GetTestDetailsButtonHTML(b.release, b.currTestResult.displayName)
 	}
 
-	// test name | bug | pass rate | higher/lower | pass rate
 	s := ""
 
 	encodedTestName := url.QueryEscape(regexp.QuoteMeta(b.currTestResult.displayName))

--- a/pkg/html/installhtml/test_detail.go
+++ b/pkg/html/installhtml/test_detail.go
@@ -1,0 +1,59 @@
+package installhtml
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/sippy/pkg/util/sets"
+
+	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+)
+
+func testDetailTests(curr, prev sippyprocessingv1.TestReport, testSubstrings []string) string {
+	dataForTestsByPlatform := getDataForTestsByPlatform(
+		curr, prev,
+		isTestDetailRelatedTest(testSubstrings),
+		neverMatch,
+	)
+
+	platforms := sets.String{}
+	for _, byPlatform := range dataForTestsByPlatform.testNameToPlatformToTestResult {
+		platforms.Insert(sets.StringKeySet(byPlatform).UnsortedList()...)
+	}
+
+	return dataForTestsByPlatform.getTableHTML("Details for Tests", "TestDetailByPlatform", "Test Details by Platform", platforms.List(), getOperatorFromTest)
+}
+
+func summaryTestDetailRelatedTests(curr, prev sippyprocessingv1.TestReport, testSubstrings []string, numDays int, release string) string {
+	// test name | test | pass rate | higher/lower | pass rate
+	s := fmt.Sprintf(`
+	<table class="table">
+		<tr>
+			<th colspan=5 class="text-center"><a class="text-dark" title="Tests, sorted by passing rate.  The link will prepopulate a BZ template to be filled out and submitted to report a test against the test." id="Tests" href="#Tests">Tests</a></th>
+		</tr>
+		<tr>
+			<th colspan=2/><th class="text-center">Latest %d Days</th><th/><th class="text-center">Previous 7 Days</th>
+		</tr>
+		<tr>
+			<th>Test Name</th><th>File a Test</th><th>Pass Rate</th><th/><th>Pass Rate</th>
+		</tr>
+	`, numDays)
+
+	s += failingTestsRows(curr.ByTest, prev.ByTest, release, isTestDetailRelatedTest(testSubstrings))
+
+	s = s + "</table>"
+
+	return s
+}
+
+func isTestDetailRelatedTest(testSubstrings []string) func(sippyprocessingv1.TestResult) bool {
+	return func(testResult sippyprocessingv1.TestResult) bool {
+		for _, testSubString := range testSubstrings {
+			if strings.Contains(testResult.Name, testSubString) {
+				return true
+			}
+		}
+
+		return false
+	}
+}

--- a/pkg/html/installhtml/test_detail.go
+++ b/pkg/html/installhtml/test_detail.go
@@ -21,7 +21,7 @@ func testDetailTests(curr, prev sippyprocessingv1.TestReport, testSubstrings []s
 		platforms.Insert(sets.StringKeySet(byPlatform).UnsortedList()...)
 	}
 
-	return dataForTestsByPlatform.getTableHTML("Details for Tests", "TestDetailByPlatform", "Test Details by Platform", platforms.List(), getOperatorFromTest)
+	return dataForTestsByPlatform.getTableHTML("Details for Tests", "TestDetailByPlatform", "Test Details by Platform", platforms.List(), noChange)
 }
 
 func summaryTestDetailRelatedTests(curr, prev sippyprocessingv1.TestReport, testSubstrings []string, numDays int, release string) string {

--- a/pkg/html/installhtml/test_detail_html.go
+++ b/pkg/html/installhtml/test_detail_html.go
@@ -1,0 +1,57 @@
+package installhtml
+
+import (
+	"fmt"
+	"net/http"
+
+	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+	"github.com/openshift/sippy/pkg/html/generichtml"
+)
+
+var (
+	testDetailTopPageHtml = `
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+<style>
+#table td, #table th {
+	border:
+}
+</style>
+
+<h1 class=text-center>Test Detail Dashboard</h1>
+
+<p class="small mb-3 text-nowrap">
+	Jump to: <a href="#TestDetailByPlatform">Test Details by Platform</a> | <a href="#Tests">Tests</a> 
+</p>
+
+`
+)
+
+func PrintTestDetailHtmlReport(w http.ResponseWriter, req *http.Request, report, prevReport sippyprocessingv1.TestReport, testSubstrings []string, numDays int, release string) {
+	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
+	fmt.Fprintf(w, generichtml.HTMLPageStart, "Test Details")
+	if len(prevReport.AnalysisWarnings)+len(report.AnalysisWarnings) > 0 {
+		warningsHTML := ""
+		for _, analysisWarning := range prevReport.AnalysisWarnings {
+			warningsHTML += "<p>" + analysisWarning + "</p>\n"
+		}
+		for _, analysisWarning := range report.AnalysisWarnings {
+			warningsHTML += "<p>" + analysisWarning + "</p>\n"
+		}
+		fmt.Fprintf(w, generichtml.WarningHeader, warningsHTML)
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, testDetailTopPageHtml)
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w)
+	fmt.Fprint(w, testDetailTests(report, prevReport, testSubstrings))
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w)
+	fmt.Fprint(w, summaryTestDetailRelatedTests(report, prevReport, testSubstrings, numDays, release))
+	fmt.Fprintln(w)
+
+	//w.Write(result)
+	fmt.Fprintf(w, generichtml.HTMLPageEnd, report.Timestamp.Format("Jan 2 15:04 2006 MST"))
+}

--- a/pkg/html/installhtml/util.go
+++ b/pkg/html/installhtml/util.go
@@ -130,9 +130,9 @@ func (a testsByPlatform) getTableHTML(
 
 	// print platform column headers
 	s += "    <tr>"
-	s += "      <td nowrap=\"nowrap\"></td>\n"
-	for _, platformName := range aggregationNames {
-		s += "      <th class=\"text-center\"><nobr>" + platformName + "</nobr></th>\n"
+	s += "      <td nowrap=\"nowrap\">Test Name</td>\n"
+	for _, aggregationName := range aggregationNames {
+		s += "      <th class=\"text-center\"><nobr>" + aggregationName + "</nobr></th>\n"
 	}
 	s += "		</tr>\n"
 

--- a/pkg/html/installhtml/util.go
+++ b/pkg/html/installhtml/util.go
@@ -176,11 +176,7 @@ func noChange(testName string) string {
 
 func installCellHTMLFromTestResult(cellResult *currPrevTestResult, colors generichtml.ColorizationCriteria) string {
 	if cellResult == nil {
-		// we filter out 100% passing results, so this almost certainly means we always pass.  We default to 100
-		passPercentage := 100.0
-		//arrow := generichtml.Flat
-		color := colors.GetColor(passPercentage)
-		return fmt.Sprintf("      <td class=\"text-center %v\"><nobr>no-data</nobr></td>", color)
+		return fmt.Sprintf("      <td class=\"text-center table-secondary\"><nobr>no-data</nobr></td>")
 	}
 
 	// we filter out 100% passing results, so this almost certainly means we always pass.  We default to 100

--- a/pkg/html/installhtml/util.go
+++ b/pkg/html/installhtml/util.go
@@ -170,6 +170,10 @@ func getOperatorFromTest(testName string) string {
 	return testName
 }
 
+func noChange(testName string) string {
+	return testName
+}
+
 func installCellHTMLFromTestResult(cellResult *currPrevTestResult, colors generichtml.ColorizationCriteria) string {
 	if cellResult == nil {
 		// we filter out 100% passing results, so this almost certainly means we always pass.  We default to 100

--- a/pkg/html/releasehtml/failing_tests.go
+++ b/pkg/html/releasehtml/failing_tests.go
@@ -11,11 +11,11 @@ import (
 )
 
 func summaryTopFailingTestsWithBug(topFailingTestsWithBug, allTests []sippyprocessingv1.FailingTestResult, numDays int, release string) string {
-	// test name | bug | pass rate | higher/lower | pass rate
+	rows, testNames := topFailingTestsRows(topFailingTestsWithBug, allTests, release)
 	s := fmt.Sprintf(`
 	<table class="table">
 		<tr>
-			<th colspan=5 class="text-center"><a class="text-dark" title="Most frequently failing tests with a known bug, sorted by passing rate.  The link will prepopulate a BZ template to be filled out and submitted to report a bug against the test." id="TopFailingTestsWithABug" href="#TopFailingTestsWithABug">Top Failing Tests With A Bug</a></th>
+			<th colspan=5 class="text-center"><a class="text-dark" title="Most frequently failing tests with a known bug, sorted by passing rate.  The link will prepopulate a BZ template to be filled out and submitted to report a bug against the test." id="TopFailingTestsWithABug" href="#TopFailingTestsWithABug">Top Failing Tests With A Bug</a> %s</th>
 		</tr>
 		<tr>
 			<th colspan=2/><th class="text-center">Latest %d Days</th><th/><th class="text-center">Previous 7 Days</th>
@@ -23,21 +23,20 @@ func summaryTopFailingTestsWithBug(topFailingTestsWithBug, allTests []sippyproce
 		<tr>
 			<th>Test Name</th><th>File a Bug</th><th>Pass Rate</th><th/><th>Pass Rate</th>
 		</tr>
-	`, numDays)
+	`, generichtml.GetTestDetailsButtonHTML(release, testNames...), numDays)
 
-	s += topFailingTestsRows(topFailingTestsWithBug, allTests, release)
-
-	s = s + "</table>"
+	s += rows
+	s += "</table>"
 
 	return s
 }
 
 func summaryTopFailingTestsWithoutBug(topFailingTestsWithBug, allTests []sippyprocessingv1.FailingTestResult, numDays int, release string) string {
-	// test name | bug | pass rate | higher/lower | pass rate
+	rows, testNames := topFailingTestsRows(topFailingTestsWithBug, allTests, release)
 	s := fmt.Sprintf(`
 	<table class="table">
 		<tr>
-			<th colspan=5 class="text-center"><a class="text-dark" title="Most frequently failing tests without a known bug, sorted by passing rate.  The link will prepopulate a BZ template to be filled out and submitted to report a bug against the test." id="TopFailingTestsWithoutABug" href="#TopFailingTestsWithoutABug">Top Failing Tests Without A Bug</a></th>
+			<th colspan=5 class="text-center"><a class="text-dark" title="Most frequently failing tests without a known bug, sorted by passing rate.  The link will prepopulate a BZ template to be filled out and submitted to report a bug against the test." id="TopFailingTestsWithoutABug" href="#TopFailingTestsWithoutABug">Top Failing Tests Without A Bug</a> %s</th>
 		</tr>
 		<tr>
 			<th colspan=2/><th class="text-center">Latest %d Days</th><th/><th class="text-center">Previous 7 Days</th>
@@ -45,21 +44,21 @@ func summaryTopFailingTestsWithoutBug(topFailingTestsWithBug, allTests []sippypr
 		<tr>
 			<th>Test Name</th><th>File a Bug</th><th>Pass Rate</th><th/><th>Pass Rate</th>
 		</tr>
-	`, numDays)
+	`, generichtml.GetTestDetailsButtonHTML(release, testNames...), numDays)
 
-	s += topFailingTestsRows(topFailingTestsWithBug, allTests, release)
-
-	s = s + "</table>"
+	s += rows
+	s += "</table>"
 
 	return s
 }
 
 func summaryCuratedTests(curr, prev sippyprocessingv1.TestReport, numDays int, release string) string {
-	// test name | bug | pass rate | higher/lower | pass rate
+	rows, testNames := topFailingTestsRows(curr.CuratedTests, prev.ByTest, release)
+
 	s := fmt.Sprintf(`
 	<table class="table">
 		<tr>
-			<th colspan=5 class="text-center"><a class="text-dark" title="Curated TRT tests for whatever reason they see fit, sorted by passing rate.  The link will prepopulate a BZ template to be filled out and submitted to report a bug against the test." id="CuratedTRTTests" href="#CuratedTRTTests">Curated TRT Tests</a></th>
+			<th colspan=5 class="text-center"><a class="text-dark" title="Curated TRT tests for whatever reason they see fit, sorted by passing rate.  The link will prepopulate a BZ template to be filled out and submitted to report a bug against the test." id="CuratedTRTTests" href="#CuratedTRTTests">Curated TRT Tests</a> %s</th>
 		</tr>
 		<tr>
 			<th colspan=2/><th class="text-center">Latest %d Days</th><th/><th class="text-center">Previous 7 Days</th>
@@ -67,18 +66,19 @@ func summaryCuratedTests(curr, prev sippyprocessingv1.TestReport, numDays int, r
 		<tr>
 			<th>Test Name</th><th>File a Bug</th><th>Pass Rate</th><th/><th>Pass Rate</th>
 		</tr>
-	`, numDays)
+	`, generichtml.GetTestDetailsButtonHTML(release, testNames...), numDays)
 
-	s += topFailingTestsRows(curr.CuratedTests, prev.ByTest, release)
-
-	s = s + "</table>"
+	s += rows
+	s += "</table>"
 
 	return s
 }
 
-func topFailingTestsRows(topFailingTests, prevTests []sippyprocessingv1.FailingTestResult, release string) string {
+// returns the rows to display and the names of the tests being show
+func topFailingTestsRows(topFailingTests, prevTests []sippyprocessingv1.FailingTestResult, release string) (string, []string) {
 	// test name | bug | pass rate | higher/lower | pass rate
 	s := ""
+	testNames := []string{}
 
 	count := 0
 	for _, testResult := range topFailingTests {
@@ -91,6 +91,7 @@ func topFailingTestsRows(topFailingTests, prevTests []sippyprocessingv1.FailingT
 		if count > 20 {
 			break
 		}
+		testNames = append(testNames, testResult.TestName)
 
 		testPrev := util.FindFailedTestResult(testResult.TestName, prevTests)
 
@@ -100,6 +101,5 @@ func topFailingTestsRows(topFailingTests, prevTests []sippyprocessingv1.FailingT
 				ToHTML()
 	}
 
-	s = s + "</table>"
-	return s
+	return s, testNames
 }

--- a/pkg/html/releasehtml/failing_tests.go
+++ b/pkg/html/releasehtml/failing_tests.go
@@ -74,7 +74,7 @@ func summaryCuratedTests(curr, prev sippyprocessingv1.TestReport, numDays int, r
 	return s
 }
 
-// returns the rows to display and the names of the tests being show
+// returns the rows to display and the names of the tests being shown
 func topFailingTestsRows(topFailingTests, prevTests []sippyprocessingv1.FailingTestResult, release string) (string, []string) {
 	// test name | bug | pass rate | higher/lower | pass rate
 	s := ""

--- a/pkg/sippyserver/install_details.go
+++ b/pkg/sippyserver/install_details.go
@@ -47,3 +47,18 @@ func (s *Server) printOperatorHealthHtmlReport(w http.ResponseWriter, req *http.
 		release,
 	)
 }
+
+func (s *Server) printTestDetailHtmlReport(w http.ResponseWriter, req *http.Request) {
+	release := req.URL.Query().Get("release")
+	if _, ok := s.currTestReports[release]; !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	installhtml.PrintTestDetailHtmlReport(w, req,
+		s.currTestReports[release].CurrentPeriodReport,
+		s.currTestReports[release].PreviousWeekReport,
+		req.URL.Query()["test"],
+		s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.NumDays,
+		release,
+	)
+}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -199,6 +199,7 @@ func (s *Server) Serve() {
 	http.DefaultServeMux.HandleFunc("/install", s.printInstallHtmlReport)
 	http.DefaultServeMux.HandleFunc("/upgrade", s.printUpgradeHtmlReport)
 	http.DefaultServeMux.HandleFunc("/operator-health", s.printOperatorHealthHtmlReport)
+	http.DefaultServeMux.HandleFunc("/testdetails", s.printTestDetailHtmlReport)
 	http.DefaultServeMux.HandleFunc("/json", s.printJSONReport)
 	http.DefaultServeMux.HandleFunc("/detailed", s.detailed)
 	http.DefaultServeMux.HandleFunc("/refresh", s.refresh)

--- a/pkg/testgridanalysis/testreportconversion/testresult.go
+++ b/pkg/testgridanalysis/testreportconversion/testresult.go
@@ -215,7 +215,7 @@ func StandardTestResultFilter(
 		TestResultFilterFuncs{
 			FilterLowValueTestsByName,
 			FilterTooFewTestRuns(minRuns),
-			FilterSuccessfulTestResults(successThreshold),
+			//FilterSuccessfulTestResults(successThreshold),
 		}.And,
 	}.Or
 }


### PR DESCRIPTION
Adds test details buttons for each aggregation we have.  It allows a button from any level to say, "are the problems on this test, job, or platform different by platform" in a quick chart

