### PR TITLE
properly set the report name

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func (o *Options) ToTestGridDashboardCoordinates() []sippyserver.TestGridDashboa
 			sippyserver.TestGridDashboardCoordinates{
 				ReportName:             tokens[0],
 				TestGridDashboardNames: strings.Split(tokens[1], ","),
-				OpenshiftRelease:       tokens[2],
+				BugzillaRelease:        tokens[2],
 			},
 		)
 	}

--- a/pkg/apis/sippyprocessing/v1/types.go
+++ b/pkg/apis/sippyprocessing/v1/types.go
@@ -10,6 +10,9 @@ import (
 
 // TestReport is a type that lives in service of producing the html rendering for sippy.
 type TestReport struct {
+	// release is the logical name used to identify the dashboard display name.  When using openshift, this corresponds
+	// to actual releases like 4.6, 4.7, etc.  For non-openshift, it corresponds to --dashboard=<display-name>; the display-name
+	// is the value of release.
 	Release   string    `json:"release"`
 	Timestamp time.Time `json:"timestamp"`
 

--- a/pkg/sippyserver/analyzer.go
+++ b/pkg/sippyserver/analyzer.go
@@ -57,12 +57,12 @@ func (a *TestReportGeneratorConfig) PrepareTestReport(
 	bugCache buganalysis.BugCache,
 ) sippyprocessingv1.TestReport {
 	testGridJobDetails, lastUpdateTime := testgridhelpers.LoadTestGridDataFromDisk(a.TestGridLoadingConfig.LocalData, dashboard.TestGridDashboardNames, a.TestGridLoadingConfig.JobFilter)
-	return a.prepareTestReportFromData(dashboard.OpenshiftRelease, syntheticTestManager, variantManager, bugCache, testGridJobDetails, lastUpdateTime)
+	return a.prepareTestReportFromData(dashboard.BugzillaRelease, syntheticTestManager, variantManager, bugCache, testGridJobDetails, lastUpdateTime)
 }
 
 // prepareTestReportFromData should always remain private unless refactored. it's a convenient way to re-use the test grid data deserialized from disk.
 func (a *TestReportGeneratorConfig) prepareTestReportFromData(
-	openshiftRelease string,
+	bugzillaRelease string,
 	syntheticTestManager testgridconversion.SythenticTestManager,
 	variantManager testidentification.VariantManager,
 	bugCache buganalysis.BugCache,
@@ -84,7 +84,7 @@ func (a *TestReportGeneratorConfig) prepareTestReportFromData(
 		rawJobResults,
 		variantManager,
 		bugCache,
-		openshiftRelease,
+		bugzillaRelease,
 		a.DisplayDataConfig.MinTestRuns,
 		a.DisplayDataConfig.TestSuccessThreshold,
 		a.RawJobResultsAnalysisConfig.NumDays,
@@ -104,11 +104,11 @@ func (a TestReportGeneratorConfig) PrepareStandardTestReports(
 	testGridJobDetails, lastUpdateTime := testgridhelpers.LoadTestGridDataFromDisk(a.TestGridLoadingConfig.LocalData, dashboard.TestGridDashboardNames, a.TestGridLoadingConfig.JobFilter)
 
 	currTimePeriodConfig := a.deepCopy()
-	currentTimePeriodReport := currTimePeriodConfig.prepareTestReportFromData(dashboard.OpenshiftRelease, syntheticTestManager, variantManager, bugCache, testGridJobDetails, lastUpdateTime)
+	currentTimePeriodReport := currTimePeriodConfig.prepareTestReportFromData(dashboard.BugzillaRelease, syntheticTestManager, variantManager, bugCache, testGridJobDetails, lastUpdateTime)
 
 	currentTwoDayPeriodConfig := a.deepCopy()
 	currentTwoDayPeriodConfig.RawJobResultsAnalysisConfig.NumDays = 2
-	currentTwoDayReport := currentTwoDayPeriodConfig.prepareTestReportFromData(dashboard.OpenshiftRelease, syntheticTestManager, variantManager, bugCache, testGridJobDetails, lastUpdateTime)
+	currentTwoDayReport := currentTwoDayPeriodConfig.prepareTestReportFromData(dashboard.BugzillaRelease, syntheticTestManager, variantManager, bugCache, testGridJobDetails, lastUpdateTime)
 
 	previousSevenDayPeriodConfig := a.deepCopy()
 	if a.RawJobResultsAnalysisConfig.StartDay >= 0 {
@@ -117,7 +117,7 @@ func (a TestReportGeneratorConfig) PrepareStandardTestReports(
 		previousSevenDayPeriodConfig.RawJobResultsAnalysisConfig.StartDay = a.RawJobResultsAnalysisConfig.StartDay - a.RawJobResultsAnalysisConfig.NumDays
 	}
 	previousSevenDayPeriodConfig.RawJobResultsAnalysisConfig.NumDays = 7
-	previousSevenDayReport := previousSevenDayPeriodConfig.prepareTestReportFromData(dashboard.OpenshiftRelease, syntheticTestManager, variantManager, bugCache, testGridJobDetails, lastUpdateTime)
+	previousSevenDayReport := previousSevenDayPeriodConfig.prepareTestReportFromData(dashboard.BugzillaRelease, syntheticTestManager, variantManager, bugCache, testGridJobDetails, lastUpdateTime)
 
 	return StandardReport{
 		CurrentPeriodReport: currentTimePeriodReport,

--- a/pkg/sippyserver/analyzer.go
+++ b/pkg/sippyserver/analyzer.go
@@ -57,11 +57,12 @@ func (a *TestReportGeneratorConfig) PrepareTestReport(
 	bugCache buganalysis.BugCache,
 ) sippyprocessingv1.TestReport {
 	testGridJobDetails, lastUpdateTime := testgridhelpers.LoadTestGridDataFromDisk(a.TestGridLoadingConfig.LocalData, dashboard.TestGridDashboardNames, a.TestGridLoadingConfig.JobFilter)
-	return a.prepareTestReportFromData(dashboard.BugzillaRelease, syntheticTestManager, variantManager, bugCache, testGridJobDetails, lastUpdateTime)
+	return a.prepareTestReportFromData(dashboard.ReportName, dashboard.BugzillaRelease, syntheticTestManager, variantManager, bugCache, testGridJobDetails, lastUpdateTime)
 }
 
 // prepareTestReportFromData should always remain private unless refactored. it's a convenient way to re-use the test grid data deserialized from disk.
 func (a *TestReportGeneratorConfig) prepareTestReportFromData(
+	reportName string,
 	bugzillaRelease string,
 	syntheticTestManager testgridconversion.SythenticTestManager,
 	variantManager testidentification.VariantManager,
@@ -81,6 +82,7 @@ func (a *TestReportGeneratorConfig) prepareTestReportFromData(
 	warnings = append(warnings, bugCacheWarnings...)
 
 	return testreportconversion.PrepareTestReport(
+		reportName,
 		rawJobResults,
 		variantManager,
 		bugCache,
@@ -104,11 +106,11 @@ func (a TestReportGeneratorConfig) PrepareStandardTestReports(
 	testGridJobDetails, lastUpdateTime := testgridhelpers.LoadTestGridDataFromDisk(a.TestGridLoadingConfig.LocalData, dashboard.TestGridDashboardNames, a.TestGridLoadingConfig.JobFilter)
 
 	currTimePeriodConfig := a.deepCopy()
-	currentTimePeriodReport := currTimePeriodConfig.prepareTestReportFromData(dashboard.BugzillaRelease, syntheticTestManager, variantManager, bugCache, testGridJobDetails, lastUpdateTime)
+	currentTimePeriodReport := currTimePeriodConfig.prepareTestReportFromData(dashboard.ReportName, dashboard.BugzillaRelease, syntheticTestManager, variantManager, bugCache, testGridJobDetails, lastUpdateTime)
 
 	currentTwoDayPeriodConfig := a.deepCopy()
 	currentTwoDayPeriodConfig.RawJobResultsAnalysisConfig.NumDays = 2
-	currentTwoDayReport := currentTwoDayPeriodConfig.prepareTestReportFromData(dashboard.BugzillaRelease, syntheticTestManager, variantManager, bugCache, testGridJobDetails, lastUpdateTime)
+	currentTwoDayReport := currentTwoDayPeriodConfig.prepareTestReportFromData(dashboard.ReportName, dashboard.BugzillaRelease, syntheticTestManager, variantManager, bugCache, testGridJobDetails, lastUpdateTime)
 
 	previousSevenDayPeriodConfig := a.deepCopy()
 	if a.RawJobResultsAnalysisConfig.StartDay >= 0 {
@@ -117,7 +119,7 @@ func (a TestReportGeneratorConfig) PrepareStandardTestReports(
 		previousSevenDayPeriodConfig.RawJobResultsAnalysisConfig.StartDay = a.RawJobResultsAnalysisConfig.StartDay - a.RawJobResultsAnalysisConfig.NumDays
 	}
 	previousSevenDayPeriodConfig.RawJobResultsAnalysisConfig.NumDays = 7
-	previousSevenDayReport := previousSevenDayPeriodConfig.prepareTestReportFromData(dashboard.BugzillaRelease, syntheticTestManager, variantManager, bugCache, testGridJobDetails, lastUpdateTime)
+	previousSevenDayReport := previousSevenDayPeriodConfig.prepareTestReportFromData(dashboard.ReportName, dashboard.BugzillaRelease, syntheticTestManager, variantManager, bugCache, testGridJobDetails, lastUpdateTime)
 
 	return StandardReport{
 		CurrentPeriodReport: currentTimePeriodReport,

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -62,7 +62,7 @@ type TestGridDashboardCoordinates struct {
 	// this is generic and is required
 	TestGridDashboardNames []string
 	// this is openshift specific, used for BZ lookup and not required
-	OpenshiftRelease string
+	BugzillaRelease string
 }
 
 type StandardReport struct {

--- a/pkg/testgridanalysis/testidentification/test_identification.go
+++ b/pkg/testgridanalysis/testidentification/test_identification.go
@@ -79,8 +79,8 @@ var (
 	machineConfigsUpgraded = "[sig-mco] Machine config pools complete upgrade"
 )
 
-func IsCuratedTest(release, testName string) bool {
-	for _, substring := range curatedTestSubstrings[release] {
+func IsCuratedTest(bugzillaRelease, testName string) bool {
+	for _, substring := range curatedTestSubstrings[bugzillaRelease] {
 		if strings.Contains(testName, substring) {
 			return true
 		}

--- a/pkg/testgridanalysis/testreportconversion/by_tests.go
+++ b/pkg/testgridanalysis/testreportconversion/by_tests.go
@@ -23,9 +23,9 @@ func getTopFailingTestsWithoutBug(testResultsByName testResultsByName, testResul
 	}, testResultFilterFn)
 }
 
-func getCuratedTests(release string, testResultsByName testResultsByName) []sippyprocessingv1.FailingTestResult {
+func getCuratedTests(bugzillaRelease string, testResultsByName testResultsByName) []sippyprocessingv1.FailingTestResult {
 	return getTopFailingTests(testResultsByName, func(testResult sippyprocessingv1.TestResult) bool {
-		return testidentification.IsCuratedTest(release, testResult.Name)
+		return testidentification.IsCuratedTest(bugzillaRelease, testResult.Name)
 	}, acceptAllTests)
 }
 

--- a/pkg/testgridanalysis/testreportconversion/jobresult.go
+++ b/pkg/testgridanalysis/testreportconversion/jobresult.go
@@ -63,12 +63,12 @@ func filterPertinentInfrequentJobResults(
 func convertRawJobResultsToProcessedJobResults(
 	rawJobResults map[string]testgridanalysisapi.RawJobResult,
 	bugCache buganalysis.BugCache, // required to associate tests with bug
-	release string, // required to limit bugs to those that apply to the release in question,
+	bugzillaRelease string, // required to limit bugs to those that apply to the release in question,
 ) []sippyprocessingv1.JobResult {
 	jobs := []sippyprocessingv1.JobResult{}
 
 	for _, rawJobResult := range rawJobResults {
-		job := convertRawJobResultToProcessedJobResult(rawJobResult, bugCache, release)
+		job := convertRawJobResultToProcessedJobResult(rawJobResult, bugCache, bugzillaRelease)
 		jobs = append(jobs, job)
 	}
 
@@ -80,13 +80,13 @@ func convertRawJobResultsToProcessedJobResults(
 func convertRawJobResultToProcessedJobResult(
 	rawJobResult testgridanalysisapi.RawJobResult,
 	bugCache buganalysis.BugCache, // required to associate tests with bug
-	release string, // required to limit bugs to those that apply to the release in question,
+	bugzillaRelease string, // required to limit bugs to those that apply to the release in question,
 ) sippyprocessingv1.JobResult {
 
 	job := sippyprocessingv1.JobResult{
 		Name:        rawJobResult.JobName,
 		TestGridUrl: rawJobResult.TestGridJobUrl,
-		TestResults: convertRawTestResultsToProcessedTestResults(rawJobResult.JobName, rawJobResult.TestResults, bugCache, release),
+		TestResults: convertRawTestResultsToProcessedTestResults(rawJobResult.JobName, rawJobResult.TestResults, bugCache, bugzillaRelease),
 	}
 
 	for _, rawJRR := range rawJobResult.JobRunResults {

--- a/pkg/testgridanalysis/testreportconversion/test_report.go
+++ b/pkg/testgridanalysis/testreportconversion/test_report.go
@@ -15,7 +15,7 @@ func PrepareTestReport(
 	rawData testgridanalysisapi.RawData,
 	variantManager testidentification.VariantManager,
 	bugCache buganalysis.BugCache, // required to associate tests with bug
-	openshiftRelease string, // required to limit bugs to those that apply to the release in question
+	bugzillaRelease string, // required to limit bugs to those that apply to the release in question
 	// TODO refactor into a test run filter
 	minRuns int, // indicates how many runs are required for a test is included in overall percentages
 	// TODO deads2k wants to eliminate the successThreshold
@@ -27,7 +27,7 @@ func PrepareTestReport(
 ) sippyprocessingv1.TestReport {
 
 	// allJobResults holds all the job results with all the test results.  It contains complete frequency information and
-	allJobResults := convertRawJobResultsToProcessedJobResults(rawData.JobResults, bugCache, openshiftRelease)
+	allJobResults := convertRawJobResultsToProcessedJobResults(rawData.JobResults, bugCache, bugzillaRelease)
 	allTestResultsByName := getTestResultsByName(allJobResults)
 
 	standardTestResultFilterFn := StandardTestResultFilter(minRuns, successThreshold)
@@ -44,7 +44,7 @@ func PrepareTestReport(
 
 	topFailingTestsWithBug := getTopFailingTestsWithBug(allTestResultsByName, standardTestResultFilterFn)
 	topFailingTestsWithoutBug := getTopFailingTestsWithoutBug(allTestResultsByName, standardTestResultFilterFn)
-	curatedTests := getCuratedTests(openshiftRelease, allTestResultsByName)
+	curatedTests := getCuratedTests(bugzillaRelease, allTestResultsByName)
 
 	// the top level indicators should exclude jobs that are not yet stable, because those failures are not informative
 	infra := excludeNeverStableJobs(allTestResultsByName[testgridanalysisapi.InfrastructureTestName], variantManager)
@@ -53,7 +53,7 @@ func PrepareTestReport(
 	finalOperatorHealth := excludeNeverStableJobs(allTestResultsByName[testgridanalysisapi.FinalOperatorHealthTestName], variantManager)
 
 	testReport := sippyprocessingv1.TestReport{
-		Release:   openshiftRelease,
+		Release:   bugzillaRelease,
 		Timestamp: reportTimestamp,
 		TopLevelIndicators: sippyprocessingv1.TopLevelIndicators{
 			Infrastructure:      infra,

--- a/pkg/testgridanalysis/testreportconversion/test_report.go
+++ b/pkg/testgridanalysis/testreportconversion/test_report.go
@@ -12,6 +12,7 @@ import (
 )
 
 func PrepareTestReport(
+	reportName string,
 	rawData testgridanalysisapi.RawData,
 	variantManager testidentification.VariantManager,
 	bugCache buganalysis.BugCache, // required to associate tests with bug
@@ -53,7 +54,7 @@ func PrepareTestReport(
 	finalOperatorHealth := excludeNeverStableJobs(allTestResultsByName[testgridanalysisapi.FinalOperatorHealthTestName], variantManager)
 
 	testReport := sippyprocessingv1.TestReport{
-		Release:   bugzillaRelease,
+		Release:   reportName,
 		Timestamp: reportTimestamp,
 		TopLevelIndicators: sippyprocessingv1.TopLevelIndicators{
 			Infrastructure:      infra,

--- a/pkg/testgridanalysis/testreportconversion/testresult.go
+++ b/pkg/testgridanalysis/testreportconversion/testresult.go
@@ -100,7 +100,7 @@ func convertRawTestResultToProcessedTestResult(
 	jobName string,
 	rawTestResult testgridanalysisapi.RawTestResult,
 	bugCache buganalysis.BugCache, // required to associate tests with bug
-	release string, // required to limit bugs to those that apply to the release in question
+	bugzillaRelease string, // required to limit bugs to those that apply to the release in question
 ) sippyprocessingv1.TestResult {
 	return sippyprocessingv1.TestResult{
 		Name:           rawTestResult.Name,
@@ -108,7 +108,7 @@ func convertRawTestResultToProcessedTestResult(
 		Failures:       rawTestResult.Failures,
 		Flakes:         rawTestResult.Flakes,
 		PassPercentage: percent(rawTestResult.Successes, rawTestResult.Failures),
-		BugList:        bugCache.ListBugs(release, jobName, rawTestResult.Name),
+		BugList:        bugCache.ListBugs(bugzillaRelease, jobName, rawTestResult.Name),
 	}
 }
 
@@ -116,13 +116,13 @@ func convertRawTestResultsToProcessedTestResults(
 	jobName string,
 	rawTestResults map[string]testgridanalysisapi.RawTestResult,
 	bugCache buganalysis.BugCache, // required to associate tests with bug
-	release string, // required to limit bugs to those that apply to the release in question
+	bugzillaRelease string, // required to limit bugs to those that apply to the release in question
 ) []sippyprocessingv1.TestResult {
 
 	ret := []sippyprocessingv1.TestResult{}
 
 	for _, rawTestResult := range rawTestResults {
-		ret = append(ret, convertRawTestResultToProcessedTestResult(jobName, rawTestResult, bugCache, release))
+		ret = append(ret, convertRawTestResultToProcessedTestResult(jobName, rawTestResult, bugCache, bugzillaRelease))
 	}
 
 	sort.Stable(testResultsByPassPercentage(ret))


### PR DESCRIPTION
This allows the variant view (the big table) work for kube and openshift releases.

If you go commit by commit, the first one is a rename to clarify the meaning of two logically different values.