### PR TITLE
Enabling the DPCR Bugzilla Updater integration

### DIFF
--- a/pkg/html/generichtml/bugs.go
+++ b/pkg/html/generichtml/bugs.go
@@ -83,7 +83,7 @@ FIXME: Provide a snippet of the test failure or error from the job log
 `
 
 	bug := fmt.Sprintf(
-		"<a target=\"_blank\" href=https://bugzilla.redhat.com/enter_bug.cgi?classification=Red%%20Hat&product=OpenShift%%20Container%%20Platform&cf_internal_whiteboard=buildcop&short_desc=%[1]s&cf_environment=%[2]s&comment=test:%%0A%[2]s%%20%%0A%%0Ais%%20failing%%20frequently%%20in%%20CI,%%20see%%20search%%20results:%%0A%[3]s%%0A%%0A%[4]s&version=%[5]s>Open a bug</a>",
+		"<a target=\"_blank\" href=https://bugzilla.redhat.com/enter_bug.cgi?classification=Red%%20Hat&product=OpenShift%%20Container%%20Platform&cf_internal_whiteboard=buildcop&short_desc=%[1]s&cf_environment=%[2]s&comment=test:%%0A%[2]s%%20%%0A%%0Ais%%20failing%%20frequently%%20in%%20CI,%%20see%%20search%%20results:%%0A%[3]s%%0A%%0A%[4]s&version=%[5]s&cc=sippy@dptools.openshift.org>Open a bug</a>",
 		url.QueryEscape(short_desc),
 		url.QueryEscape(testName),
 		url.QueryEscape(searchURL),
@@ -107,7 +107,7 @@ FIXME: Provide a snippet of the test failure or error from the job log
 `
 
 	bug := fmt.Sprintf(
-		"<a target=\"_blank\" href=https://bugzilla.redhat.com/enter_bug.cgi?classification=Red%%20Hat&product=OpenShift%%20Container%%20Platform&cf_internal_whiteboard=buildcop&short_desc=%[1]s&cf_environment=%[2]s&comment=job:%%0A%[3]s%%20%%0A%%0Ais%%20failing%%20frequently%%20in%%20CI,%%20see%%20testgrid%%20results:%%0A%[4]s%%0A%%0A%[5]s&version=%[6]s>Open a bug</a>",
+		"<a target=\"_blank\" href=https://bugzilla.redhat.com/enter_bug.cgi?classification=Red%%20Hat&product=OpenShift%%20Container%%20Platform&cf_internal_whiteboard=buildcop&short_desc=%[1]s&cf_environment=%[2]s&comment=job:%%0A%[3]s%%20%%0A%%0Ais%%20failing%%20frequently%%20in%%20CI,%%20see%%20testgrid%%20results:%%0A%[4]s%%0A%%0A%[5]s&version=%[6]s&cc=sippy@dptools.openshift.org>Open a bug</a>",
 		url.QueryEscape(short_desc),
 		url.QueryEscape(buganalysis.GetJobKey(jobName)),
 		jobName,

--- a/pkg/html/generichtml/html.go
+++ b/pkg/html/generichtml/html.go
@@ -35,7 +35,7 @@ var (
 </div>
 Data current as of: %s
 <p>
-<a href="https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/dashboards/overview">Release Dashboard</a> |
+<a href="https://amd64.ocp.releases.ci.openshift.org/dashboards/overview">Release Dashboard</a> |
 <a href="https://sippy-historical-bparees.apps.ci.l2s4.p1.openshiftapps.com/">Historical Data</a> |
 <a href="https://github.com/openshift/sippy">Source Code</a>
 <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>


### PR DESCRIPTION
This PR updates the "Open A Bug" URLs to add `sippy@dptools.openshift.org` to the CC list on newly created bugs.  This will allow our automation to receive updates, from Bugzilla, and automatically process any Sippy bugs that get "Closed as Duplicate" by updating the Duped BZ with the following information:
1. Any "[sig-sippy]" entries in the Environment Field
1. Adding `sippy@dptools.openshift.org` to the CC list

Flagging this as [WIP] while we demo this feature to any interested stakeholders.