### PR TITLE
    List bugs targeted to a different release than the one being reported on

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -106,7 +106,8 @@ func summaryTopFailingTestsWithBug(topFailingTestsWithBug, prevTestResults []sip
 						Runs:       testPrev.TestResultAcrossAllJobs.Successes + testPrev.TestResultAcrossAllJobs.Failures,
 					},
 				},
-				Bugs: test.TestResultAcrossAllJobs.BugList,
+				Bugs:           test.TestResultAcrossAllJobs.BugList,
+				AssociatedBugs: test.TestResultAcrossAllJobs.AssociatedBugList,
 			}
 		} else {
 			failedTestWithBug = sippyv1.FailingTestBug{
@@ -118,7 +119,8 @@ func summaryTopFailingTestsWithBug(topFailingTestsWithBug, prevTestResults []sip
 						Runs:       test.TestResultAcrossAllJobs.Successes + test.TestResultAcrossAllJobs.Failures,
 					},
 				},
-				Bugs: test.TestResultAcrossAllJobs.BugList,
+				Bugs:           test.TestResultAcrossAllJobs.BugList,
+				AssociatedBugs: test.TestResultAcrossAllJobs.AssociatedBugList,
 			}
 		}
 
@@ -143,8 +145,9 @@ func summaryTopFailingTestsWithoutBug(topFailingTestsWithoutBug, prevTopFailingT
 
 		if testPrev != nil {
 			failedTestWithoutBug = sippyv1.FailingTestBug{
-				Name: test.TestName,
-				Url:  testLink,
+				Name:           test.TestName,
+				Url:            testLink,
+				AssociatedBugs: test.TestResultAcrossAllJobs.AssociatedBugList,
 				PassRates: map[string]sippyv1.PassRate{
 					"latest": sippyv1.PassRate{
 						Percentage: test.TestResultAcrossAllJobs.PassPercentage,
@@ -159,8 +162,9 @@ func summaryTopFailingTestsWithoutBug(topFailingTestsWithoutBug, prevTopFailingT
 
 		} else {
 			failedTestWithoutBug = sippyv1.FailingTestBug{
-				Name: test.TestName,
-				Url:  testLink,
+				Name:           test.TestName,
+				Url:            testLink,
+				AssociatedBugs: test.TestResultAcrossAllJobs.AssociatedBugList,
 				PassRates: map[string]sippyv1.PassRate{
 					"latest": sippyv1.PassRate{
 						Percentage: test.TestResultAcrossAllJobs.PassPercentage,

--- a/pkg/apis/sippy/v1/types.go
+++ b/pkg/apis/sippy/v1/types.go
@@ -54,6 +54,8 @@ type FailingTestBug struct {
 	Url       string              `json:"url"`
 	PassRates map[string]PassRate `json:"passRates"`
 	Bugs      []bugsv1.Bug        `json:"bugs,omitempty"`
+	// AssociatedBugs are bugs that match the test/job, but do not match the target release
+	AssociatedBugs []bugsv1.Bug `json:"associatedBugs,omitempty"`
 }
 
 // JobSummaryVariant describes a single variant and its associated jobs, their pass rates, and failing tests

--- a/pkg/apis/sippyprocessing/v1/types.go
+++ b/pkg/apis/sippyprocessing/v1/types.go
@@ -122,6 +122,8 @@ type TestResult struct {
 	// TODO Inside a particular job, only bugs matching the job are present.
 	// TODO Inside a variant, only bugs matching the variant are present.
 	BugList []bugsv1.Bug `json:"bugList"`
+	// AssociatedBugList are bugs that match the test/job, but do not match the target release
+	AssociatedBugList []bugsv1.Bug `json:"associatedBugList"`
 }
 
 type JobRunResult struct {

--- a/pkg/html/generichtml/bugs.go
+++ b/pkg/html/generichtml/bugs.go
@@ -18,14 +18,25 @@ func bugLink(bug bugsv1.Bug) string {
 
 // bugHTMLForTest release and testName are required.  variant is optional, if specified it excludes test that have a
 // different variant specified, but includes bugs without any variant
-func bugHTMLForTest(bugList []bugsv1.Bug, release, variant, testName string) string {
+func bugHTMLForTest(bugList, associatedBugList []bugsv1.Bug, release, variant, testName string) string {
+	bugHTML := ""
 	if len(bugList) == 0 {
-		return openABugHTML(testName, release)
+		bugHTML += openABugHTML(testName, release)
 	}
 
-	bugHTML := "Associated Bugs: "
-	for _, bug := range bugList {
-		bugHTML += bugLink(bug)
+	if len(bugList) != 0 {
+		bugHTML += " Linked Bugs: "
+		for _, bug := range bugList {
+			bugHTML += bugLink(bug)
+		}
+		bugHTML += "<br>"
+	}
+
+	if len(associatedBugList) != 0 {
+		bugHTML += " Associated Bugs: "
+		for _, bug := range associatedBugList {
+			bugHTML += bugLink(bug)
+		}
 	}
 
 	return bugHTML

--- a/pkg/html/generichtml/testresult.go
+++ b/pkg/html/generichtml/testresult.go
@@ -23,11 +23,12 @@ func FailingTestResultHasResults(in sippyprocessingv1.FailingTestResult) bool {
 }
 
 type testResultDisplay struct {
-	displayName    string
-	displayPercent float64
-	totalRuns      int
-	flakedRuns     int
-	bugList        []bugsv1.Bug
+	displayName       string
+	displayPercent    float64
+	totalRuns         int
+	flakedRuns        int
+	bugList           []bugsv1.Bug
+	associatedBugList []bugsv1.Bug
 
 	jobResults []jobResultDisplay
 }
@@ -41,6 +42,9 @@ func testResultToDisplay(in sippyprocessingv1.TestResult) testResultDisplay {
 	}
 	for _, bug := range in.BugList {
 		ret.bugList = append(ret.bugList, bug)
+	}
+	for _, bug := range in.AssociatedBugList {
+		ret.associatedBugList = append(ret.associatedBugList, bug)
 	}
 	return ret
 }
@@ -177,7 +181,7 @@ func (b *testResultRenderBuilder) ToHTML() string {
 	testLink := fmt.Sprintf("<a target=\"_blank\" href=\"https://search.ci.openshift.org/?maxAge=168h&context=1&type=bug%%2Bjunit&name=%s&maxMatches=5&maxBytes=20971520&groupBy=job&search=%s\">%s</a>", b.release, encodedTestName, b.currTestResult.displayName)
 
 	klog.V(2).Infof("processing top failing tests %s, bugs: %v", b.currTestResult.displayName, b.currTestResult.bugList)
-	bugHTML := bugHTMLForTest(b.currTestResult.bugList, b.release, "", b.currTestResult.displayName)
+	bugHTML := bugHTMLForTest(b.currTestResult.bugList, b.currTestResult.associatedBugList, b.release, "", b.currTestResult.displayName)
 	if b.prevTestResult != nil {
 		arrow := GetArrow(b.currTestResult.totalRuns, b.currTestResult.displayPercent, b.prevTestResult.displayPercent)
 

--- a/pkg/html/releasehtml/failing_tests.go
+++ b/pkg/html/releasehtml/failing_tests.go
@@ -22,7 +22,7 @@ func summaryTopFailingTestsWithBug(topFailingTestsWithBug, allTests []sippyproce
 			<th colspan=5 class="text-center">
 				<a class="text-dark" id="TopFailingTestsWithABug" href="#TopFailingTestsWithABug">Top Failing Tests With A Bug</a>
 				%s
-				<i class="fa fa-info-circle" title="Most frequently failing tests with a known bug, sorted by passing rate.  The link will prepopulate a BZ template to be filled out and submitted to report a bug against the test."</i>
+				<i class="fa fa-info-circle" title="Most frequently failing tests with a known bug, sorted by passing rate.  Linked bugs are bugs that mention the failing test name and are targeted to the release being reported on. Associated bugs are bugs that mention the failing test name but are not targeted to the release being reported on."</i>
 			</th>
 		</tr>
 		<tr>
@@ -47,7 +47,7 @@ func summaryTopFailingTestsWithoutBug(topFailingTestsWithBug, allTests []sippypr
 			<th colspan=5 class="text-center">
 				<a class="text-dark"  id="TopFailingTestsWithoutABug" href="#TopFailingTestsWithoutABug">Top Failing Tests Without A Bug</a>
 				%s
-				<i class="fa fa-info-circle" title="Most frequently failing tests without a known bug, sorted by passing rate.  The link will prepopulate a BZ template to be filled out and submitted to report a bug against the test."</i>
+				<i class="fa fa-info-circle" title="Most frequently failing tests without a known bug, sorted by passing rate.  The link will prepopulate a BZ template to be filled out and submitted to report a bug against the test.  Associated bugs are bugs that mention the failing test name but are not targeted to the release being reported on.  It may be appropriate to clone them and target them to the release being reported on."</i>
 			</th>
 		</tr>
 		<tr>

--- a/pkg/testgridanalysis/testreportconversion/testresult.go
+++ b/pkg/testgridanalysis/testreportconversion/testresult.go
@@ -68,6 +68,7 @@ func combineTestResult(lhs, rhs sippyprocessingv1.TestResult) sippyprocessingv1.
 	combined.Flakes += rhs.Flakes
 	combined.PassPercentage = percent(combined.Successes, combined.Failures)
 	combined.BugList = combineBugLists(lhs.BugList, rhs.BugList)
+	combined.AssociatedBugList = combineBugLists(lhs.AssociatedBugList, rhs.AssociatedBugList)
 
 	return combined
 }
@@ -103,12 +104,13 @@ func convertRawTestResultToProcessedTestResult(
 	bugzillaRelease string, // required to limit bugs to those that apply to the release in question
 ) sippyprocessingv1.TestResult {
 	return sippyprocessingv1.TestResult{
-		Name:           rawTestResult.Name,
-		Successes:      rawTestResult.Successes,
-		Failures:       rawTestResult.Failures,
-		Flakes:         rawTestResult.Flakes,
-		PassPercentage: percent(rawTestResult.Successes, rawTestResult.Failures),
-		BugList:        bugCache.ListBugs(bugzillaRelease, jobName, rawTestResult.Name),
+		Name:              rawTestResult.Name,
+		Successes:         rawTestResult.Successes,
+		Failures:          rawTestResult.Failures,
+		Flakes:            rawTestResult.Flakes,
+		PassPercentage:    percent(rawTestResult.Successes, rawTestResult.Failures),
+		BugList:           bugCache.ListBugs(bugzillaRelease, jobName, rawTestResult.Name),
+		AssociatedBugList: bugCache.ListAssociatedBugs(bugzillaRelease, jobName, rawTestResult.Name),
 	}
 }
 
@@ -251,6 +253,7 @@ func excludeNeverStableJobs(in sippyprocessingv1.FailingTestResult, variantManag
 
 	for _, jobResult := range filteredFailingTestResult.JobResults {
 		filteredFailingTestResult.TestResultAcrossAllJobs.BugList = in.TestResultAcrossAllJobs.BugList
+		filteredFailingTestResult.TestResultAcrossAllJobs.AssociatedBugList = in.TestResultAcrossAllJobs.AssociatedBugList
 		filteredFailingTestResult.TestResultAcrossAllJobs.Successes += jobResult.TestSuccesses
 		filteredFailingTestResult.TestResultAcrossAllJobs.Failures += jobResult.TestFailures
 	}


### PR DESCRIPTION
List test name matching bugs that are targeted to the same release as the report as linked.
List test name matching bugs that are not targeted to the same release as the report as associated

fixes https://github.com/openshift/sippy/issues/128
