### PR TITLE
handle missing setup tests in kube tests

### DIFF
--- a/pkg/testgridanalysis/testidentification/test_identification.go
+++ b/pkg/testgridanalysis/testidentification/test_identification.go
@@ -39,6 +39,14 @@ func IsSetupContainerEquivalent(testName string) bool {
 		return true
 	}
 
+	//  kube uses this to mean the installation worked.  It's not perfectly analogous, but it's close.
+	if testName == "Up" {
+		return true
+	}
+	if strings.HasSuffix(testName, "create-cluster") {
+		return true
+	}
+
 	return false
 }
 

--- a/pkg/testgridanalysis/testreportconversion/jobresult.go
+++ b/pkg/testgridanalysis/testreportconversion/jobresult.go
@@ -107,6 +107,13 @@ func convertRawJobResultToProcessedJobResult(
 	job.PassPercentageWithKnownFailures = percent(job.Successes+job.KnownFailures, job.Failures-job.KnownFailures)
 	job.PassPercentageWithoutInfrastructureFailures = percent(job.Successes, job.Failures-job.InfrastructureFailures)
 
+	// if there are more infrastructure failures than overall failures, then something is wrong with our accounting and
+	// we should make it clear this is an invalid value.
+	// TODO wire a warning. This is strictly better than nothing at the moment though.
+	if job.InfrastructureFailures > job.Failures {
+		job.PassPercentageWithoutInfrastructureFailures = -1
+	}
+
 	return job
 }
 


### PR DESCRIPTION
These errors cause bad numbers of infrastructure failures, which in turn
cause bad numbers in parens.

This PR adds a couple common cases and then skips adding invalid numbers
of infrastructure failures when jobs don't have setup/install.