### PR TITLE
Update sippy to use ubi:8 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.15.2
+FROM registry.access.redhat.com/ubi8/ubi
 WORKDIR /go/src/sippy
 COPY . .
-RUN make build
+RUN if which dnf; then dnf install -y go make; fi && make build
 ENTRYPOINT ["/go/src/sippy/sippy"]
 EXPOSE 8080
 


### PR DESCRIPTION
This is needed to get npm.