### PR TITLE
Fix link from "job runs" page back to job list

### DIFF
--- a/sippy-ng/src/__snapshots__/App.test.js.snap
+++ b/sippy-ng/src/__snapshots__/App.test.js.snap
@@ -542,7 +542,7 @@ exports[`app should render correctly 1`] = `
                 <div class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3">
                   <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                     <a class="MuiBox-root MuiBox-root-259"
-                       href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22s390x%22%7D%5D%7D"
+                       href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22s390x%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                     >
                       <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-258 MuiPaper-elevation5 MuiPaper-rounded"
                            style="background-color: rgb(229, 115, 115);"
@@ -576,7 +576,7 @@ exports[`app should render correctly 1`] = `
                   </div>
                   <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                     <a class="MuiBox-root MuiBox-root-261"
-                       href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ppc64le%22%7D%5D%7D"
+                       href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ppc64le%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                     >
                       <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-260 MuiPaper-elevation5 MuiPaper-rounded"
                            style="background-color: rgb(236, 132, 105);"
@@ -610,7 +610,7 @@ exports[`app should render correctly 1`] = `
                   </div>
                   <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                     <a class="MuiBox-root MuiBox-root-263"
-                       href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22osd%22%7D%5D%7D"
+                       href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22osd%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                     >
                       <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-262 MuiPaper-elevation5 MuiPaper-rounded"
                            style="background-color: rgb(242, 149, 96);"
@@ -644,7 +644,7 @@ exports[`app should render correctly 1`] = `
                   </div>
                   <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                     <a class="MuiBox-root MuiBox-root-265"
-                       href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22upgrade%22%7D%5D%7D"
+                       href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22upgrade%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                     >
                       <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-264 MuiPaper-elevation5 MuiPaper-rounded"
                            style="background-color: rgb(242, 150, 95);"
@@ -678,7 +678,7 @@ exports[`app should render correctly 1`] = `
                   </div>
                   <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                     <a class="MuiBox-root MuiBox-root-267"
-                       href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22proxy%22%7D%5D%7D"
+                       href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22proxy%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                     >
                       <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-266 MuiPaper-elevation5 MuiPaper-rounded"
                            style="background-color: rgb(243, 150, 95);"
@@ -712,7 +712,7 @@ exports[`app should render correctly 1`] = `
                   </div>
                   <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                     <a class="MuiBox-root MuiBox-root-269"
-                       href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-ipi%22%7D%5D%7D"
+                       href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-ipi%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                     >
                       <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-268 MuiPaper-elevation5 MuiPaper-rounded"
                            style="background-color: rgb(246, 160, 90);"
@@ -779,7 +779,7 @@ exports[`app should render correctly 1`] = `
                       >
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-271"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22azure%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22azure%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-270 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(248, 164, 87);"
@@ -813,7 +813,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-273"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22compact%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22compact%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-272 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(250, 169, 85);"
@@ -847,7 +847,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-275"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovn%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovn%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-274 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(251, 172, 83);"
@@ -881,7 +881,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-277"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-ipi%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-ipi%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-276 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(253, 177, 80);"
@@ -915,7 +915,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-279"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22aws%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22aws%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-278 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(254, 180, 78);"
@@ -949,7 +949,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-281"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22gcp%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22gcp%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-280 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(254, 182, 78);"
@@ -983,7 +983,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-283"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22single-node%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22single-node%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-282 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(251, 183, 79);"
@@ -1017,7 +1017,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-285"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22realtime%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22realtime%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-284 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(245, 184, 81);"
@@ -1051,7 +1051,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-287"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-upi%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-upi%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-286 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(189, 191, 106);"
@@ -1085,7 +1085,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-289"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22serial%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22serial%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-288 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(183, 192, 109);"
@@ -1119,7 +1119,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-291"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovirt%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovirt%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-290 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(179, 193, 110);"
@@ -1153,7 +1153,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-293"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22openstack%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22openstack%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-292 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(175, 193, 112);"
@@ -1187,7 +1187,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-295"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-upi%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-upi%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-294 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(141, 197, 127);"
@@ -1221,7 +1221,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-297"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22fips%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22fips%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-296 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(129, 199, 132);"
@@ -1255,7 +1255,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-299"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-assisted%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-assisted%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-298 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(129, 199, 132);"
@@ -1289,7 +1289,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-301"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22promote%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22promote%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-300 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgb(129, 199, 132);"
@@ -1323,7 +1323,7 @@ exports[`app should render correctly 1`] = `
                         </div>
                         <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                           <a class="MuiBox-root MuiBox-root-303"
-                             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%5D%7D"
+                             href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                           >
                             <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-257 makeStyles-miniCard-302 MuiPaper-elevation5 MuiPaper-rounded"
                                  style="background-color: rgba(0, 0, 0, 0.38);"

