### PR TITLE
Better handling of infra failure computation for jobs with no known setup container

### DIFF
--- a/pkg/testgridanalysis/testgridanalysisapi/types.go
+++ b/pkg/testgridanalysis/testgridanalysisapi/types.go
@@ -77,6 +77,7 @@ const (
 
 	Success = "Success"
 	Failure = "Failure"
+	Unknown = "Unknown"
 )
 
 var (

--- a/pkg/testgridanalysis/testgridconversion/ocp_synthentic_tests.go
+++ b/pkg/testgridanalysis/testgridconversion/ocp_synthentic_tests.go
@@ -169,6 +169,9 @@ func (openshiftSyntheticManager) CreateSyntheticTests(rawJobResults testgridanal
 				addTestResult(jobResults.TestResults, testName, result.pass, result.fail, 0)
 			}
 
+			if len(jrr.SetupStatus) == 0 && matchJobRegexList(jobName, jobRegexesWithKnownBadSetupContainer) {
+				jrr.SetupStatus = testgridanalysisapi.Unknown
+			}
 			jobResults.JobRunResults[jrrKey] = jrr
 		}
 		if numRunsWithoutSetup > 0 && numRunsWithoutSetup == len(jobResults.JobRunResults) {

--- a/pkg/testgridanalysis/testgridconversion/to_raw_data.go
+++ b/pkg/testgridanalysis/testgridconversion/to_raw_data.go
@@ -145,6 +145,9 @@ func processTestToJobRunResults(jobResult testgridanalysisapi.RawJobResult, job 
 				switch {
 				case test.Name == "Overall":
 					jrr.Succeeded = true
+					// if the overall job succeeded, setup is always considered successful, even for jobs
+					// that don't have an explicitly defined setup test.
+					jrr.SetupStatus = testgridanalysisapi.Success
 				case testidentification.IsOperatorHealthTest(test.Name):
 					jrr.FinalOperatorStates = append(jrr.FinalOperatorStates, testgridanalysisapi.OperatorState{
 						Name:  testidentification.GetOperatorNameFromTest(test.Name),

--- a/pkg/testgridanalysis/testreportconversion/jobresult.go
+++ b/pkg/testgridanalysis/testreportconversion/jobresult.go
@@ -100,7 +100,12 @@ func convertRawJobResultToProcessedJobResult(
 		if rawJRR.Failed && areAllFailuresKnown(rawJRR, job.TestResults) {
 			job.KnownFailures++
 		}
-		if rawJRR.SetupStatus != testgridanalysisapi.Success {
+		// success - we saw the setup/infra test result, it succeeded (or the whole job succeeeded)
+		// failure - we saw the test result, it failed
+		// unknown - we know this job doesn't have a setup test, and the job didn't succeed, so we don't know if it
+		//           failed due to infra issues or not.  probably not infra.
+		// emptystring - we expected to see a test result for a setup test but we didn't and the overall job failed, probably infra
+		if rawJRR.SetupStatus != testgridanalysisapi.Success && rawJRR.SetupStatus != testgridanalysisapi.Unknown {
 			job.InfrastructureFailures++
 		}
 	}


### PR DESCRIPTION
without this change, every single run (whether successful or not) of a job with "no known setup container" was being treated as an infrastructure failure.  Which results in more infra failures than total job run failures.

this pr:

1) automatically marks infra successful if the job succeeded
2) is more nuanced about handling jobs that have explicitly declared they don't have a setup container
