### PR TITLE
Add linked/associated bug lists to job reports

### DIFF
--- a/pkg/apis/sippyprocessing/v1/types.go
+++ b/pkg/apis/sippyprocessing/v1/types.go
@@ -137,16 +137,19 @@ type JobRunResult struct {
 }
 
 type JobResult struct {
-	Name                                        string  `json:"name"`
-	Variant                                     string  `json:"platform"`
-	Failures                                    int     `json:"failures"`
-	KnownFailures                               int     `json:"knownFailures"`
-	InfrastructureFailures                      int     `json:"infrastructureFailures"`
-	Successes                                   int     `json:"successes"`
-	PassPercentage                              float64 `json:"passPercentage"`
-	PassPercentageWithKnownFailures             float64 `json:"passPercentageWithKnownFailures"`
-	PassPercentageWithoutInfrastructureFailures float64 `json:"passPercentageWithoutInfrastructureFailures"`
-	TestGridUrl                                 string  `json:"testGridUrl"`
+	Name                                        string       `json:"name"`
+	Variant                                     string       `json:"platform"`
+	Failures                                    int          `json:"failures"`
+	KnownFailures                               int          `json:"knownFailures"`
+	InfrastructureFailures                      int          `json:"infrastructureFailures"`
+	Successes                                   int          `json:"successes"`
+	PassPercentage                              float64      `json:"passPercentage"`
+	PassPercentageWithKnownFailures             float64      `json:"passPercentageWithKnownFailures"`
+	PassPercentageWithoutInfrastructureFailures float64      `json:"passPercentageWithoutInfrastructureFailures"`
+	TestGridUrl                                 string       `json:"testGridUrl"`
+	BugList                                     []bugsv1.Bug `json:"bugList"`
+	// AssociatedBugList are bugs that match the test/job, but do not match the target release
+	AssociatedBugList []bugsv1.Bug `json:"associatedBugList"`
 
 	// TestResults holds entries for each test that is a part of this aggregation.  Each entry aggregates the results of all runs of a single test.  The array is sorted from lowest PassPercentage to highest PassPercentage
 	TestResults []TestResult `json:"results"`

--- a/pkg/html/generichtml/bugs.go
+++ b/pkg/html/generichtml/bugs.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	bugsv1 "github.com/openshift/sippy/pkg/apis/bugs/v1"
+	"github.com/openshift/sippy/pkg/buganalysis"
 	"github.com/openshift/sippy/pkg/util"
 )
 
@@ -16,12 +17,12 @@ func bugLink(bug bugsv1.Bug) string {
 	return fmt.Sprintf(`<a target="_blank" href="%s">%d</a> `, bug.Url, bug.ID)
 }
 
