### PR TITLE
Add some curated TRT tests for API availability

### DIFF
--- a/pkg/testgridanalysis/testidentification/test_identification.go
+++ b/pkg/testgridanalysis/testidentification/test_identification.go
@@ -69,18 +69,11 @@ func IsSetupContainerEquivalent(testName string) bool {
 // Whoever is running or working on TRT gets freedom to choose 10-20 of these for whatever reason they need.  At the moment,
 // we're chasing problems where pods are not running reliably and we have to track it down.
 var curatedTestSubstrings = map[string][]string{
-	"4.6": []string{
-		"[Feature:SCC][Early] should not have pod creation failures during install",
-		"infrastructure should work",
-		"install should work",
+	"4.9": []string{
 		"Kubernetes APIs remain available",
 		"OAuth APIs remain available",
 		"OpenShift APIs remain available",
-		"Pod Container Status should never report success for a pending container",
-		"pods should never transition back to pending",
-		"pods should successfully create sandboxes",
-		"upgrade should work",
-		"Cluster completes upgrade",
+		"Cluster frontend ingress remain available",
 	},
 }
 


### PR DESCRIPTION
This adds the API availability tests to TRT curated, and removes the 4.6
tests.