### PR TITLE
Reconsider use of never-stable, add techpreview variant

### DIFF
--- a/pkg/testgridanalysis/testidentification/ocp_variants.go
+++ b/pkg/testgridanalysis/testidentification/ocp_variants.go
@@ -32,6 +32,7 @@ var (
 	rtRegex      = regexp.MustCompile(`(?i)-rt`)
 	s390xRegex   = regexp.MustCompile(`(?i)-s390x`)
 	serialRegex  = regexp.MustCompile(`(?i)-serial`)
+	techpreview  = regexp.MustCompile(`(?i)-techpreview`)
 	upgradeRegex = regexp.MustCompile(`(?i)-upgrade`)
 	// some vsphere jobs do not have a trailing -version segment
 	vsphereRegex    = regexp.MustCompile(`(?i)-vsphere`)
@@ -58,64 +59,46 @@ var (
 		"realtime",
 		"s390x",
 		"serial",
+		"techpreview",
 		"upgrade",
 		"vsphere-ipi",
 		"vsphere-upi",
 		"single-node",
 	)
 
-	// openshiftJobsNeverStableForVariants is a list of jobs that are
-	// below 40% passing rate. As we phase these jobs in, they should be
-	// excluded from "normal" variants and once they are passing above 40%
-	// can "graduated" from never-stable.
+	// openshiftJobsNeverStableForVariants is a list of unproven new jobs or
+	// jobs that are near permafail (i.e. < 40%) for an extended period of time.
+	// They are excluded from "normal" variants and once they are passing above
+	// 40% can "graduated" from never-stable.
+	//
+	// Jobs should have a linked BZ before being added to this list.
 	//
 	// These jobs are still listed as jobs in total and when individual
 	// tests fail, they will still be listed with these jobs as causes.
 	openshiftJobsNeverStableForVariants = sets.NewString(
+		// Experimental jobs that are under active development
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-hypershift",
-		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-ovn",
-		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-upgrade-single-node",
-		"periodic-ci-openshift-release-master-ci-4.9-e2e-gcp-ovn",
-		"periodic-ci-openshift-release-master-ci-4.9-e2e-openstack-ovn",
-		"periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-e2e-aws-ovn-upgrade",
-		"periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-e2e-aws-ovn-upgrade-rollback",
-		"periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade",
-		"periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade-rollback",
-		"periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-e2e-azure-ovn-upgrade",
-		"periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-e2e-gcp-ovn-upgrade",
-		"periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-e2e-openstack-upgrade",
-		"periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-from-stable-4.7-e2e-aws-upgrade",
-		"periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-arm64",
-		"periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-csi-migration",
-		"periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-proxy",
-		"periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-workers-rhel7",
-		"periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-ovn-dualstack",
-		"periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-ovn-dualstack-local-gateway",
-		"periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-ovn-ipv6",
-		"periodic-ci-openshift-release-master-nightly-4.9-e2e-remote-libvirt-ppc64le",
-		"periodic-ci-openshift-release-master-nightly-4.9-e2e-remote-libvirt-s390x",
-		"periodic-ci-openshift-release-master-nightly-4.9-openshift-ipi-azure-arcconformance",
-		"periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.7-e2e-aws-upgrade-paused",
-		"periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade",
-		"release-openshift-ocp-installer-e2e-azure-ovn-4.9",
-		"release-openshift-ocp-installer-e2e-gcp-ovn-4.9",
+
+		// https://issues.redhat.com/browse/OSD-8071
 		"release-openshift-ocp-osd-aws-nightly-4.9",
 		"release-openshift-ocp-osd-gcp-nightly-4.9",
-		"release-openshift-origin-installer-e2e-aws-disruptive-4.9",
-		"release-openshift-origin-installer-e2e-aws-sdn-network-stress-4.9",
-		"release-openshift-origin-installer-e2e-aws-upgrade-4.6-to-4.7-to-4.8-to-4.9-ci",
-		"release-openshift-origin-installer-old-rhcos-e2e-aws-4.9",
 
-		// Compact jobs alerting on etcdGRPCRequestsSlow
-		// BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1986119
+		// https://bugzilla.redhat.com/show_bug.cgi?id=1979966
+		"periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-workers-rhel7",
+
+		// https://bugzilla.redhat.com/show_bug.cgi?id=1997345
+		"periodic-ci-openshift-multiarch-master-nightly-4.9-ocp-e2e-remote-libvirt-ppc64le",
+		"periodic-ci-openshift-multiarch-master-nightly-4.9-ocp-e2e-compact-remote-libvirt-ppc64le",
+
+		// https://bugzilla.redhat.com/show_bug.cgi?id=1979962
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-compact",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-compact-upgrade",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-azure-compact",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-azure-compact-upgrade",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-gcp-compact",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-gcp-compact-upgrade",
-		"periodic-ci-openshift-release-master-nightly-4.9-e2e-compact-remote-libvirt-ppc64le",
-		"periodic-ci-openshift-release-master-nightly-4.9-e2e-compact-remote-libvirt-s390x",
+		"release-openshift-ocp-installer-e2e-metal-compact-4.9",
+		"release-openshift-origin-installer-e2e-aws-sdn-network-stress-4.9",
 	)
 )
 
@@ -140,8 +123,14 @@ func (v openshiftVariants) IdentifyVariants(jobName string) []string {
 		}
 	}()
 
+	// If a job is in never-stable, it is excluded from other possible variant aggregations
 	if v.IsJobNeverStable(jobName) {
 		return []string{"never-stable"}
+	}
+
+	// Tech preview jobs are excluded from other possible variant aggregations
+	if techpreview.MatchString(jobName) {
+		return []string{"techpreview"}
 	}
 
 	// if it's a promotion job, it can't be a part of any other variant aggregation
@@ -156,6 +145,7 @@ func (v openshiftVariants) IdentifyVariants(jobName string) []string {
 	if azureRegex.MatchString(jobName) {
 		variants = append(variants, "azure")
 	}
+
 	if compactRegex.MatchString(jobName) {
 		variants = append(variants, "compact")
 	}

--- a/sippy-ng/__recordings__/TestAnalysis_2684695171/should-render-correctly_3267003315/recording.har
+++ b/sippy-ng/__recordings__/TestAnalysis_2684695171/should-render-correctly_3267003315/recording.har
@@ -8,102 +8,6 @@
     },
     "entries": [
       {
-        "_id": "27469387b1f15fb06bf31401deada8d1",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "localhost:8080"
-            }
-          ],
-          "headersSize": 453,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "release",
-              "value": "4.8"
-            },
-            {
-              "name": "filter",
-              "value": "{\"items\":[{\"id\":99,\"columnField\":\"name\",\"operatorValue\":\"equals\",\"value\":\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\"}]}"
-            }
-          ],
-          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20Kubernetes%20APIs%20remain%20available%20with%20reused%20connections%22%7D%5D%7D"
-        },
-        "response": {
-          "bodySize": 1488,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1488,
-            "text": "[{\"id\":199,\"name\":\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\",\"current_successes\":201,\"current_failures\":1,\"current_flakes\":61,\"current_pass_percentage\":99.5049504950495,\"current_runs\":263,\"previous_successes\":224,\"previous_failures\":13,\"previous_flakes\":111,\"previous_pass_percentage\":94.51476793248945,\"previous_runs\":348,\"net_improvement\":4.990182562560051,\"tags\":[\"upgrade\"],\"bugs\":[{\"id\":1921157,\"status\":\"ASSIGNED\",\"last_change_time\":\"0001-01-01T00:00:00Z\",\"summary\":\"[sig-api-machinery] Kubernetes APIs remain available for new connections\",\"target_release\":[\"4.8.0\"],\"component\":[\"Node\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1921157\"}],\"associated_bugs\":[{\"id\":1983829,\"status\":\"ASSIGNED\",\"last_change_time\":\"2021-08-20T10:31:56Z\",\"summary\":\"ovn-kubernetes upgrade jobs are failing disruptive tests\",\"target_release\":[\"4.9.0\"],\"component\":[\"Networking\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1983829\"},{\"id\":1943334,\"status\":\"VERIFIED\",\"last_change_time\":\"2021-08-26T08:18:42Z\",\"summary\":\"[ovnkube] node pod should taint NoSchedule on termination; clear on startup\",\"target_release\":[\"4.9.0\"],\"component\":[\"Networking\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1943334\"},{\"id\":1983758,\"status\":\"NEW\",\"last_change_time\":\"2021-08-26T15:21:23Z\",\"summary\":\"upgrades are failing on disruptive tests\",\"target_release\":[\"---\"],\"component\":[\"Routing\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1983758\"}]}]\n"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "access-control-allow-origin",
-              "value": "*"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 27 Aug 2021 14:09:22 GMT"
-            },
-            {
-              "name": "content-length",
-              "value": "1488"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 159,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-08-27T14:09:21.955Z",
-        "time": 74,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 74
-        }
-      },
-      {
         "_id": "008136f53e0a6a3afefedbf323eedd53",
         "_order": 0,
         "cache": {},
@@ -197,6 +101,206 @@
           "send": 0,
           "ssl": -1,
           "wait": 220
+        }
+      },
+      {
+        "_id": "17761d87945ea992f235e465f483c7bc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8080"
+            }
+          ],
+          "headersSize": 437,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "release",
+              "value": "4.8"
+            },
+            {
+              "name": "filter",
+              "value": "{\"items\":[{\"columnField\":\"name\",\"operatorValue\":\"equals\",\"value\":\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\"}]}"
+            }
+          ],
+          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20Kubernetes%20APIs%20remain%20available%20with%20reused%20connections%22%7D%5D%7D"
+        },
+        "response": {
+          "bodySize": 1486,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1486,
+            "text": "[{\"id\":199,\"name\":\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\",\"current_successes\":201,\"current_failures\":1,\"current_flakes\":61,\"current_pass_percentage\":99.5049504950495,\"current_runs\":263,\"previous_successes\":224,\"previous_failures\":13,\"previous_flakes\":111,\"previous_pass_percentage\":94.51476793248945,\"previous_runs\":348,\"net_improvement\":4.990182562560051,\"tags\":[\"upgrade\"],\"bugs\":[{\"id\":1921157,\"status\":\"ASSIGNED\",\"last_change_time\":\"0001-01-01T00:00:00Z\",\"summary\":\"[sig-api-machinery] Kubernetes APIs remain available for new connections\",\"target_release\":[\"4.8.0\"],\"component\":[\"Node\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1921157\"}],\"associated_bugs\":[{\"id\":1983758,\"status\":\"NEW\",\"last_change_time\":\"2021-08-26T15:21:23Z\",\"summary\":\"upgrades are failing on disruptive tests\",\"target_release\":[\"---\"],\"component\":[\"Routing\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1983758\"},{\"id\":1943334,\"status\":\"VERIFIED\",\"last_change_time\":\"2021-08-26T08:18:42Z\",\"summary\":\"[ovnkube] node pod should taint NoSchedule on termination; clear on startup\",\"target_release\":[\"4.9.0\"],\"component\":[\"Networking\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1943334\"},{\"id\":1983829,\"status\":\"ASSIGNED\",\"last_change_time\":\"2021-08-27T14:34:54Z\",\"summary\":\"ovn-kubernetes upgrade jobs are failing disruptive tests\",\"target_release\":[\"---\"],\"component\":[\"Networking\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1983829\"}]}]\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Aug 2021 11:08:13 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1486"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 159,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-08-31T11:08:13.676Z",
+        "time": 71,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 71
+        }
+      },
+      {
+        "_id": "54e0c0bffdc23caa7352e2b0cd545391",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8080"
+            }
+          ],
+          "headersSize": 500,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "release",
+              "value": "4.8"
+            },
+            {
+              "name": "filter",
+              "value": "{\"items\":[{\"id\":99,\"columnField\":\"failedTestNames\",\"operatorValue\":\"contains\",\"value\":\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\"}]}"
+            },
+            {
+              "name": "sortField",
+              "value": "timestamp"
+            },
+            {
+              "name": "sort",
+              "value": "desc"
+            }
+          ],
+          "url": "http://localhost:8080/api/jobs/runs?release=4.8&filter=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22failedTestNames%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20Kubernetes%20APIs%20remain%20available%20with%20reused%20connections%22%7D%5D%7D&sortField=timestamp&sort=desc"
+        },
+        "response": {
+          "bodySize": 16445,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 16445,
+            "text": "[{\"id\":0,\"brief_name\":\"e2e-gcp-upgrade\",\"variants\":[\"gcp\",\"upgrade\"],\"tags\":[\"upgrade\"],\"testGridURL\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\",\"job\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\",\"url\":\"https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1419942967652651008\",\"testFailures\":7,\"failedTestNames\":[\"[sig-api-machinery] Kubernetes APIs remain available for new connections\",\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\",\"[sig-api-machinery] OAuth APIs remain available for new connections\",\"[sig-api-machinery] OAuth APIs remain available with reused connections\",\"[sig-api-machinery] OpenShift APIs remain available for new connections\",\"[sig-api-machinery] OpenShift APIs remain available with reused connections\",\"[sig-sippy] openshift-tests should work\"],\"failed\":true,\"succeeded\":false,\"timestamp\":1627375769000,\"result\":\"F\"},{\"id\":1,\"brief_name\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8\",\"variants\":[\"upgrade\",\"s390x\"],\"tags\":[\"upgrade\"],\"testGridURL\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8\",\"job\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8\",\"url\":\"https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8/1417514886165958656\",\"testFailures\":12,\"failedTestNames\":[\"[sig-network] pods should successfully create sandboxes by other\",\"[sig-arch] Check if alerts are firing during or after upgrade success\",\"[sig-cluster-lifecycle] cluster upgrade should complete in 75m (105m on AWS)\",\"[sig-network-edge] Cluster frontend ingress remain available\",\"[sig-api-machinery] OAuth APIs remain available with reused connections\",\"[sig-network] pods should successfully create sandboxes by getting pod\",\"[sig-api-machinery] OpenShift APIs remain available with reused connections\",\"[sig-api-machinery] Kubernetes APIs remain available for new connections\",\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\",\"[sig-api-machinery] OAuth APIs remain available for new connections\",\"[sig-api-machinery] OpenShift APIs remain available for new connections\",\"[sig-sippy] openshift-tests should work\"],\"failed\":true,\"succeeded\":false,\"timestamp\":1626796862000,\"result\":\"F\"},{\"id\":2,\"brief_name\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8\",\"variants\":[\"upgrade\",\"s390x\"],\"tags\":[\"upgrade\"],\"testGridURL\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8\",\"job\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8\",\"url\":\"https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8/1416790083993866240\",\"testFailures\":12,\"failedTestNames\":[\"[sig-network] pods should successfully create sandboxes by other\",\"[sig-arch] Check if alerts are firing during or after upgrade success\",\"[sig-cluster-lifecycle] cluster upgrade should complete in 75m (105m on AWS)\",\"[sig-network-edge] Cluster frontend ingress remain available\",\"[sig-api-machinery] OAuth APIs remain available with reused connections\",\"[sig-network] pods should successfully create sandboxes by getting pod\",\"[sig-api-machinery] OpenShift APIs remain available with reused connections\",\"[sig-api-machinery] Kubernetes APIs remain available for new connections\",\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\",\"[sig-api-machinery] OAuth APIs remain available for new connections\",\"[sig-api-machinery] OpenShift APIs remain available for new connections\",\"[sig-sippy] openshift-tests should work\"],\"failed\":true,\"succeeded\":false,\"timestamp\":1626624056000,\"result\":\"F\"},{\"id\":3,\"brief_name\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\",\"variants\":[\"upgrade\",\"ppc64le\"],\"tags\":[\"upgrade\"],\"testGridURL\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\",\"job\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\",\"url\":\"https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8/1416790084497182720\",\"testFailures\":11,\"failedTestNames\":[\"[sig-arch] Check if alerts are firing during or after upgrade success\",\"[sig-imageregistry] Image registry remain available\",\"[sig-network-edge] Cluster frontend ingress remain available\",\"[sig-cluster-lifecycle] cluster upgrade should complete in 75m (105m on AWS)\",\"[sig-api-machinery] Kubernetes APIs remain available for new connections\",\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\",\"[sig-api-machinery] OAuth APIs remain available for new connections\",\"[sig-api-machinery] OAuth APIs remain available with reused connections\",\"[sig-api-machinery] OpenShift APIs remain available for new connections\",\"[sig-api-machinery] OpenShift APIs remain available with reused connections\",\"[sig-sippy] openshift-tests should work\"],\"failed\":true,\"succeeded\":false,\"timestamp\":1626624055000,\"result\":\"F\"},{\"id\":13,\"brief_name\":\"e2e-azure-upgrade\",\"variants\":[\"azure\",\"upgrade\"],\"tags\":[\"upgrade\"],\"testGridURL\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-azure-upgrade\",\"job\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-azure-upgrade\",\"url\":\"https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-azure-upgrade/1416602344216334336\",\"testFailures\":9,\"failedTestNames\":[\"[sig-network] pods should successfully create sandboxes by other\",\"[sig-arch] Check if alerts are firing during or after upgrade success\",\"[sig-api-machinery] Kubernetes APIs remain available for new connections\",\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\",\"[sig-api-machinery] OAuth APIs remain available for new connections\",\"[sig-api-machinery] OAuth APIs remain available with reused connections\",\"[sig-api-machinery] OpenShift APIs remain available for new connections\",\"[sig-api-machinery] OpenShift APIs remain available with reused connections\",\"[sig-sippy] openshift-tests should work\"],\"failed\":true,\"succeeded\":false,\"timestamp\":1626579295000,\"result\":\"F\"},{\"id\":6,\"brief_name\":\"e2e-gcp-upgrade\",\"variants\":[\"gcp\",\"upgrade\"],\"tags\":[\"upgrade\"],\"testGridURL\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\",\"job\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\",\"url\":\"https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1416601085929328640\",\"testFailures\":9,\"failedTestNames\":[\"[sig-api-machinery] Kubernetes APIs remain available for new connections\",\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\",\"[sig-api-machinery] OAuth APIs remain available for new connections\",\"[sig-api-machinery] OAuth APIs remain available with reused connections\",\"[sig-api-machinery] OpenShift APIs remain available for new connections\",\"[sig-api-machinery] OpenShift APIs remain available with reused connections\",\"[sig-network] pods should successfully create sandboxes by writing network status\",\"[sig-auth][Feature:SCC][Early] should not have pod creation failures during install [Suite:openshift/conformance/parallel]\",\"[sig-sippy] openshift-tests should work\"],\"failed\":true,\"succeeded\":false,\"timestamp\":1626578995000,\"result\":\"F\"},{\"id\":7,\"brief_name\":\"e2e-gcp-upgrade\",\"variants\":[\"gcp\",\"upgrade\"],\"tags\":[\"upgrade\"],\"testGridURL\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\",\"job\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\",\"url\":\"https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1415838752525258752\",\"testFailures\":7,\"failedTestNames\":[\"[sig-api-machinery] Kubernetes APIs remain available for new connections\",\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\",\"[sig-api-machinery] OAuth APIs remain available for new connections\",\"[sig-api-machinery] OAuth APIs remain available with reused connections\",\"[sig-api-machinery] OpenShift APIs remain available for new connections\",\"[sig-api-machinery] OpenShift APIs remain available with reused connections\",\"[sig-sippy] openshift-tests should work\"],\"failed\":true,\"succeeded\":false,\"timestamp\":1626397241000,\"result\":\"F\"},{\"id\":8,\"brief_name\":\"e2e-gcp-upgrade\",\"variants\":[\"gcp\",\"upgrade\"],\"tags\":[\"upgrade\"],\"testGridURL\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\",\"job\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\",\"url\":\"https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1415816652422909952\",\"testFailures\":7,\"failedTestNames\":[\"[sig-api-machinery] Kubernetes APIs remain available for new connections\",\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\",\"[sig-api-machinery] OAuth APIs remain available for new connections\",\"[sig-api-machinery] OAuth APIs remain available with reused connections\",\"[sig-api-machinery] OpenShift APIs remain available for new connections\",\"[sig-api-machinery] OpenShift APIs remain available with reused connections\",\"[sig-sippy] openshift-tests should work\"],\"failed\":true,\"succeeded\":false,\"timestamp\":1626391972000,\"result\":\"F\"},{\"id\":9,\"brief_name\":\"e2e-gcp-upgrade\",\"variants\":[\"gcp\",\"upgrade\"],\"tags\":[\"upgrade\"],\"testGridURL\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\",\"job\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\",\"url\":\"https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1415664182107312128\",\"testFailures\":7,\"failedTestNames\":[\"[sig-api-machinery] Kubernetes APIs remain available for new connections\",\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\",\"[sig-api-machinery] OAuth APIs remain available for new connections\",\"[sig-api-machinery] OAuth APIs remain available with reused connections\",\"[sig-api-machinery] OpenShift APIs remain available for new connections\",\"[sig-api-machinery] OpenShift APIs remain available with reused connections\",\"[sig-sippy] openshift-tests should work\"],\"failed\":true,\"succeeded\":false,\"timestamp\":1626355619000,\"result\":\"F\"},{\"id\":5,\"brief_name\":\"e2e-azure-compact-upgrade\",\"variants\":[\"azure\",\"compact\",\"upgrade\"],\"tags\":[\"upgrade\"],\"testGridURL\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-azure-compact-upgrade\",\"job\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-azure-compact-upgrade\",\"url\":\"https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-azure-compact-upgrade/1415394092786913280\",\"testFailures\":7,\"failedTestNames\":[\"[sig-api-machinery] Kubernetes APIs remain available for new connections\",\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\",\"[sig-api-machinery] OAuth APIs remain available for new connections\",\"[sig-api-machinery] OAuth APIs remain available with reused connections\",\"[sig-api-machinery] OpenShift APIs remain available for new connections\",\"[sig-api-machinery] OpenShift APIs remain available with reused connections\",\"[sig-sippy] openshift-tests should work\"],\"failed\":true,\"succeeded\":false,\"timestamp\":1626291226000,\"result\":\"F\"},{\"id\":4,\"brief_name\":\"e2e-gcp-compact-upgrade\",\"variants\":[\"compact\",\"gcp\",\"upgrade\"],\"tags\":[\"upgrade\"],\"testGridURL\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-compact-upgrade\",\"job\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-compact-upgrade\",\"url\":\"https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-compact-upgrade/1415394092824662016\",\"testFailures\":7,\"failedTestNames\":[\"[sig-api-machinery] OAuth APIs remain available for new connections\",\"[sig-api-machinery] OAuth APIs remain available with reused connections\",\"[sig-api-machinery] OpenShift APIs remain available with reused connections\",\"[sig-api-machinery] Kubernetes APIs remain available for new connections\",\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\",\"[sig-api-machinery] OpenShift APIs remain available for new connections\",\"[sig-sippy] openshift-tests should work\"],\"failed\":true,\"succeeded\":false,\"timestamp\":1626291226000,\"result\":\"F\"},{\"id\":10,\"brief_name\":\"e2e-gcp-upgrade\",\"variants\":[\"gcp\",\"upgrade\"],\"tags\":[\"upgrade\"],\"testGridURL\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\",\"job\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\",\"url\":\"https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1415384175036338176\",\"testFailures\":7,\"failedTestNames\":[\"[sig-api-machinery] Kubernetes APIs remain available for new connections\",\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\",\"[sig-api-machinery] OAuth APIs remain available for new connections\",\"[sig-api-machinery] OAuth APIs remain available with reused connections\",\"[sig-api-machinery] OpenShift APIs remain available for new connections\",\"[sig-api-machinery] OpenShift APIs remain available with reused connections\",\"[sig-sippy] openshift-tests should work\"],\"failed\":true,\"succeeded\":false,\"timestamp\":1626288869000,\"result\":\"F\"},{\"id\":11,\"brief_name\":\"e2e-gcp-upgrade\",\"variants\":[\"gcp\",\"upgrade\"],\"tags\":[\"upgrade\"],\"testGridURL\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\",\"job\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\",\"url\":\"https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1415314195020255232\",\"testFailures\":7,\"failedTestNames\":[\"[sig-api-machinery] Kubernetes APIs remain available for new connections\",\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\",\"[sig-api-machinery] OAuth APIs remain available for new connections\",\"[sig-api-machinery] OAuth APIs remain available with reused connections\",\"[sig-api-machinery] OpenShift APIs remain available for new connections\",\"[sig-api-machinery] OpenShift APIs remain available with reused connections\",\"[sig-sippy] openshift-tests should work\"],\"failed\":true,\"succeeded\":false,\"timestamp\":1626272180000,\"result\":\"F\"},{\"id\":12,\"brief_name\":\"e2e-gcp-upgrade\",\"variants\":[\"gcp\",\"upgrade\"],\"tags\":[\"upgrade\"],\"testGridURL\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\",\"job\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\",\"url\":\"https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1415310931189043200\",\"testFailures\":8,\"failedTestNames\":[\"[sig-arch] Check if alerts are firing during or after upgrade success\",\"[sig-api-machinery] Kubernetes APIs remain available for new connections\",\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\",\"[sig-api-machinery] OAuth APIs remain available for new connections\",\"[sig-api-machinery] OAuth APIs remain available with reused connections\",\"[sig-api-machinery] OpenShift APIs remain available for new connections\",\"[sig-api-machinery] OpenShift APIs remain available with reused connections\",\"[sig-sippy] openshift-tests should work\"],\"failed\":true,\"succeeded\":false,\"timestamp\":1626271398000,\"result\":\"F\"}]\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Aug 2021 11:08:14 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 165,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-08-31T11:08:14.033Z",
+        "time": 106,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 106
         }
       }
     ],

--- a/sippy-ng/__recordings__/app_527074092/should-render-correctly_3267003315/recording.har
+++ b/sippy-ng/__recordings__/app_527074092/should-render-correctly_3267003315/recording.har
@@ -453,7 +453,7 @@
         }
       },
       {
-        "_id": "7be66affe30ddbb27cf7e372a8a62201",
+        "_id": "6e2912afe01b9c84c69afb55a2d9a3c2",
         "_order": 0,
         "cache": {},
         "request": {
@@ -485,7 +485,7 @@
               "value": "localhost:8080"
             }
           ],
-          "headersSize": 411,
+          "headersSize": 667,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -495,7 +495,7 @@
             },
             {
               "name": "filter",
-              "value": "{\"items\":[{\"id\":1,\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"10\"}]}"
+              "value": "{\"items\":[{\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"10\"},{\"columnField\":\"variants\",\"not\":true,\"operatorValue\":\"contains\",\"value\":\"never-stable\"},{\"columnField\":\"variants\",\"not\":true,\"operatorValue\":\"contains\",\"value\":\"techpreview\"}]}"
             },
             {
               "name": "limit",
@@ -510,14 +510,14 @@
               "value": "asc"
             }
           ],