--- a/sippy-ng/src/constants.js
+++ b/sippy-ng/src/constants.js
@@ -45,6 +45,5 @@ export const BOOKMARKS = {
   NO_LINKED_BUG: { id: 5, columnField: 'bugs', operatorValue: '=', value: '0' },
   ASSOCIATED_BUG: { id: 6, columnField: 'associated_bugs', operatorValue: '>', value: '0' },
   NO_ASSOCIATED_BUG: { id: 7, columnField: 'associated_bugs', operatorValue: '=', value: '0' },
-  TRT: { id: 8, columnField: 'tags', operatorValue: 'contains', value: 'trt' },
-  VARIANT: (v) => { return { id: 9, columnField: 'variants', operatorValue: 'contains', value: v } }
+  TRT: { id: 8, columnField: 'tags', operatorValue: 'contains', value: 'trt' }
 }

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -1,0 +1,18 @@
+// A set of functions for getting paths to specific tests and jobs.
+
+export function pathForExactJob (release, job) {
+  return `/jobs/${release}?${single(filterFor('name', 'equals', job))}`
+}
+
+export function pathForJobVariant (release, variant) {
+  return `/jobs/${release}?${single(filterFor('variants', 'contains', variant))}`
+}
+
+// Helpers used by the above
+function filterFor (column, operator, value) {
+  return { id: 99, columnField: column, operatorValue: operator, value: value }
+}
+
+function single (filter) {
+  return `filters=${encodeURIComponent(JSON.stringify({ items: [filter] }))}`
+}

--- a/sippy-ng/src/jobs/JobDetailTable.js
+++ b/sippy-ng/src/jobs/JobDetailTable.js
@@ -1,13 +1,14 @@
-import PropTypes from 'prop-types'
 import { TableContainer } from '@material-ui/core'
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
 import TableCell from '@material-ui/core/TableCell'
 import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
+import PropTypes from 'prop-types'
 import React, { Fragment } from 'react'
-import './JobDetailTable.css'
 import { Link } from 'react-router-dom'