-// bugHTMLForTest release and testName are required.  variant is optional, if specified it excludes test that have a
-// different variant specified, but includes bugs without any variant
-func bugHTMLForTest(bugList, associatedBugList []bugsv1.Bug, release, variant, testName string) string {
+// bugHTMLForTest release and testName are required.
+func bugHTMLForTest(bugList, associatedBugList []bugsv1.Bug, release, testName string) string {
 	bugHTML := ""
 	if len(bugList) == 0 {
-		bugHTML += openABugHTML(testName, release)
+		bugHTML += openATestBugHTML(testName, release)
+		bugHTML += "<br>"
 	}
 
 	if len(bugList) != 0 {
@@ -42,7 +43,32 @@ func bugHTMLForTest(bugList, associatedBugList []bugsv1.Bug, release, variant, t
 	return bugHTML
 }
 
-func openABugHTML(testName, release string) string {
+func bugHTMLForJob(bugList, associatedBugList []bugsv1.Bug, release, jobName, testgridURL string) string {
+	bugHTML := ""
+	if len(bugList) == 0 {
+		bugHTML += openAJobBugHTML(jobName, testgridURL, release)
+		bugHTML += "<br>"
+	}
+
+	if len(bugList) != 0 {
+		bugHTML += " Linked Bugs: "
+		for _, bug := range bugList {
+			bugHTML += bugLink(bug)
+		}
+		bugHTML += "<br>"
+	}
+
+	if len(associatedBugList) != 0 {
+		bugHTML += " Associated Bugs: "
+		for _, bug := range associatedBugList {
+			bugHTML += bugLink(bug)
+		}
+	}
+
+	return bugHTML
+}
+
+func openATestBugHTML(testName, release string) string {
 	short_desc := testName
 	if len(short_desc) > 255 {
 		short_desc = short_desc[:255]
@@ -61,6 +87,31 @@ FIXME: Provide a snippet of the test failure or error from the job log
 		url.QueryEscape(short_desc),
 		url.QueryEscape(testName),
 		url.QueryEscape(searchURL),
+		url.QueryEscape(exampleJob),
+		release)
+
+	return bug
+}
+
+func openAJobBugHTML(jobName, testgridURL, release string) string {
+	short_desc := jobName
+	if len(short_desc) > 255 {
+		short_desc = short_desc[:255]
+	}
+
+	exampleJob :=
+		`
+FIXME: Replace this paragraph with a particular job URI from the search results to ground discussion.  A given job may fail for several reasons, and this bug should be scoped to one of those reasons.  Ideally you'd pick a job showing the most-common reason, but since that's hard to determine, you may also chose to pick a job at random.
+
+FIXME: Provide a snippet of the test failure or error from the job log
+`
+
+	bug := fmt.Sprintf(
+		"<a target=\"_blank\" href=https://bugzilla.redhat.com/enter_bug.cgi?classification=Red%%20Hat&product=OpenShift%%20Container%%20Platform&cf_internal_whiteboard=buildcop&short_desc=%[1]s&cf_environment=%[2]s&comment=job:%%0A%[3]s%%20%%0A%%0Ais%%20failing%%20frequently%%20in%%20CI,%%20see%%20testgrid%%20results:%%0A%[4]s%%0A%%0A%[5]s&version=%[6]s>Open a bug</a>",
+		url.QueryEscape(short_desc),
+		url.QueryEscape(buganalysis.GetJobKey(jobName)),
+		jobName,
+		url.QueryEscape(testgridURL),
 		url.QueryEscape(exampleJob),
 		release)
 

--- a/pkg/html/generichtml/testresult.go
+++ b/pkg/html/generichtml/testresult.go
@@ -181,7 +181,7 @@ func (b *testResultRenderBuilder) ToHTML() string {
 	testLink := fmt.Sprintf("<a target=\"_blank\" href=\"https://search.ci.openshift.org/?maxAge=168h&context=1&type=bug%%2Bjunit&name=%s&maxMatches=5&maxBytes=20971520&groupBy=job&search=%s\">%s</a>", b.release, encodedTestName, b.currTestResult.displayName)
 
 	klog.V(2).Infof("processing top failing tests %s, bugs: %v", b.currTestResult.displayName, b.currTestResult.bugList)
-	bugHTML := bugHTMLForTest(b.currTestResult.bugList, b.currTestResult.associatedBugList, b.release, "", b.currTestResult.displayName)
+	bugHTML := bugHTMLForTest(b.currTestResult.bugList, b.currTestResult.associatedBugList, b.release, b.currTestResult.displayName)
 	if b.prevTestResult != nil {
 		arrow := GetArrow(b.currTestResult.totalRuns, b.currTestResult.displayPercent, b.prevTestResult.displayPercent)
 

--- a/pkg/html/releasehtml/html.go
+++ b/pkg/html/releasehtml/html.go
@@ -151,7 +151,7 @@ func summaryFrequentJobPassRatesByJobName(report, reportPrev sippyprocessingv1.T
 			</th>
 		</tr>
 		<tr>
-			<th>Name</th><th>Latest %d days</th><th/><th>Previous 7 days</th>
+			<th>Name</th><th>Bug</th><th>Latest %d days</th><th/><th>Previous 7 days</th>
 		</tr>
 	`, numDays)
 
@@ -179,7 +179,7 @@ func summaryInfrequentJobPassRatesByJobName(report, reportPrev sippyprocessingv1
 			</th>
 		</tr>
 		<tr>
-			<th>Name</th><th>Latest %d days</th><th/><th>Previous 7 days</th>
+			<th>Name</th><th>Bug</th><th>Latest %d days</th><th/><th>Previous 7 days</th>
 		</tr>
 	`, numDays)
 

--- a/pkg/testgridanalysis/testreportconversion/jobresult.go
+++ b/pkg/testgridanalysis/testreportconversion/jobresult.go
@@ -84,9 +84,11 @@ func convertRawJobResultToProcessedJobResult(
 ) sippyprocessingv1.JobResult {
 
 	job := sippyprocessingv1.JobResult{
-		Name:        rawJobResult.JobName,
-		TestGridUrl: rawJobResult.TestGridJobUrl,
-		TestResults: convertRawTestResultsToProcessedTestResults(rawJobResult.JobName, rawJobResult.TestResults, bugCache, bugzillaRelease),
+		Name:              rawJobResult.JobName,
+		TestGridUrl:       rawJobResult.TestGridJobUrl,
+		TestResults:       convertRawTestResultsToProcessedTestResults(rawJobResult.JobName, rawJobResult.TestResults, bugCache, bugzillaRelease),
+		BugList:           bugCache.ListBugs(bugzillaRelease, rawJobResult.JobName, ""),
+		AssociatedBugList: bugCache.ListAssociatedBugs(bugzillaRelease, rawJobResult.JobName, ""),
 	}
 
 	for _, rawJRR := range rawJobResult.JobRunResults {


### PR DESCRIPTION
this will help us track bugs reported against permfailing jobs

sample row:
![image](https://user-images.githubusercontent.com/4974046/113354846-c8f09500-930d-11eb-9ce0-ce0f6aa4d34e.png)

bugs are linked to jobs by putting the following text in a bug's environment field:
`job=$JOBNAME=all`

e.g.:

```
job=periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted-ipv6=all
```