### PR TITLE
allow sippy to wire against kube

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,7 +44,6 @@ func main() {
 		FailureClusterThreshold: 10,
 		StartDay:                0,
 		ListenAddr:              ":8080",
-		OpenshiftReleases:       []string{"4.4"},
 	}
 
 	klog.InitFlags(nil)
@@ -138,6 +137,13 @@ func (o *Options) Validate() error {
 	case "json":
 	default:
 		return fmt.Errorf("invalid output type: %s\n", o.Output)
+	}
+
+	for _, dashboard := range o.Dashboards {
+		tokens := strings.Split(dashboard, "=")
+		if len(tokens) != 3 {
+			return fmt.Errorf("must have three tokens: %q", dashboard)
+		}
 	}
 
 	return nil

--- a/pkg/html/releasehtml/html.go
+++ b/pkg/html/releasehtml/html.go
@@ -331,13 +331,13 @@ type TestReports struct {
 	Release      string
 }
 
-func WriteLandingPage(w http.ResponseWriter, releases []string) {
+func WriteLandingPage(w http.ResponseWriter, displayNames []string) {
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
 	w.WriteHeader(http.StatusNotFound)
 	fmt.Fprintf(w, generichtml.HTMLPageStart, "Release CI Health Dashboard")
-	releaseLinks := make([]string, len(releases))
-	for i := range releases {
-		releaseLinks[i] = fmt.Sprintf(`<li><a href="?release=%s">release-%[1]s</a></li>`, releases[i])
+	releaseLinks := make([]string, len(displayNames))
+	for i := range displayNames {
+		releaseLinks[i] = fmt.Sprintf(`<li><a href="?release=%s">release-%[1]s</a></li>`, displayNames[i])
 	}
 	fmt.Fprintf(w, "<h1 class='text-center'>CI Release Health Summary</h1><p><ul>%s</ul></p>", strings.Join(releaseLinks, "\n"))
 	fmt.Fprintf(w, landingHtmlPageEnd)

--- a/pkg/sippyserver/install_details.go
+++ b/pkg/sippyserver/install_details.go
@@ -7,58 +7,58 @@ import (
 )
 
 func (s *Server) printInstallHtmlReport(w http.ResponseWriter, req *http.Request) {
-	release := req.URL.Query().Get("release")
-	if _, ok := s.currTestReports[release]; !ok {
+	reportName := req.URL.Query().Get("release")
+	if _, ok := s.currTestReports[reportName]; !ok {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 	installhtml.PrintInstallHtmlReport(w, req,
-		s.currTestReports[release].CurrentPeriodReport,
-		s.currTestReports[release].PreviousWeekReport,
+		s.currTestReports[reportName].CurrentPeriodReport,
+		s.currTestReports[reportName].PreviousWeekReport,
 		s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.NumDays,
-		release,
+		reportName,
 	)
 }
 
 func (s *Server) printUpgradeHtmlReport(w http.ResponseWriter, req *http.Request) {
-	release := req.URL.Query().Get("release")
-	if _, ok := s.currTestReports[release]; !ok {
+	reportName := req.URL.Query().Get("release")
+	if _, ok := s.currTestReports[reportName]; !ok {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 	installhtml.PrintUpgradeHtmlReport(w, req,
-		s.currTestReports[release].CurrentPeriodReport,
-		s.currTestReports[release].PreviousWeekReport,
+		s.currTestReports[reportName].CurrentPeriodReport,
+		s.currTestReports[reportName].PreviousWeekReport,
 		s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.NumDays,
-		release,
+		reportName,
 	)
 }
 
 func (s *Server) printOperatorHealthHtmlReport(w http.ResponseWriter, req *http.Request) {
-	release := req.URL.Query().Get("release")
-	if _, ok := s.currTestReports[release]; !ok {
+	reportName := req.URL.Query().Get("release")
+	if _, ok := s.currTestReports[reportName]; !ok {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 	installhtml.PrintOperatorHealthHtmlReport(w, req,
-		s.currTestReports[release].CurrentPeriodReport,
-		s.currTestReports[release].PreviousWeekReport,
+		s.currTestReports[reportName].CurrentPeriodReport,
+		s.currTestReports[reportName].PreviousWeekReport,
 		s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.NumDays,
-		release,
+		reportName,
 	)
 }
 
 func (s *Server) printTestDetailHtmlReport(w http.ResponseWriter, req *http.Request) {
-	release := req.URL.Query().Get("release")
-	if _, ok := s.currTestReports[release]; !ok {
+	reportName := req.URL.Query().Get("release")
+	if _, ok := s.currTestReports[reportName]; !ok {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 	installhtml.PrintTestDetailHtmlReport(w, req,
-		s.currTestReports[release].CurrentPeriodReport,
-		s.currTestReports[release].PreviousWeekReport,
+		s.currTestReports[reportName].CurrentPeriodReport,
+		s.currTestReports[reportName].PreviousWeekReport,
 		req.URL.Query()["test"],
 		s.testReportGeneratorConfig.RawJobResultsAnalysisConfig.NumDays,
-		release,
+		reportName,
 	)
 }

--- a/pkg/testgridanalysis/testreportconversion/test_report.go
+++ b/pkg/testgridanalysis/testreportconversion/test_report.go
@@ -13,7 +13,7 @@ import (
 func PrepareTestReport(
 	rawData testgridanalysisapi.RawData,
 	bugCache buganalysis.BugCache, // required to associate tests with bug
-	release string, // required to limit bugs to those that apply to the release in question
+	openshiftRelease string, // required to limit bugs to those that apply to the release in question
 	// TODO refactor into a test run filter
 	minRuns int, // indicates how many runs are required for a test is included in overall percentages
 	// TODO deads2k wants to eliminate the successThreshold
@@ -25,7 +25,7 @@ func PrepareTestReport(
 ) sippyprocessingv1.TestReport {
 
 	// allJobResults holds all the job results with all the test results.  It contains complete frequency information and
-	allJobResults := convertRawJobResultsToProcessedJobResults(rawData.JobResults, bugCache, release)
+	allJobResults := convertRawJobResultsToProcessedJobResults(rawData.JobResults, bugCache, openshiftRelease)
 	allTestResultsByName := getTestResultsByName(allJobResults)
 
 	standardTestResultFilterFn := StandardTestResultFilter(minRuns, successThreshold)
@@ -42,7 +42,7 @@ func PrepareTestReport(
 
 	topFailingTestsWithBug := getTopFailingTestsWithBug(allTestResultsByName, standardTestResultFilterFn)
 	topFailingTestsWithoutBug := getTopFailingTestsWithoutBug(allTestResultsByName, standardTestResultFilterFn)
-	curatedTests := getCuratedTests(release, allTestResultsByName)
+	curatedTests := getCuratedTests(openshiftRelease, allTestResultsByName)
 
 	// the top level indicators should exclude jobs that are not yet stable, because those failures are not informative
 	infra := excludeNeverStableJobs(allTestResultsByName[testgridanalysisapi.InfrastructureTestName])
@@ -51,7 +51,7 @@ func PrepareTestReport(
 	finalOperatorHealth := excludeNeverStableJobs(allTestResultsByName[testgridanalysisapi.FinalOperatorHealthTestName])
 
 	testReport := sippyprocessingv1.TestReport{
-		Release:   release,
+		Release:   openshiftRelease,
 		Timestamp: reportTimestamp,
 		TopLevelIndicators: sippyprocessingv1.TopLevelIndicators{
 			Infrastructure:      infra,


### PR DESCRIPTION
Refactors the args to allow execution like `./sippy --server --local-data ../data-dir --dashboard=kube-master=sig-release-master-blocking,sig-release-master-informing=` that allows wiring against kubernetes (or non-openshift releases).

The `--release` flag still work and pipes to this new and specific mechanism.