### PR TITLE
fix inactive bug match for closed bugs

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -89,7 +89,7 @@ func RelevantJob(jobName, status string, filter *regexp.Regexp) bool {
 
 func IsActiveBug(bug bugsv1.Bug) bool {
 	switch bug.Status {
-	case "VERIFIED", "RELEASE_PENDING", "CLOSED":
+	case "VERIFIED", "RELEASE_PENDING", "CLOSED", "CLOSED WONTFIX", "CLOSED DUPLICATE", "CLOSED NOTABUG":
 		return false
 	default:
 		return true


### PR DESCRIPTION
Closed bugs in bugzilla usually have a two word status that includes the resolution
e.g CLOSED DUPLICATE. This commit adds more cases to accurately mark those bugs as inactive
and striked through on the sippy dashboard.