### PR TITLE
Make gcp variant regex match 3.11 jobs

### DIFF
--- a/pkg/testgridanalysis/testidentification/platforms.go
+++ b/pkg/testgridanalysis/testidentification/platforms.go
@@ -16,7 +16,8 @@ var (
 	metalRegex = regexp.MustCompile(`(?i)-metal-`)
 	// metal-ipi jobs do not have a trailing -version segment
 	metalIPIRegex  = regexp.MustCompile(`(?i)-metal-ipi`)
-	gcpRegex       = regexp.MustCompile(`(?i)-gcp-`)
+	// 3.11 gcp jobs don't have a trailing -version segment
+	gcpRegex       = regexp.MustCompile(`(?i)-gcp`)
 	openstackRegex = regexp.MustCompile(`(?i)-openstack-`)
 	ovirtRegex     = regexp.MustCompile(`(?i)-ovirt-`)
 	ovnRegex       = regexp.MustCompile(`(?i)-ovn-`)


### PR DESCRIPTION
3.11 job name is periodic-ci-openshift-origin-release-3.11-e2e-gcp so the current regex misses it.

@deads2k as an aside, it's probably worth us thinking about what to do in the case of "0 runs" both current and previous week for a given variant, as happens here:
https://sippy.ci.openshift.org/?release=3.11

Hiding it is a little scary since if something stops running, we lose sight of it.  But it's not hard to imagine that the set of valid variants evolves from release to release and keeping a bunch of scary looking empty red rows around for that reason doesn't seem ideal in terms of bringing visibility to the things we do care about.