### PR TITLE
Add dashboard for jobs statuses

### DIFF
--- a/pkg/api/jobs.go
+++ b/pkg/api/jobs.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	testgridv1 "github.com/openshift/sippy/pkg/apis/testgrid/v1"
+	"github.com/openshift/sippy/pkg/testgridanalysis/testgridanalysisapi"
+	"github.com/openshift/sippy/pkg/testgridanalysis/testgridconversion"
+)
+
+func jobRunStatus(result testgridanalysisapi.RawJobRunResult) string {
+	if result.Succeeded {
+		return "S" // Success
+	}
+
+	if !result.Failed {
+		return "R" // Running
+	}
+
+	if result.SetupStatus == "Failure" {
+		if len(result.FinalOperatorStates) == 0 {
+			return "N" // iNfrastructure failure
+		}
+		return "I" // Install failure
+	}
+	if result.UpgradeStarted && (result.UpgradeForOperatorsStatus == "Failure" || result.UpgradeForMachineConfigPoolsStatus == "Failure") {
+		return "U" // Upgrade failure
+	}
+	if result.OpenShiftTestsStatus == "Failure" {
+		return "F" // Failure
+	}
+	if result.SetupStatus == "" {
+		return "n" // no setup results
+	}
+	return "f" // unknown failure
+}
+
+func PrintJobsReport(w http.ResponseWriter, syntheticTestManager testgridconversion.SythenticTestManager, testGridJobDetails []testgridv1.JobDetails, lastUpdateTime time.Time) {
+	rawJobResultOptions := testgridconversion.ProcessingOptions{
+		SythenticTestManager: syntheticTestManager,
+		StartDay:             0,
+		NumDays:              1000,
+	}
+	rawJobResults, _ := rawJobResultOptions.ProcessTestGridDataIntoRawJobResults(testGridJobDetails)
+
+	type jsonJob struct {
+		Name        string   `json:"name"`
+		Timestamps  []int    `json:"timestamps"`
+		Results     []string `json:"results"`
+		BuildIDs    []string `json:"build_ids"`
+		TestGridURL string   `json:"testgrid_url"`
+	}
+	type jsonResponse struct {
+		Jobs           []jsonJob `json:"jobs"`
+		LastUpdateTime time.Time `json:"last_update_time"`
+	}
+
+	response := jsonResponse{
+		LastUpdateTime: lastUpdateTime,
+		Jobs:           []jsonJob{},
+	}
+	for _, job := range testGridJobDetails {
+		results := rawJobResults.JobResults[job.Name]
+		var statuses []string
+		for i := range job.Timestamps {
+			joburl := fmt.Sprintf("https://prow.svc.ci.openshift.org/view/gcs/%s/%s", job.Query, job.ChangeLists[i])
+			statuses = append(statuses, jobRunStatus(results.JobRunResults[joburl]))
+		}
+		response.Jobs = append(response.Jobs, jsonJob{
+			Name:        job.Name,
+			Timestamps:  job.Timestamps,
+			Results:     statuses,
+			BuildIDs:    job.ChangeLists,
+			TestGridURL: job.TestGridUrl,
+		})
+	}
+
+	json.NewEncoder(w).Encode(response)
+}

--- a/pkg/apis/testgrid/v1/types.go
+++ b/pkg/apis/testgrid/v1/types.go
@@ -1,5 +1,15 @@
 package v1
 
