### PR TITLE
Remove extraneous space in synthetic test names

### DIFF
--- a/pkg/testgridanalysis/testgridconversion/ocp_synthentic_tests.go
+++ b/pkg/testgridanalysis/testgridconversion/ocp_synthentic_tests.go
@@ -73,7 +73,7 @@ func (openshiftSyntheticManager) CreateSyntheticTests(rawJobResults testgridanal
 				syntheticTests[testgridanalysisapi.InstallTestName].pass = 1
 				// if the test succeeded, then the operator install tests should all be passes
 				for _, operatorState := range jrr.FinalOperatorStates {
-					testName := testgridanalysisapi.OperatorInstallPrefix + " " + operatorState.Name
+					testName := testgridanalysisapi.OperatorInstallPrefix + operatorState.Name
 					syntheticTests[testName] = &synthenticTestResult{
 						name: testName,
 						pass: 1,
@@ -89,7 +89,7 @@ func (openshiftSyntheticManager) CreateSyntheticTests(rawJobResults testgridanal
 
 				// if the test failed, then the operator install tests should match the operator state
 				for _, operatorState := range jrr.FinalOperatorStates {
-					testName := testgridanalysisapi.OperatorInstallPrefix + " " + operatorState.Name
+					testName := testgridanalysisapi.OperatorInstallPrefix + operatorState.Name
 					syntheticTests[testName] = &synthenticTestResult{
 						name: testName,
 					}


### PR DESCRIPTION
the prefix constant already includes a trailing space, so this was extraneous and caused confusion when doing ci search lookups.
