### PR TITLE
add option to disable bugzilla lookups to speed up debug iteration

### DIFF
--- a/pkg/buganalysis/cache.go
+++ b/pkg/buganalysis/cache.go
@@ -29,6 +29,32 @@ type BugCache interface {
 	LastUpdateError() error
 }
 
+// noOpBugCache is a no-op implementation of the bug cache/lookup interface
+// used to opt-out of bug lookups for faster test analysis/reporting.
+type noOpBugCache struct {
+}
+
+func (*noOpBugCache) ListJobBlockingBugs(job string) []bugsv1.Bug {
+	return []bugsv1.Bug{}
+}
+func (*noOpBugCache) ListBugs(release, platform, testName string) []bugsv1.Bug {
+	return []bugsv1.Bug{}
+}
+func (*noOpBugCache) UpdateForFailedTests(failedTestNames ...string) error {
+	return nil
+}
+func (*noOpBugCache) UpdateJobBlockers(jobNames ...string) error {
+	return nil
+}
+func (*noOpBugCache) Clear() {}
+func (*noOpBugCache) LastUpdateError() error {
+	return nil
+}
+
+func NewNoOpBugCache() BugCache {
+	return &noOpBugCache{}
+}
+
 type bugCache struct {
 	lock  sync.RWMutex
 	cache map[string][]bugsv1.Bug

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -21,11 +21,18 @@ func NewServer(
 	displayDataOptions DisplayDataConfig,
 	releases []string,
 	listenAddr string,
+	skipBugLookup bool,
 ) *Server {
+	var bugCache buganalysis.BugCache
+	if skipBugLookup {
+		bugCache = buganalysis.NewNoOpBugCache()
+	} else {
+		bugCache = buganalysis.NewBugCache()
+	}
 	server := &Server{
 		listenAddr: listenAddr,
 		releases:   releases,
-		bugCache:   buganalysis.NewBugCache(),
+		bugCache:   bugCache,
 		testReportGeneratorConfig: TestReportGeneratorConfig{
 			TestGridLoadingConfig:       testGridLoadingOptions,
 			RawJobResultsAnalysisConfig: rawJobResultsAnalysisOptions,


### PR DESCRIPTION
adds --skip-bug-lookup as an arg that will skip over the ci-search bz lookup.

This reduces startup analysis time substantially, useful when iterating on code
that is not related to the bug assocation/reporting.