### PR TITLE
ensure to initialize jobBlockers for new bugCache

### DIFF
--- a/pkg/buganalysis/cache.go
+++ b/pkg/buganalysis/cache.go
@@ -71,7 +71,8 @@ type bugCache struct {
 
 func NewBugCache() BugCache {
 	return &bugCache{
-		cache: map[string][]bugsv1.Bug{},
+		cache:       map[string][]bugsv1.Bug{},
+		jobBlockers: map[string][]bugsv1.Bug{},
 	}
 }
 


### PR DESCRIPTION
Running the CLI reporting panics due to unnitialized jobBlockers.

```
[jdiaz@minigoomba sippy (master *%=)]$ ./sippy --local-data ./sdata
--release 4.9
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/openshift/sippy/pkg/buganalysis.(*bugCache).UpdateJobBlockers(0xc00011e4c0,
0xc0069b4000, 0x7b, 0x7b, 0x0, 0x0)
        /home/jdiaz/projects/sippy/src/github.com/openshift/sippy/pkg/buganalysis/cache.go:122
+0x315
github.com/openshift/sippy/pkg/sippyserver.updateBugCacheForJobResults(0x93b268,
0xc00011e4c0, 0xc000116240, 0x7, 0xc0033a4000, 0x7b)
        /home/jdiaz/projects/sippy/src/github.com/openshift/sippy/pkg/sippyserver/analyzer.go:142
+0x24d
github.com/openshift/sippy/pkg/sippyserver.(*TestReportGeneratorConfig).prepareTestReportFromData(0xc00875f808,
0xc000142060, 0x3, 0xc0001420b9, 0x3, 0x931ae0, 0xbac238, 0x937ec0,
0xbac238, 0x93b268, ...)
        /home/jdiaz/projects/sippy/src/github.com/openshift/sippy/pkg/sippyserver/analyzer.go:79
+0x11c
github.com/openshift/sippy/pkg/sippyserver.(*TestReportGeneratorConfig).PrepareTestReport(0xc000377808,
0xc000142060, 0x3, 0xc00011a0e0, 0x2, 0x2, 0xc0001420b9, 0x3,
0x931ae0, 0xbac238, ...)
        /home/jdiaz/projects/sippy/src/github.com/openshift/sippy/pkg/sippyserver/analyzer.go:60
+0x197
main.(*Options).runCLIReportMode(0xc0001241a0, 0xc000118130, 0x2a)
        /home/jdiaz/projects/sippy/src/github.com/openshift/sippy/main.go:209
+0x227
```

So, initialize it.