### PR TITLE
Add 3.11 to list of jobs w/ no setup container

### DIFF
--- a/pkg/testgridanalysis/testgridconversion/synthentic_tests.go
+++ b/pkg/testgridanalysis/testgridconversion/synthentic_tests.go
@@ -182,4 +182,5 @@ var jobsWithKnownBadSetupContainer = sets.NewString(
 	"promote-release-openshift-machine-os-content-e2e-aws-4.6-s390x",
 	"promote-release-openshift-machine-os-content-e2e-aws-4.6-ppc64le",
 	"release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.5-to-4.6",
+	"periodic-ci-openshift-origin-release-3.11-e2e-gcp",
 )


### PR DESCRIPTION
fixes the 3.11 sippy dashboard