-          "url": "http://localhost:8080/api/jobs?release=4.8&filter=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%7D&limit=10&sortField=net_improvement&sort=asc"
+          "url": "http://localhost:8080/api/jobs?release=4.8&filter=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22techpreview%22%7D%5D%7D&limit=10&sortField=net_improvement&sort=asc"
         },
         "response": {
-          "bodySize": 6574,
+          "bodySize": 5984,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 6574,
-            "text": "[{\"id\":2,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance\",\"brief_name\":\"openshift-ipi-azure-arcconformance\",\"variants\":[\"azure\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":40,\"previous_pass_percentage\":0,\"previous_projected_pass_percentage\":0,\"previous_runs\":37,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance\",\"bugs\":[],\"associated_bugs\":[{\"id\":1991635,\"status\":\"NEW\",\"last_change_time\":\"2021-08-24T18:13:58Z\",\"summary\":\"periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance\",\"target_release\":[\"---\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1991635\"}]},{\"id\":3,\"name\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8\",\"brief_name\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8\",\"variants\":[\"upgrade\",\"s390x\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":13,\"previous_pass_percentage\":0,\"previous_projected_pass_percentage\":0,\"previous_runs\":14,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":20,\"name\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\",\"brief_name\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\",\"variants\":[\"upgrade\",\"ppc64le\"],\"current_pass_percentage\":15.384615384615385,\"current_projected_pass_percentage\":15.384615384615385,\"current_runs\":13,\"previous_pass_percentage\":21.428571428571427,\"previous_projected_pass_percentage\":21.428571428571427,\"previous_runs\":14,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":22,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade\",\"brief_name\":\"upgrade-from-stable-4.7-e2e-metal-ipi-upgrade\",\"variants\":[\"metal-ipi\",\"upgrade\"],\"current_pass_percentage\":23.076923076923077,\"current_projected_pass_percentage\":27.27272727272727,\"current_runs\":13,\"previous_pass_percentage\":16.666666666666664,\"previous_projected_pass_percentage\":20,\"previous_runs\":12,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":25,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-upgrade\",\"brief_name\":\"upgrade-from-stable-4.7-e2e-gcp-upgrade\",\"variants\":[\"gcp\",\"upgrade\"],\"current_pass_percentage\":25,\"current_projected_pass_percentage\":30,\"current_runs\":24,\"previous_pass_percentage\":30.434782608695656,\"previous_projected_pass_percentage\":31.818181818181817,\"previous_runs\":23,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-upgrade\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":26,\"name\":\"release-openshift-ocp-osd-aws-nightly-4.8\",\"brief_name\":\"release-openshift-ocp-osd-aws-nightly-4.8\",\"variants\":[\"aws\",\"osd\"],\"current_pass_percentage\":25.925925925925924,\"current_projected_pass_percentage\":25.925925925925924,\"current_runs\":27,\"previous_pass_percentage\":39.285714285714285,\"previous_projected_pass_percentage\":39.285714285714285,\"previous_runs\":28,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-osd-aws-nightly-4.8\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":27,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi\",\"brief_name\":\"e2e-metal-ipi\",\"variants\":[\"metal-ipi\"],\"current_pass_percentage\":29.411764705882355,\"current_projected_pass_percentage\":32.25806451612903,\"current_runs\":34,\"previous_pass_percentage\":17.142857142857142,\"previous_projected_pass_percentage\":18.181818181818183,\"previous_runs\":35,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-blocking#periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi\",\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"ASSIGNED\",\"last_change_time\":\"2021-08-25T22:30:45Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]},{\"id\":28,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy\",\"brief_name\":\"e2e-aws-proxy\",\"variants\":[\"aws\",\"proxy\"],\"current_pass_percentage\":31.25,\"current_projected_pass_percentage\":62.5,\"current_runs\":16,\"previous_pass_percentage\":50,\"previous_projected_pass_percentage\":80,\"previous_runs\":16,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":30,\"name\":\"release-openshift-ocp-osd-gcp-nightly-4.8\",\"brief_name\":\"release-openshift-ocp-osd-gcp-nightly-4.8\",\"variants\":[\"gcp\",\"osd\"],\"current_pass_percentage\":33.33333333333333,\"current_projected_pass_percentage\":33.33333333333333,\"current_runs\":27,\"previous_pass_percentage\":32.142857142857146,\"previous_projected_pass_percentage\":32.142857142857146,\"previous_runs\":28,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-osd-gcp-nightly-4.8\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":34,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade\",\"brief_name\":\"e2e-aws-upgrade\",\"variants\":[\"aws\",\"upgrade\"],\"current_pass_percentage\":33.33333333333333,\"current_projected_pass_percentage\":35.714285714285715,\"current_runs\":15,\"previous_pass_percentage\":53.333333333333336,\"previous_projected_pass_percentage\":57.14285714285714,\"previous_runs\":15,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade\",\"bugs\":[],\"associated_bugs\":[]}]\n"
+            "size": 5984,
+            "text": "[{\"id\":39,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4\",\"brief_name\":\"e2e-metal-ipi-serial-ipv4\",\"variants\":[\"metal-ipi\",\"serial\"],\"current_pass_percentage\":38.46153846153847,\"current_projected_pass_percentage\":100,\"current_runs\":13,\"previous_pass_percentage\":66.66666666666666,\"previous_projected_pass_percentage\":100,\"previous_runs\":12,\"net_improvement\":-28.20512820512819,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":62,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp\",\"brief_name\":\"e2e-gcp\",\"variants\":[\"gcp\"],\"current_pass_percentage\":69.23076923076923,\"current_projected_pass_percentage\":75,\"current_runs\":13,\"previous_pass_percentage\":92.3076923076923,\"previous_projected_pass_percentage\":92.3076923076923,\"previous_runs\":13,\"net_improvement\":-23.07692307692308,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":33,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade\",\"brief_name\":\"e2e-aws-upgrade\",\"variants\":[\"aws\",\"upgrade\"],\"current_pass_percentage\":33.33333333333333,\"current_projected_pass_percentage\":35.714285714285715,\"current_runs\":15,\"previous_pass_percentage\":53.333333333333336,\"previous_projected_pass_percentage\":57.14285714285714,\"previous_runs\":15,\"net_improvement\":-20.000000000000007,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":28,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy\",\"brief_name\":\"e2e-aws-proxy\",\"variants\":[\"aws\",\"proxy\"],\"current_pass_percentage\":31.25,\"current_projected_pass_percentage\":62.5,\"current_runs\":16,\"previous_pass_percentage\":50,\"previous_projected_pass_percentage\":80,\"previous_runs\":16,\"net_improvement\":-18.75,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":70,\"name\":\"release-openshift-ocp-installer-e2e-aws-ovn-4.8\",\"brief_name\":\"release-openshift-ocp-installer-e2e-aws-ovn-4.8\",\"variants\":[\"aws\",\"ovn\"],\"current_pass_percentage\":76.92307692307693,\"current_projected_pass_percentage\":83.33333333333334,\"current_runs\":13,\"previous_pass_percentage\":92.3076923076923,\"previous_projected_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-15.384615384615373,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-installer-e2e-aws-ovn-4.8\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":75,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-workers-rhel7\",\"brief_name\":\"e2e-aws-workers-rhel7\",\"variants\":[\"aws\"],\"current_pass_percentage\":78.57142857142857,\"current_projected_pass_percentage\":78.57142857142857,\"current_runs\":28,\"previous_pass_percentage\":92.5925925925926,\"previous_projected_pass_percentage\":96.15384615384616,\"previous_runs\":27,\"net_improvement\":-14.021164021164026,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-workers-rhel7\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":26,\"name\":\"release-openshift-ocp-osd-aws-nightly-4.8\",\"brief_name\":\"release-openshift-ocp-osd-aws-nightly-4.8\",\"variants\":[\"aws\",\"osd\"],\"current_pass_percentage\":25.925925925925924,\"current_projected_pass_percentage\":25.925925925925924,\"current_runs\":27,\"previous_pass_percentage\":39.285714285714285,\"previous_projected_pass_percentage\":39.285714285714285,\"previous_runs\":28,\"net_improvement\":-13.35978835978836,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-osd-aws-nightly-4.8\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":67,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-aws-serial\",\"brief_name\":\"e2e-aws-serial\",\"variants\":[\"aws\",\"serial\"],\"current_pass_percentage\":75,\"current_projected_pass_percentage\":75,\"current_runs\":24,\"previous_pass_percentage\":86.95652173913044,\"previous_projected_pass_percentage\":90.9090909090909,\"previous_runs\":23,\"net_improvement\":-11.956521739130437,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-blocking#periodic-ci-openshift-release-master-ci-4.8-e2e-aws-serial\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":38,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-vsphere-upgrade\",\"brief_name\":\"upgrade-from-stable-4.7-e2e-vsphere-upgrade\",\"variants\":[\"vsphere-ipi\",\"upgrade\"],\"current_pass_percentage\":38.46153846153847,\"current_projected_pass_percentage\":50,\"current_runs\":13,\"previous_pass_percentage\":50,\"previous_projected_pass_percentage\":58.333333333333336,\"previous_runs\":14,\"net_improvement\":-11.538461538461533,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-vsphere-upgrade\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":44,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-serial\",\"brief_name\":\"e2e-vsphere-serial\",\"variants\":[\"vsphere-ipi\",\"serial\"],\"current_pass_percentage\":48.64864864864865,\"current_projected_pass_percentage\":62.06896551724138,\"current_runs\":37,\"previous_pass_percentage\":58.82352941176471,\"previous_projected_pass_percentage\":74.07407407407408,\"previous_runs\":34,\"net_improvement\":-10.174880763116057,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-serial\",\"bugs\":[],\"associated_bugs\":[]}]\n"
           },
           "cookies": [],
           "headers": [
@@ -531,7 +531,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 27 Aug 2021 14:12:50 GMT"
+              "value": "Tue, 31 Aug 2021 11:08:14 GMT"
             },
             {
               "name": "connection",
@@ -548,8 +548,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-27T14:12:50.644Z",
-        "time": 332,
+        "startedDateTime": "2021-08-31T11:08:14.516Z",
+        "time": 368,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -557,11 +557,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 332
+          "wait": 368
         }
       },
       {
-        "_id": "8d1b9a1a3a44f539acc3d8419ec5b383",
+        "_id": "edfddda60a676ccc59363e27fcefcd03",
         "_order": 0,
         "cache": {},
         "request": {
@@ -593,7 +593,7 @@
               "value": "localhost:8080"
             }
           ],
-          "headersSize": 424,
+          "headersSize": 680,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -603,7 +603,7 @@
             },
             {
               "name": "filter",
-              "value": "{\"items\":[{\"id\":1,\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"1\"}]}"
+              "value": "{\"items\":[{\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"1\"},{\"columnField\":\"variants\",\"not\":true,\"operatorValue\":\"contains\",\"value\":\"never-stable\"},{\"columnField\":\"variants\",\"not\":true,\"operatorValue\":\"contains\",\"value\":\"techpreview\"}]}"
             },
             {
               "name": "limit",
@@ -622,14 +622,14 @@
               "value": "asc"
             }
           ],
-          "url": "http://localhost:8080/api/jobs?release=4.8&filter=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%7D&limit=10&period=twoDay&sortField=net_improvement&sort=asc"
+          "url": "http://localhost:8080/api/jobs?release=4.8&filter=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22techpreview%22%7D%5D%7D&limit=10&period=twoDay&sortField=net_improvement&sort=asc"
         },
         "response": {
-          "bodySize": 6075,
+          "bodySize": 6447,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 6075,
-            "text": "[{\"id\":0,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift\",\"brief_name\":\"e2e-aws-hypershift\",\"variants\":[\"aws\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":0,\"previous_projected_pass_percentage\":0,\"previous_runs\":6,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":11,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade\",\"brief_name\":\"e2e-aws-upgrade\",\"variants\":[\"aws\",\"upgrade\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":66.66666666666666,\"previous_projected_pass_percentage\":80,\"previous_runs\":6,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":12,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node\",\"brief_name\":\"e2e-aws-single-node\",\"variants\":[\"aws\",\"single-node\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":33.33333333333333,\"previous_projected_pass_percentage\":33.33333333333333,\"previous_runs\":6,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":24,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia\",\"brief_name\":\"e2e-metal-ipi-virtualmedia\",\"variants\":[\"metal-ipi\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":2,\"previous_pass_percentage\":50,\"previous_projected_pass_percentage\":53.84615384615385,\"previous_runs\":14,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia\",\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"ASSIGNED\",\"last_change_time\":\"2021-08-25T22:30:45Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]},{\"id\":30,\"name\":\"release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8\",\"brief_name\":\"release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8\",\"variants\":[\"unknown variant\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":2,\"previous_pass_percentage\":0,\"previous_projected_pass_percentage\":0,\"previous_runs\":6,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":32,\"name\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\",\"brief_name\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\",\"variants\":[\"upgrade\",\"ppc64le\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":3,\"previous_pass_percentage\":15.384615384615385,\"previous_projected_pass_percentage\":15.384615384615385,\"previous_runs\":13,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":34,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-azure-upgrade-single-node\",\"brief_name\":\"e2e-azure-upgrade-single-node\",\"variants\":[\"azure\",\"upgrade\",\"single-node\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":33.33333333333333,\"previous_projected_pass_percentage\":33.33333333333333,\"previous_runs\":6,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-azure-upgrade-single-node\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":35,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-ovn\",\"brief_name\":\"e2e-vsphere-ovn\",\"variants\":[\"vsphere-ipi\",\"ovn\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":16.666666666666664,\"previous_projected_pass_percentage\":16.666666666666664,\"previous_runs\":6,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-ovn\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":36,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-azure-ovn-upgrade\",\"brief_name\":\"upgrade-from-stable-4.7-e2e-azure-ovn-upgrade\",\"variants\":[\"azure\",\"upgrade\",\"ovn\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":0,\"previous_projected_pass_percentage\":0,\"previous_runs\":6,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-azure-ovn-upgrade\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":38,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack\",\"brief_name\":\"e2e-metal-ipi-ovn-dualstack\",\"variants\":[\"metal-ipi\",\"ovn\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":2,\"previous_pass_percentage\":38.46153846153847,\"previous_projected_pass_percentage\":45.45454545454545,\"previous_runs\":13,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack\",\"bugs\":[],\"associated_bugs\":[]}]\n"
+            "size": 6447,
+            "text": "[{\"id\":37,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade\",\"brief_name\":\"e2e-aws-upgrade\",\"variants\":[\"aws\",\"upgrade\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":66.66666666666666,\"previous_projected_pass_percentage\":80,\"previous_runs\":6,\"net_improvement\":-66.66666666666666,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":33,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-libvirt-cert-rotation\",\"brief_name\":\"e2e-gcp-libvirt-cert-rotation\",\"variants\":[\"gcp\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":57.14285714285714,\"previous_projected_pass_percentage\":66.66666666666666,\"previous_runs\":7,\"net_improvement\":-57.14285714285714,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-libvirt-cert-rotation\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":3,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia\",\"brief_name\":\"e2e-metal-ipi-virtualmedia\",\"variants\":[\"metal-ipi\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":2,\"previous_pass_percentage\":50,\"previous_projected_pass_percentage\":53.84615384615385,\"previous_runs\":14,\"net_improvement\":-50,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia\",\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"VERIFIED\",\"last_change_time\":\"2021-08-31T07:55:34Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]},{\"id\":72,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted\",\"brief_name\":\"e2e-metal-assisted\",\"variants\":[\"metal-assisted\"],\"current_pass_percentage\":50,\"current_projected_pass_percentage\":100,\"current_runs\":2,\"previous_pass_percentage\":92.85714285714286,\"previous_projected_pass_percentage\":100,\"previous_runs\":14,\"net_improvement\":-42.85714285714286,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":53,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack\",\"brief_name\":\"e2e-metal-ipi-ovn-dualstack\",\"variants\":[\"metal-ipi\",\"ovn\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":2,\"previous_pass_percentage\":38.46153846153847,\"previous_projected_pass_percentage\":45.45454545454545,\"previous_runs\":13,\"net_improvement\":-38.46153846153847,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":19,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-azure-upgrade-single-node\",\"brief_name\":\"e2e-azure-upgrade-single-node\",\"variants\":[\"azure\",\"upgrade\",\"single-node\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":33.33333333333333,\"previous_projected_pass_percentage\":33.33333333333333,\"previous_runs\":6,\"net_improvement\":-33.33333333333333,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-azure-upgrade-single-node\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":47,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node\",\"brief_name\":\"e2e-aws-single-node\",\"variants\":[\"aws\",\"single-node\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":33.33333333333333,\"previous_projected_pass_percentage\":33.33333333333333,\"previous_runs\":6,\"net_improvement\":-33.33333333333333,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":54,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-ipv6\",\"brief_name\":\"e2e-metal-ipi-ovn-ipv6\",\"variants\":[\"metal-ipi\",\"ovn\"],\"current_pass_percentage\":12.5,\"current_projected_pass_percentage\":16.666666666666664,\"current_runs\":8,\"previous_pass_percentage\":42.857142857142854,\"previous_projected_pass_percentage\":46.15384615384615,\"previous_runs\":28,\"net_improvement\":-30.357142857142854,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-blocking#periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-ipv6\",\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"VERIFIED\",\"last_change_time\":\"2021-08-31T07:55:34Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]},{\"id\":70,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-fips\",\"brief_name\":\"e2e-aws-fips\",\"variants\":[\"aws\",\"fips\"],\"current_pass_percentage\":50,\"current_projected_pass_percentage\":100,\"current_runs\":2,\"previous_pass_percentage\":76.92307692307693,\"previous_projected_pass_percentage\":83.33333333333334,\"previous_runs\":13,\"net_improvement\":-26.923076923076934,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-fips\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":74,\"name\":\"release-openshift-ocp-installer-e2e-azure-serial-4.8\",\"brief_name\":\"release-openshift-ocp-installer-e2e-azure-serial-4.8\",\"variants\":[\"azure\",\"serial\"],\"current_pass_percentage\":50,\"current_projected_pass_percentage\":50,\"current_runs\":2,\"previous_pass_percentage\":76.92307692307693,\"previous_projected_pass_percentage\":83.33333333333334,\"previous_runs\":13,\"net_improvement\":-26.923076923076934,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-installer-e2e-azure-serial-4.8\",\"bugs\":[],\"associated_bugs\":[]}]\n"
           },
           "cookies": [],
           "headers": [
@@ -643,7 +643,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 27 Aug 2021 14:12:50 GMT"
+              "value": "Tue, 31 Aug 2021 11:08:14 GMT"
             },
             {
               "name": "connection",
@@ -660,8 +660,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-27T14:12:50.644Z",
-        "time": 487,
+        "startedDateTime": "2021-08-31T11:08:14.516Z",
+        "time": 590,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -669,11 +669,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 487
+          "wait": 590
         }
       },
       {
-        "_id": "d51db0fbddbeac19059bdc4b53c9e4dc",
+        "_id": "cee88ca8682d8a9c61a15db3c7142956",
         "_order": 0,
         "cache": {},
         "request": {
@@ -705,7 +705,7 @@
               "value": "localhost:8080"
             }
           ],
-          "headersSize": 425,
+          "headersSize": 410,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -715,7 +715,7 @@
             },
             {
               "name": "filter",
-              "value": "{\"items\":[{\"id\":1,\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"1\"}]}"
+              "value": "{\"items\":[{\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"1\"}]}"
             },
             {
               "name": "limit",
@@ -734,14 +734,14 @@
               "value": "asc"
             }
           ],
-          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%7D&limit=10&period=twoDay&sortField=net_improvement&sort=asc"
+          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%7D&limit=10&period=twoDay&sortField=net_improvement&sort=asc"
         },
         "response": {
           "bodySize": 5576,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 5576,
-            "text": "[{\"id\":6,\"name\":\"operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test\",\"current_successes\":1,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":2,\"previous_successes\":13,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":92.85714285714286,\"previous_runs\":14,\"net_improvement\":-42.85714285714286,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":7,\"name\":\"operator.Run multi-stage test e2e-metal-ipi-virtualmedia - e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup container test\",\"current_successes\":1,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":2,\"previous_successes\":13,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":92.85714285714286,\"previous_runs\":14,\"net_improvement\":-42.85714285714286,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"ASSIGNED\",\"last_change_time\":\"2021-08-25T22:30:45Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]},{\"id\":5,\"name\":\"operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test\",\"current_successes\":1,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":2,\"previous_successes\":12,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":92.3076923076923,\"previous_runs\":13,\"net_improvement\":-42.30769230769231,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":12,\"name\":\"TestInstall_test_install.start_install_and_wait_for_installed(openshift_version=4.8)\",\"current_successes\":3,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":75,\"current_runs\":4,\"previous_successes\":25,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":96.15384615384616,\"previous_runs\":26,\"net_improvement\":-21.15384615384616,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":13,\"name\":\"operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test\",\"current_successes\":6,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":75,\"current_runs\":8,\"previous_successes\":26,\"previous_failures\":2,\"previous_flakes\":0,\"previous_pass_percentage\":92.85714285714286,\"previous_runs\":28,\"net_improvement\":-17.85714285714286,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"ASSIGNED\",\"last_change_time\":\"2021-08-25T22:30:45Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]},{\"id\":3,\"name\":\"[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version\",\"current_successes\":3,\"current_failures\":12,\"current_flakes\":0,\"current_pass_percentage\":20,\"current_runs\":15,\"previous_successes\":17,\"previous_failures\":29,\"previous_flakes\":0,\"previous_pass_percentage\":36.95652173913043,\"previous_runs\":46,\"net_improvement\":-16.95652173913043,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":8,\"name\":\"operator.Run template e2e-metal-serial - e2e-metal-serial container setup\",\"current_successes\":1,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":2,\"previous_successes\":8,\"previous_failures\":4,\"previous_flakes\":0,\"previous_pass_percentage\":66.66666666666666,\"previous_runs\":12,\"net_improvement\":-16.666666666666657,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":16,\"name\":\"[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Dynamic PV (default fs)] fsgroupchangepolicy (Always)[LinuxOnly], pod created with an initial fsgroup, new pod fsgroup applied to volume contents [Suite:openshift/conformance/parallel] [Suite:k8s]\",\"current_successes\":5,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":6,\"previous_successes\":48,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":97.95918367346938,\"previous_runs\":49,\"net_improvement\":-14.62585034013604,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":17,\"name\":\"[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Dynamic PV (default fs)] fsgroupchangepolicy (Always)[LinuxOnly], pod created with an initial fsgroup, volume contents ownership changed in first pod, new pod with same fsgroup applied to the volume contents [Suite:openshift/conformance/parallel] [Suite:k8s]\",\"current_successes\":5,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":6,\"previous_successes\":48,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":97.95918367346938,\"previous_runs\":49,\"net_improvement\":-14.62585034013604,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":18,\"name\":\"[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Dynamic PV (default fs)] fsgroupchangepolicy (OnRootMismatch)[LinuxOnly], pod created with an initial fsgroup, volume contents ownership changed in first pod, new pod with different fsgroup applied to the volume contents [Suite:openshift/conformance/parallel] [Suite:k8s]\",\"current_successes\":5,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":6,\"previous_successes\":48,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":97.95918367346938,\"previous_runs\":49,\"net_improvement\":-14.62585034013604,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]}]\n"
+            "text": "[{\"id\":6,\"name\":\"operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test\",\"current_successes\":1,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":2,\"previous_successes\":13,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":92.85714285714286,\"previous_runs\":14,\"net_improvement\":-42.85714285714286,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":7,\"name\":\"operator.Run multi-stage test e2e-metal-ipi-virtualmedia - e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup container test\",\"current_successes\":1,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":2,\"previous_successes\":13,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":92.85714285714286,\"previous_runs\":14,\"net_improvement\":-42.85714285714286,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"VERIFIED\",\"last_change_time\":\"2021-08-31T07:55:34Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]},{\"id\":5,\"name\":\"operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test\",\"current_successes\":1,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":2,\"previous_successes\":12,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":92.3076923076923,\"previous_runs\":13,\"net_improvement\":-42.30769230769231,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":12,\"name\":\"TestInstall_test_install.start_install_and_wait_for_installed(openshift_version=4.8)\",\"current_successes\":3,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":75,\"current_runs\":4,\"previous_successes\":25,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":96.15384615384616,\"previous_runs\":26,\"net_improvement\":-21.15384615384616,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":13,\"name\":\"operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test\",\"current_successes\":6,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":75,\"current_runs\":8,\"previous_successes\":26,\"previous_failures\":2,\"previous_flakes\":0,\"previous_pass_percentage\":92.85714285714286,\"previous_runs\":28,\"net_improvement\":-17.85714285714286,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"VERIFIED\",\"last_change_time\":\"2021-08-31T07:55:34Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]},{\"id\":3,\"name\":\"[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version\",\"current_successes\":3,\"current_failures\":12,\"current_flakes\":0,\"current_pass_percentage\":20,\"current_runs\":15,\"previous_successes\":17,\"previous_failures\":29,\"previous_flakes\":0,\"previous_pass_percentage\":36.95652173913043,\"previous_runs\":46,\"net_improvement\":-16.95652173913043,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":8,\"name\":\"operator.Run template e2e-metal-serial - e2e-metal-serial container setup\",\"current_successes\":1,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":2,\"previous_successes\":8,\"previous_failures\":4,\"previous_flakes\":0,\"previous_pass_percentage\":66.66666666666666,\"previous_runs\":12,\"net_improvement\":-16.666666666666657,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":16,\"name\":\"[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Dynamic PV (default fs)] fsgroupchangepolicy (Always)[LinuxOnly], pod created with an initial fsgroup, new pod fsgroup applied to volume contents [Suite:openshift/conformance/parallel] [Suite:k8s]\",\"current_successes\":5,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":6,\"previous_successes\":48,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":97.95918367346938,\"previous_runs\":49,\"net_improvement\":-14.62585034013604,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":17,\"name\":\"[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Dynamic PV (default fs)] fsgroupchangepolicy (Always)[LinuxOnly], pod created with an initial fsgroup, volume contents ownership changed in first pod, new pod with same fsgroup applied to the volume contents [Suite:openshift/conformance/parallel] [Suite:k8s]\",\"current_successes\":5,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":6,\"previous_successes\":48,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":97.95918367346938,\"previous_runs\":49,\"net_improvement\":-14.62585034013604,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":18,\"name\":\"[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Dynamic PV (default fs)] fsgroupchangepolicy (OnRootMismatch)[LinuxOnly], pod created with an initial fsgroup, volume contents ownership changed in first pod, new pod with different fsgroup applied to the volume contents [Suite:openshift/conformance/parallel] [Suite:k8s]\",\"current_successes\":5,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":6,\"previous_successes\":48,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":97.95918367346938,\"previous_runs\":49,\"net_improvement\":-14.62585034013604,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]}]\n"
           },
           "cookies": [],
           "headers": [
@@ -755,7 +755,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 27 Aug 2021 14:12:50 GMT"
+              "value": "Tue, 31 Aug 2021 11:08:14 GMT"
             },
             {
               "name": "connection",
@@ -772,8 +772,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-27T14:12:50.644Z",
-        "time": 884,
+        "startedDateTime": "2021-08-31T11:08:14.516Z",
+        "time": 1106,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -781,11 +781,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 884
+          "wait": 1106
         }
       },
       {
-        "_id": "b7a2cdbf6ebbf7c397fd5c50508f2a6b",
+        "_id": "cdbf158ea0b37acd21634b34a39498ea",
         "_order": 0,
         "cache": {},
         "request": {
@@ -817,7 +817,7 @@
               "value": "localhost:8080"
             }
           ],
-          "headersSize": 412,
+          "headersSize": 397,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -827,7 +827,7 @@
             },
             {
               "name": "filter",
-              "value": "{\"items\":[{\"id\":1,\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"10\"}]}"
+              "value": "{\"items\":[{\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"10\"}]}"
             },
             {
               "name": "limit",
@@ -842,14 +842,14 @@
               "value": "asc"
             }
           ],
