### PR TITLE
Include testsuite prefix in upgrade test names

### DIFF
--- a/pkg/html/installhtml/upgrade_by_operators.go
+++ b/pkg/html/installhtml/upgrade_by_operators.go
@@ -32,11 +32,16 @@ func upgradeOperatorTests(curr, prev sippyprocessingv1.TestReport) string {
 
 	// fill in the data for the first row's "All" column
 	var prevTestResult *sippyprocessingv1.TestResult
-	if installTest := util.FindFailedTestResult(testgridanalysisapi.UpgradeTestName, prev.ByTest); installTest != nil {
-		prevTestResult = &installTest.TestResultAcrossAllJobs
+	if prevInstallTest := util.FindFailedTestResult(testgridanalysisapi.UpgradeTestName, prev.ByTest); prevInstallTest != nil {
+		prevTestResult = &prevInstallTest.TestResultAcrossAllJobs
 	}
+	var currTestResult sippyprocessingv1.TestResult
+	if currInstallTest := util.FindFailedTestResult(testgridanalysisapi.UpgradeTestName, curr.ByTest); currInstallTest != nil {
+		currTestResult = currInstallTest.TestResultAcrossAllJobs
+	}
+
 	dataForTestsByVariant.aggregationToOverallTestResult["All"] = &currPrevTestResult{
-		curr: util.FindFailedTestResult(testgridanalysisapi.UpgradeTestName, curr.ByTest).TestResultAcrossAllJobs,
+		curr: currTestResult,
 		prev: prevTestResult,
 	}
 

--- a/pkg/testgridanalysis/testidentification/test_identification.go
+++ b/pkg/testgridanalysis/testidentification/test_identification.go
@@ -1,6 +1,7 @@
 package testidentification
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/openshift/sippy/pkg/testgridanalysis/testgridanalysisapi"
@@ -74,9 +75,9 @@ var curatedTestSubstrings = map[string][]string{
 }
 
 var (
-	cvoAcknowledgesUpgrade = "Cluster upgrade.[sig-cluster-lifecycle] Cluster version operator acknowledges upgrade"
-	operatorsUpgraded      = "Cluster upgrade.[sig-cluster-lifecycle] Cluster completes upgrade"
-	machineConfigsUpgraded = "Cluster upgrade.[sig-mco] Machine config pools complete upgrade"
+	cvoAcknowledgesUpgradeRegex = regexp.MustCompile(`^(Cluster upgrade\.)?\[sig-cluster-lifecycle\] Cluster version operator acknowledges upgrade$`)
+	operatorsUpgradedRegex      = regexp.MustCompile(`^(Cluster upgrade\.)?\[sig-cluster-lifecycle\] Cluster completes upgrade$`)
+	machineConfigsUpgradedRegex = regexp.MustCompile(`^(Cluster upgrade\.)?\[sig-mco\] Machine config pools complete upgrade$`)
 )
 
 func IsCuratedTest(bugzillaRelease, testName string) bool {
@@ -119,15 +120,15 @@ func IsOperatorHealthTest(testName string) bool {
 }
 
 func IsUpgradeStartedTest(testName string) bool {
-	return testName == cvoAcknowledgesUpgrade
+	return cvoAcknowledgesUpgradeRegex.MatchString(testName)
 }
 
 func IsOperatorsUpgradedTest(testName string) bool {
-	return testName == operatorsUpgraded
+	return operatorsUpgradedRegex.MatchString(testName)
 }
 
 func IsMachineConfigPoolsUpgradedTest(testName string) bool {
-	return testName == machineConfigsUpgraded
+	return machineConfigsUpgradedRegex.MatchString(testName)
 }
 
 func GetOperatorFromUpgradeTest(testName string) string {

--- a/pkg/testgridanalysis/testidentification/test_identification.go
+++ b/pkg/testgridanalysis/testidentification/test_identification.go
@@ -74,9 +74,9 @@ var curatedTestSubstrings = map[string][]string{
 }
 
 var (
-	cvoAcknowledgesUpgrade = "[sig-cluster-lifecycle] Cluster version operator acknowledges upgrade"
-	operatorsUpgraded      = "[sig-cluster-lifecycle] Cluster completes upgrade"
-	machineConfigsUpgraded = "[sig-mco] Machine config pools complete upgrade"
+	cvoAcknowledgesUpgrade = "Cluster upgrade.[sig-cluster-lifecycle] Cluster version operator acknowledges upgrade"
+	operatorsUpgraded      = "Cluster upgrade.[sig-cluster-lifecycle] Cluster completes upgrade"
+	machineConfigsUpgraded = "Cluster upgrade.[sig-mco] Machine config pools complete upgrade"
 )
 
 func IsCuratedTest(bugzillaRelease, testName string) bool {


### PR DESCRIPTION
This will allow us to report upgrade pass rates properly again. I also added a guard so that if no jobs report starting upgrade the upgrade page doesn't die