### PR TITLE
Add a new variants page

### DIFF
--- a/pkg/html/generichtml/errors.go
+++ b/pkg/html/generichtml/errors.go
@@ -1,0 +1,35 @@
+package generichtml
+
+import (
+	"html/template"
+	"k8s.io/klog"
+	"net/http"
+)
+
+var messageTemplate = template.Must(template.New("jobs").Parse(`<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>{{.StatusCode}} {{.StatusMessage}}</title>
+</head>
+<body>
+  <h1>{{.StatusCode}} {{.StatusMessage}}</h1>
+  <hr>
+  <p>{{.UserMessage}}</p>
+</body>
+</html>
+`))
+
+func PrintStatusMessage(w http.ResponseWriter, code int, message string) {
+	w.WriteHeader(code)
+	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
+
+	err := messageTemplate.Execute(w, map[string]interface{}{
+		"StatusCode":    code,
+		"StatusMessage": http.StatusText(code),
+		"UserMessage":   message,
+	})
+	if err != nil {
+		klog.Error(err)
+	}
+}

--- a/pkg/html/generichtml/errors.go
+++ b/pkg/html/generichtml/errors.go
@@ -20,6 +20,7 @@ var messageTemplate = template.Must(template.New("jobs").Parse(`<!DOCTYPE html>
 </html>
 `))
 
