### PR TITLE
Filter out spurious BZ data from ci-search

### DIFF
--- a/pkg/buganalysis/cache.go
+++ b/pkg/buganalysis/cache.go
@@ -251,6 +251,12 @@ func findBugs(testNames []string) (map[string][]bugsv1.Bug, error) {
 			bug := match.Bug
 			bug.Url = fmt.Sprintf("https://bugzilla.redhat.com/show_bug.cgi?id=%d", bug.ID)
 
+			// search.ci.openshift.org seems to occasionally return empty BZ results, filter
+			// them out.
+			if bug.ID == 0 {
+				continue
+			}
+
 			// ignore any bugs verified over a week ago, they cannot be responsible for test failures
 			// (or the bug was incorrectly verified and needs to be revisited)
 			if !util.IsActiveBug(bug) {

--- a/pkg/testgridanalysis/testreportconversion/testresult.go
+++ b/pkg/testgridanalysis/testreportconversion/testresult.go
@@ -148,7 +148,7 @@ func FilterSuccessfulTestResults(successThreshold float64 /*indicates an upper b
 }
 
 func FilterLowValueTestsByName(testResult sippyprocessingv1.TestResult) bool {
-	if testResult.Name == "Overall" || testidentification.IsSetupContainerEquivalent(testResult.Name) {
+	if testResult.Name == "Overall" || testResult.Name == "Pod" || testidentification.IsSetupContainerEquivalent(testResult.Name) {
 		return false
 	}
 	return true


### PR DESCRIPTION
also strip out the useless "Pod" test result which matches all bugs
when it fails.

fixes https://github.com/openshift/sippy/issues/217
