### PR TITLE
Add single node container to list of custom job setup containers

### DIFF
--- a/pkg/testgridanalysis/testidentification/test_identification.go
+++ b/pkg/testgridanalysis/testidentification/test_identification.go
@@ -26,6 +26,7 @@ var customJobSetupContainers = sets.NewString(
 	"e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup",
 	"e2e-metal-ipi-upgrade-baremetalds-packet-setup",
 	"e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup",
+	"e2e-metal-single-node-live-iso-baremetalds-packet-setup",
 	"e2e-ovirt-ipi-install-install container test",
 	"e2e-vsphere-ipi-install-vsphere",
 	"e2e-vsphere-serial-ipi-install-vsphere",


### PR DESCRIPTION
I believe this will resolve the message the 4.8 sippy homepage: https://sippy.ci.openshift.org/?release=4.8

![image](https://user-images.githubusercontent.com/10882062/110687678-7548cb00-81e9-11eb-85e6-83feb1a6fe66.png)
