### PR TITLE
edit ovirt variant regex

### DIFF
--- a/pkg/testgridanalysis/testidentification/ocp_variants.go
+++ b/pkg/testgridanalysis/testidentification/ocp_variants.go
@@ -22,7 +22,7 @@ var (
 	gcpRegex       = regexp.MustCompile(`(?i)-gcp`)
 	openstackRegex = regexp.MustCompile(`(?i)-openstack-`)
 	osdRegex       = regexp.MustCompile(`(?i)-osd-`)
-	ovirtRegex     = regexp.MustCompile(`(?i)-ovirt-`)
+	ovirtRegex     = regexp.MustCompile(`(?i)-ovirt`)
 	ovnRegex       = regexp.MustCompile(`(?i)-ovn-`)
 	// proxy jobs do not have a trailing -version segment
 	proxyRegex   = regexp.MustCompile(`(?i)-proxy`)
@@ -31,7 +31,7 @@ var (
 	rtRegex      = regexp.MustCompile(`(?i)-rt-`)
 	s390xRegex   = regexp.MustCompile(`(?i)-s390x-`)
 	serialRegex  = regexp.MustCompile(`(?i)-serial-`)
-	upgradeRegex = regexp.MustCompile(`(?i)-upgrade-`)
+	upgradeRegex = regexp.MustCompile(`(?i)-upgrade`)
 	// some vsphere jobs do not have a trailing -version segment
 	vsphereRegex    = regexp.MustCompile(`(?i)-vsphere`)
 	vsphereUPIRegex = regexp.MustCompile(`(?i)-vsphere-upi`)


### PR DESCRIPTION
oVirt ported to workflows and changed the name of the periodic jobs to end with e2e-ovirt:
- periodic-ci-openshift-release-master-origin-4.*-stable-to-4.*-ci-e2e-ovirt-upgrade
- periodic-ci-openshift-release-master-ocp-4.*-e2e-ovirt