### PR TITLE
Return status 200 on main sippy page

### DIFF
--- a/pkg/html/releasehtml/html.go
+++ b/pkg/html/releasehtml/html.go
@@ -364,7 +364,7 @@ type TestReports struct {
 
 func WriteLandingPage(w http.ResponseWriter, displayNames []string) {
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
-	w.WriteHeader(http.StatusNotFound)
+	w.WriteHeader(http.StatusOK)
 	fmt.Fprintf(w, generichtml.HTMLPageStart, "Release CI Health Dashboard")
 	releaseLinks := make([]string, len(displayNames))
 	for i := range displayNames {


### PR DESCRIPTION
This seem to be the problem we were facing:
- sippy was returning 404 on the main page
- as a result GCP ingress was marking the backends as unhealthy

@deads2k - assuming you agree with this change, will you be able to also build a new image (so that I can deploy it in k8s cluster)?