-          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%7D&limit=10&sortField=net_improvement&sort=asc"
+          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%7D&limit=10&sortField=net_improvement&sort=asc"
         },
         "response": {
           "bodySize": 4959,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 4959,
-            "text": "[{\"id\":25,\"name\":\"[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version\",\"current_successes\":17,\"current_failures\":29,\"current_flakes\":0,\"current_pass_percentage\":36.95652173913043,\"current_runs\":46,\"previous_successes\":46,\"previous_failures\":7,\"previous_flakes\":0,\"previous_pass_percentage\":86.79245283018868,\"previous_runs\":53,\"net_improvement\":-49.83593109105825,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":49,\"name\":\"operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test\",\"current_successes\":10,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":12,\"previous_successes\":12,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":12,\"net_improvement\":-16.666666666666657,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":27,\"name\":\"operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test\",\"current_successes\":8,\"current_failures\":8,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":16,\"previous_successes\":10,\"previous_failures\":6,\"previous_flakes\":0,\"previous_pass_percentage\":62.5,\"previous_runs\":16,\"net_improvement\":-12.5,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":48,\"name\":\"operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test\",\"current_successes\":40,\"current_failures\":8,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":48,\"previous_successes\":42,\"previous_failures\":2,\"previous_flakes\":0,\"previous_pass_percentage\":95.45454545454545,\"previous_runs\":44,\"net_improvement\":-12.12121212121211,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":55,\"name\":\"operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test\",\"current_successes\":33,\"current_failures\":4,\"current_flakes\":0,\"current_pass_percentage\":89.1891891891892,\"current_runs\":37,\"previous_successes\":35,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":35,\"net_improvement\":-10.810810810810807,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":41,\"name\":\"operator.Run template e2e-metal-serial - e2e-metal-serial container setup\",\"current_successes\":8,\"current_failures\":4,\"current_flakes\":0,\"current_pass_percentage\":66.66666666666666,\"current_runs\":12,\"previous_successes\":10,\"previous_failures\":3,\"previous_flakes\":0,\"previous_pass_percentage\":76.92307692307693,\"previous_runs\":13,\"net_improvement\":-10.256410256410277,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":63,\"name\":\"operator.Run multi-stage test e2e-gcp-rt - e2e-gcp-rt-ipi-install-install container test\",\"current_successes\":12,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.3076923076923,\"current_runs\":13,\"previous_successes\":13,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-7.692307692307693,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":62,\"name\":\"operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test\",\"current_successes\":12,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.3076923076923,\"current_runs\":13,\"previous_successes\":13,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-7.692307692307693,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":67,\"name\":\"operator.Run multi-stage test openshift-ipi-azure-arcconformance - openshift-ipi-azure-arcconformance-ipi-install-install container test\",\"current_successes\":37,\"current_failures\":3,\"current_flakes\":0,\"current_pass_percentage\":92.5,\"current_runs\":40,\"previous_successes\":36,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":36,\"net_improvement\":-7.5,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1991635,\"status\":\"NEW\",\"last_change_time\":\"2021-08-24T18:13:58Z\",\"summary\":\"periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance\",\"target_release\":[\"---\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1991635\"}]},{\"id\":69,\"name\":\"operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test\",\"current_successes\":26,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":92.85714285714286,\"current_runs\":28,\"previous_successes\":25,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":25,\"net_improvement\":-7.142857142857139,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"ASSIGNED\",\"last_change_time\":\"2021-08-25T22:30:45Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]}]\n"
+            "text": "[{\"id\":25,\"name\":\"[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version\",\"current_successes\":17,\"current_failures\":29,\"current_flakes\":0,\"current_pass_percentage\":36.95652173913043,\"current_runs\":46,\"previous_successes\":46,\"previous_failures\":7,\"previous_flakes\":0,\"previous_pass_percentage\":86.79245283018868,\"previous_runs\":53,\"net_improvement\":-49.83593109105825,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":49,\"name\":\"operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test\",\"current_successes\":10,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":12,\"previous_successes\":12,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":12,\"net_improvement\":-16.666666666666657,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":27,\"name\":\"operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test\",\"current_successes\":8,\"current_failures\":8,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":16,\"previous_successes\":10,\"previous_failures\":6,\"previous_flakes\":0,\"previous_pass_percentage\":62.5,\"previous_runs\":16,\"net_improvement\":-12.5,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":48,\"name\":\"operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test\",\"current_successes\":40,\"current_failures\":8,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":48,\"previous_successes\":42,\"previous_failures\":2,\"previous_flakes\":0,\"previous_pass_percentage\":95.45454545454545,\"previous_runs\":44,\"net_improvement\":-12.12121212121211,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":55,\"name\":\"operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test\",\"current_successes\":33,\"current_failures\":4,\"current_flakes\":0,\"current_pass_percentage\":89.1891891891892,\"current_runs\":37,\"previous_successes\":35,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":35,\"net_improvement\":-10.810810810810807,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":41,\"name\":\"operator.Run template e2e-metal-serial - e2e-metal-serial container setup\",\"current_successes\":8,\"current_failures\":4,\"current_flakes\":0,\"current_pass_percentage\":66.66666666666666,\"current_runs\":12,\"previous_successes\":10,\"previous_failures\":3,\"previous_flakes\":0,\"previous_pass_percentage\":76.92307692307693,\"previous_runs\":13,\"net_improvement\":-10.256410256410277,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":63,\"name\":\"operator.Run multi-stage test e2e-gcp-rt - e2e-gcp-rt-ipi-install-install container test\",\"current_successes\":12,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.3076923076923,\"current_runs\":13,\"previous_successes\":13,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-7.692307692307693,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":62,\"name\":\"operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test\",\"current_successes\":12,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.3076923076923,\"current_runs\":13,\"previous_successes\":13,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-7.692307692307693,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":67,\"name\":\"operator.Run multi-stage test openshift-ipi-azure-arcconformance - openshift-ipi-azure-arcconformance-ipi-install-install container test\",\"current_successes\":37,\"current_failures\":3,\"current_flakes\":0,\"current_pass_percentage\":92.5,\"current_runs\":40,\"previous_successes\":36,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":36,\"net_improvement\":-7.5,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1991635,\"status\":\"NEW\",\"last_change_time\":\"2021-08-24T18:13:58Z\",\"summary\":\"periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance\",\"target_release\":[\"---\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1991635\"}]},{\"id\":69,\"name\":\"operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test\",\"current_successes\":26,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":92.85714285714286,\"current_runs\":28,\"previous_successes\":25,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":25,\"net_improvement\":-7.142857142857139,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"VERIFIED\",\"last_change_time\":\"2021-08-31T07:55:34Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]}]\n"
           },
           "cookies": [],
           "headers": [
@@ -863,7 +863,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 27 Aug 2021 14:12:50 GMT"
+              "value": "Tue, 31 Aug 2021 11:08:14 GMT"
             },
             {
               "name": "connection",
@@ -880,8 +880,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-27T14:12:50.644Z",
-        "time": 1139,
+        "startedDateTime": "2021-08-31T11:08:14.516Z",
+        "time": 1413,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -889,11 +889,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1139
+          "wait": 1413
         }
       },
       {
-        "_id": "17731289af2d996f693d6997fb3da20f",
+        "_id": "c8bb2d1156280ceba8e93915bda0edc6",
         "_order": 0,
         "cache": {},
         "request": {
@@ -925,7 +925,7 @@
               "value": "localhost:8080"
             }
           ],
-          "headersSize": 531,
+          "headersSize": 501,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -935,7 +935,7 @@
             },
             {
               "name": "filter",
-              "value": "{\"items\":[{\"id\":1,\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"10\"},{\"id\":8,\"columnField\":\"tags\",\"operatorValue\":\"contains\",\"value\":\"trt\"}]}"
+              "value": "{\"items\":[{\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"10\"},{\"columnField\":\"tags\",\"operatorValue\":\"contains\",\"value\":\"trt\"}]}"
             },
             {
               "name": "limit",
@@ -950,7 +950,7 @@
               "value": "asc"
             }
           ],
-          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22id%22%3A8%2C%22columnField%22%3A%22tags%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22trt%22%7D%5D%7D&limit=10&sortField=net_improvement&sort=asc"
+          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22columnField%22%3A%22tags%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22trt%22%7D%5D%7D&limit=10&sortField=net_improvement&sort=asc"
         },
         "response": {
           "bodySize": 3,
@@ -971,7 +971,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 27 Aug 2021 14:12:50 GMT"
+              "value": "Tue, 31 Aug 2021 11:08:14 GMT"
             },
             {
               "name": "content-length",
@@ -988,8 +988,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-27T14:12:50.644Z",
-        "time": 1390,
+        "startedDateTime": "2021-08-31T11:08:14.516Z",
+        "time": 1784,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -997,11 +997,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1390
+          "wait": 1784
         }
       },
       {
-        "_id": "9e7487c4b26b11f6b536f98b6c52ee61",
+        "_id": "fd9cc54b5a490b5f17ce5d8475515648",
         "_order": 0,
         "cache": {},
         "request": {
@@ -1033,7 +1033,7 @@
               "value": "localhost:8080"
             }
           ],
-          "headersSize": 524,
+          "headersSize": 494,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1043,7 +1043,7 @@
             },
             {
               "name": "filter",
-              "value": "{\"items\":[{\"id\":1,\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"10\"},{\"id\":5,\"columnField\":\"bugs\",\"operatorValue\":\"=\",\"value\":\"0\"}]}"
+              "value": "{\"items\":[{\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"10\"},{\"columnField\":\"bugs\",\"operatorValue\":\"=\",\"value\":\"0\"}]}"
             },
             {
               "name": "limit",
@@ -1058,14 +1058,14 @@
               "value": "asc"
             }
           ],
-          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22id%22%3A5%2C%22columnField%22%3A%22bugs%22%2C%22operatorValue%22%3A%22%3D%22%2C%22value%22%3A%220%22%7D%5D%7D&limit=10&sortField=net_improvement&sort=asc"
+          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22columnField%22%3A%22bugs%22%2C%22operatorValue%22%3A%22%3D%22%2C%22value%22%3A%220%22%7D%5D%7D&limit=10&sortField=net_improvement&sort=asc"
         },
         "response": {
-          "bodySize": 4959,
+          "bodySize": 4691,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 4959,
-            "text": "[{\"id\":25,\"name\":\"[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version\",\"current_successes\":17,\"current_failures\":29,\"current_flakes\":0,\"current_pass_percentage\":36.95652173913043,\"current_runs\":46,\"previous_successes\":46,\"previous_failures\":7,\"previous_flakes\":0,\"previous_pass_percentage\":86.79245283018868,\"previous_runs\":53,\"net_improvement\":-49.83593109105825,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":49,\"name\":\"operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test\",\"current_successes\":10,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":12,\"previous_successes\":12,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":12,\"net_improvement\":-16.666666666666657,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":27,\"name\":\"operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test\",\"current_successes\":8,\"current_failures\":8,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":16,\"previous_successes\":10,\"previous_failures\":6,\"previous_flakes\":0,\"previous_pass_percentage\":62.5,\"previous_runs\":16,\"net_improvement\":-12.5,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":48,\"name\":\"operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test\",\"current_successes\":40,\"current_failures\":8,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":48,\"previous_successes\":42,\"previous_failures\":2,\"previous_flakes\":0,\"previous_pass_percentage\":95.45454545454545,\"previous_runs\":44,\"net_improvement\":-12.12121212121211,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":55,\"name\":\"operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test\",\"current_successes\":33,\"current_failures\":4,\"current_flakes\":0,\"current_pass_percentage\":89.1891891891892,\"current_runs\":37,\"previous_successes\":35,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":35,\"net_improvement\":-10.810810810810807,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":41,\"name\":\"operator.Run template e2e-metal-serial - e2e-metal-serial container setup\",\"current_successes\":8,\"current_failures\":4,\"current_flakes\":0,\"current_pass_percentage\":66.66666666666666,\"current_runs\":12,\"previous_successes\":10,\"previous_failures\":3,\"previous_flakes\":0,\"previous_pass_percentage\":76.92307692307693,\"previous_runs\":13,\"net_improvement\":-10.256410256410277,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":63,\"name\":\"operator.Run multi-stage test e2e-gcp-rt - e2e-gcp-rt-ipi-install-install container test\",\"current_successes\":12,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.3076923076923,\"current_runs\":13,\"previous_successes\":13,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-7.692307692307693,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":62,\"name\":\"operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test\",\"current_successes\":12,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.3076923076923,\"current_runs\":13,\"previous_successes\":13,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-7.692307692307693,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":67,\"name\":\"operator.Run multi-stage test openshift-ipi-azure-arcconformance - openshift-ipi-azure-arcconformance-ipi-install-install container test\",\"current_successes\":37,\"current_failures\":3,\"current_flakes\":0,\"current_pass_percentage\":92.5,\"current_runs\":40,\"previous_successes\":36,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":36,\"net_improvement\":-7.5,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1991635,\"status\":\"NEW\",\"last_change_time\":\"2021-08-24T18:13:58Z\",\"summary\":\"periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance\",\"target_release\":[\"---\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1991635\"}]},{\"id\":69,\"name\":\"operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test\",\"current_successes\":26,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":92.85714285714286,\"current_runs\":28,\"previous_successes\":25,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":25,\"net_improvement\":-7.142857142857139,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"ASSIGNED\",\"last_change_time\":\"2021-08-25T22:30:45Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]}]\n"
+            "size": 4691,
+            "text": "[{\"id\":25,\"name\":\"[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version\",\"current_successes\":17,\"current_failures\":29,\"current_flakes\":0,\"current_pass_percentage\":36.95652173913043,\"current_runs\":46,\"previous_successes\":46,\"previous_failures\":7,\"previous_flakes\":0,\"previous_pass_percentage\":86.79245283018868,\"previous_runs\":53,\"net_improvement\":-49.83593109105825,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":49,\"name\":\"operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test\",\"current_successes\":10,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":12,\"previous_successes\":12,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":12,\"net_improvement\":-16.666666666666657,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":27,\"name\":\"operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test\",\"current_successes\":8,\"current_failures\":8,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":16,\"previous_successes\":10,\"previous_failures\":6,\"previous_flakes\":0,\"previous_pass_percentage\":62.5,\"previous_runs\":16,\"net_improvement\":-12.5,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":48,\"name\":\"operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test\",\"current_successes\":40,\"current_failures\":8,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":48,\"previous_successes\":42,\"previous_failures\":2,\"previous_flakes\":0,\"previous_pass_percentage\":95.45454545454545,\"previous_runs\":44,\"net_improvement\":-12.12121212121211,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":55,\"name\":\"operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test\",\"current_successes\":33,\"current_failures\":4,\"current_flakes\":0,\"current_pass_percentage\":89.1891891891892,\"current_runs\":37,\"previous_successes\":35,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":35,\"net_improvement\":-10.810810810810807,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":41,\"name\":\"operator.Run template e2e-metal-serial - e2e-metal-serial container setup\",\"current_successes\":8,\"current_failures\":4,\"current_flakes\":0,\"current_pass_percentage\":66.66666666666666,\"current_runs\":12,\"previous_successes\":10,\"previous_failures\":3,\"previous_flakes\":0,\"previous_pass_percentage\":76.92307692307693,\"previous_runs\":13,\"net_improvement\":-10.256410256410277,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":62,\"name\":\"operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test\",\"current_successes\":12,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.3076923076923,\"current_runs\":13,\"previous_successes\":13,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-7.692307692307693,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":63,\"name\":\"operator.Run multi-stage test e2e-gcp-rt - e2e-gcp-rt-ipi-install-install container test\",\"current_successes\":12,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.3076923076923,\"current_runs\":13,\"previous_successes\":13,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-7.692307692307693,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":67,\"name\":\"operator.Run multi-stage test openshift-ipi-azure-arcconformance - openshift-ipi-azure-arcconformance-ipi-install-install container test\",\"current_successes\":37,\"current_failures\":3,\"current_flakes\":0,\"current_pass_percentage\":92.5,\"current_runs\":40,\"previous_successes\":36,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":36,\"net_improvement\":-7.5,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1991635,\"status\":\"NEW\",\"last_change_time\":\"2021-08-24T18:13:58Z\",\"summary\":\"periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance\",\"target_release\":[\"---\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1991635\"}]},{\"id\":68,\"name\":\"operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test\",\"current_successes\":13,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.85714285714286,\"current_runs\":14,\"previous_successes\":12,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":12,\"net_improvement\":-7.142857142857139,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]}]\n"
           },
           "cookies": [],
           "headers": [
@@ -1079,7 +1079,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 27 Aug 2021 14:12:50 GMT"
+              "value": "Tue, 31 Aug 2021 11:08:14 GMT"
             },
             {
               "name": "connection",
@@ -1096,8 +1096,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-27T14:12:50.644Z",
-        "time": 1892,
+        "startedDateTime": "2021-08-31T11:08:14.516Z",
+        "time": 2089,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1105,7 +1105,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1892
+          "wait": 2089
         }
       }
     ],

--- a/sippy-ng/__recordings__/release-overview_3101569358/should-render-correctly_3267003315/recording.har
+++ b/sippy-ng/__recordings__/release-overview_3101569358/should-render-correctly_3267003315/recording.har
@@ -192,7 +192,7 @@
         }
       },
       {
-        "_id": "7be66affe30ddbb27cf7e372a8a62201",
+        "_id": "6e2912afe01b9c84c69afb55a2d9a3c2",
         "_order": 0,
         "cache": {},
         "request": {
@@ -224,7 +224,7 @@
               "value": "localhost:8080"
             }
           ],
-          "headersSize": 411,
+          "headersSize": 667,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -234,7 +234,7 @@
             },
             {
               "name": "filter",
-              "value": "{\"items\":[{\"id\":1,\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"10\"}]}"
+              "value": "{\"items\":[{\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"10\"},{\"columnField\":\"variants\",\"not\":true,\"operatorValue\":\"contains\",\"value\":\"never-stable\"},{\"columnField\":\"variants\",\"not\":true,\"operatorValue\":\"contains\",\"value\":\"techpreview\"}]}"
             },
             {
               "name": "limit",
@@ -249,14 +249,14 @@
               "value": "asc"
             }
           ],
-          "url": "http://localhost:8080/api/jobs?release=4.8&filter=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%7D&limit=10&sortField=net_improvement&sort=asc"
+          "url": "http://localhost:8080/api/jobs?release=4.8&filter=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22techpreview%22%7D%5D%7D&limit=10&sortField=net_improvement&sort=asc"
         },
         "response": {
-          "bodySize": 6574,
+          "bodySize": 5984,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 6574,
-            "text": "[{\"id\":2,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance\",\"brief_name\":\"openshift-ipi-azure-arcconformance\",\"variants\":[\"azure\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":40,\"previous_pass_percentage\":0,\"previous_projected_pass_percentage\":0,\"previous_runs\":37,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance\",\"bugs\":[],\"associated_bugs\":[{\"id\":1991635,\"status\":\"NEW\",\"last_change_time\":\"2021-08-24T18:13:58Z\",\"summary\":\"periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance\",\"target_release\":[\"---\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1991635\"}]},{\"id\":3,\"name\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8\",\"brief_name\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8\",\"variants\":[\"upgrade\",\"s390x\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":13,\"previous_pass_percentage\":0,\"previous_projected_pass_percentage\":0,\"previous_runs\":14,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":20,\"name\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\",\"brief_name\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\",\"variants\":[\"upgrade\",\"ppc64le\"],\"current_pass_percentage\":15.384615384615385,\"current_projected_pass_percentage\":15.384615384615385,\"current_runs\":13,\"previous_pass_percentage\":21.428571428571427,\"previous_projected_pass_percentage\":21.428571428571427,\"previous_runs\":14,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":22,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade\",\"brief_name\":\"upgrade-from-stable-4.7-e2e-metal-ipi-upgrade\",\"variants\":[\"metal-ipi\",\"upgrade\"],\"current_pass_percentage\":23.076923076923077,\"current_projected_pass_percentage\":27.27272727272727,\"current_runs\":13,\"previous_pass_percentage\":16.666666666666664,\"previous_projected_pass_percentage\":20,\"previous_runs\":12,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":25,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-upgrade\",\"brief_name\":\"upgrade-from-stable-4.7-e2e-gcp-upgrade\",\"variants\":[\"gcp\",\"upgrade\"],\"current_pass_percentage\":25,\"current_projected_pass_percentage\":30,\"current_runs\":24,\"previous_pass_percentage\":30.434782608695656,\"previous_projected_pass_percentage\":31.818181818181817,\"previous_runs\":23,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-upgrade\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":26,\"name\":\"release-openshift-ocp-osd-aws-nightly-4.8\",\"brief_name\":\"release-openshift-ocp-osd-aws-nightly-4.8\",\"variants\":[\"aws\",\"osd\"],\"current_pass_percentage\":25.925925925925924,\"current_projected_pass_percentage\":25.925925925925924,\"current_runs\":27,\"previous_pass_percentage\":39.285714285714285,\"previous_projected_pass_percentage\":39.285714285714285,\"previous_runs\":28,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-osd-aws-nightly-4.8\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":27,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi\",\"brief_name\":\"e2e-metal-ipi\",\"variants\":[\"metal-ipi\"],\"current_pass_percentage\":29.411764705882355,\"current_projected_pass_percentage\":32.25806451612903,\"current_runs\":34,\"previous_pass_percentage\":17.142857142857142,\"previous_projected_pass_percentage\":18.181818181818183,\"previous_runs\":35,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-blocking#periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi\",\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"ASSIGNED\",\"last_change_time\":\"2021-08-25T22:30:45Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]},{\"id\":28,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy\",\"brief_name\":\"e2e-aws-proxy\",\"variants\":[\"aws\",\"proxy\"],\"current_pass_percentage\":31.25,\"current_projected_pass_percentage\":62.5,\"current_runs\":16,\"previous_pass_percentage\":50,\"previous_projected_pass_percentage\":80,\"previous_runs\":16,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":30,\"name\":\"release-openshift-ocp-osd-gcp-nightly-4.8\",\"brief_name\":\"release-openshift-ocp-osd-gcp-nightly-4.8\",\"variants\":[\"gcp\",\"osd\"],\"current_pass_percentage\":33.33333333333333,\"current_projected_pass_percentage\":33.33333333333333,\"current_runs\":27,\"previous_pass_percentage\":32.142857142857146,\"previous_projected_pass_percentage\":32.142857142857146,\"previous_runs\":28,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-osd-gcp-nightly-4.8\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":34,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade\",\"brief_name\":\"e2e-aws-upgrade\",\"variants\":[\"aws\",\"upgrade\"],\"current_pass_percentage\":33.33333333333333,\"current_projected_pass_percentage\":35.714285714285715,\"current_runs\":15,\"previous_pass_percentage\":53.333333333333336,\"previous_projected_pass_percentage\":57.14285714285714,\"previous_runs\":15,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade\",\"bugs\":[],\"associated_bugs\":[]}]\n"
+            "size": 5984,
+            "text": "[{\"id\":39,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4\",\"brief_name\":\"e2e-metal-ipi-serial-ipv4\",\"variants\":[\"metal-ipi\",\"serial\"],\"current_pass_percentage\":38.46153846153847,\"current_projected_pass_percentage\":100,\"current_runs\":13,\"previous_pass_percentage\":66.66666666666666,\"previous_projected_pass_percentage\":100,\"previous_runs\":12,\"net_improvement\":-28.20512820512819,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":62,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp\",\"brief_name\":\"e2e-gcp\",\"variants\":[\"gcp\"],\"current_pass_percentage\":69.23076923076923,\"current_projected_pass_percentage\":75,\"current_runs\":13,\"previous_pass_percentage\":92.3076923076923,\"previous_projected_pass_percentage\":92.3076923076923,\"previous_runs\":13,\"net_improvement\":-23.07692307692308,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":33,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade\",\"brief_name\":\"e2e-aws-upgrade\",\"variants\":[\"aws\",\"upgrade\"],\"current_pass_percentage\":33.33333333333333,\"current_projected_pass_percentage\":35.714285714285715,\"current_runs\":15,\"previous_pass_percentage\":53.333333333333336,\"previous_projected_pass_percentage\":57.14285714285714,\"previous_runs\":15,\"net_improvement\":-20.000000000000007,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":28,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy\",\"brief_name\":\"e2e-aws-proxy\",\"variants\":[\"aws\",\"proxy\"],\"current_pass_percentage\":31.25,\"current_projected_pass_percentage\":62.5,\"current_runs\":16,\"previous_pass_percentage\":50,\"previous_projected_pass_percentage\":80,\"previous_runs\":16,\"net_improvement\":-18.75,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":70,\"name\":\"release-openshift-ocp-installer-e2e-aws-ovn-4.8\",\"brief_name\":\"release-openshift-ocp-installer-e2e-aws-ovn-4.8\",\"variants\":[\"aws\",\"ovn\"],\"current_pass_percentage\":76.92307692307693,\"current_projected_pass_percentage\":83.33333333333334,\"current_runs\":13,\"previous_pass_percentage\":92.3076923076923,\"previous_projected_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-15.384615384615373,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-installer-e2e-aws-ovn-4.8\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":75,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-workers-rhel7\",\"brief_name\":\"e2e-aws-workers-rhel7\",\"variants\":[\"aws\"],\"current_pass_percentage\":78.57142857142857,\"current_projected_pass_percentage\":78.57142857142857,\"current_runs\":28,\"previous_pass_percentage\":92.5925925925926,\"previous_projected_pass_percentage\":96.15384615384616,\"previous_runs\":27,\"net_improvement\":-14.021164021164026,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-workers-rhel7\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":26,\"name\":\"release-openshift-ocp-osd-aws-nightly-4.8\",\"brief_name\":\"release-openshift-ocp-osd-aws-nightly-4.8\",\"variants\":[\"aws\",\"osd\"],\"current_pass_percentage\":25.925925925925924,\"current_projected_pass_percentage\":25.925925925925924,\"current_runs\":27,\"previous_pass_percentage\":39.285714285714285,\"previous_projected_pass_percentage\":39.285714285714285,\"previous_runs\":28,\"net_improvement\":-13.35978835978836,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-osd-aws-nightly-4.8\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":67,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-aws-serial\",\"brief_name\":\"e2e-aws-serial\",\"variants\":[\"aws\",\"serial\"],\"current_pass_percentage\":75,\"current_projected_pass_percentage\":75,\"current_runs\":24,\"previous_pass_percentage\":86.95652173913044,\"previous_projected_pass_percentage\":90.9090909090909,\"previous_runs\":23,\"net_improvement\":-11.956521739130437,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-blocking#periodic-ci-openshift-release-master-ci-4.8-e2e-aws-serial\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":38,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-vsphere-upgrade\",\"brief_name\":\"upgrade-from-stable-4.7-e2e-vsphere-upgrade\",\"variants\":[\"vsphere-ipi\",\"upgrade\"],\"current_pass_percentage\":38.46153846153847,\"current_projected_pass_percentage\":50,\"current_runs\":13,\"previous_pass_percentage\":50,\"previous_projected_pass_percentage\":58.333333333333336,\"previous_runs\":14,\"net_improvement\":-11.538461538461533,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-vsphere-upgrade\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":44,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-serial\",\"brief_name\":\"e2e-vsphere-serial\",\"variants\":[\"vsphere-ipi\",\"serial\"],\"current_pass_percentage\":48.64864864864865,\"current_projected_pass_percentage\":62.06896551724138,\"current_runs\":37,\"previous_pass_percentage\":58.82352941176471,\"previous_projected_pass_percentage\":74.07407407407408,\"previous_runs\":34,\"net_improvement\":-10.174880763116057,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-serial\",\"bugs\":[],\"associated_bugs\":[]}]\n"
           },
           "cookies": [],
           "headers": [
@@ -270,7 +270,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 27 Aug 2021 14:46:31 GMT"
+              "value": "Tue, 31 Aug 2021 11:08:15 GMT"
             },
             {
               "name": "connection",
@@ -287,8 +287,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-27T14:46:31.529Z",
-        "time": 192,
+        "startedDateTime": "2021-08-31T11:08:14.645Z",
+        "time": 531,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -296,11 +296,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 192
+          "wait": 531
         }
       },
       {
-        "_id": "8d1b9a1a3a44f539acc3d8419ec5b383",
+        "_id": "edfddda60a676ccc59363e27fcefcd03",
         "_order": 0,
         "cache": {},
         "request": {
@@ -332,7 +332,7 @@
               "value": "localhost:8080"
             }
           ],
-          "headersSize": 424,
+          "headersSize": 680,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -342,7 +342,7 @@
             },
             {
               "name": "filter",
-              "value": "{\"items\":[{\"id\":1,\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"1\"}]}"
+              "value": "{\"items\":[{\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"1\"},{\"columnField\":\"variants\",\"not\":true,\"operatorValue\":\"contains\",\"value\":\"never-stable\"},{\"columnField\":\"variants\",\"not\":true,\"operatorValue\":\"contains\",\"value\":\"techpreview\"}]}"
             },
             {
               "name": "limit",
@@ -361,14 +361,14 @@
               "value": "asc"
             }
           ],
