### PR TITLE
Identify Hypershift setup container

### DIFF
--- a/pkg/testgridanalysis/testidentification/test_identification.go
+++ b/pkg/testgridanalysis/testidentification/test_identification.go
@@ -34,6 +34,8 @@ var customJobSetupContainers = sets.NewString(
 	"e2e-vsphere-upi-upi-install-vsphere",
 	"install-install container test",
 	"install-stableinitial container test",
+	"hypershift-launch-wait-for-nodes",
+
 )
 
 // TODO We should instead try to detect whether we fail in a pre-step to determine whether setup succeeded


### PR DESCRIPTION
Should fix this warning in https://sippy.ci.openshift.org/?release=4.8:

```
Warning: Analysis Error
"periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift" is missing a test setup job to indicate successful installs
```

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift/1396468580492513280#1:build-log.txt%3A20

/cc @ironcladlou 