+import { pathForExactJob } from '../helpers'
+import './JobDetailTable.css'
 import JobDetailTestModal from './JobDetailTestModal'
 
 /**
@@ -59,7 +60,7 @@ export default function JobDetailTable (props) {
                             {rows.map((row) =>
                                 <TableRow key={'job-' + row.name} className="row-item">
                                     <TableCell component="th" scope="row" className="col-name col-first">
-                                        <Link to={`/jobs/${props.release}?job=${row.name}`}>{row.name}</Link>
+                                        <Link to={pathForExactJob(props.release, row.name)}>{row.name}</Link>
                                     </TableCell>
                                     {row.results.map((days, index) =>
                                         <TableCell className="col-day" key={'ts-' + index} style={{ verticalAlign: 'top' }}>

--- a/sippy-ng/src/jobs/VariantCards.js
+++ b/sippy-ng/src/jobs/VariantCards.js
@@ -5,7 +5,8 @@ import { Alert } from '@material-ui/lab'
 import { PropTypes } from 'prop-types'
 import React, { Fragment, useEffect } from 'react'
 import MiniCard from '../components/MiniCard'
-import { BOOKMARKS, VARIANT_THRESHOLDS } from '../constants'
+import { VARIANT_THRESHOLDS } from '../constants'
+import { pathForJobVariant } from '../helpers'
 
 export default function VariantCards (props) {
   const [jobs, setJobs] = React.useState([])
@@ -44,9 +45,7 @@ export default function VariantCards (props) {
     return (
       <Grid item key={index} md={2} sm={4}>
         <MiniCard
-          link={
-            '/jobs/' + props.release + '?sortField=net_improvement&sort=asc&filters=' + encodeURIComponent(JSON.stringify({ items: [BOOKMARKS.VARIANT(job.platform)] }))
-          }
+          link={`${pathForJobVariant(props.release, job.platform)}&sortField=net_improvement&sort=asc`}
           threshold={VARIANT_THRESHOLDS}
           name={job.platform}
           current={job.passRates.latest.percentage}

--- a/sippy-ng/src/jobs/__snapshots__/JobsDetail.test.js.snap
+++ b/sippy-ng/src/jobs/__snapshots__/JobsDetail.test.js.snap
@@ -226,7 +226,7 @@ exports[`JobsDetail should match snapshot 1`] = `
               role=\\"cell\\"
               scope=\\"row\\"
           >
-            <a href=\\"/jobs/4.8?job=periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade\\">
+            <a href=\\"/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade%22%7D%5D%7D\\">
               periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade
             </a>
           </th>

--- a/sippy-ng/src/releases/__snapshots__/ReleaseOverview.test.js.snap
+++ b/sippy-ng/src/releases/__snapshots__/ReleaseOverview.test.js.snap
@@ -311,7 +311,7 @@ exports[`release-overview should render correctly 1`] = `
             <div class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3">
               <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                 <a class="MuiBox-root MuiBox-root-221"
-                   href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22s390x%22%7D%5D%7D"
+                   href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22s390x%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                 >
                   <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-220 MuiPaper-elevation5 MuiPaper-rounded"
                        style="background-color: rgb(229, 115, 115);"
@@ -345,7 +345,7 @@ exports[`release-overview should render correctly 1`] = `
               </div>
               <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                 <a class="MuiBox-root MuiBox-root-223"
-                   href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ppc64le%22%7D%5D%7D"
+                   href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ppc64le%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                 >
                   <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-222 MuiPaper-elevation5 MuiPaper-rounded"
                        style="background-color: rgb(236, 132, 105);"
@@ -379,7 +379,7 @@ exports[`release-overview should render correctly 1`] = `
               </div>
               <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                 <a class="MuiBox-root MuiBox-root-225"
-                   href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22osd%22%7D%5D%7D"
+                   href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22osd%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                 >
                   <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-224 MuiPaper-elevation5 MuiPaper-rounded"
                        style="background-color: rgb(242, 149, 96);"
@@ -413,7 +413,7 @@ exports[`release-overview should render correctly 1`] = `
               </div>
               <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                 <a class="MuiBox-root MuiBox-root-227"
-                   href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22upgrade%22%7D%5D%7D"
+                   href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22upgrade%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                 >
                   <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-226 MuiPaper-elevation5 MuiPaper-rounded"
                        style="background-color: rgb(242, 150, 95);"
@@ -447,7 +447,7 @@ exports[`release-overview should render correctly 1`] = `
               </div>
               <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                 <a class="MuiBox-root MuiBox-root-229"
-                   href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22proxy%22%7D%5D%7D"
+                   href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22proxy%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                 >
                   <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-228 MuiPaper-elevation5 MuiPaper-rounded"
                        style="background-color: rgb(243, 150, 95);"
@@ -481,7 +481,7 @@ exports[`release-overview should render correctly 1`] = `
               </div>
               <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                 <a class="MuiBox-root MuiBox-root-231"
-                   href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-ipi%22%7D%5D%7D"
+                   href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-ipi%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                 >
                   <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-230 MuiPaper-elevation5 MuiPaper-rounded"
                        style="background-color: rgb(246, 160, 90);"
@@ -548,7 +548,7 @@ exports[`release-overview should render correctly 1`] = `
                   >
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-233"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22azure%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22azure%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-232 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(248, 164, 87);"
@@ -582,7 +582,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-235"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22compact%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22compact%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-234 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(250, 169, 85);"
@@ -616,7 +616,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-237"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovn%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovn%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-236 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(251, 172, 83);"
@@ -650,7 +650,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-239"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-ipi%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-ipi%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-238 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(253, 177, 80);"
@@ -684,7 +684,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-241"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22aws%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22aws%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-240 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(254, 180, 78);"
@@ -718,7 +718,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-243"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22gcp%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22gcp%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-242 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(254, 182, 78);"
@@ -752,7 +752,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-245"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22single-node%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22single-node%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-244 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(251, 183, 79);"
@@ -786,7 +786,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-247"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22realtime%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22realtime%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-246 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(245, 184, 81);"
@@ -820,7 +820,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-249"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-upi%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-upi%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-248 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(189, 191, 106);"
@@ -854,7 +854,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-251"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22serial%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22serial%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-250 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(183, 192, 109);"
@@ -888,7 +888,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-253"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovirt%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovirt%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-252 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(179, 193, 110);"
@@ -922,7 +922,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-255"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22openstack%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22openstack%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-254 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(175, 193, 112);"
@@ -956,7 +956,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-257"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-upi%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-upi%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-256 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(141, 197, 127);"
@@ -990,7 +990,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-259"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22fips%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22fips%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-258 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(129, 199, 132);"
@@ -1024,7 +1024,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-261"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-assisted%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22metal-assisted%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-260 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(129, 199, 132);"
@@ -1058,7 +1058,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-263"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22promote%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22promote%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-262 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgb(129, 199, 132);"
@@ -1092,7 +1092,7 @@ exports[`release-overview should render correctly 1`] = `
                     </div>
                     <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-2">
                       <a class="MuiBox-root MuiBox-root-265"
-                         href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A9%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%5D%7D"
+                         href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%5D%7D&amp;sortField=net_improvement&amp;sort=asc"
                       >
                         <div class="MuiPaper-root MuiCard-root makeStyles-miniCard-219 makeStyles-miniCard-264 MuiPaper-elevation5 MuiPaper-rounded"
                              style="background-color: rgba(0, 0, 0, 0.38);"


### PR DESCRIPTION
If you click on the job name from a page like
https://sippy.ci.openshift.org/sippy-ng/jobs/4.9/detail?job=periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-single-node-live-iso,
it doesn't filter the jobs list to only show that one job.  The new job/test
filtering is more clunky, so this adds some helpers, too.