### PR TITLE
Filter unknown symbols from CSS class names

### DIFF
--- a/pkg/html/generichtml/decorations.go
+++ b/pkg/html/generichtml/decorations.go
@@ -81,10 +81,10 @@ func (c ColorizationCriteria) GetColor(passPercentage float64, total int) string
 	}
 }
 
-var collapseNameRemoveRegex = regexp.MustCompile(`[. ,:\(\)\[\]]`)
+var collapseNameRemoveRegex = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
 
 func MakeSafeForCollapseName(in string) string {
-	return collapseNameRemoveRegex.ReplaceAllString(in, "")
+	return collapseNameRemoveRegex.ReplaceAllString(in, "-")
 }
 
 func GetExpandingButtonHTML(sectionName, buttonName string) string {


### PR DESCRIPTION
It's better to have white list of allowed symbols. The current implementation does not delete `/` from test names and generates names from `Suite:openshift/conformance/parallel` that don't work on Chrome.