### PR TITLE
build URLs with escaping

### DIFF
--- a/pkg/testgridanalysis/testgridhelpers/testgridhelpers.go
+++ b/pkg/testgridanalysis/testgridhelpers/testgridhelpers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/http/httputil"
 	"os"
 	"regexp"
 	"time"
@@ -182,7 +183,9 @@ func downloadJobDetails(dashboard, jobName, storagePath string) error {
 		return err
 	}
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("Non-200 response code fetching job details: %v", resp)
+		responseDump, _ := httputil.DumpResponse(resp, true)
+		fmt.Fprintf(os.Stderr, "response dump\n%v\n", string(responseDump))
+		return fmt.Errorf("non-200 response code fetching job details from %v: %v", url, resp)
 	}
 
 	filename := storagePath + "/" + normalizeURL(url)

--- a/pkg/testgridanalysis/testgridhelpers/testgridhelpers.go
+++ b/pkg/testgridanalysis/testgridhelpers/testgridhelpers.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
+	gourl "net/url"
 	"os"
 	"regexp"
 	"time"
@@ -89,13 +90,13 @@ func loadJobDetails(dashboard, jobName, storagePath string) (testgridv1.JobDetai
 		Name: jobName,
 	}
 
-	url := fmt.Sprintf("https://testgrid.k8s.io/%s/table?&show-stale-tests=&tab=%s&grid=old", dashboard, jobName)
+	url := URLForJobDetails(dashboard, jobName)
 
 	var buf *bytes.Buffer
-	filename := storagePath + "/" + normalizeURL(url)
+	filename := storagePath + "/" + normalizeURL(url.String())
 	b, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return details, fmt.Errorf("Could not read local data file %s: %v", filename, err)
+		return details, fmt.Errorf("could not read local data file %s: %v", filename, err)
 	}
 	buf = bytes.NewBuffer(b)
 
@@ -103,19 +104,19 @@ func loadJobDetails(dashboard, jobName, storagePath string) (testgridv1.JobDetai
 	if err != nil {
 		return details, err
 	}
-	details.TestGridUrl = fmt.Sprintf("https://testgrid.k8s.io/%s#%s&grid=old", dashboard, jobName)
+	details.TestGridUrl = URLForJob(dashboard, jobName).String()
 	return details, nil
 }
 
 func loadJobSummaries(dashboard string, storagePath string) (map[string]testgridv1.JobSummary, time.Time, error) {
 	jobs := make(map[string]testgridv1.JobSummary)
-	url := fmt.Sprintf("https://testgrid.k8s.io/%s/summary", dashboard)
+	url := URLForJobSummary(dashboard)
 
 	var buf *bytes.Buffer
-	filename := storagePath + "/" + normalizeURL(url)
+	filename := storagePath + "/" + normalizeURL(url.String())
 	b, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return jobs, time.Time{}, fmt.Errorf("Could not read local data file %s: %v", filename, err)
+		return jobs, time.Time{}, fmt.Errorf("could not read local data file %s (holds %s): %v", filename, url.String(), err)
 	}
 	buf = bytes.NewBuffer(b)
 	f, _ := os.Stat(filename)
@@ -123,7 +124,7 @@ func loadJobSummaries(dashboard string, storagePath string) (map[string]testgrid
 
 	err = json.NewDecoder(buf).Decode(&jobs)
 	if err != nil {
-		return nil, time.Time{}, err
+		return nil, time.Time{}, fmt.Errorf("could not parse local data file %s (holds %s): %v", filename, url.String(), err)
 	}
 
 	return jobs, f.ModTime(), nil
@@ -149,16 +150,16 @@ NextChar:
 }
 
 func downloadJobSummaries(dashboard string, storagePath string) error {
-	url := fmt.Sprintf("https://testgrid.k8s.io/%s/summary", dashboard)
+	url := URLForJobSummary(dashboard)
 
-	resp, err := http.Get(url)
+	resp, err := http.Get(url.String())
 	if err != nil {
 		return err
 	}
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("Non-200 response code fetching job summary: %v", resp)
+		return fmt.Errorf("non-200 response code fetching job details from %v: %v", url, resp)
 	}