+// PrintStatusMessage is used to display a proper error page to an end user.
 func PrintStatusMessage(w http.ResponseWriter, code int, message string) {
 	w.WriteHeader(code)
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")

--- a/pkg/html/releasehtml/html.go
+++ b/pkg/html/releasehtml/html.go
@@ -132,7 +132,6 @@ func summaryJobsByVariant(report, reportPrev sippyprocessingv1.TestReport, numDa
 
 	for _, currVariant := range report.ByVariant {
 		variantHTML := generichtml.NewJobAggregationResultRendererFromVariantResults("by-variant", currVariant, release).
-			GroupBy("variant").
 			WithMaxTestResultsToShow(jobTestCount).
 			WithPreviousVariantResults(util.FindVariantResultsForName(currVariant.VariantName, reportPrev.ByVariant)).
 			ToHTML()

--- a/pkg/html/releasehtml/html.go
+++ b/pkg/html/releasehtml/html.go
@@ -132,6 +132,7 @@ func summaryJobsByVariant(report, reportPrev sippyprocessingv1.TestReport, numDa
 
 	for _, currVariant := range report.ByVariant {
 		variantHTML := generichtml.NewJobAggregationResultRendererFromVariantResults("by-variant", currVariant, release).
+			GroupBy("variant").
 			WithMaxTestResultsToShow(jobTestCount).
 			WithPreviousVariantResults(util.FindVariantResultsForName(currVariant.VariantName, reportPrev.ByVariant)).
 			ToHTML()

--- a/pkg/html/releasehtml/variants.go
+++ b/pkg/html/releasehtml/variants.go
@@ -1,0 +1,56 @@
+package releasehtml
+
+import (
+	"fmt"
+	v1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+	"github.com/openshift/sippy/pkg/html/generichtml"
+	"github.com/openshift/sippy/pkg/util"
+	"html/template"
+	"net/http"
+	"time"
+)
+
+var variantsTemplate = template.Must(template.New("variants").Parse(`
+<div align="center">
+	<h1>Results for {{.Variant}} on {{.Release}}</h1>
+</div>
+
+<table class="table">
+<tr>
+<th colspan=5 class="text-center">
+<a class="text-dark"  id="PassRateByVariantJob" href="#PassRateByVariantJob">Pass Rate By Variant Job</a>
+<i class="fa fa-info-circle" title="Aggregation of all job runs for a given variant, sorted by passing rate percentage."></i>
+</th>
+</tr>
+<tr>
+<th>Job</th><th></th><th>Latest 7 days</th><th></th><th>Previous 7 days</th>
+</tr>
+{{.Results}}
+</table>
+`))
+
+type templateData struct {
+	Release string
+	Variant string
+	Results template.HTML
+}
+
+
+// PrintVariantsReport shows an aggregated listing of all jobs for a particular variant.
+func PrintVariantsReport(w http.ResponseWriter, release, variant string, currentWeek, previousWeek v1.VariantResults, timestamp time.Time) {
+	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
+
+	results := template.HTML(generichtml.NewJobAggregationResultRendererFromVariantResults("by-job", currentWeek, release).
+		WithMaxTestResultsToShow(10).
+		WithMaxJobResultsToShow(0).
+		WithPreviousVariantResults(util.FindVariantResultsForName(currentWeek.VariantName, []v1.VariantResults{previousWeek})).
+		ToHTML())
+
+	fmt.Fprintf(w, generichtml.HTMLPageStart, "Job Results for Variant " + variant)
+	variantsTemplate.Execute(w, map[string]interface{}{
+		"Variant": variant,
+		"Release": release,
+		"Results": results,
+	})
+	fmt.Fprintf(w, generichtml.HTMLPageEnd, timestamp.Format("Jan 2 15:04 2006 MST"))
+}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -320,19 +320,20 @@ func (s *Server) jobsReport(w http.ResponseWriter, req *http.Request) {
 func (s *Server) variantsReport(w http.ResponseWriter, req *http.Request) {
 	release := req.URL.Query().Get("release")
 	variant := req.URL.Query().Get("variant")
+	reports := s.currTestReports
 
 	if variant == "" || release == "" {
 		generichtml.PrintStatusMessage(w, http.StatusBadRequest, "Please specify a variant and release.")
 		return
 	}
 
-	if _, ok := s.currTestReports[release]; !ok {
+	if _, ok := reports[release]; !ok {
 		generichtml.PrintStatusMessage(w, http.StatusNotFound, fmt.Sprintf("Release %q not found.", release))
 		return
 	}
 
 	var currentWeek *sippyprocessingv1.VariantResults
-	for _, report := range s.currTestReports[release].CurrentPeriodReport.ByVariant {
+	for _, report := range reports[release].CurrentPeriodReport.ByVariant {
 		if report.VariantName == variant {
 			currentWeek = &report
 			break
@@ -340,7 +341,7 @@ func (s *Server) variantsReport(w http.ResponseWriter, req *http.Request) {
 	}
 
 	var previousWeek *sippyprocessingv1.VariantResults
-	for _, report := range s.currTestReports[release].PreviousWeekReport.ByVariant {
+	for _, report := range reports[release].PreviousWeekReport.ByVariant {
 		if report.VariantName == variant {
 			previousWeek = &report
 			break
@@ -352,8 +353,9 @@ func (s *Server) variantsReport(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	timestamp := s.currTestReports[release].CurrentPeriodReport.Timestamp
-	releasehtml.PrintVariantsReport(w, release, variant, *currentWeek, *previousWeek, timestamp)
+	timestamp := reports[release].CurrentPeriodReport.Timestamp
+
+	releasehtml.PrintVariantsReport(w, release, variant, currentWeek, previousWeek, timestamp)
 }
 
 func (s *Server) Serve() {

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -3,6 +3,7 @@ package sippyserver
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/sippy/pkg/html/generichtml"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -86,6 +87,14 @@ func (s *Server) RefreshData() {
 		s.currTestReports[dashboard.ReportName] = s.testReportGeneratorConfig.PrepareStandardTestReports(dashboard, s.syntheticTestManager, s.variantManager, s.bugCache)
 	}
 	klog.Infof("Refresh complete")
+}
+
+func (s *Server) defaultHandler(w http.ResponseWriter, req *http.Request) {
+	if req.URL.Path == "/" {
+		s.printHtmlReport(w, req)
+	} else {
+		generichtml.PrintStatusMessage(w, http.StatusNotFound, "Page not found.")
+	}
 }
 
 func (s *Server) printHtmlReport(w http.ResponseWriter, req *http.Request) {
@@ -309,7 +318,7 @@ func (s *Server) jobsReport(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *Server) Serve() {
-	http.DefaultServeMux.HandleFunc("/", s.printHtmlReport)
+	http.DefaultServeMux.HandleFunc("/", s.defaultHandler)
 	http.DefaultServeMux.HandleFunc("/install", s.printInstallHtmlReport)
 	http.DefaultServeMux.HandleFunc("/upgrade", s.printUpgradeHtmlReport)
 	http.DefaultServeMux.HandleFunc("/operator-health", s.printOperatorHealthHtmlReport)


### PR DESCRIPTION
This adds a new page to view all jobs for a specific variant. When
expanding the job details from the main page, the first few results
are shown. This adds a link to view all job results.

If you look at the production sippy, and expand the never-stable
variant, you'll see a "Plus N jobs" -- but there's no way to view them. This
links that message to a new page at `/variants?release=4.9&variant=never-stable`,
which lists all the jobs for that variant.