-          "url": "http://localhost:8080/api/jobs?release=4.8&filter=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%7D&limit=10&period=twoDay&sortField=net_improvement&sort=asc"
+          "url": "http://localhost:8080/api/jobs?release=4.8&filter=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22techpreview%22%7D%5D%7D&limit=10&period=twoDay&sortField=net_improvement&sort=asc"
         },
         "response": {
-          "bodySize": 6075,
+          "bodySize": 6447,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 6075,
-            "text": "[{\"id\":0,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift\",\"brief_name\":\"e2e-aws-hypershift\",\"variants\":[\"aws\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":0,\"previous_projected_pass_percentage\":0,\"previous_runs\":6,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":11,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade\",\"brief_name\":\"e2e-aws-upgrade\",\"variants\":[\"aws\",\"upgrade\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":66.66666666666666,\"previous_projected_pass_percentage\":80,\"previous_runs\":6,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":12,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node\",\"brief_name\":\"e2e-aws-single-node\",\"variants\":[\"aws\",\"single-node\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":33.33333333333333,\"previous_projected_pass_percentage\":33.33333333333333,\"previous_runs\":6,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":24,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia\",\"brief_name\":\"e2e-metal-ipi-virtualmedia\",\"variants\":[\"metal-ipi\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":2,\"previous_pass_percentage\":50,\"previous_projected_pass_percentage\":53.84615384615385,\"previous_runs\":14,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia\",\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"ASSIGNED\",\"last_change_time\":\"2021-08-25T22:30:45Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]},{\"id\":30,\"name\":\"release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8\",\"brief_name\":\"release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8\",\"variants\":[\"unknown variant\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":2,\"previous_pass_percentage\":0,\"previous_projected_pass_percentage\":0,\"previous_runs\":6,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":32,\"name\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\",\"brief_name\":\"release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\",\"variants\":[\"upgrade\",\"ppc64le\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":3,\"previous_pass_percentage\":15.384615384615385,\"previous_projected_pass_percentage\":15.384615384615385,\"previous_runs\":13,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":34,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-azure-upgrade-single-node\",\"brief_name\":\"e2e-azure-upgrade-single-node\",\"variants\":[\"azure\",\"upgrade\",\"single-node\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":33.33333333333333,\"previous_projected_pass_percentage\":33.33333333333333,\"previous_runs\":6,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-azure-upgrade-single-node\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":35,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-ovn\",\"brief_name\":\"e2e-vsphere-ovn\",\"variants\":[\"vsphere-ipi\",\"ovn\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":16.666666666666664,\"previous_projected_pass_percentage\":16.666666666666664,\"previous_runs\":6,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-ovn\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":36,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-azure-ovn-upgrade\",\"brief_name\":\"upgrade-from-stable-4.7-e2e-azure-ovn-upgrade\",\"variants\":[\"azure\",\"upgrade\",\"ovn\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":0,\"previous_projected_pass_percentage\":0,\"previous_runs\":6,\"net_improvement\":0,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-azure-ovn-upgrade\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":38,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack\",\"brief_name\":\"e2e-metal-ipi-ovn-dualstack\",\"variants\":[\"metal-ipi\",\"ovn\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":2,\"previous_pass_percentage\":38.46153846153847,\"previous_projected_pass_percentage\":45.45454545454545,\"previous_runs\":13,\"net_improvement\":0,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack\",\"bugs\":[],\"associated_bugs\":[]}]\n"
+            "size": 6447,
+            "text": "[{\"id\":37,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade\",\"brief_name\":\"e2e-aws-upgrade\",\"variants\":[\"aws\",\"upgrade\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":66.66666666666666,\"previous_projected_pass_percentage\":80,\"previous_runs\":6,\"net_improvement\":-66.66666666666666,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":33,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-libvirt-cert-rotation\",\"brief_name\":\"e2e-gcp-libvirt-cert-rotation\",\"variants\":[\"gcp\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":57.14285714285714,\"previous_projected_pass_percentage\":66.66666666666666,\"previous_runs\":7,\"net_improvement\":-57.14285714285714,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-libvirt-cert-rotation\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":3,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia\",\"brief_name\":\"e2e-metal-ipi-virtualmedia\",\"variants\":[\"metal-ipi\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":2,\"previous_pass_percentage\":50,\"previous_projected_pass_percentage\":53.84615384615385,\"previous_runs\":14,\"net_improvement\":-50,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia\",\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"VERIFIED\",\"last_change_time\":\"2021-08-31T07:55:34Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]},{\"id\":72,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted\",\"brief_name\":\"e2e-metal-assisted\",\"variants\":[\"metal-assisted\"],\"current_pass_percentage\":50,\"current_projected_pass_percentage\":100,\"current_runs\":2,\"previous_pass_percentage\":92.85714285714286,\"previous_projected_pass_percentage\":100,\"previous_runs\":14,\"net_improvement\":-42.85714285714286,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":53,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack\",\"brief_name\":\"e2e-metal-ipi-ovn-dualstack\",\"variants\":[\"metal-ipi\",\"ovn\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":2,\"previous_pass_percentage\":38.46153846153847,\"previous_projected_pass_percentage\":45.45454545454545,\"previous_runs\":13,\"net_improvement\":-38.46153846153847,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":19,\"name\":\"periodic-ci-openshift-release-master-ci-4.8-e2e-azure-upgrade-single-node\",\"brief_name\":\"e2e-azure-upgrade-single-node\",\"variants\":[\"azure\",\"upgrade\",\"single-node\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":33.33333333333333,\"previous_projected_pass_percentage\":33.33333333333333,\"previous_runs\":6,\"net_improvement\":-33.33333333333333,\"tags\":[\"upgrade\"],\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-azure-upgrade-single-node\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":47,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node\",\"brief_name\":\"e2e-aws-single-node\",\"variants\":[\"aws\",\"single-node\"],\"current_pass_percentage\":0,\"current_projected_pass_percentage\":0,\"current_runs\":1,\"previous_pass_percentage\":33.33333333333333,\"previous_projected_pass_percentage\":33.33333333333333,\"previous_runs\":6,\"net_improvement\":-33.33333333333333,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":54,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-ipv6\",\"brief_name\":\"e2e-metal-ipi-ovn-ipv6\",\"variants\":[\"metal-ipi\",\"ovn\"],\"current_pass_percentage\":12.5,\"current_projected_pass_percentage\":16.666666666666664,\"current_runs\":8,\"previous_pass_percentage\":42.857142857142854,\"previous_projected_pass_percentage\":46.15384615384615,\"previous_runs\":28,\"net_improvement\":-30.357142857142854,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-blocking#periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-ipv6\",\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"VERIFIED\",\"last_change_time\":\"2021-08-31T07:55:34Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]},{\"id\":70,\"name\":\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-fips\",\"brief_name\":\"e2e-aws-fips\",\"variants\":[\"aws\",\"fips\"],\"current_pass_percentage\":50,\"current_projected_pass_percentage\":100,\"current_runs\":2,\"previous_pass_percentage\":76.92307692307693,\"previous_projected_pass_percentage\":83.33333333333334,\"previous_runs\":13,\"net_improvement\":-26.923076923076934,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-fips\",\"bugs\":[],\"associated_bugs\":[]},{\"id\":74,\"name\":\"release-openshift-ocp-installer-e2e-azure-serial-4.8\",\"brief_name\":\"release-openshift-ocp-installer-e2e-azure-serial-4.8\",\"variants\":[\"azure\",\"serial\"],\"current_pass_percentage\":50,\"current_projected_pass_percentage\":50,\"current_runs\":2,\"previous_pass_percentage\":76.92307692307693,\"previous_projected_pass_percentage\":83.33333333333334,\"previous_runs\":13,\"net_improvement\":-26.923076923076934,\"tags\":null,\"test_grid_url\":\"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#release-openshift-ocp-installer-e2e-azure-serial-4.8\",\"bugs\":[],\"associated_bugs\":[]}]\n"
           },
           "cookies": [],
           "headers": [
@@ -382,7 +382,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 27 Aug 2021 14:46:31 GMT"
+              "value": "Tue, 31 Aug 2021 11:08:15 GMT"
             },
             {
               "name": "connection",
@@ -399,8 +399,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-27T14:46:31.529Z",
-        "time": 338,
+        "startedDateTime": "2021-08-31T11:08:14.645Z",
+        "time": 823,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -408,11 +408,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 338
+          "wait": 823
         }
       },
       {
-        "_id": "b7a2cdbf6ebbf7c397fd5c50508f2a6b",
+        "_id": "cee88ca8682d8a9c61a15db3c7142956",
         "_order": 0,
         "cache": {},
         "request": {
@@ -444,7 +444,7 @@
               "value": "localhost:8080"
             }
           ],
-          "headersSize": 412,
+          "headersSize": 410,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -454,115 +454,7 @@
             },
             {
               "name": "filter",
-              "value": "{\"items\":[{\"id\":1,\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"10\"}]}"
-            },
-            {
-              "name": "limit",
-              "value": "10"
-            },
-            {
-              "name": "sortField",
-              "value": "net_improvement"
-            },
-            {
-              "name": "sort",
-              "value": "asc"
-            }
-          ],
-          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%7D&limit=10&sortField=net_improvement&sort=asc"
-        },
-        "response": {
-          "bodySize": 4959,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 4959,
-            "text": "[{\"id\":25,\"name\":\"[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version\",\"current_successes\":17,\"current_failures\":29,\"current_flakes\":0,\"current_pass_percentage\":36.95652173913043,\"current_runs\":46,\"previous_successes\":46,\"previous_failures\":7,\"previous_flakes\":0,\"previous_pass_percentage\":86.79245283018868,\"previous_runs\":53,\"net_improvement\":-49.83593109105825,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":49,\"name\":\"operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test\",\"current_successes\":10,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":12,\"previous_successes\":12,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":12,\"net_improvement\":-16.666666666666657,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":27,\"name\":\"operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test\",\"current_successes\":8,\"current_failures\":8,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":16,\"previous_successes\":10,\"previous_failures\":6,\"previous_flakes\":0,\"previous_pass_percentage\":62.5,\"previous_runs\":16,\"net_improvement\":-12.5,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":48,\"name\":\"operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test\",\"current_successes\":40,\"current_failures\":8,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":48,\"previous_successes\":42,\"previous_failures\":2,\"previous_flakes\":0,\"previous_pass_percentage\":95.45454545454545,\"previous_runs\":44,\"net_improvement\":-12.12121212121211,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":55,\"name\":\"operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test\",\"current_successes\":33,\"current_failures\":4,\"current_flakes\":0,\"current_pass_percentage\":89.1891891891892,\"current_runs\":37,\"previous_successes\":35,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":35,\"net_improvement\":-10.810810810810807,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":41,\"name\":\"operator.Run template e2e-metal-serial - e2e-metal-serial container setup\",\"current_successes\":8,\"current_failures\":4,\"current_flakes\":0,\"current_pass_percentage\":66.66666666666666,\"current_runs\":12,\"previous_successes\":10,\"previous_failures\":3,\"previous_flakes\":0,\"previous_pass_percentage\":76.92307692307693,\"previous_runs\":13,\"net_improvement\":-10.256410256410277,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":63,\"name\":\"operator.Run multi-stage test e2e-gcp-rt - e2e-gcp-rt-ipi-install-install container test\",\"current_successes\":12,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.3076923076923,\"current_runs\":13,\"previous_successes\":13,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-7.692307692307693,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":62,\"name\":\"operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test\",\"current_successes\":12,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.3076923076923,\"current_runs\":13,\"previous_successes\":13,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-7.692307692307693,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":67,\"name\":\"operator.Run multi-stage test openshift-ipi-azure-arcconformance - openshift-ipi-azure-arcconformance-ipi-install-install container test\",\"current_successes\":37,\"current_failures\":3,\"current_flakes\":0,\"current_pass_percentage\":92.5,\"current_runs\":40,\"previous_successes\":36,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":36,\"net_improvement\":-7.5,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1991635,\"status\":\"NEW\",\"last_change_time\":\"2021-08-24T18:13:58Z\",\"summary\":\"periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance\",\"target_release\":[\"---\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1991635\"}]},{\"id\":69,\"name\":\"operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test\",\"current_successes\":26,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":92.85714285714286,\"current_runs\":28,\"previous_successes\":25,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":25,\"net_improvement\":-7.142857142857139,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"ASSIGNED\",\"last_change_time\":\"2021-08-25T22:30:45Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]}]\n"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "access-control-allow-origin",
-              "value": "*"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 27 Aug 2021 14:46:31 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            }
-          ],
-          "headersSize": 165,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-08-27T14:46:31.529Z",
-        "time": 605,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 605
-        }
-      },
-      {
-        "_id": "d51db0fbddbeac19059bdc4b53c9e4dc",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "localhost:8080"
-            }
-          ],
-          "headersSize": 425,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "release",
-              "value": "4.8"
-            },
-            {
-              "name": "filter",
-              "value": "{\"items\":[{\"id\":1,\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"1\"}]}"
+              "value": "{\"items\":[{\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"1\"}]}"
             },
             {
               "name": "limit",
@@ -581,14 +473,14 @@
               "value": "asc"
             }
           ],
-          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%7D&limit=10&period=twoDay&sortField=net_improvement&sort=asc"
+          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%7D&limit=10&period=twoDay&sortField=net_improvement&sort=asc"
         },
         "response": {
           "bodySize": 5576,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 5576,
-            "text": "[{\"id\":6,\"name\":\"operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test\",\"current_successes\":1,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":2,\"previous_successes\":13,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":92.85714285714286,\"previous_runs\":14,\"net_improvement\":-42.85714285714286,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":7,\"name\":\"operator.Run multi-stage test e2e-metal-ipi-virtualmedia - e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup container test\",\"current_successes\":1,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":2,\"previous_successes\":13,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":92.85714285714286,\"previous_runs\":14,\"net_improvement\":-42.85714285714286,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"ASSIGNED\",\"last_change_time\":\"2021-08-25T22:30:45Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]},{\"id\":5,\"name\":\"operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test\",\"current_successes\":1,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":2,\"previous_successes\":12,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":92.3076923076923,\"previous_runs\":13,\"net_improvement\":-42.30769230769231,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":12,\"name\":\"TestInstall_test_install.start_install_and_wait_for_installed(openshift_version=4.8)\",\"current_successes\":3,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":75,\"current_runs\":4,\"previous_successes\":25,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":96.15384615384616,\"previous_runs\":26,\"net_improvement\":-21.15384615384616,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":13,\"name\":\"operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test\",\"current_successes\":6,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":75,\"current_runs\":8,\"previous_successes\":26,\"previous_failures\":2,\"previous_flakes\":0,\"previous_pass_percentage\":92.85714285714286,\"previous_runs\":28,\"net_improvement\":-17.85714285714286,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"ASSIGNED\",\"last_change_time\":\"2021-08-25T22:30:45Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]},{\"id\":3,\"name\":\"[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version\",\"current_successes\":3,\"current_failures\":12,\"current_flakes\":0,\"current_pass_percentage\":20,\"current_runs\":15,\"previous_successes\":17,\"previous_failures\":29,\"previous_flakes\":0,\"previous_pass_percentage\":36.95652173913043,\"previous_runs\":46,\"net_improvement\":-16.95652173913043,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":8,\"name\":\"operator.Run template e2e-metal-serial - e2e-metal-serial container setup\",\"current_successes\":1,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":2,\"previous_successes\":8,\"previous_failures\":4,\"previous_flakes\":0,\"previous_pass_percentage\":66.66666666666666,\"previous_runs\":12,\"net_improvement\":-16.666666666666657,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":16,\"name\":\"[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Dynamic PV (default fs)] fsgroupchangepolicy (Always)[LinuxOnly], pod created with an initial fsgroup, new pod fsgroup applied to volume contents [Suite:openshift/conformance/parallel] [Suite:k8s]\",\"current_successes\":5,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":6,\"previous_successes\":48,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":97.95918367346938,\"previous_runs\":49,\"net_improvement\":-14.62585034013604,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":17,\"name\":\"[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Dynamic PV (default fs)] fsgroupchangepolicy (Always)[LinuxOnly], pod created with an initial fsgroup, volume contents ownership changed in first pod, new pod with same fsgroup applied to the volume contents [Suite:openshift/conformance/parallel] [Suite:k8s]\",\"current_successes\":5,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":6,\"previous_successes\":48,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":97.95918367346938,\"previous_runs\":49,\"net_improvement\":-14.62585034013604,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":18,\"name\":\"[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Dynamic PV (default fs)] fsgroupchangepolicy (OnRootMismatch)[LinuxOnly], pod created with an initial fsgroup, volume contents ownership changed in first pod, new pod with different fsgroup applied to the volume contents [Suite:openshift/conformance/parallel] [Suite:k8s]\",\"current_successes\":5,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":6,\"previous_successes\":48,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":97.95918367346938,\"previous_runs\":49,\"net_improvement\":-14.62585034013604,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]}]\n"
+            "text": "[{\"id\":6,\"name\":\"operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test\",\"current_successes\":1,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":2,\"previous_successes\":13,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":92.85714285714286,\"previous_runs\":14,\"net_improvement\":-42.85714285714286,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":7,\"name\":\"operator.Run multi-stage test e2e-metal-ipi-virtualmedia - e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup container test\",\"current_successes\":1,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":2,\"previous_successes\":13,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":92.85714285714286,\"previous_runs\":14,\"net_improvement\":-42.85714285714286,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"VERIFIED\",\"last_change_time\":\"2021-08-31T07:55:34Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]},{\"id\":5,\"name\":\"operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test\",\"current_successes\":1,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":2,\"previous_successes\":12,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":92.3076923076923,\"previous_runs\":13,\"net_improvement\":-42.30769230769231,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":12,\"name\":\"TestInstall_test_install.start_install_and_wait_for_installed(openshift_version=4.8)\",\"current_successes\":3,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":75,\"current_runs\":4,\"previous_successes\":25,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":96.15384615384616,\"previous_runs\":26,\"net_improvement\":-21.15384615384616,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":13,\"name\":\"operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test\",\"current_successes\":6,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":75,\"current_runs\":8,\"previous_successes\":26,\"previous_failures\":2,\"previous_flakes\":0,\"previous_pass_percentage\":92.85714285714286,\"previous_runs\":28,\"net_improvement\":-17.85714285714286,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"VERIFIED\",\"last_change_time\":\"2021-08-31T07:55:34Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]},{\"id\":3,\"name\":\"[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version\",\"current_successes\":3,\"current_failures\":12,\"current_flakes\":0,\"current_pass_percentage\":20,\"current_runs\":15,\"previous_successes\":17,\"previous_failures\":29,\"previous_flakes\":0,\"previous_pass_percentage\":36.95652173913043,\"previous_runs\":46,\"net_improvement\":-16.95652173913043,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":8,\"name\":\"operator.Run template e2e-metal-serial - e2e-metal-serial container setup\",\"current_successes\":1,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":2,\"previous_successes\":8,\"previous_failures\":4,\"previous_flakes\":0,\"previous_pass_percentage\":66.66666666666666,\"previous_runs\":12,\"net_improvement\":-16.666666666666657,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":16,\"name\":\"[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Dynamic PV (default fs)] fsgroupchangepolicy (Always)[LinuxOnly], pod created with an initial fsgroup, new pod fsgroup applied to volume contents [Suite:openshift/conformance/parallel] [Suite:k8s]\",\"current_successes\":5,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":6,\"previous_successes\":48,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":97.95918367346938,\"previous_runs\":49,\"net_improvement\":-14.62585034013604,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":17,\"name\":\"[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Dynamic PV (default fs)] fsgroupchangepolicy (Always)[LinuxOnly], pod created with an initial fsgroup, volume contents ownership changed in first pod, new pod with same fsgroup applied to the volume contents [Suite:openshift/conformance/parallel] [Suite:k8s]\",\"current_successes\":5,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":6,\"previous_successes\":48,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":97.95918367346938,\"previous_runs\":49,\"net_improvement\":-14.62585034013604,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":18,\"name\":\"[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Dynamic PV (default fs)] fsgroupchangepolicy (OnRootMismatch)[LinuxOnly], pod created with an initial fsgroup, volume contents ownership changed in first pod, new pod with different fsgroup applied to the volume contents [Suite:openshift/conformance/parallel] [Suite:k8s]\",\"current_successes\":5,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":6,\"previous_successes\":48,\"previous_failures\":1,\"previous_flakes\":0,\"previous_pass_percentage\":97.95918367346938,\"previous_runs\":49,\"net_improvement\":-14.62585034013604,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]}]\n"
           },
           "cookies": [],
           "headers": [
@@ -602,7 +494,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 27 Aug 2021 14:46:31 GMT"
+              "value": "Tue, 31 Aug 2021 11:08:15 GMT"
             },
             {
               "name": "connection",
@@ -619,8 +511,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-27T14:46:31.529Z",
-        "time": 770,
+        "startedDateTime": "2021-08-31T11:08:14.645Z",
+        "time": 1265,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -628,11 +520,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 770
+          "wait": 1265
         }
       },
       {
-        "_id": "17731289af2d996f693d6997fb3da20f",
+        "_id": "cdbf158ea0b37acd21634b34a39498ea",
         "_order": 0,
         "cache": {},
         "request": {
@@ -664,7 +556,7 @@
               "value": "localhost:8080"
             }
           ],
-          "headersSize": 531,
+          "headersSize": 397,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -674,7 +566,7 @@
             },
             {
               "name": "filter",
-              "value": "{\"items\":[{\"id\":1,\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"10\"},{\"id\":8,\"columnField\":\"tags\",\"operatorValue\":\"contains\",\"value\":\"trt\"}]}"
+              "value": "{\"items\":[{\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"10\"}]}"
             },
             {
               "name": "limit",
@@ -689,7 +581,223 @@
               "value": "asc"
             }
           ],
-          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22id%22%3A8%2C%22columnField%22%3A%22tags%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22trt%22%7D%5D%7D&limit=10&sortField=net_improvement&sort=asc"
+          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%7D&limit=10&sortField=net_improvement&sort=asc"
+        },
+        "response": {
+          "bodySize": 4959,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 4959,
+            "text": "[{\"id\":25,\"name\":\"[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version\",\"current_successes\":17,\"current_failures\":29,\"current_flakes\":0,\"current_pass_percentage\":36.95652173913043,\"current_runs\":46,\"previous_successes\":46,\"previous_failures\":7,\"previous_flakes\":0,\"previous_pass_percentage\":86.79245283018868,\"previous_runs\":53,\"net_improvement\":-49.83593109105825,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":49,\"name\":\"operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test\",\"current_successes\":10,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":12,\"previous_successes\":12,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":12,\"net_improvement\":-16.666666666666657,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":27,\"name\":\"operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test\",\"current_successes\":8,\"current_failures\":8,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":16,\"previous_successes\":10,\"previous_failures\":6,\"previous_flakes\":0,\"previous_pass_percentage\":62.5,\"previous_runs\":16,\"net_improvement\":-12.5,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":48,\"name\":\"operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test\",\"current_successes\":40,\"current_failures\":8,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":48,\"previous_successes\":42,\"previous_failures\":2,\"previous_flakes\":0,\"previous_pass_percentage\":95.45454545454545,\"previous_runs\":44,\"net_improvement\":-12.12121212121211,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":55,\"name\":\"operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test\",\"current_successes\":33,\"current_failures\":4,\"current_flakes\":0,\"current_pass_percentage\":89.1891891891892,\"current_runs\":37,\"previous_successes\":35,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":35,\"net_improvement\":-10.810810810810807,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":41,\"name\":\"operator.Run template e2e-metal-serial - e2e-metal-serial container setup\",\"current_successes\":8,\"current_failures\":4,\"current_flakes\":0,\"current_pass_percentage\":66.66666666666666,\"current_runs\":12,\"previous_successes\":10,\"previous_failures\":3,\"previous_flakes\":0,\"previous_pass_percentage\":76.92307692307693,\"previous_runs\":13,\"net_improvement\":-10.256410256410277,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":63,\"name\":\"operator.Run multi-stage test e2e-gcp-rt - e2e-gcp-rt-ipi-install-install container test\",\"current_successes\":12,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.3076923076923,\"current_runs\":13,\"previous_successes\":13,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-7.692307692307693,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":62,\"name\":\"operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test\",\"current_successes\":12,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.3076923076923,\"current_runs\":13,\"previous_successes\":13,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-7.692307692307693,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":67,\"name\":\"operator.Run multi-stage test openshift-ipi-azure-arcconformance - openshift-ipi-azure-arcconformance-ipi-install-install container test\",\"current_successes\":37,\"current_failures\":3,\"current_flakes\":0,\"current_pass_percentage\":92.5,\"current_runs\":40,\"previous_successes\":36,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":36,\"net_improvement\":-7.5,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1991635,\"status\":\"NEW\",\"last_change_time\":\"2021-08-24T18:13:58Z\",\"summary\":\"periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance\",\"target_release\":[\"---\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1991635\"}]},{\"id\":69,\"name\":\"operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test\",\"current_successes\":26,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":92.85714285714286,\"current_runs\":28,\"previous_successes\":25,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":25,\"net_improvement\":-7.142857142857139,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"VERIFIED\",\"last_change_time\":\"2021-08-31T07:55:34Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]}]\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Aug 2021 11:08:15 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 165,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-08-31T11:08:14.645Z",
+        "time": 1497,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1497
+        }
+      },
+      {
+        "_id": "fd9cc54b5a490b5f17ce5d8475515648",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8080"
+            }
+          ],
+          "headersSize": 494,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "release",
+              "value": "4.8"
+            },
+            {
+              "name": "filter",
+              "value": "{\"items\":[{\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"10\"},{\"columnField\":\"bugs\",\"operatorValue\":\"=\",\"value\":\"0\"}]}"
+            },
+            {
+              "name": "limit",
+              "value": "10"
+            },
+            {
+              "name": "sortField",
+              "value": "net_improvement"
+            },
+            {
+              "name": "sort",
+              "value": "asc"
+            }
+          ],
+          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22columnField%22%3A%22bugs%22%2C%22operatorValue%22%3A%22%3D%22%2C%22value%22%3A%220%22%7D%5D%7D&limit=10&sortField=net_improvement&sort=asc"
+        },
+        "response": {
+          "bodySize": 4691,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 4691,
+            "text": "[{\"id\":25,\"name\":\"[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version\",\"current_successes\":17,\"current_failures\":29,\"current_flakes\":0,\"current_pass_percentage\":36.95652173913043,\"current_runs\":46,\"previous_successes\":46,\"previous_failures\":7,\"previous_flakes\":0,\"previous_pass_percentage\":86.79245283018868,\"previous_runs\":53,\"net_improvement\":-49.83593109105825,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":49,\"name\":\"operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test\",\"current_successes\":10,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":12,\"previous_successes\":12,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":12,\"net_improvement\":-16.666666666666657,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":27,\"name\":\"operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test\",\"current_successes\":8,\"current_failures\":8,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":16,\"previous_successes\":10,\"previous_failures\":6,\"previous_flakes\":0,\"previous_pass_percentage\":62.5,\"previous_runs\":16,\"net_improvement\":-12.5,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":48,\"name\":\"operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test\",\"current_successes\":40,\"current_failures\":8,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":48,\"previous_successes\":42,\"previous_failures\":2,\"previous_flakes\":0,\"previous_pass_percentage\":95.45454545454545,\"previous_runs\":44,\"net_improvement\":-12.12121212121211,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":55,\"name\":\"operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test\",\"current_successes\":33,\"current_failures\":4,\"current_flakes\":0,\"current_pass_percentage\":89.1891891891892,\"current_runs\":37,\"previous_successes\":35,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":35,\"net_improvement\":-10.810810810810807,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":41,\"name\":\"operator.Run template e2e-metal-serial - e2e-metal-serial container setup\",\"current_successes\":8,\"current_failures\":4,\"current_flakes\":0,\"current_pass_percentage\":66.66666666666666,\"current_runs\":12,\"previous_successes\":10,\"previous_failures\":3,\"previous_flakes\":0,\"previous_pass_percentage\":76.92307692307693,\"previous_runs\":13,\"net_improvement\":-10.256410256410277,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":62,\"name\":\"operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test\",\"current_successes\":12,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.3076923076923,\"current_runs\":13,\"previous_successes\":13,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-7.692307692307693,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":63,\"name\":\"operator.Run multi-stage test e2e-gcp-rt - e2e-gcp-rt-ipi-install-install container test\",\"current_successes\":12,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.3076923076923,\"current_runs\":13,\"previous_successes\":13,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-7.692307692307693,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":67,\"name\":\"operator.Run multi-stage test openshift-ipi-azure-arcconformance - openshift-ipi-azure-arcconformance-ipi-install-install container test\",\"current_successes\":37,\"current_failures\":3,\"current_flakes\":0,\"current_pass_percentage\":92.5,\"current_runs\":40,\"previous_successes\":36,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":36,\"net_improvement\":-7.5,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1991635,\"status\":\"NEW\",\"last_change_time\":\"2021-08-24T18:13:58Z\",\"summary\":\"periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance\",\"target_release\":[\"---\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1991635\"}]},{\"id\":68,\"name\":\"operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test\",\"current_successes\":13,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.85714285714286,\"current_runs\":14,\"previous_successes\":12,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":12,\"net_improvement\":-7.142857142857139,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]}]\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Aug 2021 11:08:15 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 165,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-08-31T11:08:14.645Z",
+        "time": 1800,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1800
+        }
+      },
+      {
+        "_id": "c8bb2d1156280ceba8e93915bda0edc6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8080"
+            }
+          ],
+          "headersSize": 501,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "release",
+              "value": "4.8"
+            },
+            {
+              "name": "filter",
+              "value": "{\"items\":[{\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"10\"},{\"columnField\":\"tags\",\"operatorValue\":\"contains\",\"value\":\"trt\"}]}"
+            },
+            {
+              "name": "limit",
+              "value": "10"
+            },
+            {
+              "name": "sortField",
+              "value": "net_improvement"
+            },
+            {
+              "name": "sort",
+              "value": "asc"
+            }
+          ],
+          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22columnField%22%3A%22tags%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22trt%22%7D%5D%7D&limit=10&sortField=net_improvement&sort=asc"
         },
         "response": {
           "bodySize": 3,
@@ -710,7 +818,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 27 Aug 2021 14:46:31 GMT"
+              "value": "Tue, 31 Aug 2021 11:08:15 GMT"
             },
             {
               "name": "content-length",
@@ -727,8 +835,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-08-27T14:46:31.529Z",
-        "time": 919,
+        "startedDateTime": "2021-08-31T11:08:14.645Z",
+        "time": 2013,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -736,115 +844,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 919
-        }
-      },
-      {
-        "_id": "9e7487c4b26b11f6b536f98b6c52ee61",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "localhost:8080"
-            }
-          ],
-          "headersSize": 524,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "release",
-              "value": "4.8"
-            },
-            {
-              "name": "filter",
-              "value": "{\"items\":[{\"id\":1,\"columnField\":\"current_runs\",\"operatorValue\":\">=\",\"value\":\"10\"},{\"id\":5,\"columnField\":\"bugs\",\"operatorValue\":\"=\",\"value\":\"0\"}]}"
-            },
-            {
-              "name": "limit",
-              "value": "10"
-            },
-            {
-              "name": "sortField",
-              "value": "net_improvement"
-            },
-            {
-              "name": "sort",
-              "value": "asc"
-            }
-          ],
-          "url": "http://localhost:8080/api/tests?release=4.8&filter=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22id%22%3A5%2C%22columnField%22%3A%22bugs%22%2C%22operatorValue%22%3A%22%3D%22%2C%22value%22%3A%220%22%7D%5D%7D&limit=10&sortField=net_improvement&sort=asc"
-        },
-        "response": {
-          "bodySize": 4959,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 4959,
-            "text": "[{\"id\":25,\"name\":\"[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version\",\"current_successes\":17,\"current_failures\":29,\"current_flakes\":0,\"current_pass_percentage\":36.95652173913043,\"current_runs\":46,\"previous_successes\":46,\"previous_failures\":7,\"previous_flakes\":0,\"previous_pass_percentage\":86.79245283018868,\"previous_runs\":53,\"net_improvement\":-49.83593109105825,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":49,\"name\":\"operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test\",\"current_successes\":10,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":12,\"previous_successes\":12,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":12,\"net_improvement\":-16.666666666666657,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":27,\"name\":\"operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test\",\"current_successes\":8,\"current_failures\":8,\"current_flakes\":0,\"current_pass_percentage\":50,\"current_runs\":16,\"previous_successes\":10,\"previous_failures\":6,\"previous_flakes\":0,\"previous_pass_percentage\":62.5,\"previous_runs\":16,\"net_improvement\":-12.5,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":48,\"name\":\"operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test\",\"current_successes\":40,\"current_failures\":8,\"current_flakes\":0,\"current_pass_percentage\":83.33333333333334,\"current_runs\":48,\"previous_successes\":42,\"previous_failures\":2,\"previous_flakes\":0,\"previous_pass_percentage\":95.45454545454545,\"previous_runs\":44,\"net_improvement\":-12.12121212121211,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":55,\"name\":\"operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test\",\"current_successes\":33,\"current_failures\":4,\"current_flakes\":0,\"current_pass_percentage\":89.1891891891892,\"current_runs\":37,\"previous_successes\":35,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":35,\"net_improvement\":-10.810810810810807,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":41,\"name\":\"operator.Run template e2e-metal-serial - e2e-metal-serial container setup\",\"current_successes\":8,\"current_failures\":4,\"current_flakes\":0,\"current_pass_percentage\":66.66666666666666,\"current_runs\":12,\"previous_successes\":10,\"previous_failures\":3,\"previous_flakes\":0,\"previous_pass_percentage\":76.92307692307693,\"previous_runs\":13,\"net_improvement\":-10.256410256410277,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":63,\"name\":\"operator.Run multi-stage test e2e-gcp-rt - e2e-gcp-rt-ipi-install-install container test\",\"current_successes\":12,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.3076923076923,\"current_runs\":13,\"previous_successes\":13,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-7.692307692307693,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":62,\"name\":\"operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test\",\"current_successes\":12,\"current_failures\":1,\"current_flakes\":0,\"current_pass_percentage\":92.3076923076923,\"current_runs\":13,\"previous_successes\":13,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":13,\"net_improvement\":-7.692307692307693,\"tags\":null,\"bugs\":[],\"associated_bugs\":[]},{\"id\":67,\"name\":\"operator.Run multi-stage test openshift-ipi-azure-arcconformance - openshift-ipi-azure-arcconformance-ipi-install-install container test\",\"current_successes\":37,\"current_failures\":3,\"current_flakes\":0,\"current_pass_percentage\":92.5,\"current_runs\":40,\"previous_successes\":36,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":36,\"net_improvement\":-7.5,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1991635,\"status\":\"NEW\",\"last_change_time\":\"2021-08-24T18:13:58Z\",\"summary\":\"periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance\",\"target_release\":[\"---\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1991635\"}]},{\"id\":69,\"name\":\"operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test\",\"current_successes\":26,\"current_failures\":2,\"current_flakes\":0,\"current_pass_percentage\":92.85714285714286,\"current_runs\":28,\"previous_successes\":25,\"previous_failures\":0,\"previous_flakes\":0,\"previous_pass_percentage\":100,\"previous_runs\":25,\"net_improvement\":-7.142857142857139,\"tags\":null,\"bugs\":[],\"associated_bugs\":[{\"id\":1984582,\"status\":\"ASSIGNED\",\"last_change_time\":\"2021-08-25T22:30:45Z\",\"summary\":\"Metal IPI jobs are failing a high percentage of the time\",\"target_release\":[\"4.9.0\"],\"component\":[\"Installer\"],\"url\":\"https://bugzilla.redhat.com/show_bug.cgi?id=1984582\"}]}]\n"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "access-control-allow-origin",
-              "value": "*"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 27 Aug 2021 14:46:31 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            }
-          ],
-          "headersSize": 165,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2021-08-27T14:46:31.529Z",
-        "time": 1186,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 1186
+          "wait": 2013
         }
       }
     ],

