### PR TITLE
Add image for build root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi:latest
 WORKDIR /go/src/sippy
 COPY . .
 RUN if which dnf; then dnf install -y go make; fi && make build

--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -1,0 +1,7 @@
+# In order to use ubi:8 as a build root, we need
+# git pre-installed per the CI documentation[1].
+#
+# [1] https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image
+#
+FROM registry.access.redhat.com/ubi8/ubi:latest
+RUN dnf install -y git go make npm


### PR DESCRIPTION
In order to use ubi:8 as a build root, we need
git pre-installed per the CI documentation[1], as
well as any other deps needed to build the project.

There doesn't seem to be any ready-made image in
the cluster I can use for this, since we need
both npm and go.

[1] https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image