-	filename := storagePath + "/" + normalizeURL(url)
+	filename := storagePath + "/" + normalizeURL(url.String())
 	f, err := os.Create(filename)
 	if err != nil {
 		return err
@@ -175,10 +176,48 @@ func downloadJobSummaries(dashboard string, storagePath string) error {
 
 // https://testgrid.k8s.io/redhat-openshift-ocp-release-4.4-informing#release-openshift-origin-installer-e2e-azure-compact-4.4&show-stale-tests=&sort-by-failures=
 
-func downloadJobDetails(dashboard, jobName, storagePath string) error {
-	url := fmt.Sprintf("https://testgrid.k8s.io/%s/table?&show-stale-tests=&tab=%s&grid=old", dashboard, jobName)
+func URLForJobDetails(dashboard, jobName string) *gourl.URL {
+	url := &gourl.URL{
+		Scheme: "https",
+		Host:   "testgrid.k8s.io",
+		Path:   fmt.Sprintf("/%s/table", gourl.PathEscape(dashboard)),
+	}
+	query := url.Query()
+	query.Set("show-stale-tests", "")
+	query.Set("tab", jobName)
+	query.Set("grid", "old")
+	url.RawQuery = query.Encode()
 
-	resp, err := http.Get(url)
+	return url
+}
+func URLForJobSummary(dashboard string) *gourl.URL {
+	url := &gourl.URL{
+		Scheme: "https",
+		Host:   "testgrid.k8s.io",
+		Path:   fmt.Sprintf("/%s/summary", gourl.PathEscape(dashboard)),
+	}
+
+	return url
+}
+
+func URLForJob(dashboard, jobName string) *gourl.URL {
+	url := &gourl.URL{
+		Scheme: "https",
+		Host:   "testgrid.k8s.io",
+		Path:   fmt.Sprintf("/%s", gourl.PathEscape(dashboard)),
+	}
+	query := url.Query()
+	query.Set("grid", "old")
+	// this is a non-standard fragment honored by test-grid
+	url.Fragment = gourl.PathEscape(jobName) + "&" + query.Encode()
+
+	return url
+}
+
+func downloadJobDetails(dashboard, jobName, storagePath string) error {
+	url := URLForJobDetails(dashboard, jobName)
+
+	resp, err := http.Get(url.String())
 	if err != nil {
 		return err
 	}
@@ -188,7 +227,7 @@ func downloadJobDetails(dashboard, jobName, storagePath string) error {
 		return fmt.Errorf("non-200 response code fetching job details from %v: %v", url, resp)
 	}
 
-	filename := storagePath + "/" + normalizeURL(url)
+	filename := storagePath + "/" + normalizeURL(url.String())
 	f, err := os.Create(filename)
 	if err != nil {
 		return err

--- a/pkg/testgridanalysis/testgridhelpers/testgridhelpers_test.go
+++ b/pkg/testgridanalysis/testgridhelpers/testgridhelpers_test.go
@@ -1,6 +1,9 @@
 package testgridhelpers
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func Test_normalizeURL(t *testing.T) {
 	tests := []struct {
@@ -16,6 +19,87 @@ func Test_normalizeURL(t *testing.T) {
 		t.Run(tt.url, func(t *testing.T) {
 			if got := normalizeURL(tt.url); got != tt.want {
 				t.Errorf("normalizeURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestURLForJob(t *testing.T) {
+	type args struct {
+		dashboard string
+		jobName   string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "simple",
+			args: args{
+				dashboard: "redhat-openshift-ocp-release-4.4-informing",
+				jobName:   "release-openshift-origin-installer-e2e-azure-compact-4.4",
+			},
+			want: "https://testgrid.k8s.io/redhat-openshift-ocp-release-4.4-informing#release-openshift-origin-installer-e2e-azure-compact-4.4&grid=old",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := URLForJob(tt.args.dashboard, tt.args.jobName); !reflect.DeepEqual(got.String(), tt.want) {
+				t.Errorf("URLForJob() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestURLForJobDetails(t *testing.T) {
+	type args struct {
+		dashboard string
+		jobName   string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "simple",
+			args: args{
+				dashboard: "redhat-openshift-ocp-release-4.4-informing",
+				jobName:   "release-openshift-origin-installer-e2e-azure-compact-4.4",
+			},
+			want: "https://testgrid.k8s.io/redhat-openshift-ocp-release-4.4-informing/table?grid=old&show-stale-tests=&tab=release-openshift-origin-installer-e2e-azure-compact-4.4",
+		}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := URLForJobDetails(tt.args.dashboard, tt.args.jobName); !reflect.DeepEqual(got.String(), tt.want) {
+				t.Errorf("URLForJobDetails() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestURLForJobSummary(t *testing.T) {
+	type args struct {
+		dashboard string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "simple",
+			args: args{
+				dashboard: "redhat-openshift-ocp-release-4.4-informing",
+			},
+			want: "https://testgrid.k8s.io/redhat-openshift-ocp-release-4.4-informing/summary",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := URLForJobSummary(tt.args.dashboard); !reflect.DeepEqual(got.String(), tt.want) {
+				t.Errorf("URLForJobSummary() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Some kube jobs ran afoul of string concat.  This adds test and replaces the offending methods.