--- a/sippy-ng/src/__snapshots__/App.test.js.snap
+++ b/sippy-ng/src/__snapshots__/App.test.js.snap
@@ -467,7 +467,7 @@ exports[`app should render correctly 1`] = `
                 <div class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3">
                   <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                     <a class="MuiBox-root MuiBox-root-259"
-                       href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22s390x%22%7D%5D%7D"
+                       href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22s390x%22%7D%5D%7D"
                     >
                       <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-258 MuiPaper-elevation5 MuiPaper-rounded"
                            style="background-color: rgb(229, 115, 115);"
@@ -503,7 +503,7 @@ exports[`app should render correctly 1`] = `
                   </div>
                   <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                     <a class="MuiBox-root MuiBox-root-261"
-                       href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ppc64le%22%7D%5D%7D"
+                       href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ppc64le%22%7D%5D%7D"
                     >
                       <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-260 MuiPaper-elevation5 MuiPaper-rounded"
                            style="background-color: rgb(236, 132, 105);"
@@ -539,7 +539,7 @@ exports[`app should render correctly 1`] = `
                   </div>
                   <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                     <a class="MuiBox-root MuiBox-root-263"
-                       href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22osd%22%7D%5D%7D"
+                       href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22osd%22%7D%5D%7D"
                     >
                       <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-262 MuiPaper-elevation5 MuiPaper-rounded"
                            style="background-color: rgb(242, 149, 96);"
@@ -575,7 +575,7 @@ exports[`app should render correctly 1`] = `
                   </div>
                   <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                     <a class="MuiBox-root MuiBox-root-265"
-                       href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22upgrade%22%7D%5D%7D"
+                       href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22upgrade%22%7D%5D%7D"
                     >
                       <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-264 MuiPaper-elevation5 MuiPaper-rounded"
                            style="background-color: rgb(242, 150, 95);"
@@ -611,7 +611,7 @@ exports[`app should render correctly 1`] = `
                   </div>
                   <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                     <a class="MuiBox-root MuiBox-root-267"
-                       href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22proxy%22%7D%5D%7D"
+                       href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22proxy%22%7D%5D%7D"
                     >
                       <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-266 MuiPaper-elevation5 MuiPaper-rounded"
                            style="background-color: rgb(243, 150, 95);"
@@ -647,7 +647,7 @@ exports[`app should render correctly 1`] = `
                   </div>
                   <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                     <a class="MuiBox-root MuiBox-root-269"
-                       href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-ipi%22%7D%5D%7D"
+                       href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-ipi%22%7D%5D%7D"
                     >
                       <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-268 MuiPaper-elevation5 MuiPaper-rounded"
                            style="background-color: rgb(246, 160, 90);"
@@ -716,7 +716,7 @@ exports[`app should render correctly 1`] = `
                       >
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-271"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22azure%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22azure%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-270 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(248, 164, 87);"
@@ -752,7 +752,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-273"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22compact%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22compact%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-272 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(250, 169, 85);"
@@ -788,7 +788,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-275"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovn%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovn%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-274 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(251, 172, 83);"
@@ -824,7 +824,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-277"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-ipi%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-ipi%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-276 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(253, 177, 80);"
@@ -860,7 +860,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-279"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22aws%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22aws%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-278 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(254, 180, 78);"
@@ -896,7 +896,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-281"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22gcp%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22gcp%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-280 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(254, 182, 78);"
@@ -932,7 +932,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-283"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22single-node%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22single-node%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-282 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(251, 183, 79);"
@@ -968,7 +968,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-285"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22realtime%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22realtime%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-284 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(245, 184, 81);"
@@ -1004,7 +1004,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-287"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-upi%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-upi%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-286 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(189, 191, 106);"
@@ -1040,7 +1040,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-289"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22serial%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22serial%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-288 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(183, 192, 109);"
@@ -1076,7 +1076,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-291"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovirt%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovirt%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-290 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(179, 193, 110);"
@@ -1112,7 +1112,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-293"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22openstack%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22openstack%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-292 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(175, 193, 112);"
@@ -1148,7 +1148,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-295"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-upi%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-upi%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-294 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(141, 197, 127);"
@@ -1184,7 +1184,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-297"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22fips%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22fips%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-296 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(129, 199, 132);"
@@ -1220,7 +1220,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-299"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-assisted%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-assisted%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-298 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(129, 199, 132);"
@@ -1256,7 +1256,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-301"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22promote%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22promote%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-300 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(129, 199, 132);"
@@ -1292,7 +1292,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-303"
-                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%5D%7D"
+                             href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%5D%7D"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-302 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgba(0, 0, 0, 0.38);"
@@ -1327,14 +1327,14 @@ exports[`app should render correctly 1`] = `
             >
               <a class="MuiTypography-root MuiTypography-h5"
                  style="text-align: center;"
-                 href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
+                 href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22techpreview%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
               >
                 Most regressed jobs
                 <svg class="MuiSvgIcon-root"
                      focusable="false"
                      viewbox="0 0 24 24"
                      aria-hidden="true"
-                     title="Shows the most regressed items this week vs. last week, for those with more than 10 runs"
+                     title="Shows the most regressed items this week vs. last week, for those with more than 10 runs, excluding never-stable and techpreview."
                 >
                   <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z">
                   </path>
@@ -1539,17 +1539,17 @@ exports[`app should render correctly 1`] = `
                               <div class="MuiDataGrid-renderingZone"
                                    style="max-height: 350px; width: 200px; transform: translate3d(-0px, -0px, 0);"
                               >
-                                <div data-id="2"
+                                <div data-id="39"
                                      data-rowindex="0"
                                      role="row"
-                                     class="Mui-even JobTable-row-percent-0-54 MuiDataGrid-row"
+                                     class="Mui-even JobTable-row-percent-38-92 MuiDataGrid-row"
                                      aria-rowindex="2"
                                      aria-selected="false"
                                      style="max-height: 70px; min-height: 70px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
-                                       data-value="periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance"
+                                       data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4"
                                        data-field="name"
                                        data-rowindex="0"
                                        data-colindex="0"
@@ -1561,17 +1561,17 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="job-name">
-                                      <a title="periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance"
+                                      <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4"
                                          class
-                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance%22%7D%5D%7D"
+                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4%22%7D%5D%7D"
                                       >
-                                        openshift-ipi-azure-arcconformance
+                                        e2e-metal-ipi-serial-ipv4
                                       </a>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                        role="cell"
-                                       data-value="0"
+                                       data-value="38.46153846153847"
                                        data-field="current_pass_percentage"
                                        data-rowindex="0"
                                        data-colindex="1"
@@ -1583,16 +1583,16 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="percentage-cell">
-                                      0%
+                                      38%
                                       <br>
                                       <small>
-                                        (40 runs)
+                                        (13 runs)
                                       </small>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                        role="cell"
-                                       data-value="0"
+                                       data-value="-28.20512820512819"
                                        data-field="net_improvement"
                                        data-rowindex="0"
                                        data-colindex="2"
@@ -1607,11 +1607,11 @@ exports[`app should render correctly 1`] = `
                                          focusable="false"
                                          viewbox="0 0 24 24"
                                          aria-hidden="true"
-                                         data-icon="SyncAltRoundedIcon"
-                                         style="color: grey;"
-                                         title="0.00%"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-28.21%"
                                     >
-                                      <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                       </path>
                                     </svg>
                                   </div>
@@ -1620,17 +1620,17 @@ exports[`app should render correctly 1`] = `
                                   >
                                   </div>
                                 </div>
-                                <div data-id="3"
+                                <div data-id="62"
                                      data-rowindex="1"
                                      role="row"
-                                     class="Mui-odd JobTable-row-percent-0-54 MuiDataGrid-row"
+                                     class="Mui-odd JobTable-row-percent-69-123 MuiDataGrid-row"
                                      aria-rowindex="3"
                                      aria-selected="false"
                                      style="max-height: 70px; min-height: 70px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
-                                       data-value="release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8"
+                                       data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp"
                                        data-field="name"
                                        data-rowindex="1"
                                        data-colindex="0"
@@ -1642,17 +1642,17 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="job-name">
-                                      <a title="release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8"
+                                      <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp"
                                          class
-                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8%22%7D%5D%7D"
+                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp%22%7D%5D%7D"
                                       >
-                                        release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8
+                                        e2e-gcp
                                       </a>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                        role="cell"
-                                       data-value="0"
+                                       data-value="69.23076923076923"
                                        data-field="current_pass_percentage"
                                        data-rowindex="1"
                                        data-colindex="1"
@@ -1664,7 +1664,7 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="percentage-cell">
-                                      0%
+                                      69%
                                       <br>
                                       <small>
                                         (13 runs)
@@ -1673,7 +1673,7 @@ exports[`app should render correctly 1`] = `
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                        role="cell"
-                                       data-value="0"
+                                       data-value="-23.07692307692308"
                                        data-field="net_improvement"
                                        data-rowindex="1"
                                        data-colindex="2"
@@ -1688,11 +1688,11 @@ exports[`app should render correctly 1`] = `
                                          focusable="false"
                                          viewbox="0 0 24 24"
                                          aria-hidden="true"
-                                         data-icon="SyncAltRoundedIcon"
-                                         style="color: grey;"
-                                         title="0.00%"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-23.08%"
                                     >
-                                      <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                       </path>
                                     </svg>
                                   </div>
@@ -1701,17 +1701,17 @@ exports[`app should render correctly 1`] = `
                                   >
                                   </div>
                                 </div>
-                                <div data-id="20"
+                                <div data-id="33"
                                      data-rowindex="2"
                                      role="row"
-                                     class="Mui-even JobTable-row-percent-15-69 MuiDataGrid-row"
+                                     class="Mui-even JobTable-row-percent-33-87 MuiDataGrid-row"
                                      aria-rowindex="4"
                                      aria-selected="false"
                                      style="max-height: 70px; min-height: 70px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
-                                       data-value="release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8"
+                                       data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade"
                                        data-field="name"
                                        data-rowindex="2"
                                        data-colindex="0"
@@ -1723,17 +1723,17 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="job-name">
-                                      <a title="release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8"
+                                      <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade"
                                          class
-                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8%22%7D%5D%7D"
+                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade%22%7D%5D%7D"
                                       >
-                                        release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8
+                                        e2e-aws-upgrade
                                       </a>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                        role="cell"
-                                       data-value="15.384615384615385"
+                                       data-value="33.33333333333333"
                                        data-field="current_pass_percentage"
                                        data-rowindex="2"
                                        data-colindex="1"
@@ -1745,16 +1745,16 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="percentage-cell">
-                                      15%
+                                      33%
                                       <br>
                                       <small>
-                                        (13 runs)
+                                        (15 runs)
                                       </small>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                        role="cell"
-                                       data-value="0"
+                                       data-value="-20.000000000000007"
                                        data-field="net_improvement"
                                        data-rowindex="2"
                                        data-colindex="2"
@@ -1769,11 +1769,11 @@ exports[`app should render correctly 1`] = `
                                          focusable="false"
                                          viewbox="0 0 24 24"
                                          aria-hidden="true"
-                                         data-icon="SyncAltRoundedIcon"
-                                         style="color: grey;"
-                                         title="0.00%"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-20.00%"
                                     >
-                                      <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                       </path>
                                     </svg>
                                   </div>
@@ -1782,17 +1782,17 @@ exports[`app should render correctly 1`] = `
                                   >
                                   </div>
                                 </div>
-                                <div data-id="22"
+                                <div data-id="28"
                                      data-rowindex="3"
                                      role="row"
-                                     class="Mui-odd JobTable-row-percent-23-77 MuiDataGrid-row"
+                                     class="Mui-odd JobTable-row-percent-31-85 MuiDataGrid-row"
                                      aria-rowindex="5"
                                      aria-selected="false"
                                      style="max-height: 70px; min-height: 70px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
-                                       data-value="periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade"
+                                       data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy"
                                        data-field="name"
                                        data-rowindex="3"
                                        data-colindex="0"
@@ -1804,17 +1804,17 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="job-name">
-                                      <a title="periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade"
+                                      <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy"
                                          class
-                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade%22%7D%5D%7D"
+                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy%22%7D%5D%7D"
                                       >
-                                        upgrade-from-stable-4.7-e2e-metal-ipi-upgrade
+                                        e2e-aws-proxy
                                       </a>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                        role="cell"
-                                       data-value="23.076923076923077"
+                                       data-value="31.25"
                                        data-field="current_pass_percentage"
                                        data-rowindex="3"
                                        data-colindex="1"
@@ -1826,16 +1826,16 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="percentage-cell">
-                                      23%
+                                      31%
                                       <br>
                                       <small>
-                                        (13 runs)
+                                        (16 runs)
                                       </small>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                        role="cell"
-                                       data-value="0"
+                                       data-value="-18.75"
                                        data-field="net_improvement"
                                        data-rowindex="3"
                                        data-colindex="2"
@@ -1850,11 +1850,11 @@ exports[`app should render correctly 1`] = `
                                          focusable="false"
                                          viewbox="0 0 24 24"
                                          aria-hidden="true"
-                                         data-icon="SyncAltRoundedIcon"
-                                         style="color: grey;"
-                                         title="0.00%"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-18.75%"
                                     >
-                                      <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                       </path>
                                     </svg>
                                   </div>
@@ -1863,17 +1863,17 @@ exports[`app should render correctly 1`] = `
                                   >
                                   </div>
                                 </div>
-                                <div data-id="25"
+                                <div data-id="70"
                                      data-rowindex="4"
                                      role="row"
-                                     class="Mui-even JobTable-row-percent-25-79 MuiDataGrid-row"
+                                     class="Mui-even JobTable-row-percent-77-131 MuiDataGrid-row"
                                      aria-rowindex="6"
                                      aria-selected="false"
                                      style="max-height: 70px; min-height: 70px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
-                                       data-value="periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-upgrade"
+                                       data-value="release-openshift-ocp-installer-e2e-aws-ovn-4.8"
                                        data-field="name"
                                        data-rowindex="4"
                                        data-colindex="0"
@@ -1885,17 +1885,17 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="job-name">
-                                      <a title="periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-upgrade"
+                                      <a title="release-openshift-ocp-installer-e2e-aws-ovn-4.8"
                                          class
-                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-upgrade%22%7D%5D%7D"
+                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-e2e-aws-ovn-4.8%22%7D%5D%7D"
                                       >
-                                        upgrade-from-stable-4.7-e2e-gcp-upgrade
+                                        release-openshift-ocp-installer-e2e-aws-ovn-4.8
                                       </a>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                        role="cell"
-                                       data-value="25"
+                                       data-value="76.92307692307693"
                                        data-field="current_pass_percentage"
                                        data-rowindex="4"
                                        data-colindex="1"
@@ -1907,16 +1907,16 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="percentage-cell">
-                                      25%
+                                      77%
                                       <br>
                                       <small>
-                                        (24 runs)
+                                        (13 runs)
                                       </small>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                        role="cell"
-                                       data-value="0"
+                                       data-value="-15.384615384615373"
                                        data-field="net_improvement"
                                        data-rowindex="4"
                                        data-colindex="2"
@@ -1931,11 +1931,11 @@ exports[`app should render correctly 1`] = `
                                          focusable="false"
                                          viewbox="0 0 24 24"
                                          aria-hidden="true"
-                                         data-icon="SyncAltRoundedIcon"
-                                         style="color: grey;"
-                                         title="0.00%"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-15.38%"
                                     >
-                                      <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                       </path>
                                     </svg>
                                   </div>
@@ -2048,14 +2048,14 @@ exports[`app should render correctly 1`] = `
                  style="text-align: center;"
             >
               <a class="MuiTypography-root MuiTypography-h5"
-                 href="/jobs/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
+                 href="/jobs/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22techpreview%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
               >
                 Most regressed jobs (two day)
                 <svg class="MuiSvgIcon-root"
                      focusable="false"
                      viewbox="0 0 24 24"
                      aria-hidden="true"
-                     title="Shows the last 2 days compared to the last 7 days, sorted by most regressed."
+                     title="Shows the last 2 days compared to the last 7 days, sorted by most regressed, excluding never-stable and techpreview."
                 >
                   <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z">
                   </path>
@@ -2260,7 +2260,7 @@ exports[`app should render correctly 1`] = `
                               <div class="MuiDataGrid-renderingZone"
                                    style="max-height: 350px; width: 200px; transform: translate3d(-0px, -0px, 0);"
                               >
-                                <div data-id="0"
+                                <div data-id="37"
                                      data-rowindex="0"
                                      role="row"
                                      class="Mui-even JobTable-row-percent-0-54 MuiDataGrid-row"
@@ -2270,90 +2270,9 @@ exports[`app should render correctly 1`] = `
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
-                                       data-value="periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift"
-                                       data-field="name"
-                                       data-rowindex="0"
-                                       data-colindex="0"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
-                                       tabindex="-1"
-                                  >
-                                    <div class="job-name">
-                                      <a title="periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift"
-                                         class
-                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift%22%7D%5D%7D"
-                                      >
-                                        e2e-aws-hypershift
-                                      </a>
-                                    </div>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="0"
-                                       data-field="current_pass_percentage"
-                                       data-rowindex="0"
-                                       data-colindex="1"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
-                                       tabindex="-1"
-                                  >
-                                    <div class="percentage-cell">
-                                      0%
-                                      <br>
-                                      <small>
-                                        (1 runs)
-                                      </small>
-                                    </div>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="0"
-                                       data-field="net_improvement"
-                                       data-rowindex="0"
-                                       data-colindex="2"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
-                                       tabindex="-1"
-                                  >
-                                    <svg class="MuiSvgIcon-root"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                         data-icon="SyncAltRoundedIcon"
-                                         style="color: grey;"
-                                         title="0.00%"
-                                    >
-                                      <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
-                                      </path>
-                                    </svg>
-                                  </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
-                                       class="MuiDataGrid-cell"
-                                  >
-                                  </div>
-                                </div>
-                                <div data-id="11"
-                                     data-rowindex="1"
-                                     role="row"
-                                     class="Mui-odd JobTable-row-percent-0-54 MuiDataGrid-row"
-                                     aria-rowindex="3"
-                                     aria-selected="false"
-                                     style="max-height: 70px; min-height: 70px;"
-                                >
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                       role="cell"
                                        data-value="periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade"
                                        data-field="name"
-                                       data-rowindex="1"
+                                       data-rowindex="0"
                                        data-colindex="0"
                                        data-rowselected="false"
                                        data-editable="false"
@@ -2365,7 +2284,7 @@ exports[`app should render correctly 1`] = `
                                     <div class="job-name">
                                       <a title="periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade"
                                          class
-                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade%22%7D%5D%7D"
+                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade%22%7D%5D%7D"
                                       >
                                         e2e-aws-upgrade
                                       </a>
@@ -2375,7 +2294,7 @@ exports[`app should render correctly 1`] = `
                                        role="cell"
                                        data-value="0"
                                        data-field="current_pass_percentage"
-                                       data-rowindex="1"
+                                       data-rowindex="0"
                                        data-colindex="1"
                                        data-rowselected="false"
                                        data-editable="false"
@@ -2394,9 +2313,9 @@ exports[`app should render correctly 1`] = `
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                        role="cell"
-                                       data-value="0"
+                                       data-value="-66.66666666666666"
                                        data-field="net_improvement"
-                                       data-rowindex="1"
+                                       data-rowindex="0"
                                        data-colindex="2"
                                        data-rowselected="false"
                                        data-editable="false"
@@ -2409,11 +2328,11 @@ exports[`app should render correctly 1`] = `
                                          focusable="false"
                                          viewbox="0 0 24 24"
                                          aria-hidden="true"
-                                         data-icon="SyncAltRoundedIcon"
-                                         style="color: grey;"
-                                         title="0.00%"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-66.67%"
                                     >
-                                      <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                       </path>
                                     </svg>
                                   </div>
@@ -2422,19 +2341,19 @@ exports[`app should render correctly 1`] = `
                                   >
                                   </div>
                                 </div>
-                                <div data-id="12"
-                                     data-rowindex="2"
+                                <div data-id="33"
+                                     data-rowindex="1"
                                      role="row"
-                                     class="Mui-even JobTable-row-percent-0-54 MuiDataGrid-row"
-                                     aria-rowindex="4"
+                                     class="Mui-odd JobTable-row-percent-0-54 MuiDataGrid-row"
+                                     aria-rowindex="3"
                                      aria-selected="false"
                                      style="max-height: 70px; min-height: 70px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
-                                       data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node"
+                                       data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-libvirt-cert-rotation"
                                        data-field="name"
-                                       data-rowindex="2"
+                                       data-rowindex="1"
                                        data-colindex="0"
                                        data-rowselected="false"
                                        data-editable="false"
@@ -2444,11 +2363,11 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="job-name">
-                                      <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node"
+                                      <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-libvirt-cert-rotation"
                                          class
-                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node%22%7D%5D%7D"
+                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-libvirt-cert-rotation%22%7D%5D%7D"
                                       >
-                                        e2e-aws-single-node
+                                        e2e-gcp-libvirt-cert-rotation
                                       </a>
                                     </div>
                                   </div>
@@ -2456,7 +2375,7 @@ exports[`app should render correctly 1`] = `
                                        role="cell"
                                        data-value="0"
                                        data-field="current_pass_percentage"
-                                       data-rowindex="2"
+                                       data-rowindex="1"
                                        data-colindex="1"
                                        data-rowselected="false"
                                        data-editable="false"
@@ -2475,9 +2394,9 @@ exports[`app should render correctly 1`] = `
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                        role="cell"
-                                       data-value="0"
+                                       data-value="-57.14285714285714"
                                        data-field="net_improvement"
-                                       data-rowindex="2"
+                                       data-rowindex="1"
                                        data-colindex="2"
                                        data-rowselected="false"
                                        data-editable="false"
@@ -2490,11 +2409,11 @@ exports[`app should render correctly 1`] = `
                                          focusable="false"
                                          viewbox="0 0 24 24"
                                          aria-hidden="true"
-                                         data-icon="SyncAltRoundedIcon"
-                                         style="color: grey;"
-                                         title="0.00%"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-57.14%"
                                     >
-                                      <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                       </path>
                                     </svg>
                                   </div>
@@ -2503,11 +2422,11 @@ exports[`app should render correctly 1`] = `
                                   >
                                   </div>
                                 </div>
-                                <div data-id="24"
-                                     data-rowindex="3"
+                                <div data-id="3"
+                                     data-rowindex="2"
                                      role="row"
-                                     class="Mui-odd JobTable-row-percent-0-54 MuiDataGrid-row"
-                                     aria-rowindex="5"
+                                     class="Mui-even JobTable-row-percent-0-54 MuiDataGrid-row"
+                                     aria-rowindex="4"
                                      aria-selected="false"
                                      style="max-height: 70px; min-height: 70px;"
                                 >
@@ -2515,7 +2434,7 @@ exports[`app should render correctly 1`] = `
                                        role="cell"
                                        data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia"
                                        data-field="name"
-                                       data-rowindex="3"
+                                       data-rowindex="2"
                                        data-colindex="0"
                                        data-rowselected="false"
                                        data-editable="false"
@@ -2527,7 +2446,7 @@ exports[`app should render correctly 1`] = `
                                     <div class="job-name">
                                       <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia"
                                          class
-                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia%22%7D%5D%7D"
+                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia%22%7D%5D%7D"
                                       >
                                         e2e-metal-ipi-virtualmedia
                                       </a>
@@ -2537,7 +2456,7 @@ exports[`app should render correctly 1`] = `
                                        role="cell"
                                        data-value="0"
                                        data-field="current_pass_percentage"
-                                       data-rowindex="3"
+                                       data-rowindex="2"
                                        data-colindex="1"
                                        data-rowselected="false"
                                        data-editable="false"
@@ -2556,7 +2475,88 @@ exports[`app should render correctly 1`] = `
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                        role="cell"
-                                       data-value="0"
+                                       data-value="-50"
+                                       data-field="net_improvement"
+                                       data-rowindex="2"
+                                       data-colindex="2"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="3"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
+                                       tabindex="-1"
+                                  >
+                                    <svg class="MuiSvgIcon-root"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-50.00%"
+                                    >
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                      </path>
+                                    </svg>
+                                  </div>
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
+                                       class="MuiDataGrid-cell"
+                                  >
+                                  </div>
+                                </div>
+                                <div data-id="72"
+                                     data-rowindex="3"
+                                     role="row"
+                                     class="Mui-odd JobTable-row-percent-50-104 MuiDataGrid-row"
+                                     aria-rowindex="5"
+                                     aria-selected="false"
+                                     style="max-height: 70px; min-height: 70px;"
+                                >
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                       role="cell"
+                                       data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted"
+                                       data-field="name"
+                                       data-rowindex="3"
+                                       data-colindex="0"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="1"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
+                                       tabindex="-1"
+                                  >
+                                    <div class="job-name">
+                                      <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted"
+                                         class
+                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted%22%7D%5D%7D"
+                                      >
+                                        e2e-metal-assisted
+                                      </a>
+                                    </div>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="50"
+                                       data-field="current_pass_percentage"
+                                       data-rowindex="3"
+                                       data-colindex="1"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="2"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
+                                       tabindex="-1"
+                                  >
+                                    <div class="percentage-cell">
+                                      50%
+                                      <br>
+                                      <small>
+                                        (2 runs)
+                                      </small>
+                                    </div>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="-42.85714285714286"
                                        data-field="net_improvement"
                                        data-rowindex="3"
                                        data-colindex="2"
@@ -2571,11 +2571,11 @@ exports[`app should render correctly 1`] = `
                                          focusable="false"
                                          viewbox="0 0 24 24"
                                          aria-hidden="true"
-                                         data-icon="SyncAltRoundedIcon"
-                                         style="color: grey;"
-                                         title="0.00%"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-42.86%"
                                     >
-                                      <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                       </path>
                                     </svg>
                                   </div>
