### PR TITLE
Add links to historical data and release dashboard to footer

### DIFF
--- a/pkg/html/generichtml/html.go
+++ b/pkg/html/generichtml/html.go
@@ -31,6 +31,8 @@ var (
 </div>
 Data current as of: %s
 <p>
+<a href="https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/dashboards/overview">Release Dashboard</a> |
+<a href="https://sippy-historical-bparees.apps.ci.l2s4.p1.openshiftapps.com/">Historical Data</a> |
 <a href="https://github.com/openshift/sippy">Source Code</a>
 <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>


### PR DESCRIPTION
Looks like this at the bottom of the page:

![Screenshot from 2020-11-03 12-43-03](https://user-images.githubusercontent.com/2431974/98021351-3ab1ca80-1dd2-11eb-8d7e-4263ce765611.png)
