### PR TITLE
Minor fixes: table layouts, sorting, test links

### DIFF
--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -84,5 +84,9 @@ func PrintJobRunsReport(w http.ResponseWriter, req *http.Request, curr, prev []v
 		}
 	}
 
-	RespondWithJSON(http.StatusOK, w, apiRunResults(all).limit(req).sort(req))
+	RespondWithJSON(http.StatusOK, w,
+		apiRunResults(all).
+			sort(req).
+			limit(req),
+	)
 }

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -18,6 +18,9 @@ export function relativeTime (date) {
 }
 
 // A set of functions for getting paths to specific tests and jobs.
+export function withSort (queryString, sortField, sort) {
+  return `${queryString}&sortField=${sortField}&sort=${sort}`
+}
 
 export function pathForExactJob (release, job) {
   return `/jobs/${release}?${single(filterFor('name', 'equals', job))}`

--- a/sippy-ng/src/jobs/JobRunsTable.test.js
+++ b/sippy-ng/src/jobs/JobRunsTable.test.js
@@ -15,6 +15,7 @@ describe('JobRunsTable', () => {
   setupDefaultPolly()
 
   it('should render correctly', async () => {
+    Date.now = jest.spyOn(Date, 'now').mockImplementation(() => new Date(1628691480000))
     const fetchSpy = jest.spyOn(global, 'fetch')
 
     let wrapper

--- a/sippy-ng/src/jobs/__snapshots__/JobRunsTable.test.js.snap
+++ b/sippy-ng/src/jobs/__snapshots__/JobRunsTable.test.js.snap
@@ -395,7 +395,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"28 days ago\\"
+                      <p title=\\"19 days ago\\"
                          class
                       >
                         7/23/2021, 12:30:36 PM
@@ -464,7 +464,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"35 days ago\\"
+                      <p title=\\"27 days ago\\"
                          class
                       >
                         7/15/2021, 6:00:12 PM
@@ -533,7 +533,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"35 days ago\\"
+                      <p title=\\"27 days ago\\"
                          class
                       >
                         7/15/2021, 6:58:56 PM
@@ -602,7 +602,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"31 days ago\\"
+                      <p title=\\"22 days ago\\"
                          class
                       >
                         7/20/2021, 11:40:59 AM
@@ -671,7 +671,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"28 days ago\\"
+                      <p title=\\"19 days ago\\"
                          class
                       >
                         7/23/2021, 4:17:36 AM
@@ -740,7 +740,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"35 days ago\\"
+                      <p title=\\"27 days ago\\"
                          class
                       >
                         7/15/2021, 1:27:00 PM
@@ -809,7 +809,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"36 days ago\\"
+                      <p title=\\"28 days ago\\"
                          class
                       >
                         7/14/2021, 6:00:47 PM
@@ -878,7 +878,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"32 days ago\\"
+                      <p title=\\"23 days ago\\"
                          class
                       >
                         7/19/2021, 7:01:56 AM
@@ -947,7 +947,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"23 days ago\\"
+                      <p title=\\"15 days ago\\"
                          class
                       >
                         7/27/2021, 6:45:10 PM
@@ -1016,7 +1016,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"35 days ago\\"
+                      <p title=\\"27 days ago\\"
                          class
                       >
                         7/15/2021, 3:20:47 PM
@@ -1085,7 +1085,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"28 days ago\\"
+                      <p title=\\"20 days ago\\"
                          class
                       >
                         7/23/2021, 2:00:40 AM
@@ -1154,7 +1154,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"27 days ago\\"
+                      <p title=\\"19 days ago\\"
                          class
                       >
                         7/24/2021, 12:11:20 AM
@@ -1223,7 +1223,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"23 days ago\\"
+                      <p title=\\"15 days ago\\"
                          class
                       >
                         7/27/2021, 6:45:17 PM
@@ -1292,7 +1292,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"35 days ago\\"
+                      <p title=\\"27 days ago\\"
                          class
                       >
                         7/15/2021, 2:05:28 PM
@@ -1361,7 +1361,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"30 days ago\\"
+                      <p title=\\"22 days ago\\"
                          class
                       >
                         7/20/2021, 7:35:09 PM
@@ -1430,7 +1430,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"26 days ago\\"
+                      <p title=\\"18 days ago\\"
                          class
                       >
                         7/24/2021, 9:19:29 PM
@@ -1499,7 +1499,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"25 days ago\\"
+                      <p title=\\"16 days ago\\"
                          class
                       >
                         7/26/2021, 3:39:19 AM
@@ -1568,7 +1568,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"30 days ago\\"
+                      <p title=\\"21 days ago\\"
                          class
                       >
                         7/21/2021, 7:07:08 AM
@@ -1637,7 +1637,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"32 days ago\\"
+                      <p title=\\"24 days ago\\"
                          class
                       >
                         7/18/2021, 2:00:55 PM
@@ -1706,7 +1706,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"27 days ago\\"
+                      <p title=\\"19 days ago\\"
                          class
                       >
                         7/23/2021, 8:14:45 PM
@@ -1775,7 +1775,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"28 days ago\\"
+                      <p title=\\"19 days ago\\"
                          class
                       >
                         7/23/2021, 7:11:49 AM
@@ -1844,7 +1844,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"26 days ago\\"
+                      <p title=\\"17 days ago\\"
                          class
                       >
                         7/25/2021, 6:00:21 AM
@@ -1913,7 +1913,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"25 days ago\\"
+                      <p title=\\"17 days ago\\"
                          class
                       >
                         7/25/2021, 4:30:17 PM
@@ -1982,7 +1982,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"24 days ago\\"
+                      <p title=\\"16 days ago\\"
                          class
                       >
                         7/26/2021, 4:30:19 PM
@@ -2051,7 +2051,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"35 days ago\\"
+                      <p title=\\"27 days ago\\"
                          class
                       >
                         7/15/2021, 3:20:50 PM

--- a/sippy-ng/src/releases/Install.css
+++ b/sippy-ng/src/releases/Install.css
@@ -1,0 +1,4 @@
+.view {
+    margin: auto;
+    width: "100%";
+}

--- a/sippy-ng/src/releases/Install.js
+++ b/sippy-ng/src/releases/Install.js
@@ -7,6 +7,7 @@ import SimpleBreadcrumbs from '../components/SimpleBreadcrumbs'
 import TestByVariantTable from '../tests/TestByVariantTable'
 import TestTable from '../tests/TestTable'
 import { BOOKMARKS } from '../constants'
+import './Install.css'
 
 export default function Install (props) {
   const { path, url } = useRouteMatch()
@@ -54,7 +55,7 @@ export default function Install (props) {
             <Typography align="center" variant="h4">
               Install health for {props.release}
             </Typography>
-            <Grid container justifyContent="center" width="60%" style={{ margin: 20 }}>
+            <Grid container justifyContent="center" size="xl" className="view">
               <Paper>
                 <Tabs
                   value={location.pathname.substring(location.pathname.lastIndexOf('/') + 1)}

--- a/sippy-ng/src/releases/Upgrades.css
+++ b/sippy-ng/src/releases/Upgrades.css
@@ -1,0 +1,4 @@
+.view {
+    margin: auto;
+    width: "100%";
+}

--- a/sippy-ng/src/releases/Upgrades.js
+++ b/sippy-ng/src/releases/Upgrades.js
@@ -10,6 +10,7 @@ import SimpleBreadcrumbs from '../components/SimpleBreadcrumbs'
 import TestByVariantTable from '../tests/TestByVariantTable'
 import TestTable from '../tests/TestTable'
 import { BOOKMARKS } from '../constants'
+import './Upgrades.css'
 
 /**
  *  Upgrades is the landing page for upgrades.
@@ -60,7 +61,7 @@ export default function Upgrades (props) {
             <Typography align="center" variant="h4">
               Upgrade health for {props.release}
             </Typography>
-            <Grid container justifyContent="center" width="60%" style={{ margin: 20 }}>
+            <Grid container justifyContent="center" size="xl" className="view">
               <Paper>
                 <Tabs
                   value={location.pathname.substring(location.pathname.lastIndexOf('/') + 1)}

--- a/sippy-ng/src/releases/__snapshots__/Install.test.js.snap
+++ b/sippy-ng/src/releases/__snapshots__/Install.test.js.snap
@@ -25,10 +25,7 @@ exports[`install should render correctly 1`] = `
 <h4 class="MuiTypography-root MuiTypography-h4 MuiTypography-alignCenter">
   Install health for 4.8
 </h4>
-<div class="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-center"
-     width="60%"
-     style="margin: 20px;"
->
+<div class="MuiGrid-root view MuiGrid-container MuiGrid-justify-content-xs-center">
   <div class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded">
     <div class="MuiTabs-root">
       <div class="MuiTabs-scroller MuiTabs-fixed"

--- a/sippy-ng/src/releases/__snapshots__/Upgrades.test.js.snap
+++ b/sippy-ng/src/releases/__snapshots__/Upgrades.test.js.snap
@@ -25,10 +25,7 @@ exports[`upgrades should render correctly 1`] = `
 <h4 class="MuiTypography-root MuiTypography-h4 MuiTypography-alignCenter">
   Upgrade health for 4.8
 </h4>
-<div class="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-center"
-     width="60%"
-     style="margin: 20px;"
->
+<div class="MuiGrid-root view MuiGrid-container MuiGrid-justify-content-xs-center">
   <div class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded">
     <div class="MuiTabs-root">
       <div class="MuiTabs-scroller MuiTabs-fixed"

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -13,7 +13,7 @@ import PassRateIcon from '../components/PassRateIcon'
 import { BOOKMARKS, TEST_THRESHOLDS } from '../constants'
 import GridToolbar from '../datagrid/GridToolbar'
 import { generateClasses } from '../datagrid/utils'
-import { pathForExactTest, pathForJobRunsWithTestFailure } from '../helpers'
+import { pathForExactTest, pathForJobRunsWithTestFailure, withSort } from '../helpers'
 
 const bookmarks = [
   {
@@ -125,7 +125,7 @@ function TestTable (props) {
             <Button
               startIcon={<DirectionsRun />}
               component={Link}
-              to={pathForJobRunsWithTestFailure(props.release, params.row.name)}
+              to={withSort(pathForJobRunsWithTestFailure(props.release, params.row.name), 'timestamp', 'desc')}
             />
           </Tooltip>
         )


### PR DESCRIPTION
A handful of minor fixes:

- Fix divs for install and upgrade. This prevents the browser from rendering two sets of horizontal scroll
bars.
- Ensure stable Date.now for consistent snapshots
- Job runs sort before limit
- Tests link to runs sorted by date