### PR TITLE
update prow url

### DIFF
--- a/pkg/api/jobs.go
+++ b/pkg/api/jobs.go
@@ -66,7 +66,7 @@ func PrintJobsReport(w http.ResponseWriter, syntheticTestManager testgridconvers
 		results := rawJobResults.JobResults[job.Name]
 		var statuses []string
 		for i := range job.Timestamps {
-			joburl := fmt.Sprintf("https://prow.svc.ci.openshift.org/view/gcs/%s/%s", job.Query, job.ChangeLists[i])
+			joburl := fmt.Sprintf("https://prow.ci.openshift.org/view/gcs/%s/%s", job.Query, job.ChangeLists[i])
 			statuses = append(statuses, jobRunStatus(results.JobRunResults[joburl]))
 		}
 		response.Jobs = append(response.Jobs, jsonJob{

--- a/pkg/apis/testgrid/v1/types.go
+++ b/pkg/apis/testgrid/v1/types.go
@@ -19,7 +19,7 @@ type JobDetails struct {
 	Name       string
 	Tests      []Test `json:"tests"`
 	Timestamps []int  `json:"timestamps"`
-	// append to https://prow.svc.ci.openshift.org/view/gcs and suffix with changelist element to view job run details
+	// append to https://prow.ci.openshift.org/view/gcs and suffix with changelist element to view job run details
 	Query       string   `json:"query"`
 	ChangeLists []string `json:"changelists"`
 	// not part of testgrid json, but we want to store the url of the testgrid job page for later usage

--- a/pkg/testgridanalysis/testgridconversion/to_raw_data.go
+++ b/pkg/testgridanalysis/testgridconversion/to_raw_data.go
@@ -134,7 +134,7 @@ func processTestToJobRunResults(jobResult testgridanalysisapi.RawJobResult, job 
 				if result.Value == testgridv1.TestStatusFlake {
 					flaked++
 				}
-				joburl := fmt.Sprintf("https://prow.svc.ci.openshift.org/view/gcs/%s/%s", job.Query, job.ChangeLists[i])
+				joburl := fmt.Sprintf("https://prow.ci.openshift.org/view/gcs/%s/%s", job.Query, job.ChangeLists[i])
 				jrr, ok := jobResult.JobRunResults[joburl]
 				if !ok {
 					jrr = testgridanalysisapi.RawJobRunResult{
@@ -172,7 +172,7 @@ func processTestToJobRunResults(jobResult testgridanalysisapi.RawJobResult, job 
 		case testgridv1.TestStatusFailure:
 			for i := col; i < col+remaining && i < endCol; i++ {
 				failed++
-				joburl := fmt.Sprintf("https://prow.svc.ci.openshift.org/view/gcs/%s/%s", job.Query, job.ChangeLists[i])
+				joburl := fmt.Sprintf("https://prow.ci.openshift.org/view/gcs/%s/%s", job.Query, job.ChangeLists[i])
 				jrr, ok := jobResult.JobRunResults[joburl]
 				if !ok {
 					jrr = testgridanalysisapi.RawJobRunResult{


### PR DESCRIPTION
Sippy references the old Prow URL, which results in a dead link on some reports. Updates all references from https://prow.svc.ci.openshift.org to https://prow.ci.openshift.org.