### PR TITLE
Update jobsWithKnownBadSetupContainer to include 4.7 versions of the already known issues

### DIFF
--- a/pkg/testgridanalysis/testgridconversion/synthentic_tests.go
+++ b/pkg/testgridanalysis/testgridconversion/synthentic_tests.go
@@ -182,5 +182,9 @@ var jobsWithKnownBadSetupContainer = sets.NewString(
 	"promote-release-openshift-machine-os-content-e2e-aws-4.6-s390x",
 	"promote-release-openshift-machine-os-content-e2e-aws-4.6-ppc64le",
 	"release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.5-to-4.6",
+	"promote-release-openshift-machine-os-content-e2e-aws-4.7",
+	"promote-release-openshift-machine-os-content-e2e-aws-4.7-s390x",
+	"promote-release-openshift-machine-os-content-e2e-aws-4.7-ppc64le",
+	"release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.6-to-4.7",
 	"periodic-ci-openshift-origin-release-3.11-e2e-gcp",
 )


### PR DESCRIPTION
Since we're seeing the same analysis errors I'm making the assumption that this hasn't changed since 4.6. If these are never expected to work perhaps we should change them to a regex match so that it won't need to be updated for future releases.

Alternatively, if we do expect this to be fixed over time as the comment suggests, is there currently some way we can track/are tracking it in a GH issue/PR/BZ? Then we could at least add that info to the warning so it's clear it can be ignored for the time being.