### PR TITLE
update ovirt install test

### DIFF
--- a/pkg/testgridanalysis/testidentification/test_identification.go
+++ b/pkg/testgridanalysis/testidentification/test_identification.go
@@ -24,7 +24,7 @@ var customJobSetupContainers = sets.NewString(
 	"e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup",
 	"e2e-metal-ipi-upgrade-baremetalds-packet-setup",
 	"e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup",
-	"e2e-ovirt-ipi-install-ovirt-setup container test",
+	"e2e-ovirt-ipi-install-install container test",
 	"e2e-vsphere-ipi-install-vsphere",
 	"e2e-vsphere-serial-ipi-install-vsphere",
 	"e2e-vsphere-upi-serial-upi-install-vsphere",


### PR DESCRIPTION
We get errors on 4.8 sippy that "periodic-ci-openshift-release-master-ocp-4.8-e2e-ovirt" is missing a test setup job to indicate successful installs on the sippy release pages.
We moved to use ipi-intall-install recently and therefore needed this change