@@ -2584,7 +2584,7 @@ exports[`app should render correctly 1`] = `
                                   >
                                   </div>
                                 </div>
-                                <div data-id="30"
+                                <div data-id="53"
                                      data-rowindex="4"
                                      role="row"
                                      class="Mui-even JobTable-row-percent-0-54 MuiDataGrid-row"
@@ -2594,7 +2594,7 @@ exports[`app should render correctly 1`] = `
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
-                                       data-value="release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8"
+                                       data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack"
                                        data-field="name"
                                        data-rowindex="4"
                                        data-colindex="0"
@@ -2606,11 +2606,11 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="job-name">
-                                      <a title="release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8"
+                                      <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack"
                                          class
-                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8%22%7D%5D%7D"
+                                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack%22%7D%5D%7D"
                                       >
-                                        release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8
+                                        e2e-metal-ipi-ovn-dualstack
                                       </a>
                                     </div>
                                   </div>
@@ -2637,7 +2637,7 @@ exports[`app should render correctly 1`] = `
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                        role="cell"
-                                       data-value="0"
+                                       data-value="-38.46153846153847"
                                        data-field="net_improvement"
                                        data-rowindex="4"
                                        data-colindex="2"
@@ -2652,11 +2652,11 @@ exports[`app should render correctly 1`] = `
                                          focusable="false"
                                          viewbox="0 0 24 24"
                                          aria-hidden="true"
-                                         data-icon="SyncAltRoundedIcon"
-                                         style="color: grey;"
-                                         title="0.00%"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-38.46%"
                                     >
-                                      <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                       </path>
                                     </svg>
                                   </div>
@@ -2770,14 +2770,14 @@ exports[`app should render correctly 1`] = `
             >
               <a class="MuiTypography-root MuiTypography-h5"
                  style="text-align: center;"
-                 href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D&amp;sortField=net_improvement&amp;sort=asc"
+                 href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D&amp;sortField=net_improvement&amp;sort=asc"
               >
                 Most regressed tests
                 <svg class="MuiSvgIcon-root"
                      focusable="false"
                      viewbox="0 0 24 24"
                      aria-hidden="true"
-                     title="Shows the most regressed items this week vs. last week, for those with more than 10 runs"
+                     title="Shows the most regressed items this week vs. last week, for those with more than 10 runs, excluding never-stable and techpreview."
                 >
                   <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z">
                   </path>
@@ -3482,14 +3482,14 @@ exports[`app should render correctly 1`] = `
             >
               <a class="MuiTypography-root MuiTypography-h5"
                  style="text-align: center;"
-                 href="/tests/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
+                 href="/tests/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
               >
                 Most regressed tests (two day)
                 <svg class="MuiSvgIcon-root"
                      focusable="false"
                      viewbox="0 0 24 24"
                      aria-hidden="true"
-                     title="Shows the last 2 days compared to the last 7 days, sorted by most regressed."
+                     title="Shows the last 2 days compared to the last 7 days, sorted by most regressed, excluding never-stable and techpreview."
                 >
                   <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z">
                   </path>
@@ -4194,7 +4194,7 @@ exports[`app should render correctly 1`] = `
             >
               <a class="MuiTypography-root MuiTypography-h5"
                  style="text-align: center;"
-                 href="/tests/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22id%22%3A5%2C%22columnField%22%3A%22bugs%22%2C%22operatorValue%22%3A%22%3D%22%2C%22value%22%3A%220%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
+                 href="/tests/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22columnField%22%3A%22bugs%22%2C%22operatorValue%22%3A%22%3D%22%2C%22value%22%3A%220%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
               >
                 Top failing tests without a bug
                 <svg class="MuiSvgIcon-root"
@@ -4906,7 +4906,7 @@ exports[`app should render correctly 1`] = `
             >
               <a class="MuiTypography-root MuiTypography-h5"
                  style="text-align: center;"
-                 href="/tests/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A8%2C%22columnField%22%3A%22tags%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22trt%22%7D%5D%7D"
+                 href="/tests/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22tags%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22trt%22%7D%5D%7D"
               >
                 Curated by TRT
                 <svg class="MuiSvgIcon-root"

