### PR TITLE
Use grid=old for links given in summaries

### DIFF
--- a/pkg/testgridanalysis/testgridhelpers/testgridhelpers.go
+++ b/pkg/testgridanalysis/testgridhelpers/testgridhelpers.go
@@ -102,7 +102,7 @@ func loadJobDetails(dashboard, jobName, storagePath string) (testgridv1.JobDetai
 	if err != nil {
 		return details, err
 	}
-	details.TestGridUrl = fmt.Sprintf("https://testgrid.k8s.io/%s#%s", dashboard, jobName)
+	details.TestGridUrl = fmt.Sprintf("https://testgrid.k8s.io/%s#%s&grid=old", dashboard, jobName)
 	return details, nil
 }
 


### PR DESCRIPTION
without grid=old the testgrid summary might not show the
most recent results and if the user doesn't recognize this
they may be confused and think the job hasn't run recently
or not realize the current state of the job.

this is a known issue I guess and has some discussion
here: https://github.com/GoogleCloudPlatform/testgrid/issues/211

Signed-off-by: Jamo Luhrsen <jluhrsen@redhat.com>