### PR TITLE
Ignore looking for setup container in ocp-osd jobs

### DIFF
--- a/pkg/testgridanalysis/testgridconversion/ocp_synthentic_tests.go
+++ b/pkg/testgridanalysis/testgridconversion/ocp_synthentic_tests.go
@@ -187,6 +187,7 @@ func (openshiftSyntheticManager) CreateSyntheticTests(rawJobResults testgridanal
 var jobRegexesWithKnownBadSetupContainer = sets.NewString(
 	"promote-release-openshift-machine-os-content-e2e-aws-4.[1-7].*",
 	"periodic-ci-openshift-origin-release-3.11-e2e-gcp",
+	"release-openshift-ocp-osd",
 )
 
 func matchJobRegexList(jobName string, regexList sets.String) bool {


### PR DESCRIPTION
These jobs don't run from ci-operator it seems so we don't get
the junit to look for a setup container. This will ignore
those jobs to prevent them from being warnings for missing
a setup to indicate a successful install.

Signed-off-by: Jamo Luhrsen <jluhrsen@redhat.com>