### PR TITLE
Add guard for bug.Component to prevent panic when loading /detailed endpoint

### DIFF
--- a/pkg/testgridanalysis/testreportconversion/by_component.go
+++ b/pkg/testgridanalysis/testreportconversion/by_component.go
@@ -124,7 +124,9 @@ func getBugzillaComponentsFromTestResult(testResult sippyprocessingv1.TestResult
 	bzComponents := sets.String{}
 	bugList := testResult.BugList
 	for _, bug := range bugList {
-		bzComponents.Insert(bug.Component[0])
+		if len(bug.Component) > 0 {
+			bzComponents.Insert(bug.Component[0])
+		}
 	}
 	if len(bzComponents) > 0 {
 		return bzComponents.List()


### PR DESCRIPTION
Currently when viewing the /detailed endpoint sippy will panic and the content will not be served