### PR TITLE
Print all releases as links from top of PrintHtmlReport

### DIFF
--- a/pkg/html/releasehtml/html.go
+++ b/pkg/html/releasehtml/html.go
@@ -44,6 +44,8 @@ const (
 
 <h1 class=text-center>CI Release {{ .Release }} Health Summary</h1>
 
+{{ releasesList .ReportNames }}
+
 <p class="small mb-3 text-nowrap">
 	Jump to: <a href="#JobPassRatesByVariant">Job Pass Rates By Variant</a> | <a href="#CuratedTRTTests">Curated TRT Tests</a> | <a href="#TopFailingTestsWithoutABug">Top Failing Tests Without a Bug</a> | <a href="#TopFailingTestsWithABug">Top Failing Tests With a Bug</a> | <a href="#JobPassRatesByJobName">Job Pass Rates By Job Name</a> |
 			 <br/>	          
@@ -357,6 +359,7 @@ type TestReports struct {
 	NumDays      int
 	JobTestCount int
 	Release      string
+	ReportNames  []string
 }
 
 func WriteLandingPage(w http.ResponseWriter, displayNames []string) {
@@ -371,7 +374,7 @@ func WriteLandingPage(w http.ResponseWriter, displayNames []string) {
 	fmt.Fprintf(w, landingHtmlPageEnd)
 }
 
-func PrintHtmlReport(w http.ResponseWriter, req *http.Request, report, twoDayReport, prevReport sippyprocessingv1.TestReport, numDays, jobTestCount int) {
+func PrintHtmlReport(w http.ResponseWriter, req *http.Request, report, twoDayReport, prevReport sippyprocessingv1.TestReport, numDays, jobTestCount int, allReportNames []string) {
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
 	fmt.Fprintf(w, generichtml.HTMLPageStart, "Release CI Health Dashboard")
 	if len(prevReport.AnalysisWarnings)+len(report.AnalysisWarnings) > 0 {
@@ -401,6 +404,7 @@ func PrintHtmlReport(w http.ResponseWriter, req *http.Request, report, twoDayRep
 			"summaryJobsFailuresByBugzillaComponent": summaryJobsFailuresByBugzillaComponent,
 			"summaryTopNegativelyMovingJobs":         summaryTopNegativelyMovingJobs,
 			"topLevelIndicators":                     topLevelIndicators,
+			"releasesList":                           releasesList,
 		},
 	).Parse(dashboardPageHtml))
 
@@ -411,6 +415,7 @@ func PrintHtmlReport(w http.ResponseWriter, req *http.Request, report, twoDayRep
 		NumDays:      numDays,
 		JobTestCount: jobTestCount,
 		Release:      report.Release,
+		ReportNames:  allReportNames,
 	}); err != nil {
 		klog.Errorf("Unable to render page: %v", err)
 	}

--- a/pkg/html/releasehtml/releases.go
+++ b/pkg/html/releasehtml/releases.go
@@ -1,0 +1,18 @@
+package releasehtml
+
+import (
+	"fmt"
+	"strings"
+)
+
+// releasesList expects an array of report/release names like "4.8"
+func releasesList(reportNames []string) string {
+	if len(reportNames) == 0 {
+		return ""
+	}
+	releaseLinks := make([]string, len(reportNames))
+	for i := range reportNames {
+		releaseLinks[i] = fmt.Sprintf(`[<a href="?release=%s">release-%[1]s</a>] `, reportNames[i])
+	}
+	return fmt.Sprintf("<p class=text-center>%s</p>", strings.Join(releaseLinks, "\n"))
+}


### PR DESCRIPTION
Also default the "detailed" view to the first release in the array (which presumably is sorted correctly).

@wking @smarterclayton 