--- a/sippy-ng/src/constants.js
+++ b/sippy-ng/src/constants.js
@@ -37,42 +37,48 @@ export const TEST_THRESHOLDS = {
 // Saved searches
 export const BOOKMARKS = {
   RUN_1: {
-    id: 1,
     columnField: 'current_runs',
     operatorValue: '>=',
     value: '1',
   },
   RUN_10: {
-    id: 1,
     columnField: 'current_runs',
     operatorValue: '>=',
     value: '10',
   },
+  NO_NEVER_STABLE: {
+    columnField: 'variants',
+    not: true,
+    operatorValue: 'contains',
+    value: 'never-stable',
+  },
+  NO_TECHPREVIEW: {
+    columnField: 'variants',
+    not: true,
+    operatorValue: 'contains',
+    value: 'techpreview',
+  },
   UPGRADE: {
-    id: 2,
     columnField: 'tags',
     operatorValue: 'contains',
     value: 'upgrade',
   },
   INSTALL: {
-    id: 3,
     columnField: 'tags',
     operatorValue: 'contains',
     value: 'install',
   },
-  LINKED_BUG: { id: 4, columnField: 'bugs', operatorValue: '>', value: '0' },
-  NO_LINKED_BUG: { id: 5, columnField: 'bugs', operatorValue: '=', value: '0' },
+  LINKED_BUG: { columnField: 'bugs', operatorValue: '>', value: '0' },
+  NO_LINKED_BUG: { columnField: 'bugs', operatorValue: '=', value: '0' },
   ASSOCIATED_BUG: {
-    id: 6,
     columnField: 'associated_bugs',
     operatorValue: '>',
     value: '0',
   },
   NO_ASSOCIATED_BUG: {
-    id: 7,
     columnField: 'associated_bugs',
     operatorValue: '=',
     value: '0',
   },
-  TRT: { id: 8, columnField: 'tags', operatorValue: 'contains', value: 'trt' },
+  TRT: { columnField: 'tags', operatorValue: 'contains', value: 'trt' },
 }

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -115,7 +115,24 @@ export function pathForJobVariant(release, variant) {
 
 // Helpers used by the above
 export function filterFor(column, operator, value) {
-  return { id: 99, columnField: column, operatorValue: operator, value: value }
+  return { columnField: column, operatorValue: operator, value: value }
+}
+
+export function withoutUnstable() {
+  return [
+    {
+      columnField: 'variants',
+      not: true,
+      operators: 'contains',
+      value: 'never-stable',
+    },
+    {
+      columnField: 'variants',
+      not: true,
+      operators: 'contains',
+      value: 'tech-preview',
+    },
+  ]
 }
 
 function multiple(...filters) {

--- a/sippy-ng/src/jobs/__snapshots__/JobRunsTable.test.js.snap
+++ b/sippy-ng/src/jobs/__snapshots__/JobRunsTable.test.js.snap
@@ -413,7 +413,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x
                         </a>
@@ -482,7 +482,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node
                         </a>
@@ -551,7 +551,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-compact-remote-libvirt-s390x\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-compact-remote-libvirt-s390x%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-compact-remote-libvirt-s390x%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-compact-remote-libvirt-s390x
                         </a>
@@ -620,7 +620,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x
                         </a>
@@ -689,7 +689,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-rt\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-rt%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-rt%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-rt
                         </a>
@@ -758,7 +758,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-e2e-gcp\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-gcp%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-gcp%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-e2e-gcp
                         </a>
@@ -827,7 +827,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x
                         </a>
@@ -896,7 +896,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x
                         </a>
@@ -965,7 +965,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-azure-ovn-upgrade\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-azure-ovn-upgrade%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-azure-ovn-upgrade%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-azure-ovn-upgrade
                         </a>
@@ -1034,7 +1034,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x
                         </a>
@@ -1103,7 +1103,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack
                         </a>
@@ -1172,7 +1172,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi
                         </a>
@@ -1241,7 +1241,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"release-openshift-ocp-installer-e2e-azure-serial-4.8\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-e2e-azure-serial-4.8%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-e2e-azure-serial-4.8%22%7D%5D%7D\\"
                         >
                           release-openshift-ocp-installer-e2e-azure-serial-4.8
                         </a>
@@ -1310,7 +1310,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi
                         </a>
@@ -1379,7 +1379,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere
                         </a>
@@ -1448,7 +1448,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"release-openshift-ocp-installer-e2e-azure-serial-4.8\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-e2e-azure-serial-4.8%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-e2e-azure-serial-4.8%22%7D%5D%7D\\"
                         >
                           release-openshift-ocp-installer-e2e-azure-serial-4.8
                         </a>
@@ -1517,7 +1517,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-e2e-ovirt\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-ovirt%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-ovirt%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-nightly-4.8-e2e-ovirt
                         </a>
@@ -1586,7 +1586,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-e2e-azure-ovn\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-azure-ovn%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-azure-ovn%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-e2e-azure-ovn
                         </a>
@@ -1655,7 +1655,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"release-openshift-ocp-installer-e2e-aws-upi-4.8\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-e2e-aws-upi-4.8%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-e2e-aws-upi-4.8%22%7D%5D%7D\\"
                         >
                           release-openshift-ocp-installer-e2e-aws-upi-4.8
                         </a>
@@ -1724,7 +1724,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-e2e-aws\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-aws%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-aws%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-nightly-4.8-e2e-aws
                         </a>
@@ -1793,7 +1793,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi-serial\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi-serial%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi-serial%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi-serial
                         </a>
@@ -1862,7 +1862,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"release-openshift-ocp-installer-e2e-gcp-serial-4.8\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-e2e-gcp-serial-4.8%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-e2e-gcp-serial-4.8%22%7D%5D%7D\\"
                         >
                           release-openshift-ocp-installer-e2e-gcp-serial-4.8
                         </a>
@@ -1931,7 +1931,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi-serial\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi-serial%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi-serial%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi-serial
                         </a>
@@ -2000,7 +2000,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-e2e-azure-ovn\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-azure-ovn%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-azure-ovn%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-e2e-azure-ovn
                         </a>
@@ -2069,7 +2069,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                       <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
                         <a title=\\"release-openshift-ocp-installer-e2e-gcp-serial-4.8\\"
                            class
-                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-e2e-gcp-serial-4.8%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-e2e-gcp-serial-4.8%22%7D%5D%7D\\"
                         >
                           release-openshift-ocp-installer-e2e-gcp-serial-4.8
                         </a>

--- a/sippy-ng/src/jobs/__snapshots__/JobTable.test.js.snap
+++ b/sippy-ng/src/jobs/__snapshots__/JobTable.test.js.snap
@@ -381,7 +381,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"release-openshift-origin-installer-old-rhcos-e2e-aws-4.8\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-origin-installer-old-rhcos-e2e-aws-4.8%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-origin-installer-old-rhcos-e2e-aws-4.8%22%7D%5D%7D\\"
                         >
                           release-openshift-origin-installer-old-rhcos-e2e-aws-4.8
                         </a>
@@ -474,7 +474,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8%22%7D%5D%7D\\"
                         >
                           release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8
                         </a>
@@ -567,7 +567,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-ovn-upgrade\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-ovn-upgrade%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-ovn-upgrade%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-ovn-upgrade
                         </a>
@@ -660,7 +660,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-e2e-aws-calico\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-aws-calico%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-aws-calico%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-e2e-aws-calico
                         </a>
@@ -753,7 +753,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-upgrade-rollback\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-upgrade-rollback%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-upgrade-rollback%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-upgrade-rollback
                         </a>
@@ -846,7 +846,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"release-openshift-origin-installer-e2e-aws-upgrade-4.5-to-4.6-to-4.7-to-4.8-ci\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-origin-installer-e2e-aws-upgrade-4.5-to-4.6-to-4.7-to-4.8-ci%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-origin-installer-e2e-aws-upgrade-4.5-to-4.6-to-4.7-to-4.8-ci%22%7D%5D%7D\\"
                         >
                           release-openshift-origin-installer-e2e-aws-upgrade-4.5-to-4.6-to-4.7-to-4.8-ci
                         </a>
@@ -939,7 +939,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-e2e-openstack-kuryr\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-openstack-kuryr%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-openstack-kuryr%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-e2e-openstack-kuryr
                         </a>
@@ -1032,7 +1032,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-compact\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-compact%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-compact%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-compact
                         </a>
@@ -1125,7 +1125,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-compact-remote-libvirt-ppc64le\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-compact-remote-libvirt-ppc64le%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-compact-remote-libvirt-ppc64le%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-compact-remote-libvirt-ppc64le
                         </a>
@@ -1218,7 +1218,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-openstack-upgrade\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-openstack-upgrade%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-openstack-upgrade%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-openstack-upgrade
                         </a>
@@ -1311,7 +1311,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-e2e-azure-compact\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-azure-compact%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-azure-compact%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-e2e-azure-compact
                         </a>
@@ -1404,7 +1404,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-azure-ovn-upgrade\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-azure-ovn-upgrade%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-azure-ovn-upgrade%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-azure-ovn-upgrade
                         </a>
@@ -1497,7 +1497,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift
                         </a>
@@ -1590,7 +1590,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"release-openshift-origin-installer-e2e-aws-disruptive-4.8\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-origin-installer-e2e-aws-disruptive-4.8%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-origin-installer-e2e-aws-disruptive-4.8%22%7D%5D%7D\\"
                         >
                           release-openshift-origin-installer-e2e-aws-disruptive-4.8
                         </a>
@@ -1683,7 +1683,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-ovn-upgrade\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-ovn-upgrade%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-ovn-upgrade%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-ovn-upgrade
                         </a>
@@ -1776,7 +1776,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-e2e-aws-ovn-network-stress\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-aws-ovn-network-stress%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-aws-ovn-network-stress%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-e2e-aws-ovn-network-stress
                         </a>
@@ -1869,7 +1869,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-ovn-upgrade-rollback\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-ovn-upgrade-rollback%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-ovn-upgrade-rollback%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-ovn-upgrade-rollback
                         </a>
@@ -1962,7 +1962,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-upgrade\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-upgrade%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-upgrade%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-upgrade
                         </a>
@@ -2055,7 +2055,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack
                         </a>
@@ -2148,7 +2148,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade
                         </a>
@@ -2241,7 +2241,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade
                         </a>
@@ -2334,7 +2334,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-remote-libvirt-s390x
                         </a>
@@ -2427,7 +2427,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi
                         </a>
@@ -2520,7 +2520,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-from-stable-4.7-from-stable-4.6-e2e-aws-upgrade\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-from-stable-4.7-from-stable-4.6-e2e-aws-upgrade%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-from-stable-4.7-from-stable-4.6-e2e-aws-upgrade%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-release-master-ci-4.8-upgrade-from-from-stable-4.7-from-stable-4.6-e2e-aws-upgrade
                         </a>
@@ -2613,7 +2613,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-compact-remote-libvirt-s390x\\"
                            class
-                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-compact-remote-libvirt-s390x%22%7D%5D%7D\\"
+                           href=\\"/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-compact-remote-libvirt-s390x%22%7D%5D%7D\\"
                         >
                           periodic-ci-openshift-multiarch-master-nightly-4.8-ocp-e2e-compact-remote-libvirt-s390x
                         </a>

--- a/sippy-ng/src/jobs/__snapshots__/JobsDetail.test.js.snap
+++ b/sippy-ng/src/jobs/__snapshots__/JobsDetail.test.js.snap
@@ -226,7 +226,7 @@ exports[`JobsDetail should match snapshot 1`] = `
               role=\\"cell\\"
               scope=\\"row\\"
           >
-            <a href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade%22%7D%5D%7D\\">
+            <a href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade%22%7D%5D%7D\\">
               periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade
             </a>
           </th>

--- a/sippy-ng/src/releases/ReleaseOverview.js
+++ b/sippy-ng/src/releases/ReleaseOverview.js
@@ -22,13 +22,13 @@ import VariantCards from '../jobs/VariantCards'
 
 export const TOOLTIP = 'Top level release indicators showing product health'
 export const REGRESSED_TOOLTIP =
-  'Shows the most regressed items this week vs. last week, for those with more than 10 runs'
+  'Shows the most regressed items this week vs. last week, for those with more than 10 runs, excluding never-stable and techpreview.'
 export const NOBUG_TOOLTIP =
   'Shows the list of tests ordered by least successful and without a bug, for those with more than 10 runs'
 export const TRT_TOOLTIP =
   'Shows a curated list of tests selected by the TRT team'
 export const TWODAY_WARNING =
-  'Shows the last 2 days compared to the last 7 days, sorted by most regressed.'
+  'Shows the last 2 days compared to the last 7 days, sorted by most regressed, excluding never-stable and techpreview.'
 
 const defaultTheme = createTheme()
 const useStyles = makeStyles(
@@ -195,7 +195,9 @@ export default function ReleaseOverview(props) {
                   to={`/jobs/${
                     props.release
                   }?sortField=net_improvement&sort=asc&${queryForBookmark(
-                    BOOKMARKS.RUN_10
+                    BOOKMARKS.RUN_10,
+                    BOOKMARKS.NO_NEVER_STABLE,
+                    BOOKMARKS.NO_TECHPREVIEW
                   )}`}
                   style={{ textAlign: 'center' }}
                   variant="h5"
@@ -212,7 +214,11 @@ export default function ReleaseOverview(props) {
                   sort="asc"
                   limit={10}
                   filterModel={{
-                    items: [BOOKMARKS.RUN_10],
+                    items: [
+                      BOOKMARKS.RUN_10,
+                      BOOKMARKS.NO_NEVER_STABLE,
+                      BOOKMARKS.NO_TECHPREVIEW,
+                    ],
                   }}
                   pageSize={5}
                   release={props.release}
@@ -228,7 +234,9 @@ export default function ReleaseOverview(props) {
                   to={`/jobs/${
                     props.release
                   }?period=twoDay&sortField=net_improvement&sort=asc&${queryForBookmark(
-                    BOOKMARKS.RUN_1
+                    BOOKMARKS.RUN_1,
+                    BOOKMARKS.NO_NEVER_STABLE,
+                    BOOKMARKS.NO_TECHPREVIEW
                   )}`}
                   variant="h5"
                 >
@@ -244,7 +252,11 @@ export default function ReleaseOverview(props) {
                   sort="asc"
                   limit={10}
                   filterModel={{
-                    items: [BOOKMARKS.RUN_1],
+                    items: [
+                      BOOKMARKS.RUN_1,
+                      BOOKMARKS.NO_NEVER_STABLE,
+                      BOOKMARKS.NO_TECHPREVIEW,
+                    ],
                   }}
                   pageSize={5}
                   period="twoDay"

--- a/sippy-ng/src/releases/__snapshots__/Install.test.js.snap
+++ b/sippy-ng/src/releases/__snapshots__/Install.test.js.snap
@@ -228,7 +228,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="Overall"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22Overall%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22Overall%22%7D%5D%7D">
                 Overall
               </a>
             </p>
@@ -547,7 +547,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="authentication"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22authentication%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22authentication%22%7D%5D%7D">
                 authentication
               </a>
             </p>
@@ -866,7 +866,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="baremetal"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22baremetal%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22baremetal%22%7D%5D%7D">
                 baremetal
               </a>
             </p>
@@ -1185,7 +1185,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="cloud-controller-manager"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22cloud-controller-manager%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22cloud-controller-manager%22%7D%5D%7D">
                 cloud-controller-manager
               </a>
             </p>
@@ -1504,7 +1504,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="cloud-credential"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22cloud-credential%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22cloud-credential%22%7D%5D%7D">
                 cloud-credential
               </a>
             </p>
@@ -1823,7 +1823,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="cluster-autoscaler"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22cluster-autoscaler%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22cluster-autoscaler%22%7D%5D%7D">
                 cluster-autoscaler
               </a>
             </p>
@@ -2142,7 +2142,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="config-operator"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22config-operator%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22config-operator%22%7D%5D%7D">
                 config-operator
               </a>
             </p>
@@ -2461,7 +2461,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="console"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22console%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22console%22%7D%5D%7D">
                 console
               </a>
             </p>
@@ -2780,7 +2780,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="csi-snapshot-controller"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22csi-snapshot-controller%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22csi-snapshot-controller%22%7D%5D%7D">
                 csi-snapshot-controller
               </a>
             </p>
@@ -3099,7 +3099,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="dns"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22dns%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22dns%22%7D%5D%7D">
                 dns
               </a>
             </p>
@@ -3418,7 +3418,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="etcd"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22etcd%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22etcd%22%7D%5D%7D">
                 etcd
               </a>
             </p>
@@ -3737,7 +3737,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="image-registry"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22image-registry%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22image-registry%22%7D%5D%7D">
                 image-registry
               </a>
             </p>
@@ -4056,7 +4056,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="ingress"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22ingress%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22ingress%22%7D%5D%7D">
                 ingress
               </a>
             </p>
@@ -4375,7 +4375,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="insights"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22insights%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22insights%22%7D%5D%7D">
                 insights
               </a>
             </p>
@@ -4694,7 +4694,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="kube-apiserver"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22kube-apiserver%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22kube-apiserver%22%7D%5D%7D">
                 kube-apiserver
               </a>
             </p>
@@ -5013,7 +5013,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="kube-controller-manager"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22kube-controller-manager%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22kube-controller-manager%22%7D%5D%7D">
                 kube-controller-manager
               </a>
             </p>
@@ -5332,7 +5332,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="kube-scheduler"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22kube-scheduler%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22kube-scheduler%22%7D%5D%7D">
                 kube-scheduler
               </a>
             </p>
@@ -5651,7 +5651,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="kube-storage-version-migrator"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22kube-storage-version-migrator%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22kube-storage-version-migrator%22%7D%5D%7D">
                 kube-storage-version-migrator
               </a>
             </p>
@@ -5970,7 +5970,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="machine-api"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22machine-api%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22machine-api%22%7D%5D%7D">
                 machine-api
               </a>
             </p>
@@ -6289,7 +6289,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="machine-approver"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22machine-approver%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22machine-approver%22%7D%5D%7D">
                 machine-approver
               </a>
             </p>
@@ -6608,7 +6608,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="machine-config"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22machine-config%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22machine-config%22%7D%5D%7D">
                 machine-config
               </a>
             </p>
@@ -6927,7 +6927,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="marketplace"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22marketplace%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22marketplace%22%7D%5D%7D">
                 marketplace
               </a>
             </p>
@@ -7246,7 +7246,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="monitoring"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22monitoring%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22monitoring%22%7D%5D%7D">
                 monitoring
               </a>
             </p>
@@ -7565,7 +7565,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="network"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22network%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22network%22%7D%5D%7D">
                 network
               </a>
             </p>
@@ -7884,7 +7884,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="node-tuning"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22node-tuning%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22node-tuning%22%7D%5D%7D">
                 node-tuning
               </a>
             </p>
@@ -8203,7 +8203,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="openshift-apiserver"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22openshift-apiserver%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22openshift-apiserver%22%7D%5D%7D">
                 openshift-apiserver
               </a>
             </p>
@@ -8522,7 +8522,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="openshift-controller-manager"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22openshift-controller-manager%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22openshift-controller-manager%22%7D%5D%7D">
                 openshift-controller-manager
               </a>
             </p>
@@ -8841,7 +8841,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="openshift-samples"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22openshift-samples%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22openshift-samples%22%7D%5D%7D">
                 openshift-samples
               </a>
             </p>
@@ -9160,7 +9160,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="operator-lifecycle-manager"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator-lifecycle-manager%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator-lifecycle-manager%22%7D%5D%7D">
                 operator-lifecycle-manager
               </a>
             </p>
@@ -9479,7 +9479,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="operator-lifecycle-manager-catalog"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator-lifecycle-manager-catalog%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator-lifecycle-manager-catalog%22%7D%5D%7D">
                 operator-lifecycle-manager-catalog
               </a>
             </p>
@@ -9798,7 +9798,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="operator-lifecycle-manager-packageserver"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator-lifecycle-manager-packageserver%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator-lifecycle-manager-packageserver%22%7D%5D%7D">
                 operator-lifecycle-manager-packageserver
               </a>
             </p>
@@ -10117,7 +10117,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="page"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22page%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22page%22%7D%5D%7D">
                 page
               </a>
             </p>
@@ -10436,7 +10436,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="service-ca"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22service-ca%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22service-ca%22%7D%5D%7D">
                 service-ca
               </a>
             </p>
@@ -10755,7 +10755,7 @@ exports[`install should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="storage"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22storage%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22storage%22%7D%5D%7D">
                 storage
               </a>
             </p>

--- a/sippy-ng/src/releases/__snapshots__/ReleaseOverview.test.js.snap
+++ b/sippy-ng/src/releases/__snapshots__/ReleaseOverview.test.js.snap
@@ -236,7 +236,7 @@ exports[`release-overview should render correctly 1`] = `
             <div class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3">
               <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                 <a class="MuiBox-root MuiBox-root-221"
-                   href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22s390x%22%7D%5D%7D"
+                   href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22s390x%22%7D%5D%7D"
                 >
                   <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-220 MuiPaper-elevation5 MuiPaper-rounded"
                        style="background-color: rgb(229, 115, 115);"
@@ -272,7 +272,7 @@ exports[`release-overview should render correctly 1`] = `
               </div>
               <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                 <a class="MuiBox-root MuiBox-root-223"
-                   href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ppc64le%22%7D%5D%7D"
+                   href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ppc64le%22%7D%5D%7D"
                 >
                   <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-222 MuiPaper-elevation5 MuiPaper-rounded"
                        style="background-color: rgb(236, 132, 105);"
@@ -308,7 +308,7 @@ exports[`release-overview should render correctly 1`] = `
               </div>
               <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                 <a class="MuiBox-root MuiBox-root-225"
-                   href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22osd%22%7D%5D%7D"
+                   href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22osd%22%7D%5D%7D"
                 >
                   <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-224 MuiPaper-elevation5 MuiPaper-rounded"
                        style="background-color: rgb(242, 149, 96);"
@@ -344,7 +344,7 @@ exports[`release-overview should render correctly 1`] = `
               </div>
               <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                 <a class="MuiBox-root MuiBox-root-227"
-                   href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22upgrade%22%7D%5D%7D"
+                   href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22upgrade%22%7D%5D%7D"
                 >
                   <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-226 MuiPaper-elevation5 MuiPaper-rounded"
                        style="background-color: rgb(242, 150, 95);"
@@ -380,7 +380,7 @@ exports[`release-overview should render correctly 1`] = `
               </div>
               <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                 <a class="MuiBox-root MuiBox-root-229"
-                   href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22proxy%22%7D%5D%7D"
+                   href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22proxy%22%7D%5D%7D"
                 >
                   <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-228 MuiPaper-elevation5 MuiPaper-rounded"
                        style="background-color: rgb(243, 150, 95);"
@@ -416,7 +416,7 @@ exports[`release-overview should render correctly 1`] = `
               </div>
               <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                 <a class="MuiBox-root MuiBox-root-231"
-                   href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-ipi%22%7D%5D%7D"
+                   href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-ipi%22%7D%5D%7D"
                 >
                   <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-230 MuiPaper-elevation5 MuiPaper-rounded"
                        style="background-color: rgb(246, 160, 90);"
@@ -485,7 +485,7 @@ exports[`release-overview should render correctly 1`] = `
                   >
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-233"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22azure%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22azure%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-232 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(248, 164, 87);"
@@ -521,7 +521,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-235"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22compact%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22compact%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-234 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(250, 169, 85);"
@@ -557,7 +557,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-237"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovn%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovn%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-236 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(251, 172, 83);"
@@ -593,7 +593,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-239"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-ipi%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-ipi%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-238 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(253, 177, 80);"
@@ -629,7 +629,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-241"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22aws%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22aws%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-240 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(254, 180, 78);"
@@ -665,7 +665,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-243"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22gcp%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22gcp%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-242 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(254, 182, 78);"
@@ -701,7 +701,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-245"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22single-node%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22single-node%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-244 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(251, 183, 79);"
@@ -737,7 +737,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-247"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22realtime%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22realtime%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-246 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(245, 184, 81);"
@@ -773,7 +773,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-249"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-upi%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-upi%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-248 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(189, 191, 106);"
@@ -809,7 +809,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-251"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22serial%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22serial%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-250 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(183, 192, 109);"
@@ -845,7 +845,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-253"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovirt%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovirt%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-252 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(179, 193, 110);"
@@ -881,7 +881,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-255"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22openstack%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22openstack%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-254 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(175, 193, 112);"
@@ -917,7 +917,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-257"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-upi%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-upi%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-256 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(141, 197, 127);"
@@ -953,7 +953,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-259"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22fips%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22fips%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-258 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(129, 199, 132);"
@@ -989,7 +989,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-261"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-assisted%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-assisted%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-260 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(129, 199, 132);"
@@ -1025,7 +1025,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-263"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22promote%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22promote%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-262 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(129, 199, 132);"
@@ -1061,7 +1061,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-265"
-                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%5D%7D"
+                         href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%5D%7D"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-264 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgba(0, 0, 0, 0.38);"
@@ -1096,14 +1096,14 @@ exports[`release-overview should render correctly 1`] = `
         >
           <a class="MuiTypography-root MuiTypography-h5"
              style="text-align: center;"
-             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
+             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22techpreview%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
           >
             Most regressed jobs
             <svg class="MuiSvgIcon-root"
                  focusable="false"
                  viewbox="0 0 24 24"
                  aria-hidden="true"
-                 title="Shows the most regressed items this week vs. last week, for those with more than 10 runs"
+                 title="Shows the most regressed items this week vs. last week, for those with more than 10 runs, excluding never-stable and techpreview."
             >
               <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z">
               </path>
@@ -1308,17 +1308,17 @@ exports[`release-overview should render correctly 1`] = `
                           <div class="MuiDataGrid-renderingZone"
                                style="max-height: 350px; width: 200px; transform: translate3d(-0px, -0px, 0);"
                           >
-                            <div data-id="2"
+                            <div data-id="39"
                                  data-rowindex="0"
                                  role="row"
-                                 class="Mui-even JobTable-row-percent-0-16 MuiDataGrid-row"
+                                 class="Mui-even JobTable-row-percent-38-54 MuiDataGrid-row"
                                  aria-rowindex="2"
                                  aria-selected="false"
                                  style="max-height: 70px; min-height: 70px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
-                                   data-value="periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance"
+                                   data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4"
                                    data-field="name"
                                    data-rowindex="0"
                                    data-colindex="0"
@@ -1330,17 +1330,17 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="job-name">
-                                  <a title="periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance"
+                                  <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4"
                                      class
-                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance%22%7D%5D%7D"
+                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4%22%7D%5D%7D"
                                   >
-                                    openshift-ipi-azure-arcconformance
+                                    e2e-metal-ipi-serial-ipv4
                                   </a>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                    role="cell"
-                                   data-value="0"
+                                   data-value="38.46153846153847"
                                    data-field="current_pass_percentage"
                                    data-rowindex="0"
                                    data-colindex="1"
@@ -1352,16 +1352,16 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="percentage-cell">
-                                  0%
+                                  38%
                                   <br>
                                   <small>
-                                    (40 runs)
+                                    (13 runs)
                                   </small>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                    role="cell"
-                                   data-value="0"
+                                   data-value="-28.20512820512819"
                                    data-field="net_improvement"
                                    data-rowindex="0"
                                    data-colindex="2"
@@ -1376,11 +1376,11 @@ exports[`release-overview should render correctly 1`] = `
                                      focusable="false"
                                      viewbox="0 0 24 24"
                                      aria-hidden="true"
-                                     data-icon="SyncAltRoundedIcon"
-                                     style="color: grey;"
-                                     title="0.00%"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-28.21%"
                                 >
-                                  <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                   </path>
                                 </svg>
                               </div>
@@ -1389,17 +1389,17 @@ exports[`release-overview should render correctly 1`] = `
                               >
                               </div>
                             </div>
-                            <div data-id="3"
+                            <div data-id="62"
                                  data-rowindex="1"
                                  role="row"
-                                 class="Mui-odd JobTable-row-percent-0-16 MuiDataGrid-row"
+                                 class="Mui-odd JobTable-row-percent-69-85 MuiDataGrid-row"
                                  aria-rowindex="3"
                                  aria-selected="false"
                                  style="max-height: 70px; min-height: 70px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
-                                   data-value="release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8"
+                                   data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp"
                                    data-field="name"
                                    data-rowindex="1"
                                    data-colindex="0"
@@ -1411,17 +1411,17 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="job-name">
-                                  <a title="release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8"
+                                  <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp"
                                      class
-                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8%22%7D%5D%7D"
+                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp%22%7D%5D%7D"
                                   >
-                                    release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8
+                                    e2e-gcp
                                   </a>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                    role="cell"
-                                   data-value="0"
+                                   data-value="69.23076923076923"
                                    data-field="current_pass_percentage"
                                    data-rowindex="1"
                                    data-colindex="1"
@@ -1433,7 +1433,7 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="percentage-cell">
-                                  0%
+                                  69%
                                   <br>
                                   <small>
                                     (13 runs)
@@ -1442,7 +1442,7 @@ exports[`release-overview should render correctly 1`] = `
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                    role="cell"
-                                   data-value="0"
+                                   data-value="-23.07692307692308"
                                    data-field="net_improvement"
                                    data-rowindex="1"
                                    data-colindex="2"
@@ -1457,11 +1457,11 @@ exports[`release-overview should render correctly 1`] = `
                                      focusable="false"
                                      viewbox="0 0 24 24"
                                      aria-hidden="true"
-                                     data-icon="SyncAltRoundedIcon"
-                                     style="color: grey;"
-                                     title="0.00%"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-23.08%"
                                 >
-                                  <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                   </path>
                                 </svg>
                               </div>
@@ -1470,17 +1470,17 @@ exports[`release-overview should render correctly 1`] = `
                               >
                               </div>
                             </div>
-                            <div data-id="20"
+                            <div data-id="33"
                                  data-rowindex="2"
                                  role="row"
-                                 class="Mui-even JobTable-row-percent-15-31 MuiDataGrid-row"
+                                 class="Mui-even JobTable-row-percent-33-49 MuiDataGrid-row"
                                  aria-rowindex="4"
                                  aria-selected="false"
                                  style="max-height: 70px; min-height: 70px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
-                                   data-value="release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8"
+                                   data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade"
                                    data-field="name"
                                    data-rowindex="2"
                                    data-colindex="0"
@@ -1492,17 +1492,17 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="job-name">
-                                  <a title="release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8"
+                                  <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade"
                                      class
-                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8%22%7D%5D%7D"
+                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade%22%7D%5D%7D"
                                   >
-                                    release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8
+                                    e2e-aws-upgrade
                                   </a>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                    role="cell"
-                                   data-value="15.384615384615385"
+                                   data-value="33.33333333333333"
                                    data-field="current_pass_percentage"
                                    data-rowindex="2"
                                    data-colindex="1"
@@ -1514,16 +1514,16 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="percentage-cell">
-                                  15%
+                                  33%
                                   <br>
                                   <small>
-                                    (13 runs)
+                                    (15 runs)
                                   </small>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                    role="cell"
-                                   data-value="0"
+                                   data-value="-20.000000000000007"
                                    data-field="net_improvement"
                                    data-rowindex="2"
                                    data-colindex="2"
@@ -1538,11 +1538,11 @@ exports[`release-overview should render correctly 1`] = `
                                      focusable="false"
                                      viewbox="0 0 24 24"
                                      aria-hidden="true"
-                                     data-icon="SyncAltRoundedIcon"
-                                     style="color: grey;"
-                                     title="0.00%"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-20.00%"
                                 >
-                                  <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                   </path>
                                 </svg>
                               </div>
@@ -1551,17 +1551,17 @@ exports[`release-overview should render correctly 1`] = `
                               >
                               </div>
                             </div>
-                            <div data-id="22"
+                            <div data-id="28"
                                  data-rowindex="3"
                                  role="row"
-                                 class="Mui-odd JobTable-row-percent-23-39 MuiDataGrid-row"
+                                 class="Mui-odd JobTable-row-percent-31-47 MuiDataGrid-row"
                                  aria-rowindex="5"
                                  aria-selected="false"
                                  style="max-height: 70px; min-height: 70px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
-                                   data-value="periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade"
+                                   data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy"
                                    data-field="name"
                                    data-rowindex="3"
                                    data-colindex="0"
@@ -1573,17 +1573,17 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="job-name">
-                                  <a title="periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade"
+                                  <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy"
                                      class
-                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade%22%7D%5D%7D"
+                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy%22%7D%5D%7D"
                                   >
-                                    upgrade-from-stable-4.7-e2e-metal-ipi-upgrade
+                                    e2e-aws-proxy
                                   </a>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                    role="cell"
-                                   data-value="23.076923076923077"
+                                   data-value="31.25"
                                    data-field="current_pass_percentage"
                                    data-rowindex="3"
                                    data-colindex="1"
@@ -1595,16 +1595,16 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="percentage-cell">
-                                  23%
+                                  31%
                                   <br>
                                   <small>
-                                    (13 runs)
+                                    (16 runs)
                                   </small>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                    role="cell"
-                                   data-value="0"
+                                   data-value="-18.75"
                                    data-field="net_improvement"
                                    data-rowindex="3"
                                    data-colindex="2"
@@ -1619,11 +1619,11 @@ exports[`release-overview should render correctly 1`] = `
                                      focusable="false"
                                      viewbox="0 0 24 24"
                                      aria-hidden="true"
-                                     data-icon="SyncAltRoundedIcon"
-                                     style="color: grey;"
-                                     title="0.00%"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-18.75%"
                                 >
-                                  <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                   </path>
                                 </svg>
                               </div>
@@ -1632,17 +1632,17 @@ exports[`release-overview should render correctly 1`] = `
                               >
                               </div>
                             </div>
-                            <div data-id="25"
+                            <div data-id="70"
                                  data-rowindex="4"
                                  role="row"
-                                 class="Mui-even JobTable-row-percent-25-41 MuiDataGrid-row"
+                                 class="Mui-even JobTable-row-percent-77-93 MuiDataGrid-row"
                                  aria-rowindex="6"
                                  aria-selected="false"
                                  style="max-height: 70px; min-height: 70px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
-                                   data-value="periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-upgrade"
+                                   data-value="release-openshift-ocp-installer-e2e-aws-ovn-4.8"
                                    data-field="name"
                                    data-rowindex="4"
                                    data-colindex="0"
@@ -1654,17 +1654,17 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="job-name">
-                                  <a title="periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-upgrade"
+                                  <a title="release-openshift-ocp-installer-e2e-aws-ovn-4.8"
                                      class
-                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-upgrade%22%7D%5D%7D"
+                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-e2e-aws-ovn-4.8%22%7D%5D%7D"
                                   >
-                                    upgrade-from-stable-4.7-e2e-gcp-upgrade
+                                    release-openshift-ocp-installer-e2e-aws-ovn-4.8
                                   </a>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                    role="cell"
-                                   data-value="25"
+                                   data-value="76.92307692307693"
                                    data-field="current_pass_percentage"
                                    data-rowindex="4"
                                    data-colindex="1"
@@ -1676,16 +1676,16 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="percentage-cell">
-                                  25%
+                                  77%
                                   <br>
                                   <small>
-                                    (24 runs)
+                                    (13 runs)
                                   </small>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                    role="cell"
-                                   data-value="0"
+                                   data-value="-15.384615384615373"
                                    data-field="net_improvement"
                                    data-rowindex="4"
                                    data-colindex="2"
@@ -1700,11 +1700,11 @@ exports[`release-overview should render correctly 1`] = `
                                      focusable="false"
                                      viewbox="0 0 24 24"
                                      aria-hidden="true"
-                                     data-icon="SyncAltRoundedIcon"
-                                     style="color: grey;"
-                                     title="0.00%"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-15.38%"
                                 >
-                                  <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                   </path>
                                 </svg>
                               </div>
@@ -1817,14 +1817,14 @@ exports[`release-overview should render correctly 1`] = `
              style="text-align: center;"
         >
           <a class="MuiTypography-root MuiTypography-h5"
-             href="/jobs/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
+             href="/jobs/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22techpreview%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
           >
             Most regressed jobs (two day)
             <svg class="MuiSvgIcon-root"
                  focusable="false"
                  viewbox="0 0 24 24"
                  aria-hidden="true"
-                 title="Shows the last 2 days compared to the last 7 days, sorted by most regressed."
+                 title="Shows the last 2 days compared to the last 7 days, sorted by most regressed, excluding never-stable and techpreview."
             >
               <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z">
               </path>
@@ -2029,7 +2029,7 @@ exports[`release-overview should render correctly 1`] = `
                           <div class="MuiDataGrid-renderingZone"
                                style="max-height: 350px; width: 200px; transform: translate3d(-0px, -0px, 0);"
                           >
-                            <div data-id="0"
+                            <div data-id="37"
                                  data-rowindex="0"
                                  role="row"
                                  class="Mui-even JobTable-row-percent-0-16 MuiDataGrid-row"
@@ -2039,90 +2039,9 @@ exports[`release-overview should render correctly 1`] = `
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
-                                   data-value="periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift"
-                                   data-field="name"
-                                   data-rowindex="0"
-                                   data-colindex="0"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
-                                   tabindex="-1"
-                              >
-                                <div class="job-name">
-                                  <a title="periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift"
-                                     class
-                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift%22%7D%5D%7D"
-                                  >
-                                    e2e-aws-hypershift
-                                  </a>
-                                </div>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="0"
-                                   data-field="current_pass_percentage"
-                                   data-rowindex="0"
-                                   data-colindex="1"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
-                                   tabindex="-1"
-                              >
-                                <div class="percentage-cell">
-                                  0%
-                                  <br>
-                                  <small>
-                                    (1 runs)
-                                  </small>
-                                </div>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="0"
-                                   data-field="net_improvement"
-                                   data-rowindex="0"
-                                   data-colindex="2"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
-                                   tabindex="-1"
-                              >
-                                <svg class="MuiSvgIcon-root"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                     data-icon="SyncAltRoundedIcon"
-                                     style="color: grey;"
-                                     title="0.00%"
-                                >
-                                  <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
-                                  </path>
-                                </svg>
-                              </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
-                                   class="MuiDataGrid-cell"
-                              >
-                              </div>
-                            </div>
-                            <div data-id="11"
-                                 data-rowindex="1"
-                                 role="row"
-                                 class="Mui-odd JobTable-row-percent-0-16 MuiDataGrid-row"
-                                 aria-rowindex="3"
-                                 aria-selected="false"
-                                 style="max-height: 70px; min-height: 70px;"
-                            >
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                   role="cell"
                                    data-value="periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade"
                                    data-field="name"
-                                   data-rowindex="1"
+                                   data-rowindex="0"
                                    data-colindex="0"
                                    data-rowselected="false"
                                    data-editable="false"
@@ -2134,7 +2053,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <div class="job-name">
                                   <a title="periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade"
                                      class
-                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade%22%7D%5D%7D"
+                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade%22%7D%5D%7D"
                                   >
                                     e2e-aws-upgrade
                                   </a>
@@ -2144,7 +2063,7 @@ exports[`release-overview should render correctly 1`] = `
                                    role="cell"
                                    data-value="0"
                                    data-field="current_pass_percentage"
-                                   data-rowindex="1"
+                                   data-rowindex="0"
                                    data-colindex="1"
                                    data-rowselected="false"
                                    data-editable="false"
@@ -2163,9 +2082,9 @@ exports[`release-overview should render correctly 1`] = `
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                    role="cell"
-                                   data-value="0"
+                                   data-value="-66.66666666666666"
                                    data-field="net_improvement"
-                                   data-rowindex="1"
+                                   data-rowindex="0"
                                    data-colindex="2"
                                    data-rowselected="false"
                                    data-editable="false"
@@ -2178,11 +2097,11 @@ exports[`release-overview should render correctly 1`] = `
                                      focusable="false"
                                      viewbox="0 0 24 24"
                                      aria-hidden="true"
-                                     data-icon="SyncAltRoundedIcon"
-                                     style="color: grey;"
-                                     title="0.00%"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-66.67%"
                                 >
-                                  <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                   </path>
                                 </svg>
                               </div>
@@ -2191,19 +2110,19 @@ exports[`release-overview should render correctly 1`] = `
                               >
                               </div>
                             </div>
-                            <div data-id="12"
-                                 data-rowindex="2"
+                            <div data-id="33"
+                                 data-rowindex="1"
                                  role="row"
-                                 class="Mui-even JobTable-row-percent-0-16 MuiDataGrid-row"
-                                 aria-rowindex="4"
+                                 class="Mui-odd JobTable-row-percent-0-16 MuiDataGrid-row"
+                                 aria-rowindex="3"
                                  aria-selected="false"
                                  style="max-height: 70px; min-height: 70px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
-                                   data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node"
+                                   data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-libvirt-cert-rotation"
                                    data-field="name"
-                                   data-rowindex="2"
+                                   data-rowindex="1"
                                    data-colindex="0"
                                    data-rowselected="false"
                                    data-editable="false"
@@ -2213,11 +2132,11 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="job-name">
-                                  <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node"
+                                  <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-libvirt-cert-rotation"
                                      class
-                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node%22%7D%5D%7D"
+                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-libvirt-cert-rotation%22%7D%5D%7D"
                                   >
-                                    e2e-aws-single-node
+                                    e2e-gcp-libvirt-cert-rotation
                                   </a>
                                 </div>
                               </div>
@@ -2225,7 +2144,7 @@ exports[`release-overview should render correctly 1`] = `
                                    role="cell"
                                    data-value="0"
                                    data-field="current_pass_percentage"
-                                   data-rowindex="2"
+                                   data-rowindex="1"
                                    data-colindex="1"
                                    data-rowselected="false"
                                    data-editable="false"
@@ -2244,9 +2163,9 @@ exports[`release-overview should render correctly 1`] = `
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                    role="cell"
-                                   data-value="0"
+                                   data-value="-57.14285714285714"
                                    data-field="net_improvement"
-                                   data-rowindex="2"
+                                   data-rowindex="1"
                                    data-colindex="2"
                                    data-rowselected="false"
                                    data-editable="false"
@@ -2259,11 +2178,11 @@ exports[`release-overview should render correctly 1`] = `
                                      focusable="false"
                                      viewbox="0 0 24 24"
                                      aria-hidden="true"
-                                     data-icon="SyncAltRoundedIcon"
-                                     style="color: grey;"
-                                     title="0.00%"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-57.14%"
                                 >
-                                  <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                   </path>
                                 </svg>
                               </div>
@@ -2272,11 +2191,11 @@ exports[`release-overview should render correctly 1`] = `
                               >
                               </div>
                             </div>
-                            <div data-id="24"
-                                 data-rowindex="3"
+                            <div data-id="3"
+                                 data-rowindex="2"
                                  role="row"
-                                 class="Mui-odd JobTable-row-percent-0-16 MuiDataGrid-row"
-                                 aria-rowindex="5"
+                                 class="Mui-even JobTable-row-percent-0-16 MuiDataGrid-row"
+                                 aria-rowindex="4"
                                  aria-selected="false"
                                  style="max-height: 70px; min-height: 70px;"
                             >
@@ -2284,7 +2203,7 @@ exports[`release-overview should render correctly 1`] = `
                                    role="cell"
                                    data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia"
                                    data-field="name"
-                                   data-rowindex="3"
+                                   data-rowindex="2"
                                    data-colindex="0"
                                    data-rowselected="false"
                                    data-editable="false"
@@ -2296,7 +2215,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <div class="job-name">
                                   <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia"
                                      class
-                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia%22%7D%5D%7D"
+                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia%22%7D%5D%7D"
                                   >
                                     e2e-metal-ipi-virtualmedia
                                   </a>
@@ -2306,7 +2225,7 @@ exports[`release-overview should render correctly 1`] = `
                                    role="cell"
                                    data-value="0"
                                    data-field="current_pass_percentage"
-                                   data-rowindex="3"
+                                   data-rowindex="2"
                                    data-colindex="1"
                                    data-rowselected="false"
                                    data-editable="false"
@@ -2325,7 +2244,88 @@ exports[`release-overview should render correctly 1`] = `
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                    role="cell"
-                                   data-value="0"
+                                   data-value="-50"
+                                   data-field="net_improvement"
+                                   data-rowindex="2"
+                                   data-colindex="2"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="3"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
+                                   tabindex="-1"
+                              >
+                                <svg class="MuiSvgIcon-root"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-50.00%"
+                                >
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                  </path>
+                                </svg>
+                              </div>
+                              <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
+                                   class="MuiDataGrid-cell"
+                              >
+                              </div>
+                            </div>
+                            <div data-id="72"
+                                 data-rowindex="3"
+                                 role="row"
+                                 class="Mui-odd JobTable-row-percent-50-66 MuiDataGrid-row"
+                                 aria-rowindex="5"
+                                 aria-selected="false"
+                                 style="max-height: 70px; min-height: 70px;"
+                            >
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                   role="cell"
+                                   data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted"
+                                   data-field="name"
+                                   data-rowindex="3"
+                                   data-colindex="0"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="1"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
+                                   tabindex="-1"
+                              >
+                                <div class="job-name">
+                                  <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted"
+                                     class
+                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted%22%7D%5D%7D"
+                                  >
+                                    e2e-metal-assisted
+                                  </a>
+                                </div>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="50"
+                                   data-field="current_pass_percentage"
+                                   data-rowindex="3"
+                                   data-colindex="1"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="2"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
+                                   tabindex="-1"
+                              >
+                                <div class="percentage-cell">
+                                  50%
+                                  <br>
+                                  <small>
+                                    (2 runs)
+                                  </small>
+                                </div>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="-42.85714285714286"
                                    data-field="net_improvement"
                                    data-rowindex="3"
                                    data-colindex="2"
@@ -2340,11 +2340,11 @@ exports[`release-overview should render correctly 1`] = `
                                      focusable="false"
                                      viewbox="0 0 24 24"
                                      aria-hidden="true"
-                                     data-icon="SyncAltRoundedIcon"
-                                     style="color: grey;"
-                                     title="0.00%"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-42.86%"
                                 >
-                                  <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                   </path>
                                 </svg>
                               </div>
@@ -2353,7 +2353,7 @@ exports[`release-overview should render correctly 1`] = `
                               >
                               </div>
                             </div>
-                            <div data-id="30"
+                            <div data-id="53"
                                  data-rowindex="4"
                                  role="row"
                                  class="Mui-even JobTable-row-percent-0-16 MuiDataGrid-row"
@@ -2363,7 +2363,7 @@ exports[`release-overview should render correctly 1`] = `
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
-                                   data-value="release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8"
+                                   data-value="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack"
                                    data-field="name"
                                    data-rowindex="4"
                                    data-colindex="0"
@@ -2375,11 +2375,11 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="job-name">
-                                  <a title="release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8"
+                                  <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack"
                                      class
-                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8%22%7D%5D%7D"
+                                     href="/jobs/4.8/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack%22%7D%5D%7D"
                                   >
-                                    release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8
+                                    e2e-metal-ipi-ovn-dualstack
                                   </a>
                                 </div>
                               </div>
@@ -2406,7 +2406,7 @@ exports[`release-overview should render correctly 1`] = `
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
                                    role="cell"
-                                   data-value="0"
+                                   data-value="-38.46153846153847"
                                    data-field="net_improvement"
                                    data-rowindex="4"
                                    data-colindex="2"
@@ -2421,11 +2421,11 @@ exports[`release-overview should render correctly 1`] = `
                                      focusable="false"
                                      viewbox="0 0 24 24"
                                      aria-hidden="true"
-                                     data-icon="SyncAltRoundedIcon"
-                                     style="color: grey;"
-                                     title="0.00%"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-38.46%"
                                 >
-                                  <path d="M21.65 7.65l-2.79-2.79c-.32-.32-.86-.1-.86.35V7H4c-.55 0-1 .45-1 1s.45 1 1 1h14v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.19.2-.51.01-.7zM2.35 16.35l2.79 2.79c.32.32.86.1.86-.35V17h14c.55 0 1-.45 1-1s-.45-1-1-1H6v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.19-.2.51-.01.7z">
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
                                   </path>
                                 </svg>
                               </div>
@@ -2539,14 +2539,14 @@ exports[`release-overview should render correctly 1`] = `
         >
           <a class="MuiTypography-root MuiTypography-h5"
              style="text-align: center;"
-             href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D&amp;sortField=net_improvement&amp;sort=asc"
+             href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D&amp;sortField=net_improvement&amp;sort=asc"
           >
             Most regressed tests
             <svg class="MuiSvgIcon-root"
                  focusable="false"
                  viewbox="0 0 24 24"
                  aria-hidden="true"
-                 title="Shows the most regressed items this week vs. last week, for those with more than 10 runs"
+                 title="Shows the most regressed items this week vs. last week, for those with more than 10 runs, excluding never-stable and techpreview."
             >
               <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z">
               </path>
@@ -3251,14 +3251,14 @@ exports[`release-overview should render correctly 1`] = `
         >
           <a class="MuiTypography-root MuiTypography-h5"
              style="text-align: center;"
-             href="/tests/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
+             href="/tests/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
           >
             Most regressed tests (two day)
             <svg class="MuiSvgIcon-root"
                  focusable="false"
                  viewbox="0 0 24 24"
                  aria-hidden="true"
-                 title="Shows the last 2 days compared to the last 7 days, sorted by most regressed."
+                 title="Shows the last 2 days compared to the last 7 days, sorted by most regressed, excluding never-stable and techpreview."
             >
               <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z">
               </path>
@@ -3963,7 +3963,7 @@ exports[`release-overview should render correctly 1`] = `
         >
           <a class="MuiTypography-root MuiTypography-h5"
              style="text-align: center;"
-             href="/tests/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22id%22%3A5%2C%22columnField%22%3A%22bugs%22%2C%22operatorValue%22%3A%22%3D%22%2C%22value%22%3A%220%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
+             href="/tests/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22columnField%22%3A%22bugs%22%2C%22operatorValue%22%3A%22%3D%22%2C%22value%22%3A%220%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
           >
             Top failing tests without a bug
             <svg class="MuiSvgIcon-root"
@@ -4675,7 +4675,7 @@ exports[`release-overview should render correctly 1`] = `
         >
           <a class="MuiTypography-root MuiTypography-h5"
              style="text-align: center;"
-             href="/tests/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A8%2C%22columnField%22%3A%22tags%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22trt%22%7D%5D%7D"
+             href="/tests/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22tags%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22trt%22%7D%5D%7D"
           >
             Curated by TRT
             <svg class="MuiSvgIcon-root"

--- a/sippy-ng/src/releases/__snapshots__/Upgrades.test.js.snap
+++ b/sippy-ng/src/releases/__snapshots__/Upgrades.test.js.snap
@@ -196,7 +196,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="Overall"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22Overall%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22Overall%22%7D%5D%7D">
                 Overall
               </a>
             </p>
@@ -389,7 +389,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="[sig-api-machinery] Kubernetes APIs remain available for new connections"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20Kubernetes%20APIs%20remain%20available%20for%20new%20connections%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20Kubernetes%20APIs%20remain%20available%20for%20new%20connections%22%7D%5D%7D">
                 [sig-api-machinery] Kubernetes APIs remain available for new connections
               </a>
             </p>
@@ -582,7 +582,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="[sig-api-machinery] Kubernetes APIs remain available with reused connections"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20Kubernetes%20APIs%20remain%20available%20with%20reused%20connections%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20Kubernetes%20APIs%20remain%20available%20with%20reused%20connections%22%7D%5D%7D">
                 [sig-api-machinery] Kubernetes APIs remain available with reused connections
               </a>
             </p>
@@ -775,7 +775,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="[sig-api-machinery] OAuth APIs remain available for new connections"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20OAuth%20APIs%20remain%20available%20for%20new%20connections%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20OAuth%20APIs%20remain%20available%20for%20new%20connections%22%7D%5D%7D">
                 [sig-api-machinery] OAuth APIs remain available for new connections
               </a>
             </p>
@@ -968,7 +968,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="[sig-api-machinery] OAuth APIs remain available with reused connections"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20OAuth%20APIs%20remain%20available%20with%20reused%20connections%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20OAuth%20APIs%20remain%20available%20with%20reused%20connections%22%7D%5D%7D">
                 [sig-api-machinery] OAuth APIs remain available with reused connections
               </a>
             </p>
@@ -1161,7 +1161,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="[sig-api-machinery] OpenShift APIs remain available for new connections"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20OpenShift%20APIs%20remain%20available%20for%20new%20connections%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20OpenShift%20APIs%20remain%20available%20for%20new%20connections%22%7D%5D%7D">
                 [sig-api-machinery] OpenShift APIs remain available for new connections
               </a>
             </p>
@@ -1354,7 +1354,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="[sig-api-machinery] OpenShift APIs remain available with reused connections"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20OpenShift%20APIs%20remain%20available%20with%20reused%20connections%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20OpenShift%20APIs%20remain%20available%20with%20reused%20connections%22%7D%5D%7D">
                 [sig-api-machinery] OpenShift APIs remain available with reused connections
               </a>
             </p>
@@ -1547,7 +1547,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="[sig-cluster-lifecycle] Cluster completes upgrade"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-cluster-lifecycle%5D%20Cluster%20completes%20upgrade%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-cluster-lifecycle%5D%20Cluster%20completes%20upgrade%22%7D%5D%7D">
                 [sig-cluster-lifecycle] Cluster completes upgrade
               </a>
             </p>
@@ -1740,7 +1740,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="[sig-cluster-lifecycle] Cluster version operator acknowledges upgrade"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-cluster-lifecycle%5D%20Cluster%20version%20operator%20acknowledges%20upgrade%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-cluster-lifecycle%5D%20Cluster%20version%20operator%20acknowledges%20upgrade%22%7D%5D%7D">
                 [sig-cluster-lifecycle] Cluster version operator acknowledges upgrade
               </a>
             </p>
@@ -1933,7 +1933,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="[sig-cluster-lifecycle] cluster upgrade should be fast"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-cluster-lifecycle%5D%20cluster%20upgrade%20should%20be%20fast%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-cluster-lifecycle%5D%20cluster%20upgrade%20should%20be%20fast%22%7D%5D%7D">
                 [sig-cluster-lifecycle] cluster upgrade should be fast
               </a>
             </p>
@@ -2126,7 +2126,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="[sig-mco] Machine config pools complete upgrade"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-mco%5D%20Machine%20config%20pools%20complete%20upgrade%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-mco%5D%20Machine%20config%20pools%20complete%20upgrade%22%7D%5D%7D">
                 [sig-mco] Machine config pools complete upgrade
               </a>
             </p>
@@ -2319,7 +2319,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="[sig-sippy] upgrade should work"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-sippy%5D%20upgrade%20should%20work%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-sippy%5D%20upgrade%20should%20work%22%7D%5D%7D">
                 [sig-sippy] upgrade should work
               </a>
             </p>
@@ -2512,7 +2512,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="authentication"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22authentication%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22authentication%22%7D%5D%7D">
                 authentication
               </a>
             </p>
@@ -2705,7 +2705,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="baremetal"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22baremetal%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22baremetal%22%7D%5D%7D">
                 baremetal
               </a>
             </p>
@@ -2898,7 +2898,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="cloud-controller-manager"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22cloud-controller-manager%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22cloud-controller-manager%22%7D%5D%7D">
                 cloud-controller-manager
               </a>
             </p>
@@ -3091,7 +3091,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="cloud-credential"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22cloud-credential%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22cloud-credential%22%7D%5D%7D">
                 cloud-credential
               </a>
             </p>
@@ -3284,7 +3284,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="cluster-autoscaler"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22cluster-autoscaler%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22cluster-autoscaler%22%7D%5D%7D">
                 cluster-autoscaler
               </a>
             </p>
@@ -3477,7 +3477,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="config-operator"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22config-operator%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22config-operator%22%7D%5D%7D">
                 config-operator
               </a>
             </p>
@@ -3670,7 +3670,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="console"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22console%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22console%22%7D%5D%7D">
                 console
               </a>
             </p>
@@ -3863,7 +3863,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="csi-snapshot-controller"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22csi-snapshot-controller%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22csi-snapshot-controller%22%7D%5D%7D">
                 csi-snapshot-controller
               </a>
             </p>
@@ -4056,7 +4056,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="dns"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22dns%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22dns%22%7D%5D%7D">
                 dns
               </a>
             </p>
@@ -4249,7 +4249,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="etcd"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22etcd%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22etcd%22%7D%5D%7D">
                 etcd
               </a>
             </p>
@@ -4442,7 +4442,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="image-registry"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22image-registry%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22image-registry%22%7D%5D%7D">
                 image-registry
               </a>
             </p>
@@ -4635,7 +4635,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="ingress"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22ingress%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22ingress%22%7D%5D%7D">
                 ingress
               </a>
             </p>
@@ -4828,7 +4828,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="insights"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22insights%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22insights%22%7D%5D%7D">
                 insights
               </a>
             </p>
@@ -5021,7 +5021,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="kube-apiserver"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22kube-apiserver%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22kube-apiserver%22%7D%5D%7D">
                 kube-apiserver
               </a>
             </p>
@@ -5214,7 +5214,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="kube-controller-manager"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22kube-controller-manager%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22kube-controller-manager%22%7D%5D%7D">
                 kube-controller-manager
               </a>
             </p>
@@ -5407,7 +5407,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="kube-scheduler"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22kube-scheduler%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22kube-scheduler%22%7D%5D%7D">
                 kube-scheduler
               </a>
             </p>
@@ -5600,7 +5600,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="kube-storage-version-migrator"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22kube-storage-version-migrator%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22kube-storage-version-migrator%22%7D%5D%7D">
                 kube-storage-version-migrator
               </a>
             </p>
@@ -5793,7 +5793,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="machine-api"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22machine-api%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22machine-api%22%7D%5D%7D">
                 machine-api
               </a>
             </p>
@@ -5986,7 +5986,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="machine-approver"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22machine-approver%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22machine-approver%22%7D%5D%7D">
                 machine-approver
               </a>
             </p>
@@ -6179,7 +6179,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="machine-config"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22machine-config%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22machine-config%22%7D%5D%7D">
                 machine-config
               </a>
             </p>
@@ -6372,7 +6372,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="marketplace"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22marketplace%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22marketplace%22%7D%5D%7D">
                 marketplace
               </a>
             </p>
@@ -6565,7 +6565,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="monitoring"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22monitoring%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22monitoring%22%7D%5D%7D">
                 monitoring
               </a>
             </p>
@@ -6758,7 +6758,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="network"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22network%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22network%22%7D%5D%7D">
                 network
               </a>
             </p>
@@ -6951,7 +6951,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="node-tuning"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22node-tuning%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22node-tuning%22%7D%5D%7D">
                 node-tuning
               </a>
             </p>
@@ -7144,7 +7144,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="openshift-apiserver"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22openshift-apiserver%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22openshift-apiserver%22%7D%5D%7D">
                 openshift-apiserver
               </a>
             </p>
@@ -7337,7 +7337,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="openshift-controller-manager"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22openshift-controller-manager%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22openshift-controller-manager%22%7D%5D%7D">
                 openshift-controller-manager
               </a>
             </p>
@@ -7530,7 +7530,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="openshift-samples"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22openshift-samples%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22openshift-samples%22%7D%5D%7D">
                 openshift-samples
               </a>
             </p>
@@ -7723,7 +7723,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="operator-lifecycle-manager"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator-lifecycle-manager%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator-lifecycle-manager%22%7D%5D%7D">
                 operator-lifecycle-manager
               </a>
             </p>
@@ -7916,7 +7916,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="operator-lifecycle-manager-catalog"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator-lifecycle-manager-catalog%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator-lifecycle-manager-catalog%22%7D%5D%7D">
                 operator-lifecycle-manager-catalog
               </a>
             </p>
@@ -8109,7 +8109,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="operator-lifecycle-manager-packageserver"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator-lifecycle-manager-packageserver%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator-lifecycle-manager-packageserver%22%7D%5D%7D">
                 operator-lifecycle-manager-packageserver
               </a>
             </p>
@@ -8302,7 +8302,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="service-ca"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22service-ca%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22service-ca%22%7D%5D%7D">
                 service-ca
               </a>
             </p>
@@ -8495,7 +8495,7 @@ exports[`upgrades should render correctly 1`] = `
             <p class="MuiTypography-root cell-name MuiTypography-body1"
                title="storage"
             >
-              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22storage%22%7D%5D%7D">
+              <a href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22storage%22%7D%5D%7D">
                 storage
               </a>
             </p>

--- a/sippy-ng/src/tests/__snapshots__/TestAnalysis.test.js.snap
+++ b/sippy-ng/src/tests/__snapshots__/TestAnalysis.test.js.snap
@@ -115,7 +115,7 @@ exports[`TestAnalysis should render correctly 1`] = `
              tabindex="0"
              role="button"
              aria-disabled="false"
-             href="/jobs/4.8/runs?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22failedTestNames%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20Kubernetes%20APIs%20remain%20available%20with%20reused%20connections%22%7D%5D%7D&amp;sortField=timestamp&amp;sort=desc"
+             href="/jobs/4.8/runs?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22failedTestNames%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20Kubernetes%20APIs%20remain%20available%20with%20reused%20connections%22%7D%5D%7D&amp;sortField=timestamp&amp;sort=desc"
           >
             <span class="MuiButton-label">
               See all job runs
@@ -157,31 +157,646 @@ exports[`TestAnalysis should render correctly 1`] = `
       >
         <a class="MuiTypography-root MuiTypography-h5"
            style="margin-bottom: 20px;"
-           href="/jobs/4.8/runs?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22failedTestNames%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20Kubernetes%20APIs%20remain%20available%20with%20reused%20connections%22%7D%5D%7D&amp;sortField=timestamp&amp;sort=desc"
+           href="/jobs/4.8/runs?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22failedTestNames%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20Kubernetes%20APIs%20remain%20available%20with%20reused%20connections%22%7D%5D%7D&amp;sortField=timestamp&amp;sort=desc"
         >
           Job runs with test failure
         </a>
-        <div class="MuiBackdrop-root"
-             aria-hidden="true"
-             style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+        <div class="MuiDataGrid-root MuiDataGrid-root MuiDataGrid-autoHeight"
+             role="grid"
+             aria-colcount="5"
+             aria-rowcount="14"
+             aria-multiselectable="false"
         >
-          Fetching data...
-          <div class="MuiCircularProgress-root MuiCircularProgress-indeterminate"
-               style="width: 40px; height: 40px;"
-               role="progressbar"
-          >
-            <svg class="MuiCircularProgress-svg"
-                 viewbox="22 22 44 44"
+          <div>
+            <div>
+            </div>
+          </div>
+          <div class="MuiDataGrid-main">
+            <div class="MuiDataGrid-columnsContainer"
+                 style="min-height: 56px; max-height: 56px; line-height: 56px;"
             >
-              <circle class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate"
-                      cx="44"
-                      cy="44"
-                      r="20.2"
-                      fill="none"
-                      stroke-width="3.6"
+              <div class="MuiDataGrid-columnHeaderWrapper scroll"
+                   aria-rowindex="1"
+                   role="row"
+                   style="transform: translate3d(-0px, 0, 0); min-width: 250px;"
               >
-              </circle>
-            </svg>
+                <div class="MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--sorted MuiDataGrid-columnHeader"
+                     data-field="timestamp"
+                     style="width: 50px; min-width: 50px; max-width: 50px;"
+                     role="columnheader"
+                     tabindex="0"
+                     aria-colindex="1"
+                     aria-sort="descending"
+                >
+                  <div class="MuiDataGrid-columnHeaderDraggableContainer"
+                       draggable="false"
+                  >
+                    <div class="MuiDataGrid-columnHeaderTitleContainer">
+                      <div class="MuiDataGrid-columnHeaderTitle"
+                           title
+                      >
+                        Date / Time
+                      </div>
+                      <div class="MuiDataGrid-iconButtonContainer">
+                        <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                                tabindex="-1"
+                                type="button"
+                                aria-label="Sort"
+                                title="Sort"
+                        >
+                          <span class="MuiIconButton-label">
+                            <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
+                                 focusable="false"
+                                 viewbox="0 0 24 24"
+                                 aria-hidden="true"
+                            >
+                              <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
+                              </path>
+                            </svg>
+                          </span>
+                          <span class="MuiTouchRipple-root">
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="MuiDataGrid-columnSeparator"
+                       style="min-height: 56px; opacity: 1;"
+                  >
+                    <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
+                         focusable="false"
+                         viewbox="0 0 24 24"
+                         aria-hidden="true"
+                    >
+                      <path d="M11 19V5h2v14z">
+                      </path>
+                    </svg>
+                  </div>
+                </div>
+                <div class="MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader"
+                     data-field="job"
+                     style="width: 50px; min-width: 50px; max-width: 50px;"
+                     role="columnheader"
+                     tabindex="-1"
+                     aria-colindex="2"
+                >
+                  <div class="MuiDataGrid-columnHeaderDraggableContainer"
+                       draggable="false"
+                  >
+                    <div class="MuiDataGrid-columnHeaderTitleContainer">
+                      <div class="MuiDataGrid-columnHeaderTitle"
+                           title
+                      >
+                        Job name
+                      </div>
+                      <div class="MuiDataGrid-iconButtonContainer">
+                        <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                                tabindex="-1"
+                                type="button"
+                                aria-label="Sort"
+                                title="Sort"
+                        >
+                          <span class="MuiIconButton-label">
+                            <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
+                                 focusable="false"
+                                 viewbox="0 0 24 24"
+                                 aria-hidden="true"
+                            >
+                              <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
+                              </path>
+                            </svg>
+                          </span>
+                          <span class="MuiTouchRipple-root">
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="MuiDataGrid-columnSeparator"
+                       style="min-height: 56px; opacity: 1;"
+                  >
+                    <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
+                         focusable="false"
+                         viewbox="0 0 24 24"
+                         aria-hidden="true"
+                    >
+                      <path d="M11 19V5h2v14z">
+                      </path>
+                    </svg>
+                  </div>
+                </div>
+                <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
+                     data-field="testFailures"
+                     style="width: 50px; min-width: 50px; max-width: 50px;"
+                     role="columnheader"
+                     tabindex="-1"
+                     aria-colindex="3"
+                >
+                  <div class="MuiDataGrid-columnHeaderDraggableContainer"
+                       draggable="false"
+                  >
+                    <div class="MuiDataGrid-columnHeaderTitleContainer">
+                      <div class="MuiDataGrid-columnHeaderTitle"
+                           title
+                      >
+                        Test Failures
+                      </div>
+                      <div class="MuiDataGrid-iconButtonContainer">
+                        <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                                tabindex="-1"
+                                type="button"
+                                aria-label="Sort"
+                                title="Sort"
+                        >
+                          <span class="MuiIconButton-label">
+                            <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
+                                 focusable="false"
+                                 viewbox="0 0 24 24"
+                                 aria-hidden="true"
+                            >
+                              <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
+                              </path>
+                            </svg>
+                          </span>
+                          <span class="MuiTouchRipple-root">
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="MuiDataGrid-columnSeparator"
+                       style="min-height: 56px; opacity: 1;"
+                  >
+                    <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
+                         focusable="false"
+                         viewbox="0 0 24 24"
+                         aria-hidden="true"
+                    >
+                      <path d="M11 19V5h2v14z">
+                      </path>
+                    </svg>
+                  </div>
+                </div>
+                <div style="min-width: 100px; max-width: 100px; line-height: 55px; min-height: 56px; max-height: 56px;"
+                     class="MuiDataGrid-cell"
+                >
+                </div>
+              </div>
+            </div>
+            <div style="overflow: visible; width: 0px;">
+              <div class="MuiDataGrid-windowContainer"
+                   style="width: 0px; height: 316px;"
+              >
+                <div class="MuiDataGrid-window"
+                     style="top: 56px; overflow-y: hidden;"
+                >
+                  <div class="MuiDataGrid-dataContainer"
+                       style="min-width: 250px; min-height: 260px;"
+                  >
+                    <div class="MuiDataGrid-viewport"
+                         style="min-width: 0; max-width: 0; max-height: 260px;"
+                    >
+                      <div class="MuiDataGrid-renderingZone"
+                           style="max-height: 260px; width: 250px; transform: translate3d(-0px, -0px, 0);"
+                      >
+                        <div data-id="0"
+                             data-rowindex="0"
+                             role="row"
+                             class="Mui-even MuiDataGrid-row"
+                             aria-rowindex="2"
+                             aria-selected="false"
+                             style="max-height: 52px; min-height: 52px;"
+                        >
+                          <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                               role="cell"
+                               data-value="1627375769000"
+                               data-field="timestamp"
+                               data-rowindex="0"
+                               data-colindex="0"
+                               data-rowselected="false"
+                               data-editable="false"
+                               data-mode="view"
+                               aria-colindex="1"
+                               style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               tabindex="-1"
+                          >
+                            <p title="15 days ago"
+                               class
+                            >
+                              7/27/2021, 8:49:29 AM
+                            </p>
+                          </div>
+                          <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                               role="cell"
+                               data-value="periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade"
+                               data-field="job"
+                               data-rowindex="0"
+                               data-colindex="1"
+                               data-rowselected="false"
+                               data-editable="false"
+                               data-mode="view"
+                               aria-colindex="2"
+                               style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               tabindex="-1"
+                          >
+                            <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                              <a title="periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade"
+                                 class
+                                 href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade%22%7D%5D%7D"
+                              >
+                                e2e-gcp-upgrade
+                              </a>
+                            </div>
+                          </div>
+                          <div class="MuiDataGrid-cell MuiDataGrid-cell--textRight"
+                               role="cell"
+                               data-value="7"
+                               data-field="testFailures"
+                               data-rowindex="0"
+                               data-colindex="2"
+                               data-rowselected="false"
+                               data-editable="false"
+                               data-mode="view"
+                               aria-colindex="3"
+                               style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               tabindex="-1"
+                          >
+                            7
+                          </div>
+                          <div style="min-width: 100px; max-width: 100px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               class="MuiDataGrid-cell"
+                          >
+                          </div>
+                        </div>
+                        <div data-id="1"
+                             data-rowindex="1"
+                             role="row"
+                             class="Mui-odd MuiDataGrid-row"
+                             aria-rowindex="3"
+                             aria-selected="false"
+                             style="max-height: 52px; min-height: 52px;"
+                        >
+                          <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                               role="cell"
+                               data-value="1626796862000"
+                               data-field="timestamp"
+                               data-rowindex="1"
+                               data-colindex="0"
+                               data-rowselected="false"
+                               data-editable="false"
+                               data-mode="view"
+                               aria-colindex="1"
+                               style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               tabindex="-1"
+                          >
+                            <p title="22 days ago"
+                               class
+                            >
+                              7/20/2021, 4:01:02 PM
+                            </p>
+                          </div>
+                          <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                               role="cell"
+                               data-value="release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8"
+                               data-field="job"
+                               data-rowindex="1"
+                               data-colindex="1"
+                               data-rowselected="false"
+                               data-editable="false"
+                               data-mode="view"
+                               aria-colindex="2"
+                               style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               tabindex="-1"
+                          >
+                            <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                              <a title="release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8"
+                                 class
+                                 href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8%22%7D%5D%7D"
+                              >
+                                release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8
+                              </a>
+                            </div>
+                          </div>
+                          <div class="MuiDataGrid-cell MuiDataGrid-cell--textRight"
+                               role="cell"
+                               data-value="12"
+                               data-field="testFailures"
+                               data-rowindex="1"
+                               data-colindex="2"
+                               data-rowselected="false"
+                               data-editable="false"
+                               data-mode="view"
+                               aria-colindex="3"
+                               style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               tabindex="-1"
+                          >
+                            12
+                          </div>
+                          <div style="min-width: 100px; max-width: 100px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               class="MuiDataGrid-cell"
+                          >
+                          </div>
+                        </div>
+                        <div data-id="2"
+                             data-rowindex="2"
+                             role="row"
+                             class="Mui-even MuiDataGrid-row"
+                             aria-rowindex="4"
+                             aria-selected="false"
+                             style="max-height: 52px; min-height: 52px;"
+                        >
+                          <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                               role="cell"
+                               data-value="1626624056000"
+                               data-field="timestamp"
+                               data-rowindex="2"
+                               data-colindex="0"
+                               data-rowselected="false"
+                               data-editable="false"
+                               data-mode="view"
+                               aria-colindex="1"
+                               style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               tabindex="-1"
+                          >
+                            <p title="24 days ago"
+                               class
+                            >
+                              7/18/2021, 4:00:56 PM
+                            </p>
+                          </div>
+                          <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                               role="cell"
+                               data-value="release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8"
+                               data-field="job"
+                               data-rowindex="2"
+                               data-colindex="1"
+                               data-rowselected="false"
+                               data-editable="false"
+                               data-mode="view"
+                               aria-colindex="2"
+                               style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               tabindex="-1"
+                          >
+                            <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                              <a title="release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8"
+                                 class
+                                 href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8%22%7D%5D%7D"
+                              >
+                                release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8
+                              </a>
+                            </div>
+                          </div>
+                          <div class="MuiDataGrid-cell MuiDataGrid-cell--textRight"
+                               role="cell"
+                               data-value="12"
+                               data-field="testFailures"
+                               data-rowindex="2"
+                               data-colindex="2"
+                               data-rowselected="false"
+                               data-editable="false"
+                               data-mode="view"
+                               aria-colindex="3"
+                               style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               tabindex="-1"
+                          >
+                            12
+                          </div>
+                          <div style="min-width: 100px; max-width: 100px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               class="MuiDataGrid-cell"
+                          >
+                          </div>
+                        </div>
+                        <div data-id="3"
+                             data-rowindex="3"
+                             role="row"
+                             class="Mui-odd MuiDataGrid-row"
+                             aria-rowindex="5"
+                             aria-selected="false"
+                             style="max-height: 52px; min-height: 52px;"
+                        >
+                          <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                               role="cell"
+                               data-value="1626624055000"
+                               data-field="timestamp"
+                               data-rowindex="3"
+                               data-colindex="0"
+                               data-rowselected="false"
+                               data-editable="false"
+                               data-mode="view"
+                               aria-colindex="1"
+                               style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               tabindex="-1"
+                          >
+                            <p title="24 days ago"
+                               class
+                            >
+                              7/18/2021, 4:00:55 PM
+                            </p>
+                          </div>
+                          <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                               role="cell"
+                               data-value="release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8"
+                               data-field="job"
+                               data-rowindex="3"
+                               data-colindex="1"
+                               data-rowselected="false"
+                               data-editable="false"
+                               data-mode="view"
+                               aria-colindex="2"
+                               style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               tabindex="-1"
+                          >
+                            <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                              <a title="release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8"
+                                 class
+                                 href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8%22%7D%5D%7D"
+                              >
+                                release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8
+                              </a>
+                            </div>
+                          </div>
+                          <div class="MuiDataGrid-cell MuiDataGrid-cell--textRight"
+                               role="cell"
+                               data-value="11"
+                               data-field="testFailures"
+                               data-rowindex="3"
+                               data-colindex="2"
+                               data-rowselected="false"
+                               data-editable="false"
+                               data-mode="view"
+                               aria-colindex="3"
+                               style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               tabindex="-1"
+                          >
+                            11
+                          </div>
+                          <div style="min-width: 100px; max-width: 100px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               class="MuiDataGrid-cell"
+                          >
+                          </div>
+                        </div>
+                        <div data-id="13"
+                             data-rowindex="4"
+                             role="row"
+                             class="Mui-even MuiDataGrid-row"
+                             aria-rowindex="6"
+                             aria-selected="false"
+                             style="max-height: 52px; min-height: 52px;"
+                        >
+                          <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                               role="cell"
+                               data-value="1626579295000"
+                               data-field="timestamp"
+                               data-rowindex="4"
+                               data-colindex="0"
+                               data-rowselected="false"
+                               data-editable="false"
+                               data-mode="view"
+                               aria-colindex="1"
+                               style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               tabindex="-1"
+                          >
+                            <p title="24 days ago"
+                               class
+                            >
+                              7/18/2021, 3:34:55 AM
+                            </p>
+                          </div>
+                          <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                               role="cell"
+                               data-value="periodic-ci-openshift-release-master-ci-4.8-e2e-azure-upgrade"
+                               data-field="job"
+                               data-rowindex="4"
+                               data-colindex="1"
+                               data-rowselected="false"
+                               data-editable="false"
+                               data-mode="view"
+                               aria-colindex="2"
+                               style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               tabindex="-1"
+                          >
+                            <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                              <a title="periodic-ci-openshift-release-master-ci-4.8-e2e-azure-upgrade"
+                                 class
+                                 href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-azure-upgrade%22%7D%5D%7D"
+                              >
+                                e2e-azure-upgrade
+                              </a>
+                            </div>
+                          </div>
+                          <div class="MuiDataGrid-cell MuiDataGrid-cell--textRight"
+                               role="cell"
+                               data-value="9"
+                               data-field="testFailures"
+                               data-rowindex="4"
+                               data-colindex="2"
+                               data-rowselected="false"
+                               data-editable="false"
+                               data-mode="view"
+                               aria-colindex="3"
+                               style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               tabindex="-1"
+                          >
+                            9
+                          </div>
+                          <div style="min-width: 100px; max-width: 100px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                               class="MuiDataGrid-cell"
+                          >
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="Mui-resizeTriggers">
+              <div class="expand-trigger">
+                <div style="width: 1px; height: 1px;">
+                </div>
+              </div>
+              <div class="contract-trigger">
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="MuiDataGrid-footerContainer">
+              <div>
+              </div>
+              <div class="MuiTablePagination-root">
+                <div class="MuiToolbar-root MuiToolbar-regular MuiTablePagination-toolbar MuiToolbar-gutters">
+                  <div class="MuiTablePagination-spacer">
+                  </div>
+                  <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-5 MuiTypography-body2 MuiTypography-colorInherit">
+                    Rows per page:
+                  </p>
+                  <div class="MuiInputBase-root MuiTablePagination-input makeStyles-input-6 MuiTablePagination-selectRoot">
+                    <div class="MuiSelect-root MuiSelect-select MuiTablePagination-select MuiSelect-selectMenu MuiInputBase-input"
+                         tabindex="0"
+                         role="button"
+                         aria-haspopup="listbox"
+                    >
+                      5
+                    </div>
+                    <input aria-hidden="true"
+                           tabindex="-1"
+                           class="MuiSelect-nativeInput"
+                           value="5"
+                    >
+                    <svg class="MuiSvgIcon-root MuiSelect-icon MuiTablePagination-selectIcon"
+                         focusable="false"
+                         viewbox="0 0 24 24"
+                         aria-hidden="true"
+                    >
+                      <path d="M7 10l5 5 5-5z">
+                      </path>
+                    </svg>
+                  </div>
+                  <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-5 MuiTypography-body2 MuiTypography-colorInherit">
+                    1-5 of 14
+                  </p>
+                  <div class="MuiTablePagination-actions">
+                    <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
+                            tabindex="-1"
+                            type="button"
+                            disabled
+                            title="Previous page"
+                            aria-label="Previous page"
+                    >
+                      <span class="MuiIconButton-label">
+                        <svg class="MuiSvgIcon-root"
+                             focusable="false"
+                             viewbox="0 0 24 24"
+                             aria-hidden="true"
+                        >
+                          <path d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z">
+                          </path>
+                        </svg>
+                      </span>
+                    </button>
+                    <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+                            tabindex="0"
+                            type="button"
+                            title="Next page"
+                            aria-label="Next page"
+                    >
+                      <span class="MuiIconButton-label">
+                        <svg class="MuiSvgIcon-root"
+                             focusable="false"
+                             viewbox="0 0 24 24"
+                             aria-hidden="true"
+                        >
+                          <path d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z">
+                          </path>
+                        </svg>
+                      </span>
+                      <span class="MuiTouchRipple-root">
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -322,21 +937,21 @@ name but are not targeted to the release being reported on."
                 <td class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     scope="row"
                 >
-                  <a href="https://bugzilla.redhat.com/show_bug.cgi?id=1983829">
-                    1983829
+                  <a href="https://bugzilla.redhat.com/show_bug.cgi?id=1983758">
+                    1983758
                   </a>
                 </td>
                 <td class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall">
-                  ovn-kubernetes upgrade jobs are failing disruptive tests
+                  upgrades are failing on disruptive tests
                 </td>
                 <td class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall">
-                  ASSIGNED
+                  NEW
                 </td>
                 <td class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall">
-                  Networking
+                  Routing
                 </td>
                 <td class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall">
-                  4.9.0
+                  ---
                 </td>
               </tr>
               <tr class="MuiTableRow-root">
@@ -364,18 +979,18 @@ name but are not targeted to the release being reported on."
                 <td class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
                     scope="row"
                 >
-                  <a href="https://bugzilla.redhat.com/show_bug.cgi?id=1983758">
-                    1983758
+                  <a href="https://bugzilla.redhat.com/show_bug.cgi?id=1983829">
+                    1983829
                   </a>
                 </td>
                 <td class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall">
-                  upgrades are failing on disruptive tests
+                  ovn-kubernetes upgrade jobs are failing disruptive tests
                 </td>
                 <td class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall">
-                  NEW
+                  ASSIGNED
                 </td>
                 <td class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall">
-                  Routing
+                  Networking
                 </td>
                 <td class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall">
                   ---

--- a/sippy-ng/src/tests/__snapshots__/TestsDetail.test.js.snap
+++ b/sippy-ng/src/tests/__snapshots__/TestsDetail.test.js.snap
@@ -149,7 +149,7 @@ exports[`TestsDetail should render correctly 1`] = `
             <p class=\\"MuiTypography-root cell-name MuiTypography-body1\\"
                title=\\"[sig-api-machinery] Kubernetes APIs remain available for new connections\\"
             >
-              <a href=\\"/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20Kubernetes%20APIs%20remain%20available%20for%20new%20connections%22%7D%5D%7D\\">
+              <a href=\\"/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20Kubernetes%20APIs%20remain%20available%20for%20new%20connections%22%7D%5D%7D\\">
                 [sig-api-machinery] Kubernetes APIs remain available for new connections
               </a>
             </p>
@@ -314,7 +314,7 @@ exports[`TestsDetail should render correctly 1`] = `
             <p class=\\"MuiTypography-root cell-name MuiTypography-body1\\"
                title=\\"[sig-api-machinery] Kubernetes APIs remain available with reused connections\\"
             >
-              <a href=\\"/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20Kubernetes%20APIs%20remain%20available%20with%20reused%20connections%22%7D%5D%7D\\">
+              <a href=\\"/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-api-machinery%5D%20Kubernetes%20APIs%20remain%20available%20with%20reused%20connections%22%7D%5D%7D\\">
                 [sig-api-machinery] Kubernetes APIs remain available with reused connections
               </a>
             </p>


### PR DESCRIPTION
- I haven't found being more liberal with adding jobs to the never-stable
list to be particularly helpful, especially with so many failing. I
think each should be investigated, and a bug filed -- and then added to
the never-stable list.

- Exclude never-stable jobs from home page widgets

- Adds a new techpreview variant, for TPNU jobs (being added in https://github.com/openshift/release/pull/19845)