+type TestStatus int
+
+const (
+	TestStatusAbsent  TestStatus = 0
+	TestStatusSuccess TestStatus = 1
+	TestStatusRunning TestStatus = 4
+	TestStatusFailure TestStatus = 12
+	TestStatusFlake   TestStatus = 13
+)
+
 // testgrid datastructures
 type JobSummary struct {
 	OverallStatus string `json:"overall_status"`
@@ -22,6 +32,6 @@ type Test struct {
 }
 
 type TestResult struct {
-	Count int `json:"count"`
-	Value int `json:"value"`
+	Count int        `json:"count"`
+	Value TestStatus `json:"value"`
 }

--- a/pkg/html/releasehtml/jobs.go
+++ b/pkg/html/releasehtml/jobs.go
@@ -1,0 +1,44 @@
+package releasehtml
+
+import (
+	"html/template"
+	"log"
+	"net/http"
+)
+
+var jobsTemplate = template.Must(template.New("jobs").Parse(`
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Release {{.Release}} Jobs Dashboard</title>
+  <link href="/static/jobs.css" rel="stylesheet">
+</head>
+<body>
+  <div id="app"></div>
+
+  <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+
+  <script>
+    var release = {{.Release}};
+  </script>
+  <script data-plugins="transform-modules-umd" data-presets="react" data-type="module" type="text/babel" src="/static/jobsdashboard.mjs"></script>
+  <script data-plugins="transform-modules-umd" data-presets="react" data-type="module" type="text/babel">
+    import { JobsDashboard } from '/static/jobsdashboard.mjs';
+    const domContainer = document.querySelector('#app');
+    ReactDOM.render(<JobsDashboard release={release} />, domContainer);
+  </script>
+</body>
+</html>
+`))
+
+func PrintJobsReport(w http.ResponseWriter, release string) {
+	err := jobsTemplate.Execute(w, map[string]interface{}{
+		"Release": release,
+	})
+	if err != nil {
+		log.Print(err)
+	}
+}

--- a/pkg/testgridanalysis/testgridanalysisapi/types.go
+++ b/pkg/testgridanalysis/testgridanalysisapi/types.go
@@ -57,6 +57,9 @@ type RawJobRunResult struct {
 	UpgradeForOperatorsStatus string
 	// Success, Failure, or ""
 	UpgradeForMachineConfigPoolsStatus string
+
+	// OpenShiftTestsStatus can be "", "Success", "Failure"
+	OpenShiftTestsStatus string
 }
 
 type OperatorState struct {
@@ -74,6 +77,7 @@ const (
 	InstallTestName        = `[sig-sippy] install should work`
 	InstallTimeoutTestName = `[sig-sippy] install should not timeout`
 	UpgradeTestName        = `[sig-sippy] upgrade should work`
+	OpenShiftTestsName     = `[sig-sippy] openshift-tests should work`
 
 	Success = "Success"
 	Failure = "Failure"

--- a/pkg/testgridanalysis/testgridconversion/ocp_synthentic_tests.go
+++ b/pkg/testgridanalysis/testgridconversion/ocp_synthentic_tests.go
@@ -40,6 +40,7 @@ func (openshiftSyntheticManager) CreateSyntheticTests(rawJobResults testgridanal
 				testgridanalysisapi.InstallTimeoutTestName:      &synthenticTestResult{name: testgridanalysisapi.InstallTestName},
 				testgridanalysisapi.InfrastructureTestName:      &synthenticTestResult{name: testgridanalysisapi.InfrastructureTestName},
 				testgridanalysisapi.FinalOperatorHealthTestName: &synthenticTestResult{name: testgridanalysisapi.FinalOperatorHealthTestName},
+				testgridanalysisapi.OpenShiftTestsName:          &synthenticTestResult{name: testgridanalysisapi.OpenShiftTestsName},
 			}
 			// upgrades should only be indicated on jobs that run upgrades
 			if jrr.UpgradeStarted {
@@ -159,6 +160,13 @@ func (openshiftSyntheticManager) CreateSyntheticTests(rawJobResults testgridanal
 						}
 					}
 				}
+			}
+
+			switch {
+			case jrr.Failed && jrr.OpenShiftTestsStatus == testgridanalysisapi.Failure:
+				syntheticTests[testgridanalysisapi.OpenShiftTestsName].fail = 1
+			case jrr.OpenShiftTestsStatus == testgridanalysisapi.Success:
+				syntheticTests[testgridanalysisapi.OpenShiftTestsName].pass = 1
 			}
 
 			for testName, result := range syntheticTests {

--- a/pkg/testgridanalysis/testidentification/test_identification.go
+++ b/pkg/testgridanalysis/testidentification/test_identification.go
@@ -84,6 +84,7 @@ var (
 	cvoAcknowledgesUpgradeRegex = regexp.MustCompile(`^(Cluster upgrade\.)?\[sig-cluster-lifecycle\] Cluster version operator acknowledges upgrade$`)
 	operatorsUpgradedRegex      = regexp.MustCompile(`^(Cluster upgrade\.)?\[sig-cluster-lifecycle\] Cluster completes upgrade$`)
 	machineConfigsUpgradedRegex = regexp.MustCompile(`^(Cluster upgrade\.)?\[sig-mco\] Machine config pools complete upgrade$`)
+	openshiftTestsRegex         = regexp.MustCompile(`(?:^openshift-tests\.|\[Suite:openshift|\[k8s\.io\]|\[sig-|\[bz-)`)
 )
 
 func IsCuratedTest(bugzillaRelease, testName string) bool {
@@ -135,6 +136,10 @@ func IsOperatorsUpgradedTest(testName string) bool {
 
 func IsMachineConfigPoolsUpgradedTest(testName string) bool {
 	return machineConfigsUpgradedRegex.MatchString(testName)
+}
+
+func IsOpenShiftTest(testName string) bool {
+	return openshiftTestsRegex.MatchString(testName)
 }
 
 func GetOperatorFromUpgradeTest(testName string) string {

--- a/static/jobs.css
+++ b/static/jobs.css
@@ -1,0 +1,52 @@
+a {
+    color: #000;
+    text-decoration: none;
+}
+a:hover {
+    color: #33f;
+}
+table {
+    margin-top: 0.5em;
+    table-layout: fixed;
+    width: 100%;
+}
+.col-header {
+    text-align: center;
+}
+.col-header input {
+    box-sizing: border-box;
+    width: 100%;
+}
+.col-name {
+    width: 700px;
+}
+.col-day {
+    width: 200px;
+    background: #eee;
+}
+.results {
+    display: flex;
+}
+.results-demo {
+    width: 30px;
+    display: inline-flex;
+}
+.legend-item {
+    margin-right: 1em;
+}
+.result {
+    color: black;
+    flex: 1 1 auto;
+    text-align: center;
+    background: #aaa;
+}
+.result:hover {
+    color: black;
+}
+.result-F { background: #a00; }
+.result-f { background: #d33; }
+.result-U { background: #d60; }
+.result-I { background: #d60; }
+.result-N, .result-N:hover { background: #633; color: #a99; }
+.result-n, .result-n:hover { background: #633; color: #a99; }
+.result-S { background: #0a0; }

--- a/static/jobsdashboard.mjs
+++ b/static/jobsdashboard.mjs
@@ -1,0 +1,121 @@
+export class JobsDashboard extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            loaded: false,
+            filter: '',
+            jobs: [],
+            error: null,
+        };
+    }
+
+    componentDidMount() {
+        fetch('/api/jobs?release=' + encodeURIComponent(this.props.release))
+            .then(response => response.json())
+            .then(response => {
+                let jobs = response.jobs;
+                jobs.sort((a, b) => a.name > b.name ? 1 : a.name < b.name ? -1 : 0);
+                this.setState({
+                    loaded: true,
+                    jobs: jobs,
+                });
+            })
+            .catch(error => {
+                this.setState({
+                    loaded: true,
+                    error: error.toString(),
+                });
+            });
+    }
+
+    render() {
+        if (!this.state.loaded) {
+            return 'Loading...';
+        }
+        if (this.state.error) {
+            return 'Failed to load data: ' + this.state.error;
+        }
+
+        let filter = new RegExp(this.state.filter);
+
+        let timestampBegin = 0;
+        let timestampEnd = 0;
+        for (let job of this.state.jobs) {
+            if (!filter.test(job.name)) {
+                continue;
+            }
+            for (let ts of  job.timestamps) {
+                if (timestampBegin == 0 || ts < timestampBegin) {
+                    timestampBegin = ts;
+                }
+                if (timestampEnd == 0 || ts > timestampEnd) {
+                    timestampEnd = ts;
+                }
+            }
+        }
+
+        const msPerDay = 86400*1000;
+        timestampBegin = Math.floor(timestampBegin/msPerDay)*msPerDay;
+        timestampEnd = Math.floor(timestampEnd/msPerDay)*msPerDay;
+
+        let periodBegin = new Date(timestampBegin);
+        let periodEnd = new Date(timestampEnd);
+
+        let header = [
+            <td className="col-header col-name" key="name">
+                <input value={this.state.filter} placeholder="regular expression to filter jobs" onChange={(e) => this.setState({filter: e.target.value})} />
+            </td>
+        ];
+        let ts = timestampEnd;
+        while (ts >= timestampBegin) {
+            let d = new Date(ts);
+            let value = (d.getUTCMonth() + 1) + '/' + d.getUTCDate();
+            header.push(<td className="col-header col-day">{value}</td>);
+            ts -= msPerDay;
+        }
+
+        let rows = [];
+        for (let job of this.state.jobs) {
+            if (!filter.test(job.name)) {
+                continue;
+            }
+            let row = [<td className="col-name" key="name"><a href={job.testgrid_url}>{job.name}</a></td>];
+            let ts = timestampEnd;
+            let i = 0;
+            while (ts >= timestampBegin) {
+                let results = [];
+                while (job.timestamps[i] >= ts) {
+                    results.push(<a className={'result result-' + job.results[i]} href={'https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/' + job.name + '/' + job.build_ids[i]}>{job.results[i]}</a>);
+                    i++;
+                }
+                row.push(<td className="col-day"><div className="results">{results}</div></td>);
+                ts -= msPerDay;
+            }
+
+            rows.push(<tr key={"job-" + job.name}>{row}</tr>);
+        }
+
+        return (
+            <div>
+                <div>
+                    <span className="legend-item"><span className="results results-demo"><span className="result result-S">S</span></span> success</span>
+                    <span className="legend-item"><span className="results results-demo"><span className="result result-F">F</span></span> failure (e2e tests)</span>
+                    <span className="legend-item"><span className="results results-demo"><span className="result result-f">f</span></span> failure (other tests)</span>
+                    <span className="legend-item"><span className="results results-demo"><span className="result result-U">U</span></span> upgrade failure</span>
+                    <span className="legend-item"><span className="results results-demo"><span className="result result-I">I</span></span> setup failure (installer)</span>
+                    <span className="legend-item"><span className="results results-demo"><span className="result result-N">N</span></span> setup failure (infra)</span>
+                    <span className="legend-item"><span className="results results-demo"><span className="result result-n">n</span></span> failure before setup (infra)</span>
+                    <span className="legend-item"><span className="results results-demo"><span className="result result-R">R</span></span> running</span>
+                </div>
+                <table>
+                    <thead>
+                        <tr>{header}</tr>
+                    </thead>
+                    <tbody>
+                        {rows}
+                    </tbody>
+                </table>
+            </div>
+        );
+    }
+}


### PR DESCRIPTION
A new dashboard (similar to TestGrid) with all jobs.

This PR adds two new endpoints:

* `/api/jobs` that returns a JSON with statuses of all jobs
* `/jobs` with React app that shows data from `/api/jobs`

![image](https://user-images.githubusercontent.com/443137/113190747-fa5d5800-925c-11eb-83ea-f4ef2363e4e4.png)