### PR TITLE
remove extraneous whitespace in test name

### DIFF
--- a/pkg/testgridanalysis/testgridconversion/ocp_synthentic_tests.go
+++ b/pkg/testgridanalysis/testgridconversion/ocp_synthentic_tests.go
@@ -138,7 +138,7 @@ func (openshiftSyntheticManager) CreateSyntheticTests(rawJobResults testgridanal
 					syntheticTests[testgridanalysisapi.UpgradeTestName].pass = 1
 					// if the test succeeded, then the operator install tests should all be passes
 					for _, operatorState := range jrr.FinalOperatorStates {
-						testName := testgridanalysisapi.OperatorUpgradePrefix + " " + operatorState.Name
+						testName := testgridanalysisapi.OperatorUpgradePrefix + operatorState.Name
 						syntheticTests[testName] = &synthenticTestResult{
 							name: testName,
 							pass: 1,
@@ -149,7 +149,7 @@ func (openshiftSyntheticManager) CreateSyntheticTests(rawJobResults testgridanal
 					syntheticTests[testgridanalysisapi.UpgradeTestName].fail = 1
 					// if the test failed, then the operator upgrade tests should match the operator state
 					for _, operatorState := range jrr.FinalOperatorStates {
-						testName := testgridanalysisapi.OperatorUpgradePrefix + " " + operatorState.Name
+						testName := testgridanalysisapi.OperatorUpgradePrefix + operatorState.Name
 						syntheticTests[testName] = &synthenticTestResult{
 							name: testName,
 						}


### PR DESCRIPTION
this was causing issues when we sent the search string to ci-search and got no results