### PR TITLE
Fix wrapping of test names

### DIFF
--- a/sippy-ng/src/__snapshots__/App.test.js.snap
+++ b/sippy-ng/src/__snapshots__/App.test.js.snap
@@ -1381,719 +1381,7 @@ exports[`app should render correctly 1`] = `
             >
               <a class="MuiTypography-root MuiTypography-h5"
                  style="text-align: center;"
-                 href="/tests/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%7D"
-              >
-                Most regressed tests
-                <svg class="MuiSvgIcon-root"
-                     focusable="false"
-                     viewbox="0 0 24 24"
-                     aria-hidden="true"
-                     title="Shows the most regressed items this week vs. last week, for those with more than 10 runs"
-                >
-                  <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z">
-                  </path>
-                </svg>
-              </a>
-              <div class="MuiContainer-root MuiContainer-maxWidthLg">
-                <div class="MuiDataGrid-root MuiDataGrid-root MuiDataGrid-autoHeight"
-                     role="grid"
-                     aria-colcount="4"
-                     aria-rowcount="10"
-                     aria-multiselectable="false"
-                >
-                  <div>
-                    <div>
-                    </div>
-                  </div>
-                  <div class="MuiDataGrid-main">
-                    <div class="MuiDataGrid-columnsContainer"
-                         style="min-height: 56px; max-height: 56px; line-height: 56px;"
-                    >
-                      <div class="MuiDataGrid-columnHeaderWrapper scroll"
-                           aria-rowindex="1"
-                           role="row"
-                           style="transform: translate3d(-0px, 0, 0); min-width: 200px;"
-                      >
-                        <div class="MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader"
-                             data-field="name"
-                             style="width: 50px; min-width: 50px; max-width: 50px;"
-                             role="columnheader"
-                             tabindex="0"
-                             aria-colindex="1"
-                        >
-                          <div class="MuiDataGrid-columnHeaderDraggableContainer"
-                               draggable="false"
-                          >
-                            <div class="MuiDataGrid-columnHeaderTitleContainer">
-                              <div class="MuiDataGrid-columnHeaderTitle"
-                                   title
-                              >
-                                Name
-                              </div>
-                              <div class="MuiDataGrid-iconButtonContainer">
-                                <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                                        tabindex="-1"
-                                        type="button"
-                                        aria-label="Sort"
-                                        title="Sort"
-                                >
-                                  <span class="MuiIconButton-label">
-                                    <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                    >
-                                      <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
-                                      </path>
-                                    </svg>
-                                  </span>
-                                  <span class="MuiTouchRipple-root">
-                                  </span>
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-                          <div class="MuiDataGrid-columnSeparator"
-                               style="min-height: 56px; opacity: 1;"
-                          >
-                            <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
-                                 focusable="false"
-                                 viewbox="0 0 24 24"
-                                 aria-hidden="true"
-                            >
-                              <path d="M11 19V5h2v14z">
-                              </path>
-                            </svg>
-                          </div>
-                        </div>
-                        <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
-                             data-field="current_pass_percentage"
-                             style="width: 50px; min-width: 50px; max-width: 50px;"
-                             role="columnheader"
-                             tabindex="-1"
-                             aria-colindex="2"
-                        >
-                          <div class="MuiDataGrid-columnHeaderDraggableContainer"
-                               draggable="false"
-                          >
-                            <div class="MuiDataGrid-columnHeaderTitleContainer">
-                              <div class="MuiDataGrid-columnHeaderTitle"
-                                   title
-                              >
-                                Current Period
-                              </div>
-                              <div class="MuiDataGrid-iconButtonContainer">
-                                <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                                        tabindex="-1"
-                                        type="button"
-                                        aria-label="Sort"
-                                        title="Sort"
-                                >
-                                  <span class="MuiIconButton-label">
-                                    <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                    >
-                                      <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
-                                      </path>
-                                    </svg>
-                                  </span>
-                                  <span class="MuiTouchRipple-root">
-                                  </span>
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-                          <div class="MuiDataGrid-columnSeparator"
-                               style="min-height: 56px; opacity: 1;"
-                          >
-                            <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
-                                 focusable="false"
-                                 viewbox="0 0 24 24"
-                                 aria-hidden="true"
-                            >
-                              <path d="M11 19V5h2v14z">
-                              </path>
-                            </svg>
-                          </div>
-                        </div>
-                        <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--sorted MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
-                             data-field="net_improvement"
-                             style="width: 50px; min-width: 50px; max-width: 50px;"
-                             role="columnheader"
-                             tabindex="-1"
-                             aria-colindex="3"
-                             aria-sort="ascending"
-                        >
-                          <div class="MuiDataGrid-columnHeaderDraggableContainer"
-                               draggable="false"
-                          >
-                            <div class="MuiDataGrid-columnHeaderTitleContainer">
-                              <div class="MuiDataGrid-columnHeaderTitle"
-                                   title
-                              >
-                                Improvement
-                              </div>
-                              <div class="MuiDataGrid-iconButtonContainer">
-                                <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                                        tabindex="-1"
-                                        type="button"
-                                        aria-label="Sort"
-                                        title="Sort"
-                                >
-                                  <span class="MuiIconButton-label">
-                                    <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                    >
-                                      <path d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z">
-                                      </path>
-                                    </svg>
-                                  </span>
-                                  <span class="MuiTouchRipple-root">
-                                  </span>
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-                          <div class="MuiDataGrid-columnSeparator"
-                               style="min-height: 56px; opacity: 1;"
-                          >
-                            <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
-                                 focusable="false"
-                                 viewbox="0 0 24 24"
-                                 aria-hidden="true"
-                            >
-                              <path d="M11 19V5h2v14z">
-                              </path>
-                            </svg>
-                          </div>
-                        </div>
-                        <div style="min-width: 50px; max-width: 50px; line-height: 55px; min-height: 56px; max-height: 56px;"
-                             class="MuiDataGrid-cell"
-                        >
-                        </div>
-                      </div>
-                    </div>
-                    <div style="overflow: visible; width: 0px;">
-                      <div class="MuiDataGrid-windowContainer"
-                           style="width: 0px; height: 316px;"
-                      >
-                        <div class="MuiDataGrid-window"
-                             style="top: 56px; overflow-y: hidden;"
-                        >
-                          <div class="MuiDataGrid-dataContainer"
-                               style="min-width: 200px; min-height: 260px;"
-                          >
-                            <div class="MuiDataGrid-viewport"
-                                 style="min-width: 0; max-width: 0; max-height: 260px;"
-                            >
-                              <div class="MuiDataGrid-renderingZone"
-                                   style="max-height: 260px; width: 200px; transform: translate3d(-0px, -0px, 0);"
-                              >
-                                <div data-id="25"
-                                     data-rowindex="0"
-                                     role="row"
-                                     class="Mui-even TestTable-row-percent-37-91 MuiDataGrid-row"
-                                     aria-rowindex="2"
-                                     aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
-                                >
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                       role="cell"
-                                       data-value="[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version"
-                                       data-field="name"
-                                       data-rowindex="0"
-                                       data-colindex="0"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                      <a title="[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version"
-                                         class
-                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Binstall%5D%20%5BSuite%3A%20operators%5D%20%5BOSD%5D%20RBAC%20Operator%20Operator%20Upgrade%20should%20upgrade%20from%20the%20replaced%20version%22%7D%5D%7D"
-                                      >
-                                        [install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version
-                                      </a>
-                                    </div>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="36.95652173913043"
-                                       data-field="current_pass_percentage"
-                                       data-rowindex="0"
-                                       data-colindex="1"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <p title="46 runs"
-                                       class
-                                    >
-                                      36.96%
-                                    </p>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="-49.83593109105825"
-                                       data-field="net_improvement"
-                                       data-rowindex="0"
-                                       data-colindex="2"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <svg class="MuiSvgIcon-root"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                         data-icon="ArrowDownwardRoundedIcon"
-                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                         title="-49.84%"
-                                    >
-                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                      </path>
-                                    </svg>
-                                  </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       class="MuiDataGrid-cell"
-                                  >
-                                  </div>
-                                </div>
-                                <div data-id="49"
-                                     data-rowindex="1"
-                                     role="row"
-                                     class="Mui-odd TestTable-row-percent-83-137 MuiDataGrid-row"
-                                     aria-rowindex="3"
-                                     aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
-                                >
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                       role="cell"
-                                       data-value="operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test"
-                                       data-field="name"
-                                       data-rowindex="1"
-                                       data-colindex="0"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                      <a title="operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test"
-                                         class
-                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-vsphere-upgrade%20-%20e2e-vsphere-upgrade-ipi-install-install-stableinitial%20container%20test%22%7D%5D%7D"
-                                      >
-                                        operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test
-                                      </a>
-                                    </div>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="83.33333333333334"
-                                       data-field="current_pass_percentage"
-                                       data-rowindex="1"
-                                       data-colindex="1"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <p title="12 runs"
-                                       class
-                                    >
-                                      83.33%
-                                    </p>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="-16.666666666666657"
-                                       data-field="net_improvement"
-                                       data-rowindex="1"
-                                       data-colindex="2"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <svg class="MuiSvgIcon-root"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                         data-icon="ArrowDownwardRoundedIcon"
-                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                         title="-16.67%"
-                                    >
-                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                      </path>
-                                    </svg>
-                                  </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       class="MuiDataGrid-cell"
-                                  >
-                                  </div>
-                                </div>
-                                <div data-id="27"
-                                     data-rowindex="2"
-                                     role="row"
-                                     class="Mui-even TestTable-row-percent-50-104 MuiDataGrid-row"
-                                     aria-rowindex="4"
-                                     aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
-                                >
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                       role="cell"
-                                       data-value="operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test"
-                                       data-field="name"
-                                       data-rowindex="2"
-                                       data-colindex="0"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                      <a title="operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test"
-                                         class
-                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-aws-proxy%20-%20e2e-aws-proxy-ipi-install-install%20container%20test%22%7D%5D%7D"
-                                      >
-                                        operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test
-                                      </a>
-                                    </div>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="50"
-                                       data-field="current_pass_percentage"
-                                       data-rowindex="2"
-                                       data-colindex="1"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <p title="16 runs"
-                                       class
-                                    >
-                                      50.00%
-                                    </p>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="-12.5"
-                                       data-field="net_improvement"
-                                       data-rowindex="2"
-                                       data-colindex="2"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <svg class="MuiSvgIcon-root"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                         data-icon="ArrowDownwardRoundedIcon"
-                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                         title="-12.50%"
-                                    >
-                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                      </path>
-                                    </svg>
-                                  </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       class="MuiDataGrid-cell"
-                                  >
-                                  </div>
-                                </div>
-                                <div data-id="48"
-                                     data-rowindex="3"
-                                     role="row"
-                                     class="Mui-odd TestTable-row-percent-83-137 MuiDataGrid-row"
-                                     aria-rowindex="5"
-                                     aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
-                                >
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                       role="cell"
-                                       data-value="operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test"
-                                       data-field="name"
-                                       data-rowindex="3"
-                                       data-colindex="0"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                      <a title="operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test"
-                                         class
-                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-gcp-upgrade%20-%20e2e-gcp-upgrade-ipi-install-install-stableinitial%20container%20test%22%7D%5D%7D"
-                                      >
-                                        operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test
-                                      </a>
-                                    </div>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="83.33333333333334"
-                                       data-field="current_pass_percentage"
-                                       data-rowindex="3"
-                                       data-colindex="1"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <p title="48 runs"
-                                       class
-                                    >
-                                      83.33%
-                                    </p>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="-12.12121212121211"
-                                       data-field="net_improvement"
-                                       data-rowindex="3"
-                                       data-colindex="2"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <svg class="MuiSvgIcon-root"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                         data-icon="ArrowDownwardRoundedIcon"
-                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                         title="-12.12%"
-                                    >
-                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                      </path>
-                                    </svg>
-                                  </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       class="MuiDataGrid-cell"
-                                  >
-                                  </div>
-                                </div>
-                                <div data-id="55"
-                                     data-rowindex="4"
-                                     role="row"
-                                     class="Mui-even TestTable-row-percent-89-143 MuiDataGrid-row"
-                                     aria-rowindex="6"
-                                     aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
-                                >
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                       role="cell"
-                                       data-value="operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test"
-                                       data-field="name"
-                                       data-rowindex="4"
-                                       data-colindex="0"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                      <a title="operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test"
-                                         class
-                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-gcp%20-%20e2e-gcp-ipi-install-install%20container%20test%22%7D%5D%7D"
-                                      >
-                                        operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test
-                                      </a>
-                                    </div>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="89.1891891891892"
-                                       data-field="current_pass_percentage"
-                                       data-rowindex="4"
-                                       data-colindex="1"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <p title="37 runs"
-                                       class
-                                    >
-                                      89.19%
-                                    </p>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="-10.810810810810807"
-                                       data-field="net_improvement"
-                                       data-rowindex="4"
-                                       data-colindex="2"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <svg class="MuiSvgIcon-root"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                         data-icon="ArrowDownwardRoundedIcon"
-                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                         title="-10.81%"
-                                    >
-                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                      </path>
-                                    </svg>
-                                  </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       class="MuiDataGrid-cell"
-                                  >
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div class="Mui-resizeTriggers">
-                      <div class="expand-trigger">
-                        <div style="width: 1px; height: 1px;">
-                        </div>
-                      </div>
-                      <div class="contract-trigger">
-                      </div>
-                    </div>
-                  </div>
-                  <div>
-                    <div class="MuiDataGrid-footerContainer">
-                      <div>
-                      </div>
-                      <div class="MuiTablePagination-root">
-                        <div class="MuiToolbar-root MuiToolbar-regular MuiTablePagination-toolbar MuiToolbar-gutters">
-                          <div class="MuiTablePagination-spacer">
-                          </div>
-                          <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-307 MuiTypography-body2 MuiTypography-colorInherit">
-                            Rows per page:
-                          </p>
-                          <div class="MuiInputBase-root MuiTablePagination-input makeStyles-input-308 MuiTablePagination-selectRoot">
-                            <div class="MuiSelect-root MuiSelect-select MuiTablePagination-select MuiSelect-selectMenu MuiInputBase-input"
-                                 tabindex="0"
-                                 role="button"
-                                 aria-haspopup="listbox"
-                            >
-                              5
-                            </div>
-                            <input aria-hidden="true"
-                                   tabindex="-1"
-                                   class="MuiSelect-nativeInput"
-                                   value="5"
-                            >
-                            <svg class="MuiSvgIcon-root MuiSelect-icon MuiTablePagination-selectIcon"
-                                 focusable="false"
-                                 viewbox="0 0 24 24"
-                                 aria-hidden="true"
-                            >
-                              <path d="M7 10l5 5 5-5z">
-                              </path>
-                            </svg>
-                          </div>
-                          <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-307 MuiTypography-body2 MuiTypography-colorInherit">
-                            1-5 of 10
-                          </p>
-                          <div class="MuiTablePagination-actions">
-                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
-                                    tabindex="-1"
-                                    type="button"
-                                    disabled
-                                    title="Previous page"
-                                    aria-label="Previous page"
-                            >
-                              <span class="MuiIconButton-label">
-                                <svg class="MuiSvgIcon-root"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                >
-                                  <path d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z">
-                                  </path>
-                                </svg>
-                              </span>
-                            </button>
-                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-                                    tabindex="0"
-                                    type="button"
-                                    title="Next page"
-                                    aria-label="Next page"
-                            >
-                              <span class="MuiIconButton-label">
-                                <svg class="MuiSvgIcon-root"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                >
-                                  <path d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z">
-                                  </path>
-                                </svg>
-                              </span>
-                              <span class="MuiTouchRipple-root">
-                              </span>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-12 MuiGrid-grid-md-6">
-            <div class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
-                 enhancement="5"
-                 style="text-align: center;"
-            >
-              <a class="MuiTypography-root MuiTypography-h5"
-                 style="text-align: center;"
-                 href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%7D"
+                 href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
               >
                 Most regressed jobs
                 <svg class="MuiSvgIcon-root"
@@ -2308,7 +1596,7 @@ exports[`app should render correctly 1`] = `
                                 <div data-id="40"
                                      data-rowindex="0"
                                      role="row"
-                                     class="Mui-even JobTable-row-percent-38-193 MuiDataGrid-row"
+                                     class="Mui-even JobTable-row-percent-38-92 MuiDataGrid-row"
                                      aria-rowindex="2"
                                      aria-selected="false"
                                      style="max-height: 52px; min-height: 52px;"
@@ -2351,7 +1639,7 @@ exports[`app should render correctly 1`] = `
                                     <div class="MuiBox-root MuiBox-root-309"
                                          title="13 runs"
                                     >
-                                      38.46%
+                                      38%
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2387,7 +1675,7 @@ exports[`app should render correctly 1`] = `
                                 <div data-id="62"
                                      data-rowindex="1"
                                      role="row"
-                                     class="Mui-odd JobTable-row-percent-69-224 MuiDataGrid-row"
+                                     class="Mui-odd JobTable-row-percent-69-123 MuiDataGrid-row"
                                      aria-rowindex="3"
                                      aria-selected="false"
                                      style="max-height: 52px; min-height: 52px;"
@@ -2430,7 +1718,7 @@ exports[`app should render correctly 1`] = `
                                     <div class="MuiBox-root MuiBox-root-310"
                                          title="13 runs"
                                     >
-                                      69.23%
+                                      69%
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2466,7 +1754,7 @@ exports[`app should render correctly 1`] = `
                                 <div data-id="31"
                                      data-rowindex="2"
                                      role="row"
-                                     class="Mui-even JobTable-row-percent-33-188 MuiDataGrid-row"
+                                     class="Mui-even JobTable-row-percent-33-87 MuiDataGrid-row"
                                      aria-rowindex="4"
                                      aria-selected="false"
                                      style="max-height: 52px; min-height: 52px;"
@@ -2509,7 +1797,7 @@ exports[`app should render correctly 1`] = `
                                     <div class="MuiBox-root MuiBox-root-311"
                                          title="15 runs"
                                     >
-                                      33.33%
+                                      33%
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2545,7 +1833,7 @@ exports[`app should render correctly 1`] = `
                                 <div data-id="28"
                                      data-rowindex="3"
                                      role="row"
-                                     class="Mui-odd JobTable-row-percent-31-186 MuiDataGrid-row"
+                                     class="Mui-odd JobTable-row-percent-31-85 MuiDataGrid-row"
                                      aria-rowindex="5"
                                      aria-selected="false"
                                      style="max-height: 52px; min-height: 52px;"
@@ -2588,7 +1876,7 @@ exports[`app should render correctly 1`] = `
                                     <div class="MuiBox-root MuiBox-root-312"
                                          title="16 runs"
                                     >
-                                      31.25%
+                                      31%
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2624,7 +1912,7 @@ exports[`app should render correctly 1`] = `
                                 <div data-id="73"
                                      data-rowindex="4"
                                      role="row"
-                                     class="Mui-even JobTable-row-percent-77-232 MuiDataGrid-row"
+                                     class="Mui-even JobTable-row-percent-77-131 MuiDataGrid-row"
                                      aria-rowindex="6"
                                      aria-selected="false"
                                      style="max-height: 52px; min-height: 52px;"
@@ -2667,7 +1955,7 @@ exports[`app should render correctly 1`] = `
                                     <div class="MuiBox-root MuiBox-root-313"
                                          title="13 runs"
                                     >
-                                      76.92%
+                                      77%
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2804,720 +2092,7 @@ exports[`app should render correctly 1`] = `
                  style="text-align: center;"
             >
               <a class="MuiTypography-root MuiTypography-h5"
-                 style="text-align: center;"
-                 href="/tests/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%7D"
-              >
-                Most regressed tests (two day)
-                <svg class="MuiSvgIcon-root"
-                     focusable="false"
-                     viewbox="0 0 24 24"
-                     aria-hidden="true"
-                     title="Shows the last 2 days compared to the last 7 days, sorted by most regressed."
-                >
-                  <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z">
-                  </path>
-                </svg>
-              </a>
-              <div class="MuiContainer-root MuiContainer-maxWidthLg">
-                <div class="MuiDataGrid-root MuiDataGrid-root MuiDataGrid-autoHeight"
-                     role="grid"
-                     aria-colcount="4"
-                     aria-rowcount="10"
-                     aria-multiselectable="false"
-                >
-                  <div>
-                    <div>
-                    </div>
-                  </div>
-                  <div class="MuiDataGrid-main">
-                    <div class="MuiDataGrid-columnsContainer"
-                         style="min-height: 56px; max-height: 56px; line-height: 56px;"
-                    >
-                      <div class="MuiDataGrid-columnHeaderWrapper scroll"
-                           aria-rowindex="1"
-                           role="row"
-                           style="transform: translate3d(-0px, 0, 0); min-width: 200px;"
-                      >
-                        <div class="MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader"
-                             data-field="name"
-                             style="width: 50px; min-width: 50px; max-width: 50px;"
-                             role="columnheader"
-                             tabindex="0"
-                             aria-colindex="1"
-                        >
-                          <div class="MuiDataGrid-columnHeaderDraggableContainer"
-                               draggable="false"
-                          >
-                            <div class="MuiDataGrid-columnHeaderTitleContainer">
-                              <div class="MuiDataGrid-columnHeaderTitle"
-                                   title
-                              >
-                                Name
-                              </div>
-                              <div class="MuiDataGrid-iconButtonContainer">
-                                <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                                        tabindex="-1"
-                                        type="button"
-                                        aria-label="Sort"
-                                        title="Sort"
-                                >
-                                  <span class="MuiIconButton-label">
-                                    <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                    >
-                                      <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
-                                      </path>
-                                    </svg>
-                                  </span>
-                                  <span class="MuiTouchRipple-root">
-                                  </span>
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-                          <div class="MuiDataGrid-columnSeparator"
-                               style="min-height: 56px; opacity: 1;"
-                          >
-                            <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
-                                 focusable="false"
-                                 viewbox="0 0 24 24"
-                                 aria-hidden="true"
-                            >
-                              <path d="M11 19V5h2v14z">
-                              </path>
-                            </svg>
-                          </div>
-                        </div>
-                        <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
-                             data-field="current_pass_percentage"
-                             style="width: 50px; min-width: 50px; max-width: 50px;"
-                             role="columnheader"
-                             tabindex="-1"
-                             aria-colindex="2"
-                        >
-                          <div class="MuiDataGrid-columnHeaderDraggableContainer"
-                               draggable="false"
-                          >
-                            <div class="MuiDataGrid-columnHeaderTitleContainer">
-                              <div class="MuiDataGrid-columnHeaderTitle"
-                                   title
-                              >
-                                Current Period
-                              </div>
-                              <div class="MuiDataGrid-iconButtonContainer">
-                                <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                                        tabindex="-1"
-                                        type="button"
-                                        aria-label="Sort"
-                                        title="Sort"
-                                >
-                                  <span class="MuiIconButton-label">
-                                    <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                    >
-                                      <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
-                                      </path>
-                                    </svg>
-                                  </span>
-                                  <span class="MuiTouchRipple-root">
-                                  </span>
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-                          <div class="MuiDataGrid-columnSeparator"
-                               style="min-height: 56px; opacity: 1;"
-                          >
-                            <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
-                                 focusable="false"
-                                 viewbox="0 0 24 24"
-                                 aria-hidden="true"
-                            >
-                              <path d="M11 19V5h2v14z">
-                              </path>
-                            </svg>
-                          </div>
-                        </div>
-                        <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--sorted MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
-                             data-field="net_improvement"
-                             style="width: 50px; min-width: 50px; max-width: 50px;"
-                             role="columnheader"
-                             tabindex="-1"
-                             aria-colindex="3"
-                             aria-sort="ascending"
-                        >
-                          <div class="MuiDataGrid-columnHeaderDraggableContainer"
-                               draggable="false"
-                          >
-                            <div class="MuiDataGrid-columnHeaderTitleContainer">
-                              <div class="MuiDataGrid-columnHeaderTitle"
-                                   title
-                              >
-                                Improvement
-                              </div>
-                              <div class="MuiDataGrid-iconButtonContainer">
-                                <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                                        tabindex="-1"
-                                        type="button"
-                                        aria-label="Sort"
-                                        title="Sort"
-                                >
-                                  <span class="MuiIconButton-label">
-                                    <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                    >
-                                      <path d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z">
-                                      </path>
-                                    </svg>
-                                  </span>
-                                  <span class="MuiTouchRipple-root">
-                                  </span>
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-                          <div class="MuiDataGrid-columnSeparator"
-                               style="min-height: 56px; opacity: 1;"
-                          >
-                            <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
-                                 focusable="false"
-                                 viewbox="0 0 24 24"
-                                 aria-hidden="true"
-                            >
-                              <path d="M11 19V5h2v14z">
-                              </path>
-                            </svg>
-                          </div>
-                        </div>
-                        <div style="min-width: 50px; max-width: 50px; line-height: 55px; min-height: 56px; max-height: 56px;"
-                             class="MuiDataGrid-cell"
-                        >
-                        </div>
-                      </div>
-                    </div>
-                    <div style="overflow: visible; width: 0px;">
-                      <div class="MuiDataGrid-windowContainer"
-                           style="width: 0px; height: 316px;"
-                      >
-                        <div class="MuiDataGrid-window"
-                             style="top: 56px; overflow-y: hidden;"
-                        >
-                          <div class="MuiDataGrid-dataContainer"
-                               style="min-width: 200px; min-height: 260px;"
-                          >
-                            <div class="MuiDataGrid-viewport"
-                                 style="min-width: 0; max-width: 0; max-height: 260px;"
-                            >
-                              <div class="MuiDataGrid-renderingZone"
-                                   style="max-height: 260px; width: 200px; transform: translate3d(-0px, -0px, 0);"
-                              >
-                                <div data-id="6"
-                                     data-rowindex="0"
-                                     role="row"
-                                     class="Mui-even TestTable-row-percent-50-104 MuiDataGrid-row"
-                                     aria-rowindex="2"
-                                     aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
-                                >
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                       role="cell"
-                                       data-value="operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test"
-                                       data-field="name"
-                                       data-rowindex="0"
-                                       data-colindex="0"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                      <a title="operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test"
-                                         class
-                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-metal-assisted%20-%20e2e-metal-assisted-baremetalds-assisted-setup%20container%20test%22%7D%5D%7D"
-                                      >
-                                        operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test
-                                      </a>
-                                    </div>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="50"
-                                       data-field="current_pass_percentage"
-                                       data-rowindex="0"
-                                       data-colindex="1"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <p title="2 runs"
-                                       class
-                                    >
-                                      50.00%
-                                    </p>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="-42.85714285714286"
-                                       data-field="net_improvement"
-                                       data-rowindex="0"
-                                       data-colindex="2"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <svg class="MuiSvgIcon-root"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                         data-icon="ArrowDownwardRoundedIcon"
-                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                         title="-42.86%"
-                                    >
-                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                      </path>
-                                    </svg>
-                                  </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       class="MuiDataGrid-cell"
-                                  >
-                                  </div>
-                                </div>
-                                <div data-id="7"
-                                     data-rowindex="1"
-                                     role="row"
-                                     class="Mui-odd TestTable-row-percent-50-104 MuiDataGrid-row"
-                                     aria-rowindex="3"
-                                     aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
-                                >
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                       role="cell"
-                                       data-value="operator.Run multi-stage test e2e-metal-ipi-virtualmedia - e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup container test"
-                                       data-field="name"
-                                       data-rowindex="1"
-                                       data-colindex="0"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                      <a title="operator.Run multi-stage test e2e-metal-ipi-virtualmedia - e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup container test"
-                                         class
-                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-metal-ipi-virtualmedia%20-%20e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup%20container%20test%22%7D%5D%7D"
-                                      >
-                                        operator.Run multi-stage test e2e-metal-ipi-virtualmedia - e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup container test
-                                      </a>
-                                    </div>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="50"
-                                       data-field="current_pass_percentage"
-                                       data-rowindex="1"
-                                       data-colindex="1"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <p title="2 runs"
-                                       class
-                                    >
-                                      50.00%
-                                    </p>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="-42.85714285714286"
-                                       data-field="net_improvement"
-                                       data-rowindex="1"
-                                       data-colindex="2"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <svg class="MuiSvgIcon-root"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                         data-icon="ArrowDownwardRoundedIcon"
-                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                         title="-42.86%"
-                                    >
-                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                      </path>
-                                    </svg>
-                                  </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       class="MuiDataGrid-cell"
-                                  >
-                                  </div>
-                                </div>
-                                <div data-id="5"
-                                     data-rowindex="2"
-                                     role="row"
-                                     class="Mui-even TestTable-row-percent-50-104 MuiDataGrid-row"
-                                     aria-rowindex="4"
-                                     aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
-                                >
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                       role="cell"
-                                       data-value="operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test"
-                                       data-field="name"
-                                       data-rowindex="2"
-                                       data-colindex="0"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                      <a title="operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test"
-                                         class
-                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-aws-fips%20-%20e2e-aws-fips-ipi-install-install%20container%20test%22%7D%5D%7D"
-                                      >
-                                        operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test
-                                      </a>
-                                    </div>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="50"
-                                       data-field="current_pass_percentage"
-                                       data-rowindex="2"
-                                       data-colindex="1"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <p title="2 runs"
-                                       class
-                                    >
-                                      50.00%
-                                    </p>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="-42.30769230769231"
-                                       data-field="net_improvement"
-                                       data-rowindex="2"
-                                       data-colindex="2"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <svg class="MuiSvgIcon-root"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                         data-icon="ArrowDownwardRoundedIcon"
-                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                         title="-42.31%"
-                                    >
-                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                      </path>
-                                    </svg>
-                                  </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       class="MuiDataGrid-cell"
-                                  >
-                                  </div>
-                                </div>
-                                <div data-id="12"
-                                     data-rowindex="3"
-                                     role="row"
-                                     class="Mui-odd TestTable-row-percent-75-129 MuiDataGrid-row"
-                                     aria-rowindex="5"
-                                     aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
-                                >
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                       role="cell"
-                                       data-value="TestInstall_test_install.start_install_and_wait_for_installed(openshift_version=4.8)"
-                                       data-field="name"
-                                       data-rowindex="3"
-                                       data-colindex="0"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                      <a title="TestInstall_test_install.start_install_and_wait_for_installed(openshift_version=4.8)"
-                                         class
-                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22TestInstall_test_install.start_install_and_wait_for_installed(openshift_version%3D4.8)%22%7D%5D%7D"
-                                      >
-                                        TestInstall_test_install.start_install_and_wait_for_installed(openshift_version=4.8)
-                                      </a>
-                                    </div>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="75"
-                                       data-field="current_pass_percentage"
-                                       data-rowindex="3"
-                                       data-colindex="1"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <p title="4 runs"
-                                       class
-                                    >
-                                      75.00%
-                                    </p>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="-21.15384615384616"
-                                       data-field="net_improvement"
-                                       data-rowindex="3"
-                                       data-colindex="2"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <svg class="MuiSvgIcon-root"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                         data-icon="ArrowDownwardRoundedIcon"
-                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                         title="-21.15%"
-                                    >
-                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                      </path>
-                                    </svg>
-                                  </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       class="MuiDataGrid-cell"
-                                  >
-                                  </div>
-                                </div>
-                                <div data-id="13"
-                                     data-rowindex="4"
-                                     role="row"
-                                     class="Mui-even TestTable-row-percent-75-129 MuiDataGrid-row"
-                                     aria-rowindex="6"
-                                     aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
-                                >
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                       role="cell"
-                                       data-value="operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test"
-                                       data-field="name"
-                                       data-rowindex="4"
-                                       data-colindex="0"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                      <a title="operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test"
-                                         class
-                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-metal-ipi-ovn-ipv6%20-%20e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup%20container%20test%22%7D%5D%7D"
-                                      >
-                                        operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test
-                                      </a>
-                                    </div>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="75"
-                                       data-field="current_pass_percentage"
-                                       data-rowindex="4"
-                                       data-colindex="1"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <p title="8 runs"
-                                       class
-                                    >
-                                      75.00%
-                                    </p>
-                                  </div>
-                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                       role="cell"
-                                       data-value="-17.85714285714286"
-                                       data-field="net_improvement"
-                                       data-rowindex="4"
-                                       data-colindex="2"
-                                       data-rowselected="false"
-                                       data-editable="false"
-                                       data-mode="view"
-                                       aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       tabindex="-1"
-                                  >
-                                    <svg class="MuiSvgIcon-root"
-                                         focusable="false"
-                                         viewbox="0 0 24 24"
-                                         aria-hidden="true"
-                                         data-icon="ArrowDownwardRoundedIcon"
-                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                         title="-17.86%"
-                                    >
-                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                      </path>
-                                    </svg>
-                                  </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                       class="MuiDataGrid-cell"
-                                  >
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div class="Mui-resizeTriggers">
-                      <div class="expand-trigger">
-                        <div style="width: 1px; height: 1px;">
-                        </div>
-                      </div>
-                      <div class="contract-trigger">
-                      </div>
-                    </div>
-                  </div>
-                  <div>
-                    <div class="MuiDataGrid-footerContainer">
-                      <div>
-                      </div>
-                      <div class="MuiTablePagination-root">
-                        <div class="MuiToolbar-root MuiToolbar-regular MuiTablePagination-toolbar MuiToolbar-gutters">
-                          <div class="MuiTablePagination-spacer">
-                          </div>
-                          <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-307 MuiTypography-body2 MuiTypography-colorInherit">
-                            Rows per page:
-                          </p>
-                          <div class="MuiInputBase-root MuiTablePagination-input makeStyles-input-308 MuiTablePagination-selectRoot">
-                            <div class="MuiSelect-root MuiSelect-select MuiTablePagination-select MuiSelect-selectMenu MuiInputBase-input"
-                                 tabindex="0"
-                                 role="button"
-                                 aria-haspopup="listbox"
-                            >
-                              5
-                            </div>
-                            <input aria-hidden="true"
-                                   tabindex="-1"
-                                   class="MuiSelect-nativeInput"
-                                   value="5"
-                            >
-                            <svg class="MuiSvgIcon-root MuiSelect-icon MuiTablePagination-selectIcon"
-                                 focusable="false"
-                                 viewbox="0 0 24 24"
-                                 aria-hidden="true"
-                            >
-                              <path d="M7 10l5 5 5-5z">
-                              </path>
-                            </svg>
-                          </div>
-                          <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-307 MuiTypography-body2 MuiTypography-colorInherit">
-                            1-5 of 10
-                          </p>
-                          <div class="MuiTablePagination-actions">
-                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
-                                    tabindex="-1"
-                                    type="button"
-                                    disabled
-                                    title="Previous page"
-                                    aria-label="Previous page"
-                            >
-                              <span class="MuiIconButton-label">
-                                <svg class="MuiSvgIcon-root"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                >
-                                  <path d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z">
-                                  </path>
-                                </svg>
-                              </span>
-                            </button>
-                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-                                    tabindex="0"
-                                    type="button"
-                                    title="Next page"
-                                    aria-label="Next page"
-                            >
-                              <span class="MuiIconButton-label">
-                                <svg class="MuiSvgIcon-root"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                >
-                                  <path d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z">
-                                  </path>
-                                </svg>
-                              </span>
-                              <span class="MuiTouchRipple-root">
-                              </span>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-12 MuiGrid-grid-md-6">
-            <div class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
-                 enhancement="5"
-                 style="text-align: center;"
-            >
-              <a class="MuiTypography-root MuiTypography-h5"
-                 style="text-align: center;"
-                 href="/jobs/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%7D"
+                 href="/jobs/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
               >
                 Most regressed jobs (two day)
                 <svg class="MuiSvgIcon-root"
@@ -3732,7 +2307,7 @@ exports[`app should render correctly 1`] = `
                                 <div data-id="38"
                                      data-rowindex="0"
                                      role="row"
-                                     class="Mui-even JobTable-row-percent-0-155 MuiDataGrid-row"
+                                     class="Mui-even JobTable-row-percent-0-54 MuiDataGrid-row"
                                      aria-rowindex="2"
                                      aria-selected="false"
                                      style="max-height: 52px; min-height: 52px;"
@@ -3775,7 +2350,7 @@ exports[`app should render correctly 1`] = `
                                     <div class="MuiBox-root MuiBox-root-314"
                                          title="1 runs"
                                     >
-                                      0.00%
+                                      0%
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3811,7 +2386,7 @@ exports[`app should render correctly 1`] = `
                                 <div data-id="33"
                                      data-rowindex="1"
                                      role="row"
-                                     class="Mui-odd JobTable-row-percent-0-155 MuiDataGrid-row"
+                                     class="Mui-odd JobTable-row-percent-0-54 MuiDataGrid-row"
                                      aria-rowindex="3"
                                      aria-selected="false"
                                      style="max-height: 52px; min-height: 52px;"
@@ -3854,7 +2429,7 @@ exports[`app should render correctly 1`] = `
                                     <div class="MuiBox-root MuiBox-root-315"
                                          title="1 runs"
                                     >
-                                      0.00%
+                                      0%
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3890,7 +2465,7 @@ exports[`app should render correctly 1`] = `
                                 <div data-id="30"
                                      data-rowindex="2"
                                      role="row"
-                                     class="Mui-even JobTable-row-percent-0-155 MuiDataGrid-row"
+                                     class="Mui-even JobTable-row-percent-0-54 MuiDataGrid-row"
                                      aria-rowindex="4"
                                      aria-selected="false"
                                      style="max-height: 52px; min-height: 52px;"
@@ -3933,7 +2508,7 @@ exports[`app should render correctly 1`] = `
                                     <div class="MuiBox-root MuiBox-root-316"
                                          title="2 runs"
                                     >
-                                      0.00%
+                                      0%
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3969,7 +2544,7 @@ exports[`app should render correctly 1`] = `
                                 <div data-id="72"
                                      data-rowindex="3"
                                      role="row"
-                                     class="Mui-odd JobTable-row-percent-50-205 MuiDataGrid-row"
+                                     class="Mui-odd JobTable-row-percent-50-104 MuiDataGrid-row"
                                      aria-rowindex="5"
                                      aria-selected="false"
                                      style="max-height: 52px; min-height: 52px;"
@@ -4012,7 +2587,7 @@ exports[`app should render correctly 1`] = `
                                     <div class="MuiBox-root MuiBox-root-317"
                                          title="2 runs"
                                     >
-                                      50.00%
+                                      50%
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4048,7 +2623,7 @@ exports[`app should render correctly 1`] = `
                                 <div data-id="47"
                                      data-rowindex="4"
                                      role="row"
-                                     class="Mui-even JobTable-row-percent-0-155 MuiDataGrid-row"
+                                     class="Mui-even JobTable-row-percent-0-54 MuiDataGrid-row"
                                      aria-rowindex="6"
                                      aria-selected="false"
                                      style="max-height: 52px; min-height: 52px;"
@@ -4091,7 +2666,7 @@ exports[`app should render correctly 1`] = `
                                     <div class="MuiBox-root MuiBox-root-318"
                                          title="2 runs"
                                     >
-                                      0.00%
+                                      0%
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4229,7 +2804,1431 @@ exports[`app should render correctly 1`] = `
             >
               <a class="MuiTypography-root MuiTypography-h5"
                  style="text-align: center;"
-                 href="/tests/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22id%22%3A5%2C%22columnField%22%3A%22bugs%22%2C%22operatorValue%22%3A%22%3D%22%2C%22value%22%3A%220%22%7D%5D%7D"
+                 href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D&amp;sortField=net_improvement&amp;sort=asc"
+              >
+                Most regressed tests
+                <svg class="MuiSvgIcon-root"
+                     focusable="false"
+                     viewbox="0 0 24 24"
+                     aria-hidden="true"
+                     title="Shows the most regressed items this week vs. last week, for those with more than 10 runs"
+                >
+                  <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z">
+                  </path>
+                </svg>
+              </a>
+              <div class="MuiContainer-root MuiContainer-maxWidthLg">
+                <div class="MuiDataGrid-root MuiDataGrid-root MuiDataGrid-autoHeight"
+                     role="grid"
+                     aria-colcount="4"
+                     aria-rowcount="10"
+                     aria-multiselectable="false"
+                >
+                  <div>
+                    <div>
+                    </div>
+                  </div>
+                  <div class="MuiDataGrid-main">
+                    <div class="MuiDataGrid-columnsContainer"
+                         style="min-height: 56px; max-height: 56px; line-height: 56px;"
+                    >
+                      <div class="MuiDataGrid-columnHeaderWrapper scroll"
+                           aria-rowindex="1"
+                           role="row"
+                           style="transform: translate3d(-0px, 0, 0); min-width: 200px;"
+                      >
+                        <div class="MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader"
+                             data-field="name"
+                             style="width: 50px; min-width: 50px; max-width: 50px;"
+                             role="columnheader"
+                             tabindex="0"
+                             aria-colindex="1"
+                        >
+                          <div class="MuiDataGrid-columnHeaderDraggableContainer"
+                               draggable="false"
+                          >
+                            <div class="MuiDataGrid-columnHeaderTitleContainer">
+                              <div class="MuiDataGrid-columnHeaderTitle"
+                                   title
+                              >
+                                Name
+                              </div>
+                              <div class="MuiDataGrid-iconButtonContainer">
+                                <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                                        tabindex="-1"
+                                        type="button"
+                                        aria-label="Sort"
+                                        title="Sort"
+                                >
+                                  <span class="MuiIconButton-label">
+                                    <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                    >
+                                      <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
+                                      </path>
+                                    </svg>
+                                  </span>
+                                  <span class="MuiTouchRipple-root">
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="MuiDataGrid-columnSeparator"
+                               style="min-height: 56px; opacity: 1;"
+                          >
+                            <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
+                                 focusable="false"
+                                 viewbox="0 0 24 24"
+                                 aria-hidden="true"
+                            >
+                              <path d="M11 19V5h2v14z">
+                              </path>
+                            </svg>
+                          </div>
+                        </div>
+                        <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
+                             data-field="current_pass_percentage"
+                             style="width: 50px; min-width: 50px; max-width: 50px;"
+                             role="columnheader"
+                             tabindex="-1"
+                             aria-colindex="2"
+                        >
+                          <div class="MuiDataGrid-columnHeaderDraggableContainer"
+                               draggable="false"
+                          >
+                            <div class="MuiDataGrid-columnHeaderTitleContainer">
+                              <div class="MuiDataGrid-columnHeaderTitle"
+                                   title
+                              >
+                                Current Period
+                              </div>
+                              <div class="MuiDataGrid-iconButtonContainer">
+                                <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                                        tabindex="-1"
+                                        type="button"
+                                        aria-label="Sort"
+                                        title="Sort"
+                                >
+                                  <span class="MuiIconButton-label">
+                                    <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                    >
+                                      <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
+                                      </path>
+                                    </svg>
+                                  </span>
+                                  <span class="MuiTouchRipple-root">
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="MuiDataGrid-columnSeparator"
+                               style="min-height: 56px; opacity: 1;"
+                          >
+                            <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
+                                 focusable="false"
+                                 viewbox="0 0 24 24"
+                                 aria-hidden="true"
+                            >
+                              <path d="M11 19V5h2v14z">
+                              </path>
+                            </svg>
+                          </div>
+                        </div>
+                        <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--sorted MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
+                             data-field="net_improvement"
+                             style="width: 50px; min-width: 50px; max-width: 50px;"
+                             role="columnheader"
+                             tabindex="-1"
+                             aria-colindex="3"
+                             aria-sort="ascending"
+                        >
+                          <div class="MuiDataGrid-columnHeaderDraggableContainer"
+                               draggable="false"
+                          >
+                            <div class="MuiDataGrid-columnHeaderTitleContainer">
+                              <div class="MuiDataGrid-columnHeaderTitle"
+                                   title
+                              >
+                                Improvement
+                              </div>
+                              <div class="MuiDataGrid-iconButtonContainer">
+                                <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                                        tabindex="-1"
+                                        type="button"
+                                        aria-label="Sort"
+                                        title="Sort"
+                                >
+                                  <span class="MuiIconButton-label">
+                                    <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                    >
+                                      <path d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z">
+                                      </path>
+                                    </svg>
+                                  </span>
+                                  <span class="MuiTouchRipple-root">
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="MuiDataGrid-columnSeparator"
+                               style="min-height: 56px; opacity: 1;"
+                          >
+                            <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
+                                 focusable="false"
+                                 viewbox="0 0 24 24"
+                                 aria-hidden="true"
+                            >
+                              <path d="M11 19V5h2v14z">
+                              </path>
+                            </svg>
+                          </div>
+                        </div>
+                        <div style="min-width: 50px; max-width: 50px; line-height: 55px; min-height: 56px; max-height: 56px;"
+                             class="MuiDataGrid-cell"
+                        >
+                        </div>
+                      </div>
+                    </div>
+                    <div style="overflow: visible; width: 0px;">
+                      <div class="MuiDataGrid-windowContainer"
+                           style="width: 0px; height: 556px;"
+                      >
+                        <div class="MuiDataGrid-window"
+                             style="top: 56px; overflow-y: hidden;"
+                        >
+                          <div class="MuiDataGrid-dataContainer"
+                               style="min-width: 200px; min-height: 500px;"
+                          >
+                            <div class="MuiDataGrid-viewport"
+                                 style="min-width: 0; max-width: 0; max-height: 500px;"
+                            >
+                              <div class="MuiDataGrid-renderingZone"
+                                   style="max-height: 500px; width: 200px; transform: translate3d(-0px, -0px, 0);"
+                              >
+                                <div data-id="25"
+                                     data-rowindex="0"
+                                     role="row"
+                                     class="Mui-even TestTable-row-percent-37-192 MuiDataGrid-row"
+                                     aria-rowindex="2"
+                                     aria-selected="false"
+                                     style="max-height: 100px; min-height: 100px;"
+                                >
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                       role="cell"
+                                       data-value="[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version"
+                                       data-field="name"
+                                       data-rowindex="0"
+                                       data-colindex="0"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="1"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <div class="test-name">
+                                      <a title="[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version"
+                                         class
+                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Binstall%5D%20%5BSuite%3A%20operators%5D%20%5BOSD%5D%20RBAC%20Operator%20Operator%20Upgrade%20should%20upgrade%20from%20the%20replaced%20version%22%7D%5D%7D"
+                                      >
+                                        [install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version
+                                      </a>
+                                    </div>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="36.95652173913043"
+                                       data-field="current_pass_percentage"
+                                       data-rowindex="0"
+                                       data-colindex="1"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="2"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <p title="46 runs"
+                                       class
+                                    >
+                                      37%
+                                    </p>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="-49.83593109105825"
+                                       data-field="net_improvement"
+                                       data-rowindex="0"
+                                       data-colindex="2"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="3"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <svg class="MuiSvgIcon-root"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-49.84%"
+                                    >
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                      </path>
+                                    </svg>
+                                  </div>
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       class="MuiDataGrid-cell"
+                                  >
+                                  </div>
+                                </div>
+                                <div data-id="49"
+                                     data-rowindex="1"
+                                     role="row"
+                                     class="Mui-odd TestTable-row-percent-83-238 MuiDataGrid-row"
+                                     aria-rowindex="3"
+                                     aria-selected="false"
+                                     style="max-height: 100px; min-height: 100px;"
+                                >
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                       role="cell"
+                                       data-value="operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test"
+                                       data-field="name"
+                                       data-rowindex="1"
+                                       data-colindex="0"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="1"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <div class="test-name">
+                                      <a title="operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test"
+                                         class
+                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-vsphere-upgrade%20-%20e2e-vsphere-upgrade-ipi-install-install-stableinitial%20container%20test%22%7D%5D%7D"
+                                      >
+                                        operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test
+                                      </a>
+                                    </div>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="83.33333333333334"
+                                       data-field="current_pass_percentage"
+                                       data-rowindex="1"
+                                       data-colindex="1"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="2"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <p title="12 runs"
+                                       class
+                                    >
+                                      83%
+                                    </p>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="-16.666666666666657"
+                                       data-field="net_improvement"
+                                       data-rowindex="1"
+                                       data-colindex="2"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="3"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <svg class="MuiSvgIcon-root"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-16.67%"
+                                    >
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                      </path>
+                                    </svg>
+                                  </div>
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       class="MuiDataGrid-cell"
+                                  >
+                                  </div>
+                                </div>
+                                <div data-id="27"
+                                     data-rowindex="2"
+                                     role="row"
+                                     class="Mui-even TestTable-row-percent-50-205 MuiDataGrid-row"
+                                     aria-rowindex="4"
+                                     aria-selected="false"
+                                     style="max-height: 100px; min-height: 100px;"
+                                >
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                       role="cell"
+                                       data-value="operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test"
+                                       data-field="name"
+                                       data-rowindex="2"
+                                       data-colindex="0"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="1"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <div class="test-name">
+                                      <a title="operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test"
+                                         class
+                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-aws-proxy%20-%20e2e-aws-proxy-ipi-install-install%20container%20test%22%7D%5D%7D"
+                                      >
+                                        operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test
+                                      </a>
+                                    </div>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="50"
+                                       data-field="current_pass_percentage"
+                                       data-rowindex="2"
+                                       data-colindex="1"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="2"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <p title="16 runs"
+                                       class
+                                    >
+                                      50%
+                                    </p>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="-12.5"
+                                       data-field="net_improvement"
+                                       data-rowindex="2"
+                                       data-colindex="2"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="3"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <svg class="MuiSvgIcon-root"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-12.50%"
+                                    >
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                      </path>
+                                    </svg>
+                                  </div>
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       class="MuiDataGrid-cell"
+                                  >
+                                  </div>
+                                </div>
+                                <div data-id="48"
+                                     data-rowindex="3"
+                                     role="row"
+                                     class="Mui-odd TestTable-row-percent-83-238 MuiDataGrid-row"
+                                     aria-rowindex="5"
+                                     aria-selected="false"
+                                     style="max-height: 100px; min-height: 100px;"
+                                >
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                       role="cell"
+                                       data-value="operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test"
+                                       data-field="name"
+                                       data-rowindex="3"
+                                       data-colindex="0"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="1"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <div class="test-name">
+                                      <a title="operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test"
+                                         class
+                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-gcp-upgrade%20-%20e2e-gcp-upgrade-ipi-install-install-stableinitial%20container%20test%22%7D%5D%7D"
+                                      >
+                                        operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test
+                                      </a>
+                                    </div>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="83.33333333333334"
+                                       data-field="current_pass_percentage"
+                                       data-rowindex="3"
+                                       data-colindex="1"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="2"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <p title="48 runs"
+                                       class
+                                    >
+                                      83%
+                                    </p>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="-12.12121212121211"
+                                       data-field="net_improvement"
+                                       data-rowindex="3"
+                                       data-colindex="2"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="3"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <svg class="MuiSvgIcon-root"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-12.12%"
+                                    >
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                      </path>
+                                    </svg>
+                                  </div>
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       class="MuiDataGrid-cell"
+                                  >
+                                  </div>
+                                </div>
+                                <div data-id="55"
+                                     data-rowindex="4"
+                                     role="row"
+                                     class="Mui-even TestTable-row-percent-89-244 MuiDataGrid-row"
+                                     aria-rowindex="6"
+                                     aria-selected="false"
+                                     style="max-height: 100px; min-height: 100px;"
+                                >
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                       role="cell"
+                                       data-value="operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test"
+                                       data-field="name"
+                                       data-rowindex="4"
+                                       data-colindex="0"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="1"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <div class="test-name">
+                                      <a title="operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test"
+                                         class
+                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-gcp%20-%20e2e-gcp-ipi-install-install%20container%20test%22%7D%5D%7D"
+                                      >
+                                        operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test
+                                      </a>
+                                    </div>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="89.1891891891892"
+                                       data-field="current_pass_percentage"
+                                       data-rowindex="4"
+                                       data-colindex="1"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="2"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <p title="37 runs"
+                                       class
+                                    >
+                                      89%
+                                    </p>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="-10.810810810810807"
+                                       data-field="net_improvement"
+                                       data-rowindex="4"
+                                       data-colindex="2"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="3"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <svg class="MuiSvgIcon-root"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-10.81%"
+                                    >
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                      </path>
+                                    </svg>
+                                  </div>
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       class="MuiDataGrid-cell"
+                                  >
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="Mui-resizeTriggers">
+                      <div class="expand-trigger">
+                        <div style="width: 1px; height: 1px;">
+                        </div>
+                      </div>
+                      <div class="contract-trigger">
+                      </div>
+                    </div>
+                  </div>
+                  <div>
+                    <div class="MuiDataGrid-footerContainer">
+                      <div>
+                      </div>
+                      <div class="MuiTablePagination-root">
+                        <div class="MuiToolbar-root MuiToolbar-regular MuiTablePagination-toolbar MuiToolbar-gutters">
+                          <div class="MuiTablePagination-spacer">
+                          </div>
+                          <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-307 MuiTypography-body2 MuiTypography-colorInherit">
+                            Rows per page:
+                          </p>
+                          <div class="MuiInputBase-root MuiTablePagination-input makeStyles-input-308 MuiTablePagination-selectRoot">
+                            <div class="MuiSelect-root MuiSelect-select MuiTablePagination-select MuiSelect-selectMenu MuiInputBase-input"
+                                 tabindex="0"
+                                 role="button"
+                                 aria-haspopup="listbox"
+                            >
+                              5
+                            </div>
+                            <input aria-hidden="true"
+                                   tabindex="-1"
+                                   class="MuiSelect-nativeInput"
+                                   value="5"
+                            >
+                            <svg class="MuiSvgIcon-root MuiSelect-icon MuiTablePagination-selectIcon"
+                                 focusable="false"
+                                 viewbox="0 0 24 24"
+                                 aria-hidden="true"
+                            >
+                              <path d="M7 10l5 5 5-5z">
+                              </path>
+                            </svg>
+                          </div>
+                          <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-307 MuiTypography-body2 MuiTypography-colorInherit">
+                            1-5 of 10
+                          </p>
+                          <div class="MuiTablePagination-actions">
+                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
+                                    tabindex="-1"
+                                    type="button"
+                                    disabled
+                                    title="Previous page"
+                                    aria-label="Previous page"
+                            >
+                              <span class="MuiIconButton-label">
+                                <svg class="MuiSvgIcon-root"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                >
+                                  <path d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z">
+                                  </path>
+                                </svg>
+                              </span>
+                            </button>
+                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+                                    tabindex="0"
+                                    type="button"
+                                    title="Next page"
+                                    aria-label="Next page"
+                            >
+                              <span class="MuiIconButton-label">
+                                <svg class="MuiSvgIcon-root"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                >
+                                  <path d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z">
+                                  </path>
+                                </svg>
+                              </span>
+                              <span class="MuiTouchRipple-root">
+                              </span>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-12 MuiGrid-grid-md-6">
+            <div class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
+                 enhancement="5"
+                 style="text-align: center;"
+            >
+              <a class="MuiTypography-root MuiTypography-h5"
+                 style="text-align: center;"
+                 href="/tests/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
+              >
+                Most regressed tests (two day)
+                <svg class="MuiSvgIcon-root"
+                     focusable="false"
+                     viewbox="0 0 24 24"
+                     aria-hidden="true"
+                     title="Shows the last 2 days compared to the last 7 days, sorted by most regressed."
+                >
+                  <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z">
+                  </path>
+                </svg>
+              </a>
+              <div class="MuiContainer-root MuiContainer-maxWidthLg">
+                <div class="MuiDataGrid-root MuiDataGrid-root MuiDataGrid-autoHeight"
+                     role="grid"
+                     aria-colcount="4"
+                     aria-rowcount="10"
+                     aria-multiselectable="false"
+                >
+                  <div>
+                    <div>
+                    </div>
+                  </div>
+                  <div class="MuiDataGrid-main">
+                    <div class="MuiDataGrid-columnsContainer"
+                         style="min-height: 56px; max-height: 56px; line-height: 56px;"
+                    >
+                      <div class="MuiDataGrid-columnHeaderWrapper scroll"
+                           aria-rowindex="1"
+                           role="row"
+                           style="transform: translate3d(-0px, 0, 0); min-width: 200px;"
+                      >
+                        <div class="MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader"
+                             data-field="name"
+                             style="width: 50px; min-width: 50px; max-width: 50px;"
+                             role="columnheader"
+                             tabindex="0"
+                             aria-colindex="1"
+                        >
+                          <div class="MuiDataGrid-columnHeaderDraggableContainer"
+                               draggable="false"
+                          >
+                            <div class="MuiDataGrid-columnHeaderTitleContainer">
+                              <div class="MuiDataGrid-columnHeaderTitle"
+                                   title
+                              >
+                                Name
+                              </div>
+                              <div class="MuiDataGrid-iconButtonContainer">
+                                <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                                        tabindex="-1"
+                                        type="button"
+                                        aria-label="Sort"
+                                        title="Sort"
+                                >
+                                  <span class="MuiIconButton-label">
+                                    <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                    >
+                                      <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
+                                      </path>
+                                    </svg>
+                                  </span>
+                                  <span class="MuiTouchRipple-root">
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="MuiDataGrid-columnSeparator"
+                               style="min-height: 56px; opacity: 1;"
+                          >
+                            <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
+                                 focusable="false"
+                                 viewbox="0 0 24 24"
+                                 aria-hidden="true"
+                            >
+                              <path d="M11 19V5h2v14z">
+                              </path>
+                            </svg>
+                          </div>
+                        </div>
+                        <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
+                             data-field="current_pass_percentage"
+                             style="width: 50px; min-width: 50px; max-width: 50px;"
+                             role="columnheader"
+                             tabindex="-1"
+                             aria-colindex="2"
+                        >
+                          <div class="MuiDataGrid-columnHeaderDraggableContainer"
+                               draggable="false"
+                          >
+                            <div class="MuiDataGrid-columnHeaderTitleContainer">
+                              <div class="MuiDataGrid-columnHeaderTitle"
+                                   title
+                              >
+                                Current Period
+                              </div>
+                              <div class="MuiDataGrid-iconButtonContainer">
+                                <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                                        tabindex="-1"
+                                        type="button"
+                                        aria-label="Sort"
+                                        title="Sort"
+                                >
+                                  <span class="MuiIconButton-label">
+                                    <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                    >
+                                      <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
+                                      </path>
+                                    </svg>
+                                  </span>
+                                  <span class="MuiTouchRipple-root">
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="MuiDataGrid-columnSeparator"
+                               style="min-height: 56px; opacity: 1;"
+                          >
+                            <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
+                                 focusable="false"
+                                 viewbox="0 0 24 24"
+                                 aria-hidden="true"
+                            >
+                              <path d="M11 19V5h2v14z">
+                              </path>
+                            </svg>
+                          </div>
+                        </div>
+                        <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--sorted MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
+                             data-field="net_improvement"
+                             style="width: 50px; min-width: 50px; max-width: 50px;"
+                             role="columnheader"
+                             tabindex="-1"
+                             aria-colindex="3"
+                             aria-sort="ascending"
+                        >
+                          <div class="MuiDataGrid-columnHeaderDraggableContainer"
+                               draggable="false"
+                          >
+                            <div class="MuiDataGrid-columnHeaderTitleContainer">
+                              <div class="MuiDataGrid-columnHeaderTitle"
+                                   title
+                              >
+                                Improvement
+                              </div>
+                              <div class="MuiDataGrid-iconButtonContainer">
+                                <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                                        tabindex="-1"
+                                        type="button"
+                                        aria-label="Sort"
+                                        title="Sort"
+                                >
+                                  <span class="MuiIconButton-label">
+                                    <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                    >
+                                      <path d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z">
+                                      </path>
+                                    </svg>
+                                  </span>
+                                  <span class="MuiTouchRipple-root">
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="MuiDataGrid-columnSeparator"
+                               style="min-height: 56px; opacity: 1;"
+                          >
+                            <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
+                                 focusable="false"
+                                 viewbox="0 0 24 24"
+                                 aria-hidden="true"
+                            >
+                              <path d="M11 19V5h2v14z">
+                              </path>
+                            </svg>
+                          </div>
+                        </div>
+                        <div style="min-width: 50px; max-width: 50px; line-height: 55px; min-height: 56px; max-height: 56px;"
+                             class="MuiDataGrid-cell"
+                        >
+                        </div>
+                      </div>
+                    </div>
+                    <div style="overflow: visible; width: 0px;">
+                      <div class="MuiDataGrid-windowContainer"
+                           style="width: 0px; height: 556px;"
+                      >
+                        <div class="MuiDataGrid-window"
+                             style="top: 56px; overflow-y: hidden;"
+                        >
+                          <div class="MuiDataGrid-dataContainer"
+                               style="min-width: 200px; min-height: 500px;"
+                          >
+                            <div class="MuiDataGrid-viewport"
+                                 style="min-width: 0; max-width: 0; max-height: 500px;"
+                            >
+                              <div class="MuiDataGrid-renderingZone"
+                                   style="max-height: 500px; width: 200px; transform: translate3d(-0px, -0px, 0);"
+                              >
+                                <div data-id="6"
+                                     data-rowindex="0"
+                                     role="row"
+                                     class="Mui-even TestTable-row-percent-50-205 MuiDataGrid-row"
+                                     aria-rowindex="2"
+                                     aria-selected="false"
+                                     style="max-height: 100px; min-height: 100px;"
+                                >
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                       role="cell"
+                                       data-value="operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test"
+                                       data-field="name"
+                                       data-rowindex="0"
+                                       data-colindex="0"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="1"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <div class="test-name">
+                                      <a title="operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test"
+                                         class
+                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-metal-assisted%20-%20e2e-metal-assisted-baremetalds-assisted-setup%20container%20test%22%7D%5D%7D"
+                                      >
+                                        operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test
+                                      </a>
+                                    </div>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="50"
+                                       data-field="current_pass_percentage"
+                                       data-rowindex="0"
+                                       data-colindex="1"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="2"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <p title="2 runs"
+                                       class
+                                    >
+                                      50%
+                                    </p>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="-42.85714285714286"
+                                       data-field="net_improvement"
+                                       data-rowindex="0"
+                                       data-colindex="2"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="3"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <svg class="MuiSvgIcon-root"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-42.86%"
+                                    >
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                      </path>
+                                    </svg>
+                                  </div>
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       class="MuiDataGrid-cell"
+                                  >
+                                  </div>
+                                </div>
+                                <div data-id="7"
+                                     data-rowindex="1"
+                                     role="row"
+                                     class="Mui-odd TestTable-row-percent-50-205 MuiDataGrid-row"
+                                     aria-rowindex="3"
+                                     aria-selected="false"
+                                     style="max-height: 100px; min-height: 100px;"
+                                >
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                       role="cell"
+                                       data-value="operator.Run multi-stage test e2e-metal-ipi-virtualmedia - e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup container test"
+                                       data-field="name"
+                                       data-rowindex="1"
+                                       data-colindex="0"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="1"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <div class="test-name">
+                                      <a title="operator.Run multi-stage test e2e-metal-ipi-virtualmedia - e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup container test"
+                                         class
+                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-metal-ipi-virtualmedia%20-%20e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup%20container%20test%22%7D%5D%7D"
+                                      >
+                                        operator.Run multi-stage test e2e-metal-ipi-virtualmedia - e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup container test
+                                      </a>
+                                    </div>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="50"
+                                       data-field="current_pass_percentage"
+                                       data-rowindex="1"
+                                       data-colindex="1"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="2"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <p title="2 runs"
+                                       class
+                                    >
+                                      50%
+                                    </p>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="-42.85714285714286"
+                                       data-field="net_improvement"
+                                       data-rowindex="1"
+                                       data-colindex="2"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="3"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <svg class="MuiSvgIcon-root"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-42.86%"
+                                    >
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                      </path>
+                                    </svg>
+                                  </div>
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       class="MuiDataGrid-cell"
+                                  >
+                                  </div>
+                                </div>
+                                <div data-id="5"
+                                     data-rowindex="2"
+                                     role="row"
+                                     class="Mui-even TestTable-row-percent-50-205 MuiDataGrid-row"
+                                     aria-rowindex="4"
+                                     aria-selected="false"
+                                     style="max-height: 100px; min-height: 100px;"
+                                >
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                       role="cell"
+                                       data-value="operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test"
+                                       data-field="name"
+                                       data-rowindex="2"
+                                       data-colindex="0"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="1"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <div class="test-name">
+                                      <a title="operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test"
+                                         class
+                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-aws-fips%20-%20e2e-aws-fips-ipi-install-install%20container%20test%22%7D%5D%7D"
+                                      >
+                                        operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test
+                                      </a>
+                                    </div>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="50"
+                                       data-field="current_pass_percentage"
+                                       data-rowindex="2"
+                                       data-colindex="1"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="2"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <p title="2 runs"
+                                       class
+                                    >
+                                      50%
+                                    </p>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="-42.30769230769231"
+                                       data-field="net_improvement"
+                                       data-rowindex="2"
+                                       data-colindex="2"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="3"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <svg class="MuiSvgIcon-root"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-42.31%"
+                                    >
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                      </path>
+                                    </svg>
+                                  </div>
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       class="MuiDataGrid-cell"
+                                  >
+                                  </div>
+                                </div>
+                                <div data-id="12"
+                                     data-rowindex="3"
+                                     role="row"
+                                     class="Mui-odd TestTable-row-percent-75-230 MuiDataGrid-row"
+                                     aria-rowindex="5"
+                                     aria-selected="false"
+                                     style="max-height: 100px; min-height: 100px;"
+                                >
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                       role="cell"
+                                       data-value="TestInstall_test_install.start_install_and_wait_for_installed(openshift_version=4.8)"
+                                       data-field="name"
+                                       data-rowindex="3"
+                                       data-colindex="0"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="1"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <div class="test-name">
+                                      <a title="TestInstall_test_install.start_install_and_wait_for_installed(openshift_version=4.8)"
+                                         class
+                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22TestInstall_test_install.start_install_and_wait_for_installed(openshift_version%3D4.8)%22%7D%5D%7D"
+                                      >
+                                        TestInstall_test_install.start_install_and_wait_for_installed(openshift_version=4.8)
+                                      </a>
+                                    </div>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="75"
+                                       data-field="current_pass_percentage"
+                                       data-rowindex="3"
+                                       data-colindex="1"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="2"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <p title="4 runs"
+                                       class
+                                    >
+                                      75%
+                                    </p>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="-21.15384615384616"
+                                       data-field="net_improvement"
+                                       data-rowindex="3"
+                                       data-colindex="2"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="3"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <svg class="MuiSvgIcon-root"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-21.15%"
+                                    >
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                      </path>
+                                    </svg>
+                                  </div>
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       class="MuiDataGrid-cell"
+                                  >
+                                  </div>
+                                </div>
+                                <div data-id="13"
+                                     data-rowindex="4"
+                                     role="row"
+                                     class="Mui-even TestTable-row-percent-75-230 MuiDataGrid-row"
+                                     aria-rowindex="6"
+                                     aria-selected="false"
+                                     style="max-height: 100px; min-height: 100px;"
+                                >
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                       role="cell"
+                                       data-value="operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test"
+                                       data-field="name"
+                                       data-rowindex="4"
+                                       data-colindex="0"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="1"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <div class="test-name">
+                                      <a title="operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test"
+                                         class
+                                         href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-metal-ipi-ovn-ipv6%20-%20e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup%20container%20test%22%7D%5D%7D"
+                                      >
+                                        operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test
+                                      </a>
+                                    </div>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="75"
+                                       data-field="current_pass_percentage"
+                                       data-rowindex="4"
+                                       data-colindex="1"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="2"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <p title="8 runs"
+                                       class
+                                    >
+                                      75%
+                                    </p>
+                                  </div>
+                                  <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                       role="cell"
+                                       data-value="-17.85714285714286"
+                                       data-field="net_improvement"
+                                       data-rowindex="4"
+                                       data-colindex="2"
+                                       data-rowselected="false"
+                                       data-editable="false"
+                                       data-mode="view"
+                                       aria-colindex="3"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       tabindex="-1"
+                                  >
+                                    <svg class="MuiSvgIcon-root"
+                                         focusable="false"
+                                         viewbox="0 0 24 24"
+                                         aria-hidden="true"
+                                         data-icon="ArrowDownwardRoundedIcon"
+                                         style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                         title="-17.86%"
+                                    >
+                                      <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                      </path>
+                                    </svg>
+                                  </div>
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                       class="MuiDataGrid-cell"
+                                  >
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="Mui-resizeTriggers">
+                      <div class="expand-trigger">
+                        <div style="width: 1px; height: 1px;">
+                        </div>
+                      </div>
+                      <div class="contract-trigger">
+                      </div>
+                    </div>
+                  </div>
+                  <div>
+                    <div class="MuiDataGrid-footerContainer">
+                      <div>
+                      </div>
+                      <div class="MuiTablePagination-root">
+                        <div class="MuiToolbar-root MuiToolbar-regular MuiTablePagination-toolbar MuiToolbar-gutters">
+                          <div class="MuiTablePagination-spacer">
+                          </div>
+                          <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-307 MuiTypography-body2 MuiTypography-colorInherit">
+                            Rows per page:
+                          </p>
+                          <div class="MuiInputBase-root MuiTablePagination-input makeStyles-input-308 MuiTablePagination-selectRoot">
+                            <div class="MuiSelect-root MuiSelect-select MuiTablePagination-select MuiSelect-selectMenu MuiInputBase-input"
+                                 tabindex="0"
+                                 role="button"
+                                 aria-haspopup="listbox"
+                            >
+                              5
+                            </div>
+                            <input aria-hidden="true"
+                                   tabindex="-1"
+                                   class="MuiSelect-nativeInput"
+                                   value="5"
+                            >
+                            <svg class="MuiSvgIcon-root MuiSelect-icon MuiTablePagination-selectIcon"
+                                 focusable="false"
+                                 viewbox="0 0 24 24"
+                                 aria-hidden="true"
+                            >
+                              <path d="M7 10l5 5 5-5z">
+                              </path>
+                            </svg>
+                          </div>
+                          <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-307 MuiTypography-body2 MuiTypography-colorInherit">
+                            1-5 of 10
+                          </p>
+                          <div class="MuiTablePagination-actions">
+                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
+                                    tabindex="-1"
+                                    type="button"
+                                    disabled
+                                    title="Previous page"
+                                    aria-label="Previous page"
+                            >
+                              <span class="MuiIconButton-label">
+                                <svg class="MuiSvgIcon-root"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                >
+                                  <path d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z">
+                                  </path>
+                                </svg>
+                              </span>
+                            </button>
+                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+                                    tabindex="0"
+                                    type="button"
+                                    title="Next page"
+                                    aria-label="Next page"
+                            >
+                              <span class="MuiIconButton-label">
+                                <svg class="MuiSvgIcon-root"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                >
+                                  <path d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z">
+                                  </path>
+                                </svg>
+                              </span>
+                              <span class="MuiTouchRipple-root">
+                              </span>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-12 MuiGrid-grid-md-6">
+            <div class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
+                 enhancement="5"
+                 style="text-align: center;"
+            >
+              <a class="MuiTypography-root MuiTypography-h5"
+                 style="text-align: center;"
+                 href="/tests/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22id%22%3A5%2C%22columnField%22%3A%22bugs%22%2C%22operatorValue%22%3A%22%3D%22%2C%22value%22%3A%220%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
               >
                 Top failing tests without a bug
                 <svg class="MuiSvgIcon-root"
@@ -4427,27 +4426,27 @@ exports[`app should render correctly 1`] = `
                     </div>
                     <div style="overflow: visible; width: 0px;">
                       <div class="MuiDataGrid-windowContainer"
-                           style="width: 0px; height: 316px;"
+                           style="width: 0px; height: 556px;"
                       >
                         <div class="MuiDataGrid-window"
                              style="top: 56px; overflow-y: hidden;"
                         >
                           <div class="MuiDataGrid-dataContainer"
-                               style="min-width: 200px; min-height: 260px;"
+                               style="min-width: 200px; min-height: 500px;"
                           >
                             <div class="MuiDataGrid-viewport"
-                                 style="min-width: 0; max-width: 0; max-height: 260px;"
+                                 style="min-width: 0; max-width: 0; max-height: 500px;"
                             >
                               <div class="MuiDataGrid-renderingZone"
-                                   style="max-height: 260px; width: 200px; transform: translate3d(-0px, -0px, 0);"
+                                   style="max-height: 500px; width: 200px; transform: translate3d(-0px, -0px, 0);"
                               >
                                 <div data-id="25"
                                      data-rowindex="0"
                                      role="row"
-                                     class="Mui-even TestTable-row-percent-37-91 MuiDataGrid-row"
+                                     class="Mui-even TestTable-row-percent-37-192 MuiDataGrid-row"
                                      aria-rowindex="2"
                                      aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
+                                     style="max-height: 100px; min-height: 100px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
@@ -4459,10 +4458,10 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        tabindex="-1"
                                   >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                    <div class="test-name">
                                       <a title="[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version"
                                          class
                                          href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Binstall%5D%20%5BSuite%3A%20operators%5D%20%5BOSD%5D%20RBAC%20Operator%20Operator%20Upgrade%20should%20upgrade%20from%20the%20replaced%20version%22%7D%5D%7D"
@@ -4481,13 +4480,13 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        tabindex="-1"
                                   >
                                     <p title="46 runs"
                                        class
                                     >
-                                      36.96%
+                                      37%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4500,7 +4499,7 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        tabindex="-1"
                                   >
                                     <svg class="MuiSvgIcon-root"
@@ -4515,7 +4514,7 @@ exports[`app should render correctly 1`] = `
                                       </path>
                                     </svg>
                                   </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        class="MuiDataGrid-cell"
                                   >
                                   </div>
@@ -4523,10 +4522,10 @@ exports[`app should render correctly 1`] = `
                                 <div data-id="49"
                                      data-rowindex="1"
                                      role="row"
-                                     class="Mui-odd TestTable-row-percent-83-137 MuiDataGrid-row"
+                                     class="Mui-odd TestTable-row-percent-83-238 MuiDataGrid-row"
                                      aria-rowindex="3"
                                      aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
+                                     style="max-height: 100px; min-height: 100px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
@@ -4538,10 +4537,10 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        tabindex="-1"
                                   >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                    <div class="test-name">
                                       <a title="operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test"
                                          class
                                          href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-vsphere-upgrade%20-%20e2e-vsphere-upgrade-ipi-install-install-stableinitial%20container%20test%22%7D%5D%7D"
@@ -4560,13 +4559,13 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        tabindex="-1"
                                   >
                                     <p title="12 runs"
                                        class
                                     >
-                                      83.33%
+                                      83%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4579,7 +4578,7 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        tabindex="-1"
                                   >
                                     <svg class="MuiSvgIcon-root"
@@ -4594,7 +4593,7 @@ exports[`app should render correctly 1`] = `
                                       </path>
                                     </svg>
                                   </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        class="MuiDataGrid-cell"
                                   >
                                   </div>
@@ -4602,10 +4601,10 @@ exports[`app should render correctly 1`] = `
                                 <div data-id="27"
                                      data-rowindex="2"
                                      role="row"
-                                     class="Mui-even TestTable-row-percent-50-104 MuiDataGrid-row"
+                                     class="Mui-even TestTable-row-percent-50-205 MuiDataGrid-row"
                                      aria-rowindex="4"
                                      aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
+                                     style="max-height: 100px; min-height: 100px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
@@ -4617,10 +4616,10 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        tabindex="-1"
                                   >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                    <div class="test-name">
                                       <a title="operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test"
                                          class
                                          href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-aws-proxy%20-%20e2e-aws-proxy-ipi-install-install%20container%20test%22%7D%5D%7D"
@@ -4639,13 +4638,13 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        tabindex="-1"
                                   >
                                     <p title="16 runs"
                                        class
                                     >
-                                      50.00%
+                                      50%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4658,7 +4657,7 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        tabindex="-1"
                                   >
                                     <svg class="MuiSvgIcon-root"
@@ -4673,7 +4672,7 @@ exports[`app should render correctly 1`] = `
                                       </path>
                                     </svg>
                                   </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        class="MuiDataGrid-cell"
                                   >
                                   </div>
@@ -4681,10 +4680,10 @@ exports[`app should render correctly 1`] = `
                                 <div data-id="48"
                                      data-rowindex="3"
                                      role="row"
-                                     class="Mui-odd TestTable-row-percent-83-137 MuiDataGrid-row"
+                                     class="Mui-odd TestTable-row-percent-83-238 MuiDataGrid-row"
                                      aria-rowindex="5"
                                      aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
+                                     style="max-height: 100px; min-height: 100px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
@@ -4696,10 +4695,10 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        tabindex="-1"
                                   >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                    <div class="test-name">
                                       <a title="operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test"
                                          class
                                          href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-gcp-upgrade%20-%20e2e-gcp-upgrade-ipi-install-install-stableinitial%20container%20test%22%7D%5D%7D"
@@ -4718,13 +4717,13 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        tabindex="-1"
                                   >
                                     <p title="48 runs"
                                        class
                                     >
-                                      83.33%
+                                      83%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4737,7 +4736,7 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        tabindex="-1"
                                   >
                                     <svg class="MuiSvgIcon-root"
@@ -4752,7 +4751,7 @@ exports[`app should render correctly 1`] = `
                                       </path>
                                     </svg>
                                   </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        class="MuiDataGrid-cell"
                                   >
                                   </div>
@@ -4760,10 +4759,10 @@ exports[`app should render correctly 1`] = `
                                 <div data-id="55"
                                      data-rowindex="4"
                                      role="row"
-                                     class="Mui-even TestTable-row-percent-89-143 MuiDataGrid-row"
+                                     class="Mui-even TestTable-row-percent-89-244 MuiDataGrid-row"
                                      aria-rowindex="6"
                                      aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
+                                     style="max-height: 100px; min-height: 100px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
@@ -4775,10 +4774,10 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        tabindex="-1"
                                   >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                    <div class="test-name">
                                       <a title="operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test"
                                          class
                                          href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-gcp%20-%20e2e-gcp-ipi-install-install%20container%20test%22%7D%5D%7D"
@@ -4797,13 +4796,13 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        tabindex="-1"
                                   >
                                     <p title="37 runs"
                                        class
                                     >
-                                      89.19%
+                                      89%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4816,7 +4815,7 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        tabindex="-1"
                                   >
                                     <svg class="MuiSvgIcon-root"
@@ -4831,7 +4830,7 @@ exports[`app should render correctly 1`] = `
                                       </path>
                                     </svg>
                                   </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                        class="MuiDataGrid-cell"
                                   >
                                   </div>
@@ -5144,7 +5143,7 @@ exports[`app should render correctly 1`] = `
                     </div>
                     <div style="overflow: visible; width: 0px;">
                       <div class="MuiDataGrid-windowContainer"
-                           style="width: 0px; height: 160px;"
+                           style="width: 0px; height: 256px;"
                       >
                         <div class="MuiDataGrid-window"
                              style="top: 56px; overflow-y: hidden;"

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -22,6 +22,10 @@ export function withSort (queryString, sortField, sort) {
   return `${queryString}&sortField=${sortField}&sort=${sort}`
 }
 
+export function queryForBookmark (...bookmarks) {
+  return multiple(...bookmarks)
+}
+
 export function pathForExactJob (release, job) {
   return `/jobs/${release}?${single(filterFor('name', 'equals', job))}`
 }

--- a/sippy-ng/src/jobs/JobTable.js
+++ b/sippy-ng/src/jobs/JobTable.js
@@ -51,7 +51,7 @@ function JobTable (props) {
     {
       field: 'name',
       headerName: 'Name',
-      flex: 3,
+      flex: 4,
       renderCell: (params) => {
         return (
           <div style={{ display: 'block', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
@@ -68,11 +68,11 @@ function JobTable (props) {
       field: 'current_pass_percentage',
       headerName: 'Current Period',
       type: 'number',
-      flex: 1,
+      flex: 0.5,
       renderCell: (params) => (
         <Tooltip title={params.row.current_runs + ' runs'}>
           <Box>
-            {Number(params.value).toFixed(2).toLocaleString()}%
+            {Number(params.value).toFixed(0).toLocaleString()}%
           </Box>
         </Tooltip>
       )
@@ -91,12 +91,12 @@ function JobTable (props) {
     {
       field: 'previous_pass_percentage',
       headerName: 'Previous Period',
-      flex: 1,
+      flex: 0.5,
       type: 'number',
       renderCell: (params) => (
         <Tooltip title={params.row.current_runs + ' runs'}>
           <Box>
-            {Number(params.value).toFixed(2).toLocaleString()}%
+            {Number(params.value).toFixed(0).toLocaleString()}%
           </Box>
         </Tooltip>
       )

--- a/sippy-ng/src/jobs/__snapshots__/JobTable.test.js.snap
+++ b/sippy-ng/src/jobs/__snapshots__/JobTable.test.js.snap
@@ -373,7 +373,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-107\\"
                            title=\\"3 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -452,7 +452,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-108\\"
                            title=\\"3 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -531,7 +531,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-109\\"
                            title=\\"6 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -610,7 +610,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-110\\"
                            title=\\"3 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -689,7 +689,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-111\\"
                            title=\\"3 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -768,7 +768,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-112\\"
                            title=\\"13 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -847,7 +847,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-113\\"
                            title=\\"3 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -926,7 +926,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-114\\"
                            title=\\"3 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1005,7 +1005,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-115\\"
                            title=\\"3 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1084,7 +1084,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-116\\"
                            title=\\"3 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1163,7 +1163,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-117\\"
                            title=\\"40 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1242,7 +1242,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-118\\"
                            title=\\"3 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1321,7 +1321,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-119\\"
                            title=\\"3 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1400,7 +1400,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-120\\"
                            title=\\"3 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1479,7 +1479,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-121\\"
                            title=\\"3 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1558,7 +1558,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-122\\"
                            title=\\"6 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1637,7 +1637,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-123\\"
                            title=\\"6 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1716,7 +1716,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-124\\"
                            title=\\"6 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1795,7 +1795,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-125\\"
                            title=\\"3 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1874,7 +1874,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-126\\"
                            title=\\"6 runs\\"
                       >
-                        0.00%
+                        0%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1953,7 +1953,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-127\\"
                            title=\\"13 runs\\"
                       >
-                        15.38%
+                        15%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -2032,7 +2032,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-128\\"
                            title=\\"6 runs\\"
                       >
-                        16.67%
+                        17%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -2111,7 +2111,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-129\\"
                            title=\\"13 runs\\"
                       >
-                        23.08%
+                        23%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -2190,7 +2190,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-130\\"
                            title=\\"4 runs\\"
                       >
-                        25.00%
+                        25%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -2269,7 +2269,7 @@ exports[`JobTable should render correctly 1`] = `
                       <div class=\\"MuiBox-root MuiBox-root-131\\"
                            title=\\"4 runs\\"
                       >
-                        25.00%
+                        25%
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"

--- a/sippy-ng/src/releases/ReleaseOverview.js
+++ b/sippy-ng/src/releases/ReleaseOverview.js
@@ -3,16 +3,17 @@ import Grid from '@material-ui/core/Grid'
 import { createTheme, makeStyles } from '@material-ui/core/styles'
 import InfoIcon from '@material-ui/icons/Info'
 import Alert from '@material-ui/lab/Alert'
-import PropTypes from 'prop-types'
 import React, { Fragment, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import PassRateIcon from '../components/PassRateIcon'
 import SimpleBreadcrumbs from '../components/SimpleBreadcrumbs'
 import SummaryCard from '../components/SummaryCard'
 import { BOOKMARKS, INFRASTRUCTURE_THRESHOLDS, INSTALL_THRESHOLDS, UPGRADE_THRESHOLDS } from '../constants'
-import JobTable from '../jobs/JobTable'
 import VariantCards from '../jobs/VariantCards'
+import { queryForBookmark } from '../helpers'
+import JobTable from '../jobs/JobTable'
 import TestTable from '../tests/TestTable'
+import PropTypes from 'prop-types'
 
 export const TOOLTIP = 'Top level release indicators showing product health'
 export const REGRESSED_TOOLTIP = 'Shows the most regressed items this week vs. last week, for those with more than 10 runs'
@@ -156,34 +157,13 @@ export default function ReleaseOverview (props) {
             </Grid>
 
             <VariantCards release={props.release} />
-
             <Grid item md={6} sm={12}>
               <Card enhancement="5" style={{ textAlign: 'center' }}>
-                <Typography component={Link} to={'/tests/' + props.release + '?sortField=net_improvement&sort=asc&filters=' + encodeURIComponent(JSON.stringify({ items: [BOOKMARKS.RUN_10] }))} style={{ textAlign: 'center' }} variant="h5">
-                  Most regressed tests
-                  <Tooltip title={REGRESSED_TOOLTIP}>
-                    <InfoIcon />
-                  </Tooltip>
-                </Typography>
-
-                <TestTable
-                  hideControls={true}
-                  sortField="net_improvement"
-                  sort="asc"
-                  limit={10}
-                  filterModel={{
-                    items: [BOOKMARKS.RUN_10]
-                  }}
-                  pageSize={5}
-                  briefTable={true}
-                  release={props.release} />
-
-              </Card>
-            </Grid>
-
-            <Grid item md={6} sm={12}>
-              <Card enhancement="5" style={{ textAlign: 'center' }}>
-                <Typography component={Link} to={'/jobs/' + props.release + '?sortField=net_improvement&sort=asc&filters=' + encodeURIComponent(JSON.stringify({ items: [BOOKMARKS.RUN_10] }))} style={{ textAlign: 'center' }} variant="h5">
+                <Typography
+                  component={Link}
+                  to={`/jobs/${props.release}?sortField=net_improvement&sort=asc&${queryForBookmark(BOOKMARKS.RUN_10)}`}
+                  style={{ textAlign: 'center' }}
+                  variant="h5">
                   Most regressed jobs
                   <Tooltip title={REGRESSED_TOOLTIP}>
                     <InfoIcon />
@@ -207,8 +187,65 @@ export default function ReleaseOverview (props) {
 
             <Grid item md={6} sm={12}>
               <Card enhancement="5" style={{ textAlign: 'center' }}>
-                <Typography component={Link} to={'/tests/' + props.release + '?period=twoDay&sortField=net_improvement&sort=asc&filters=' + encodeURIComponent(JSON.stringify({ items: [BOOKMARKS.RUN_1] }))} style={{ textAlign: 'center' }}
-                            variant="h5">
+                <Typography
+                  component={Link}
+                  to={`/jobs/${props.release}?period=twoDay&sortField=net_improvement&sort=asc&${queryForBookmark(BOOKMARKS.RUN_1)}`}
+                  variant="h5">
+                  Most regressed jobs (two day)
+                  <Tooltip title={TWODAY_WARNING}>
+                    <InfoIcon />
+                  </Tooltip>
+                </Typography>
+
+                <JobTable
+                  hideControls={true}
+                  sortField="net_improvement"
+                  sort="asc"
+                  limit={10}
+                  filterModel={{
+                    items: [BOOKMARKS.RUN_1]
+                  }}
+                  pageSize={5}
+                  period="twoDay"
+                  release={props.release}
+                  briefTable={true} />
+              </Card>
+            </Grid>
+            <Grid item md={6} sm={12}>
+              <Card enhancement="5" style={{ textAlign: 'center' }}>
+                <Typography
+                  component={Link}
+                  to={`/tests/${props.release}?${queryForBookmark(BOOKMARKS.RUN_10)}&sortField=net_improvement&sort=asc`}
+                  style={{ textAlign: 'center' }}
+                  variant="h5">
+                  Most regressed tests
+                  <Tooltip title={REGRESSED_TOOLTIP}>
+                    <InfoIcon />
+                  </Tooltip>
+                </Typography>
+
+                <TestTable
+                  hideControls={true}
+                  sortField="net_improvement"
+                  sort="asc"
+                  limit={10}
+                  filterModel={{
+                    items: [BOOKMARKS.RUN_10]
+                  }}
+                  pageSize={5}
+                  briefTable={true}
+                  release={props.release} />
+
+              </Card>
+            </Grid>
+
+            <Grid item md={6} sm={12}>
+              <Card enhancement="5" style={{ textAlign: 'center' }}>
+                <Typography
+                  component={Link}
+                  to={`/tests/${props.release}?period=twoDay&sortField=net_improvement&sort=asc&${queryForBookmark(BOOKMARKS.RUN_1)}`}
+                  style={{ textAlign: 'center' }}
+                  variant="h5">
                   Most regressed tests (two day)
                   <Tooltip title={TWODAY_WARNING}>
                     <InfoIcon />
@@ -232,33 +269,11 @@ export default function ReleaseOverview (props) {
 
             <Grid item md={6} sm={12}>
               <Card enhancement="5" style={{ textAlign: 'center' }}>
-                <Typography component={Link} to={'/jobs/' + props.release + '?period=twoDay&sortField=net_improvement&sort=asc&filters=' + encodeURIComponent(JSON.stringify({ items: [BOOKMARKS.RUN_1] }))} style={{ textAlign: 'center' }}
-                            variant="h5">
-                  Most regressed jobs (two day)
-                  <Tooltip title={TWODAY_WARNING}>
-                    <InfoIcon />
-                  </Tooltip>
-                </Typography>
-
-                <JobTable
-                  hideControls={true}
-                  sortField="net_improvement"
-                  sort="asc"
-                  limit={10}
-                  filterModel={{
-                    items: [BOOKMARKS.RUN_1]
-                  }}
-                  pageSize={5}
-                  period="twoDay"
-                  release={props.release}
-                  briefTable={true} />
-              </Card>
-            </Grid>
-
-            <Grid item md={6} sm={12}>
-              <Card enhancement="5" style={{ textAlign: 'center' }}>
-                <Typography component={Link} to={'/tests/' + props.release + '?sortField=net_improvement&sort=asc&filters=' + encodeURIComponent(JSON.stringify({ items: [BOOKMARKS.RUN_10, BOOKMARKS.NO_LINKED_BUG] }))}
-                            style={{ textAlign: 'center' }} variant="h5">
+                <Typography
+                  component={Link}
+                  to={`/tests/${props.release}?sortField=net_improvement&sort=asc&${queryForBookmark(BOOKMARKS.RUN_10, BOOKMARKS.NO_LINKED_BUG)}`}
+                  style={{ textAlign: 'center' }}
+                  variant="h5">
                   Top failing tests without a bug
                   <Tooltip title={NOBUG_TOOLTIP}>
                     <InfoIcon />

--- a/sippy-ng/src/releases/__snapshots__/ReleaseOverview.test.js.snap
+++ b/sippy-ng/src/releases/__snapshots__/ReleaseOverview.test.js.snap
@@ -1150,719 +1150,7 @@ exports[`release-overview should render correctly 1`] = `
         >
           <a class="MuiTypography-root MuiTypography-h5"
              style="text-align: center;"
-             href="/tests/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%7D"
-          >
-            Most regressed tests
-            <svg class="MuiSvgIcon-root"
-                 focusable="false"
-                 viewbox="0 0 24 24"
-                 aria-hidden="true"
-                 title="Shows the most regressed items this week vs. last week, for those with more than 10 runs"
-            >
-              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z">
-              </path>
-            </svg>
-          </a>
-          <div class="MuiContainer-root MuiContainer-maxWidthLg">
-            <div class="MuiDataGrid-root MuiDataGrid-root MuiDataGrid-autoHeight"
-                 role="grid"
-                 aria-colcount="4"
-                 aria-rowcount="10"
-                 aria-multiselectable="false"
-            >
-              <div>
-                <div>
-                </div>
-              </div>
-              <div class="MuiDataGrid-main">
-                <div class="MuiDataGrid-columnsContainer"
-                     style="min-height: 56px; max-height: 56px; line-height: 56px;"
-                >
-                  <div class="MuiDataGrid-columnHeaderWrapper scroll"
-                       aria-rowindex="1"
-                       role="row"
-                       style="transform: translate3d(-0px, 0, 0); min-width: 200px;"
-                  >
-                    <div class="MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader"
-                         data-field="name"
-                         style="width: 50px; min-width: 50px; max-width: 50px;"
-                         role="columnheader"
-                         tabindex="0"
-                         aria-colindex="1"
-                    >
-                      <div class="MuiDataGrid-columnHeaderDraggableContainer"
-                           draggable="false"
-                      >
-                        <div class="MuiDataGrid-columnHeaderTitleContainer">
-                          <div class="MuiDataGrid-columnHeaderTitle"
-                               title
-                          >
-                            Name
-                          </div>
-                          <div class="MuiDataGrid-iconButtonContainer">
-                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                                    tabindex="-1"
-                                    type="button"
-                                    aria-label="Sort"
-                                    title="Sort"
-                            >
-                              <span class="MuiIconButton-label">
-                                <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                >
-                                  <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
-                                  </path>
-                                </svg>
-                              </span>
-                              <span class="MuiTouchRipple-root">
-                              </span>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="MuiDataGrid-columnSeparator"
-                           style="min-height: 56px; opacity: 1;"
-                      >
-                        <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
-                             focusable="false"
-                             viewbox="0 0 24 24"
-                             aria-hidden="true"
-                        >
-                          <path d="M11 19V5h2v14z">
-                          </path>
-                        </svg>
-                      </div>
-                    </div>
-                    <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
-                         data-field="current_pass_percentage"
-                         style="width: 50px; min-width: 50px; max-width: 50px;"
-                         role="columnheader"
-                         tabindex="-1"
-                         aria-colindex="2"
-                    >
-                      <div class="MuiDataGrid-columnHeaderDraggableContainer"
-                           draggable="false"
-                      >
-                        <div class="MuiDataGrid-columnHeaderTitleContainer">
-                          <div class="MuiDataGrid-columnHeaderTitle"
-                               title
-                          >
-                            Current Period
-                          </div>
-                          <div class="MuiDataGrid-iconButtonContainer">
-                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                                    tabindex="-1"
-                                    type="button"
-                                    aria-label="Sort"
-                                    title="Sort"
-                            >
-                              <span class="MuiIconButton-label">
-                                <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                >
-                                  <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
-                                  </path>
-                                </svg>
-                              </span>
-                              <span class="MuiTouchRipple-root">
-                              </span>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="MuiDataGrid-columnSeparator"
-                           style="min-height: 56px; opacity: 1;"
-                      >
-                        <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
-                             focusable="false"
-                             viewbox="0 0 24 24"
-                             aria-hidden="true"
-                        >
-                          <path d="M11 19V5h2v14z">
-                          </path>
-                        </svg>
-                      </div>
-                    </div>
-                    <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--sorted MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
-                         data-field="net_improvement"
-                         style="width: 50px; min-width: 50px; max-width: 50px;"
-                         role="columnheader"
-                         tabindex="-1"
-                         aria-colindex="3"
-                         aria-sort="ascending"
-                    >
-                      <div class="MuiDataGrid-columnHeaderDraggableContainer"
-                           draggable="false"
-                      >
-                        <div class="MuiDataGrid-columnHeaderTitleContainer">
-                          <div class="MuiDataGrid-columnHeaderTitle"
-                               title
-                          >
-                            Improvement
-                          </div>
-                          <div class="MuiDataGrid-iconButtonContainer">
-                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                                    tabindex="-1"
-                                    type="button"
-                                    aria-label="Sort"
-                                    title="Sort"
-                            >
-                              <span class="MuiIconButton-label">
-                                <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                >
-                                  <path d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z">
-                                  </path>
-                                </svg>
-                              </span>
-                              <span class="MuiTouchRipple-root">
-                              </span>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="MuiDataGrid-columnSeparator"
-                           style="min-height: 56px; opacity: 1;"
-                      >
-                        <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
-                             focusable="false"
-                             viewbox="0 0 24 24"
-                             aria-hidden="true"
-                        >
-                          <path d="M11 19V5h2v14z">
-                          </path>
-                        </svg>
-                      </div>
-                    </div>
-                    <div style="min-width: 50px; max-width: 50px; line-height: 55px; min-height: 56px; max-height: 56px;"
-                         class="MuiDataGrid-cell"
-                    >
-                    </div>
-                  </div>
-                </div>
-                <div style="overflow: visible; width: 0px;">
-                  <div class="MuiDataGrid-windowContainer"
-                       style="width: 0px; height: 316px;"
-                  >
-                    <div class="MuiDataGrid-window"
-                         style="top: 56px; overflow-y: hidden;"
-                    >
-                      <div class="MuiDataGrid-dataContainer"
-                           style="min-width: 200px; min-height: 260px;"
-                      >
-                        <div class="MuiDataGrid-viewport"
-                             style="min-width: 0; max-width: 0; max-height: 260px;"
-                        >
-                          <div class="MuiDataGrid-renderingZone"
-                               style="max-height: 260px; width: 200px; transform: translate3d(-0px, -0px, 0);"
-                          >
-                            <div data-id="25"
-                                 data-rowindex="0"
-                                 role="row"
-                                 class="Mui-even TestTable-row-percent-37-53 MuiDataGrid-row"
-                                 aria-rowindex="2"
-                                 aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
-                            >
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                   role="cell"
-                                   data-value="[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version"
-                                   data-field="name"
-                                   data-rowindex="0"
-                                   data-colindex="0"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                  <a title="[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version"
-                                     class
-                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Binstall%5D%20%5BSuite%3A%20operators%5D%20%5BOSD%5D%20RBAC%20Operator%20Operator%20Upgrade%20should%20upgrade%20from%20the%20replaced%20version%22%7D%5D%7D"
-                                  >
-                                    [install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version
-                                  </a>
-                                </div>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="36.95652173913043"
-                                   data-field="current_pass_percentage"
-                                   data-rowindex="0"
-                                   data-colindex="1"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <p title="46 runs"
-                                   class
-                                >
-                                  36.96%
-                                </p>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="-49.83593109105825"
-                                   data-field="net_improvement"
-                                   data-rowindex="0"
-                                   data-colindex="2"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <svg class="MuiSvgIcon-root"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                     data-icon="ArrowDownwardRoundedIcon"
-                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                     title="-49.84%"
-                                >
-                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                  </path>
-                                </svg>
-                              </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   class="MuiDataGrid-cell"
-                              >
-                              </div>
-                            </div>
-                            <div data-id="49"
-                                 data-rowindex="1"
-                                 role="row"
-                                 class="Mui-odd TestTable-row-percent-83-99 MuiDataGrid-row"
-                                 aria-rowindex="3"
-                                 aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
-                            >
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                   role="cell"
-                                   data-value="operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test"
-                                   data-field="name"
-                                   data-rowindex="1"
-                                   data-colindex="0"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                  <a title="operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test"
-                                     class
-                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-vsphere-upgrade%20-%20e2e-vsphere-upgrade-ipi-install-install-stableinitial%20container%20test%22%7D%5D%7D"
-                                  >
-                                    operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test
-                                  </a>
-                                </div>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="83.33333333333334"
-                                   data-field="current_pass_percentage"
-                                   data-rowindex="1"
-                                   data-colindex="1"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <p title="12 runs"
-                                   class
-                                >
-                                  83.33%
-                                </p>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="-16.666666666666657"
-                                   data-field="net_improvement"
-                                   data-rowindex="1"
-                                   data-colindex="2"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <svg class="MuiSvgIcon-root"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                     data-icon="ArrowDownwardRoundedIcon"
-                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                     title="-16.67%"
-                                >
-                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                  </path>
-                                </svg>
-                              </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   class="MuiDataGrid-cell"
-                              >
-                              </div>
-                            </div>
-                            <div data-id="27"
-                                 data-rowindex="2"
-                                 role="row"
-                                 class="Mui-even TestTable-row-percent-50-66 MuiDataGrid-row"
-                                 aria-rowindex="4"
-                                 aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
-                            >
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                   role="cell"
-                                   data-value="operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test"
-                                   data-field="name"
-                                   data-rowindex="2"
-                                   data-colindex="0"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                  <a title="operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test"
-                                     class
-                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-aws-proxy%20-%20e2e-aws-proxy-ipi-install-install%20container%20test%22%7D%5D%7D"
-                                  >
-                                    operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test
-                                  </a>
-                                </div>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="50"
-                                   data-field="current_pass_percentage"
-                                   data-rowindex="2"
-                                   data-colindex="1"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <p title="16 runs"
-                                   class
-                                >
-                                  50.00%
-                                </p>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="-12.5"
-                                   data-field="net_improvement"
-                                   data-rowindex="2"
-                                   data-colindex="2"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <svg class="MuiSvgIcon-root"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                     data-icon="ArrowDownwardRoundedIcon"
-                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                     title="-12.50%"
-                                >
-                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                  </path>
-                                </svg>
-                              </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   class="MuiDataGrid-cell"
-                              >
-                              </div>
-                            </div>
-                            <div data-id="48"
-                                 data-rowindex="3"
-                                 role="row"
-                                 class="Mui-odd TestTable-row-percent-83-99 MuiDataGrid-row"
-                                 aria-rowindex="5"
-                                 aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
-                            >
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                   role="cell"
-                                   data-value="operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test"
-                                   data-field="name"
-                                   data-rowindex="3"
-                                   data-colindex="0"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                  <a title="operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test"
-                                     class
-                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-gcp-upgrade%20-%20e2e-gcp-upgrade-ipi-install-install-stableinitial%20container%20test%22%7D%5D%7D"
-                                  >
-                                    operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test
-                                  </a>
-                                </div>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="83.33333333333334"
-                                   data-field="current_pass_percentage"
-                                   data-rowindex="3"
-                                   data-colindex="1"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <p title="48 runs"
-                                   class
-                                >
-                                  83.33%
-                                </p>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="-12.12121212121211"
-                                   data-field="net_improvement"
-                                   data-rowindex="3"
-                                   data-colindex="2"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <svg class="MuiSvgIcon-root"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                     data-icon="ArrowDownwardRoundedIcon"
-                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                     title="-12.12%"
-                                >
-                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                  </path>
-                                </svg>
-                              </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   class="MuiDataGrid-cell"
-                              >
-                              </div>
-                            </div>
-                            <div data-id="55"
-                                 data-rowindex="4"
-                                 role="row"
-                                 class="Mui-even TestTable-row-percent-89-105 MuiDataGrid-row"
-                                 aria-rowindex="6"
-                                 aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
-                            >
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                   role="cell"
-                                   data-value="operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test"
-                                   data-field="name"
-                                   data-rowindex="4"
-                                   data-colindex="0"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                  <a title="operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test"
-                                     class
-                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-gcp%20-%20e2e-gcp-ipi-install-install%20container%20test%22%7D%5D%7D"
-                                  >
-                                    operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test
-                                  </a>
-                                </div>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="89.1891891891892"
-                                   data-field="current_pass_percentage"
-                                   data-rowindex="4"
-                                   data-colindex="1"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <p title="37 runs"
-                                   class
-                                >
-                                  89.19%
-                                </p>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="-10.810810810810807"
-                                   data-field="net_improvement"
-                                   data-rowindex="4"
-                                   data-colindex="2"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <svg class="MuiSvgIcon-root"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                     data-icon="ArrowDownwardRoundedIcon"
-                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                     title="-10.81%"
-                                >
-                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                  </path>
-                                </svg>
-                              </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   class="MuiDataGrid-cell"
-                              >
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div class="Mui-resizeTriggers">
-                  <div class="expand-trigger">
-                    <div style="width: 1px; height: 1px;">
-                    </div>
-                  </div>
-                  <div class="contract-trigger">
-                  </div>
-                </div>
-              </div>
-              <div>
-                <div class="MuiDataGrid-footerContainer">
-                  <div>
-                  </div>
-                  <div class="MuiTablePagination-root">
-                    <div class="MuiToolbar-root MuiToolbar-regular MuiTablePagination-toolbar MuiToolbar-gutters">
-                      <div class="MuiTablePagination-spacer">
-                      </div>
-                      <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-269 MuiTypography-body2 MuiTypography-colorInherit">
-                        Rows per page:
-                      </p>
-                      <div class="MuiInputBase-root MuiTablePagination-input makeStyles-input-270 MuiTablePagination-selectRoot">
-                        <div class="MuiSelect-root MuiSelect-select MuiTablePagination-select MuiSelect-selectMenu MuiInputBase-input"
-                             tabindex="0"
-                             role="button"
-                             aria-haspopup="listbox"
-                        >
-                          5
-                        </div>
-                        <input aria-hidden="true"
-                               tabindex="-1"
-                               class="MuiSelect-nativeInput"
-                               value="5"
-                        >
-                        <svg class="MuiSvgIcon-root MuiSelect-icon MuiTablePagination-selectIcon"
-                             focusable="false"
-                             viewbox="0 0 24 24"
-                             aria-hidden="true"
-                        >
-                          <path d="M7 10l5 5 5-5z">
-                          </path>
-                        </svg>
-                      </div>
-                      <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-269 MuiTypography-body2 MuiTypography-colorInherit">
-                        1-5 of 10
-                      </p>
-                      <div class="MuiTablePagination-actions">
-                        <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
-                                tabindex="-1"
-                                type="button"
-                                disabled
-                                title="Previous page"
-                                aria-label="Previous page"
-                        >
-                          <span class="MuiIconButton-label">
-                            <svg class="MuiSvgIcon-root"
-                                 focusable="false"
-                                 viewbox="0 0 24 24"
-                                 aria-hidden="true"
-                            >
-                              <path d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z">
-                              </path>
-                            </svg>
-                          </span>
-                        </button>
-                        <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-                                tabindex="0"
-                                type="button"
-                                title="Next page"
-                                aria-label="Next page"
-                        >
-                          <span class="MuiIconButton-label">
-                            <svg class="MuiSvgIcon-root"
-                                 focusable="false"
-                                 viewbox="0 0 24 24"
-                                 aria-hidden="true"
-                            >
-                              <path d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z">
-                              </path>
-                            </svg>
-                          </span>
-                          <span class="MuiTouchRipple-root">
-                          </span>
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-12 MuiGrid-grid-md-6">
-        <div class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
-             enhancement="5"
-             style="text-align: center;"
-        >
-          <a class="MuiTypography-root MuiTypography-h5"
-             style="text-align: center;"
-             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%7D"
+             href="/jobs/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
           >
             Most regressed jobs
             <svg class="MuiSvgIcon-root"
@@ -2077,7 +1365,7 @@ exports[`release-overview should render correctly 1`] = `
                             <div data-id="38"
                                  data-rowindex="0"
                                  role="row"
-                                 class="Mui-even JobTable-row-percent-38-155 MuiDataGrid-row"
+                                 class="Mui-even JobTable-row-percent-38-54 MuiDataGrid-row"
                                  aria-rowindex="2"
                                  aria-selected="false"
                                  style="max-height: 52px; min-height: 52px;"
@@ -2120,7 +1408,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <div class="MuiBox-root MuiBox-root-271"
                                      title="13 runs"
                                 >
-                                  38.46%
+                                  38%
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2156,7 +1444,7 @@ exports[`release-overview should render correctly 1`] = `
                             <div data-id="62"
                                  data-rowindex="1"
                                  role="row"
-                                 class="Mui-odd JobTable-row-percent-69-186 MuiDataGrid-row"
+                                 class="Mui-odd JobTable-row-percent-69-85 MuiDataGrid-row"
                                  aria-rowindex="3"
                                  aria-selected="false"
                                  style="max-height: 52px; min-height: 52px;"
@@ -2199,7 +1487,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <div class="MuiBox-root MuiBox-root-272"
                                      title="13 runs"
                                 >
-                                  69.23%
+                                  69%
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2235,7 +1523,7 @@ exports[`release-overview should render correctly 1`] = `
                             <div data-id="32"
                                  data-rowindex="2"
                                  role="row"
-                                 class="Mui-even JobTable-row-percent-33-150 MuiDataGrid-row"
+                                 class="Mui-even JobTable-row-percent-33-49 MuiDataGrid-row"
                                  aria-rowindex="4"
                                  aria-selected="false"
                                  style="max-height: 52px; min-height: 52px;"
@@ -2278,7 +1566,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <div class="MuiBox-root MuiBox-root-273"
                                      title="15 runs"
                                 >
-                                  33.33%
+                                  33%
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2314,7 +1602,7 @@ exports[`release-overview should render correctly 1`] = `
                             <div data-id="28"
                                  data-rowindex="3"
                                  role="row"
-                                 class="Mui-odd JobTable-row-percent-31-148 MuiDataGrid-row"
+                                 class="Mui-odd JobTable-row-percent-31-47 MuiDataGrid-row"
                                  aria-rowindex="5"
                                  aria-selected="false"
                                  style="max-height: 52px; min-height: 52px;"
@@ -2357,7 +1645,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <div class="MuiBox-root MuiBox-root-274"
                                      title="16 runs"
                                 >
-                                  31.25%
+                                  31%
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2393,7 +1681,7 @@ exports[`release-overview should render correctly 1`] = `
                             <div data-id="69"
                                  data-rowindex="4"
                                  role="row"
-                                 class="Mui-even JobTable-row-percent-77-194 MuiDataGrid-row"
+                                 class="Mui-even JobTable-row-percent-77-93 MuiDataGrid-row"
                                  aria-rowindex="6"
                                  aria-selected="false"
                                  style="max-height: 52px; min-height: 52px;"
@@ -2436,7 +1724,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <div class="MuiBox-root MuiBox-root-275"
                                      title="13 runs"
                                 >
-                                  76.92%
+                                  77%
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2573,720 +1861,7 @@ exports[`release-overview should render correctly 1`] = `
              style="text-align: center;"
         >
           <a class="MuiTypography-root MuiTypography-h5"
-             style="text-align: center;"
-             href="/tests/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%7D"
-          >
-            Most regressed tests (two day)
-            <svg class="MuiSvgIcon-root"
-                 focusable="false"
-                 viewbox="0 0 24 24"
-                 aria-hidden="true"
-                 title="Shows the last 2 days compared to the last 7 days, sorted by most regressed."
-            >
-              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z">
-              </path>
-            </svg>
-          </a>
-          <div class="MuiContainer-root MuiContainer-maxWidthLg">
-            <div class="MuiDataGrid-root MuiDataGrid-root MuiDataGrid-autoHeight"
-                 role="grid"
-                 aria-colcount="4"
-                 aria-rowcount="10"
-                 aria-multiselectable="false"
-            >
-              <div>
-                <div>
-                </div>
-              </div>
-              <div class="MuiDataGrid-main">
-                <div class="MuiDataGrid-columnsContainer"
-                     style="min-height: 56px; max-height: 56px; line-height: 56px;"
-                >
-                  <div class="MuiDataGrid-columnHeaderWrapper scroll"
-                       aria-rowindex="1"
-                       role="row"
-                       style="transform: translate3d(-0px, 0, 0); min-width: 200px;"
-                  >
-                    <div class="MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader"
-                         data-field="name"
-                         style="width: 50px; min-width: 50px; max-width: 50px;"
-                         role="columnheader"
-                         tabindex="0"
-                         aria-colindex="1"
-                    >
-                      <div class="MuiDataGrid-columnHeaderDraggableContainer"
-                           draggable="false"
-                      >
-                        <div class="MuiDataGrid-columnHeaderTitleContainer">
-                          <div class="MuiDataGrid-columnHeaderTitle"
-                               title
-                          >
-                            Name
-                          </div>
-                          <div class="MuiDataGrid-iconButtonContainer">
-                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                                    tabindex="-1"
-                                    type="button"
-                                    aria-label="Sort"
-                                    title="Sort"
-                            >
-                              <span class="MuiIconButton-label">
-                                <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                >
-                                  <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
-                                  </path>
-                                </svg>
-                              </span>
-                              <span class="MuiTouchRipple-root">
-                              </span>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="MuiDataGrid-columnSeparator"
-                           style="min-height: 56px; opacity: 1;"
-                      >
-                        <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
-                             focusable="false"
-                             viewbox="0 0 24 24"
-                             aria-hidden="true"
-                        >
-                          <path d="M11 19V5h2v14z">
-                          </path>
-                        </svg>
-                      </div>
-                    </div>
-                    <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
-                         data-field="current_pass_percentage"
-                         style="width: 50px; min-width: 50px; max-width: 50px;"
-                         role="columnheader"
-                         tabindex="-1"
-                         aria-colindex="2"
-                    >
-                      <div class="MuiDataGrid-columnHeaderDraggableContainer"
-                           draggable="false"
-                      >
-                        <div class="MuiDataGrid-columnHeaderTitleContainer">
-                          <div class="MuiDataGrid-columnHeaderTitle"
-                               title
-                          >
-                            Current Period
-                          </div>
-                          <div class="MuiDataGrid-iconButtonContainer">
-                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                                    tabindex="-1"
-                                    type="button"
-                                    aria-label="Sort"
-                                    title="Sort"
-                            >
-                              <span class="MuiIconButton-label">
-                                <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                >
-                                  <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
-                                  </path>
-                                </svg>
-                              </span>
-                              <span class="MuiTouchRipple-root">
-                              </span>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="MuiDataGrid-columnSeparator"
-                           style="min-height: 56px; opacity: 1;"
-                      >
-                        <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
-                             focusable="false"
-                             viewbox="0 0 24 24"
-                             aria-hidden="true"
-                        >
-                          <path d="M11 19V5h2v14z">
-                          </path>
-                        </svg>
-                      </div>
-                    </div>
-                    <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--sorted MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
-                         data-field="net_improvement"
-                         style="width: 50px; min-width: 50px; max-width: 50px;"
-                         role="columnheader"
-                         tabindex="-1"
-                         aria-colindex="3"
-                         aria-sort="ascending"
-                    >
-                      <div class="MuiDataGrid-columnHeaderDraggableContainer"
-                           draggable="false"
-                      >
-                        <div class="MuiDataGrid-columnHeaderTitleContainer">
-                          <div class="MuiDataGrid-columnHeaderTitle"
-                               title
-                          >
-                            Improvement
-                          </div>
-                          <div class="MuiDataGrid-iconButtonContainer">
-                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                                    tabindex="-1"
-                                    type="button"
-                                    aria-label="Sort"
-                                    title="Sort"
-                            >
-                              <span class="MuiIconButton-label">
-                                <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                >
-                                  <path d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z">
-                                  </path>
-                                </svg>
-                              </span>
-                              <span class="MuiTouchRipple-root">
-                              </span>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="MuiDataGrid-columnSeparator"
-                           style="min-height: 56px; opacity: 1;"
-                      >
-                        <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
-                             focusable="false"
-                             viewbox="0 0 24 24"
-                             aria-hidden="true"
-                        >
-                          <path d="M11 19V5h2v14z">
-                          </path>
-                        </svg>
-                      </div>
-                    </div>
-                    <div style="min-width: 50px; max-width: 50px; line-height: 55px; min-height: 56px; max-height: 56px;"
-                         class="MuiDataGrid-cell"
-                    >
-                    </div>
-                  </div>
-                </div>
-                <div style="overflow: visible; width: 0px;">
-                  <div class="MuiDataGrid-windowContainer"
-                       style="width: 0px; height: 316px;"
-                  >
-                    <div class="MuiDataGrid-window"
-                         style="top: 56px; overflow-y: hidden;"
-                    >
-                      <div class="MuiDataGrid-dataContainer"
-                           style="min-width: 200px; min-height: 260px;"
-                      >
-                        <div class="MuiDataGrid-viewport"
-                             style="min-width: 0; max-width: 0; max-height: 260px;"
-                        >
-                          <div class="MuiDataGrid-renderingZone"
-                               style="max-height: 260px; width: 200px; transform: translate3d(-0px, -0px, 0);"
-                          >
-                            <div data-id="6"
-                                 data-rowindex="0"
-                                 role="row"
-                                 class="Mui-even TestTable-row-percent-50-66 MuiDataGrid-row"
-                                 aria-rowindex="2"
-                                 aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
-                            >
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                   role="cell"
-                                   data-value="operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test"
-                                   data-field="name"
-                                   data-rowindex="0"
-                                   data-colindex="0"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                  <a title="operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test"
-                                     class
-                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-metal-assisted%20-%20e2e-metal-assisted-baremetalds-assisted-setup%20container%20test%22%7D%5D%7D"
-                                  >
-                                    operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test
-                                  </a>
-                                </div>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="50"
-                                   data-field="current_pass_percentage"
-                                   data-rowindex="0"
-                                   data-colindex="1"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <p title="2 runs"
-                                   class
-                                >
-                                  50.00%
-                                </p>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="-42.85714285714286"
-                                   data-field="net_improvement"
-                                   data-rowindex="0"
-                                   data-colindex="2"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <svg class="MuiSvgIcon-root"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                     data-icon="ArrowDownwardRoundedIcon"
-                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                     title="-42.86%"
-                                >
-                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                  </path>
-                                </svg>
-                              </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   class="MuiDataGrid-cell"
-                              >
-                              </div>
-                            </div>
-                            <div data-id="7"
-                                 data-rowindex="1"
-                                 role="row"
-                                 class="Mui-odd TestTable-row-percent-50-66 MuiDataGrid-row"
-                                 aria-rowindex="3"
-                                 aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
-                            >
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                   role="cell"
-                                   data-value="operator.Run multi-stage test e2e-metal-ipi-virtualmedia - e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup container test"
-                                   data-field="name"
-                                   data-rowindex="1"
-                                   data-colindex="0"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                  <a title="operator.Run multi-stage test e2e-metal-ipi-virtualmedia - e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup container test"
-                                     class
-                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-metal-ipi-virtualmedia%20-%20e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup%20container%20test%22%7D%5D%7D"
-                                  >
-                                    operator.Run multi-stage test e2e-metal-ipi-virtualmedia - e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup container test
-                                  </a>
-                                </div>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="50"
-                                   data-field="current_pass_percentage"
-                                   data-rowindex="1"
-                                   data-colindex="1"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <p title="2 runs"
-                                   class
-                                >
-                                  50.00%
-                                </p>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="-42.85714285714286"
-                                   data-field="net_improvement"
-                                   data-rowindex="1"
-                                   data-colindex="2"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <svg class="MuiSvgIcon-root"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                     data-icon="ArrowDownwardRoundedIcon"
-                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                     title="-42.86%"
-                                >
-                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                  </path>
-                                </svg>
-                              </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   class="MuiDataGrid-cell"
-                              >
-                              </div>
-                            </div>
-                            <div data-id="5"
-                                 data-rowindex="2"
-                                 role="row"
-                                 class="Mui-even TestTable-row-percent-50-66 MuiDataGrid-row"
-                                 aria-rowindex="4"
-                                 aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
-                            >
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                   role="cell"
-                                   data-value="operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test"
-                                   data-field="name"
-                                   data-rowindex="2"
-                                   data-colindex="0"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                  <a title="operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test"
-                                     class
-                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-aws-fips%20-%20e2e-aws-fips-ipi-install-install%20container%20test%22%7D%5D%7D"
-                                  >
-                                    operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test
-                                  </a>
-                                </div>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="50"
-                                   data-field="current_pass_percentage"
-                                   data-rowindex="2"
-                                   data-colindex="1"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <p title="2 runs"
-                                   class
-                                >
-                                  50.00%
-                                </p>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="-42.30769230769231"
-                                   data-field="net_improvement"
-                                   data-rowindex="2"
-                                   data-colindex="2"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <svg class="MuiSvgIcon-root"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                     data-icon="ArrowDownwardRoundedIcon"
-                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                     title="-42.31%"
-                                >
-                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                  </path>
-                                </svg>
-                              </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   class="MuiDataGrid-cell"
-                              >
-                              </div>
-                            </div>
-                            <div data-id="12"
-                                 data-rowindex="3"
-                                 role="row"
-                                 class="Mui-odd TestTable-row-percent-75-91 MuiDataGrid-row"
-                                 aria-rowindex="5"
-                                 aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
-                            >
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                   role="cell"
-                                   data-value="TestInstall_test_install.start_install_and_wait_for_installed(openshift_version=4.8)"
-                                   data-field="name"
-                                   data-rowindex="3"
-                                   data-colindex="0"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                  <a title="TestInstall_test_install.start_install_and_wait_for_installed(openshift_version=4.8)"
-                                     class
-                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22TestInstall_test_install.start_install_and_wait_for_installed(openshift_version%3D4.8)%22%7D%5D%7D"
-                                  >
-                                    TestInstall_test_install.start_install_and_wait_for_installed(openshift_version=4.8)
-                                  </a>
-                                </div>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="75"
-                                   data-field="current_pass_percentage"
-                                   data-rowindex="3"
-                                   data-colindex="1"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <p title="4 runs"
-                                   class
-                                >
-                                  75.00%
-                                </p>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="-21.15384615384616"
-                                   data-field="net_improvement"
-                                   data-rowindex="3"
-                                   data-colindex="2"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <svg class="MuiSvgIcon-root"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                     data-icon="ArrowDownwardRoundedIcon"
-                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                     title="-21.15%"
-                                >
-                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                  </path>
-                                </svg>
-                              </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   class="MuiDataGrid-cell"
-                              >
-                              </div>
-                            </div>
-                            <div data-id="13"
-                                 data-rowindex="4"
-                                 role="row"
-                                 class="Mui-even TestTable-row-percent-75-91 MuiDataGrid-row"
-                                 aria-rowindex="6"
-                                 aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
-                            >
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
-                                   role="cell"
-                                   data-value="operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test"
-                                   data-field="name"
-                                   data-rowindex="4"
-                                   data-colindex="0"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                  <a title="operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test"
-                                     class
-                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-metal-ipi-ovn-ipv6%20-%20e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup%20container%20test%22%7D%5D%7D"
-                                  >
-                                    operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test
-                                  </a>
-                                </div>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="75"
-                                   data-field="current_pass_percentage"
-                                   data-rowindex="4"
-                                   data-colindex="1"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <p title="8 runs"
-                                   class
-                                >
-                                  75.00%
-                                </p>
-                              </div>
-                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
-                                   role="cell"
-                                   data-value="-17.85714285714286"
-                                   data-field="net_improvement"
-                                   data-rowindex="4"
-                                   data-colindex="2"
-                                   data-rowselected="false"
-                                   data-editable="false"
-                                   data-mode="view"
-                                   aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   tabindex="-1"
-                              >
-                                <svg class="MuiSvgIcon-root"
-                                     focusable="false"
-                                     viewbox="0 0 24 24"
-                                     aria-hidden="true"
-                                     data-icon="ArrowDownwardRoundedIcon"
-                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
-                                     title="-17.86%"
-                                >
-                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
-                                  </path>
-                                </svg>
-                              </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
-                                   class="MuiDataGrid-cell"
-                              >
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div class="Mui-resizeTriggers">
-                  <div class="expand-trigger">
-                    <div style="width: 1px; height: 1px;">
-                    </div>
-                  </div>
-                  <div class="contract-trigger">
-                  </div>
-                </div>
-              </div>
-              <div>
-                <div class="MuiDataGrid-footerContainer">
-                  <div>
-                  </div>
-                  <div class="MuiTablePagination-root">
-                    <div class="MuiToolbar-root MuiToolbar-regular MuiTablePagination-toolbar MuiToolbar-gutters">
-                      <div class="MuiTablePagination-spacer">
-                      </div>
-                      <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-269 MuiTypography-body2 MuiTypography-colorInherit">
-                        Rows per page:
-                      </p>
-                      <div class="MuiInputBase-root MuiTablePagination-input makeStyles-input-270 MuiTablePagination-selectRoot">
-                        <div class="MuiSelect-root MuiSelect-select MuiTablePagination-select MuiSelect-selectMenu MuiInputBase-input"
-                             tabindex="0"
-                             role="button"
-                             aria-haspopup="listbox"
-                        >
-                          5
-                        </div>
-                        <input aria-hidden="true"
-                               tabindex="-1"
-                               class="MuiSelect-nativeInput"
-                               value="5"
-                        >
-                        <svg class="MuiSvgIcon-root MuiSelect-icon MuiTablePagination-selectIcon"
-                             focusable="false"
-                             viewbox="0 0 24 24"
-                             aria-hidden="true"
-                        >
-                          <path d="M7 10l5 5 5-5z">
-                          </path>
-                        </svg>
-                      </div>
-                      <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-269 MuiTypography-body2 MuiTypography-colorInherit">
-                        1-5 of 10
-                      </p>
-                      <div class="MuiTablePagination-actions">
-                        <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
-                                tabindex="-1"
-                                type="button"
-                                disabled
-                                title="Previous page"
-                                aria-label="Previous page"
-                        >
-                          <span class="MuiIconButton-label">
-                            <svg class="MuiSvgIcon-root"
-                                 focusable="false"
-                                 viewbox="0 0 24 24"
-                                 aria-hidden="true"
-                            >
-                              <path d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z">
-                              </path>
-                            </svg>
-                          </span>
-                        </button>
-                        <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-                                tabindex="0"
-                                type="button"
-                                title="Next page"
-                                aria-label="Next page"
-                        >
-                          <span class="MuiIconButton-label">
-                            <svg class="MuiSvgIcon-root"
-                                 focusable="false"
-                                 viewbox="0 0 24 24"
-                                 aria-hidden="true"
-                            >
-                              <path d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z">
-                              </path>
-                            </svg>
-                          </span>
-                          <span class="MuiTouchRipple-root">
-                          </span>
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-12 MuiGrid-grid-md-6">
-        <div class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
-             enhancement="5"
-             style="text-align: center;"
-        >
-          <a class="MuiTypography-root MuiTypography-h5"
-             style="text-align: center;"
-             href="/jobs/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%7D"
+             href="/jobs/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
           >
             Most regressed jobs (two day)
             <svg class="MuiSvgIcon-root"
@@ -3501,7 +2076,7 @@ exports[`release-overview should render correctly 1`] = `
                             <div data-id="16"
                                  data-rowindex="0"
                                  role="row"
-                                 class="Mui-even JobTable-row-percent-0-117 MuiDataGrid-row"
+                                 class="Mui-even JobTable-row-percent-0-16 MuiDataGrid-row"
                                  aria-rowindex="2"
                                  aria-selected="false"
                                  style="max-height: 52px; min-height: 52px;"
@@ -3544,7 +2119,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <div class="MuiBox-root MuiBox-root-276"
                                      title="1 runs"
                                 >
-                                  0.00%
+                                  0%
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3580,7 +2155,7 @@ exports[`release-overview should render correctly 1`] = `
                             <div data-id="52"
                                  data-rowindex="1"
                                  role="row"
-                                 class="Mui-odd JobTable-row-percent-0-117 MuiDataGrid-row"
+                                 class="Mui-odd JobTable-row-percent-0-16 MuiDataGrid-row"
                                  aria-rowindex="3"
                                  aria-selected="false"
                                  style="max-height: 52px; min-height: 52px;"
@@ -3623,7 +2198,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <div class="MuiBox-root MuiBox-root-277"
                                      title="1 runs"
                                 >
-                                  0.00%
+                                  0%
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3659,7 +2234,7 @@ exports[`release-overview should render correctly 1`] = `
                             <div data-id="0"
                                  data-rowindex="2"
                                  role="row"
-                                 class="Mui-even JobTable-row-percent-0-117 MuiDataGrid-row"
+                                 class="Mui-even JobTable-row-percent-0-16 MuiDataGrid-row"
                                  aria-rowindex="4"
                                  aria-selected="false"
                                  style="max-height: 52px; min-height: 52px;"
@@ -3702,7 +2277,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <div class="MuiBox-root MuiBox-root-278"
                                      title="2 runs"
                                 >
-                                  0.00%
+                                  0%
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3738,7 +2313,7 @@ exports[`release-overview should render correctly 1`] = `
                             <div data-id="71"
                                  data-rowindex="3"
                                  role="row"
-                                 class="Mui-odd JobTable-row-percent-50-167 MuiDataGrid-row"
+                                 class="Mui-odd JobTable-row-percent-50-66 MuiDataGrid-row"
                                  aria-rowindex="5"
                                  aria-selected="false"
                                  style="max-height: 52px; min-height: 52px;"
@@ -3781,7 +2356,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <div class="MuiBox-root MuiBox-root-279"
                                      title="2 runs"
                                 >
-                                  50.00%
+                                  50%
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3817,7 +2392,7 @@ exports[`release-overview should render correctly 1`] = `
                             <div data-id="7"
                                  data-rowindex="4"
                                  role="row"
-                                 class="Mui-even JobTable-row-percent-0-117 MuiDataGrid-row"
+                                 class="Mui-even JobTable-row-percent-0-16 MuiDataGrid-row"
                                  aria-rowindex="6"
                                  aria-selected="false"
                                  style="max-height: 52px; min-height: 52px;"
@@ -3860,7 +2435,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <div class="MuiBox-root MuiBox-root-280"
                                      title="2 runs"
                                 >
-                                  0.00%
+                                  0%
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3998,7 +2573,1431 @@ exports[`release-overview should render correctly 1`] = `
         >
           <a class="MuiTypography-root MuiTypography-h5"
              style="text-align: center;"
-             href="/tests/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22id%22%3A5%2C%22columnField%22%3A%22bugs%22%2C%22operatorValue%22%3A%22%3D%22%2C%22value%22%3A%220%22%7D%5D%7D"
+             href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D&amp;sortField=net_improvement&amp;sort=asc"
+          >
+            Most regressed tests
+            <svg class="MuiSvgIcon-root"
+                 focusable="false"
+                 viewbox="0 0 24 24"
+                 aria-hidden="true"
+                 title="Shows the most regressed items this week vs. last week, for those with more than 10 runs"
+            >
+              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z">
+              </path>
+            </svg>
+          </a>
+          <div class="MuiContainer-root MuiContainer-maxWidthLg">
+            <div class="MuiDataGrid-root MuiDataGrid-root MuiDataGrid-autoHeight"
+                 role="grid"
+                 aria-colcount="4"
+                 aria-rowcount="10"
+                 aria-multiselectable="false"
+            >
+              <div>
+                <div>
+                </div>
+              </div>
+              <div class="MuiDataGrid-main">
+                <div class="MuiDataGrid-columnsContainer"
+                     style="min-height: 56px; max-height: 56px; line-height: 56px;"
+                >
+                  <div class="MuiDataGrid-columnHeaderWrapper scroll"
+                       aria-rowindex="1"
+                       role="row"
+                       style="transform: translate3d(-0px, 0, 0); min-width: 200px;"
+                  >
+                    <div class="MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader"
+                         data-field="name"
+                         style="width: 50px; min-width: 50px; max-width: 50px;"
+                         role="columnheader"
+                         tabindex="0"
+                         aria-colindex="1"
+                    >
+                      <div class="MuiDataGrid-columnHeaderDraggableContainer"
+                           draggable="false"
+                      >
+                        <div class="MuiDataGrid-columnHeaderTitleContainer">
+                          <div class="MuiDataGrid-columnHeaderTitle"
+                               title
+                          >
+                            Name
+                          </div>
+                          <div class="MuiDataGrid-iconButtonContainer">
+                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                                    tabindex="-1"
+                                    type="button"
+                                    aria-label="Sort"
+                                    title="Sort"
+                            >
+                              <span class="MuiIconButton-label">
+                                <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                >
+                                  <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
+                                  </path>
+                                </svg>
+                              </span>
+                              <span class="MuiTouchRipple-root">
+                              </span>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="MuiDataGrid-columnSeparator"
+                           style="min-height: 56px; opacity: 1;"
+                      >
+                        <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
+                             focusable="false"
+                             viewbox="0 0 24 24"
+                             aria-hidden="true"
+                        >
+                          <path d="M11 19V5h2v14z">
+                          </path>
+                        </svg>
+                      </div>
+                    </div>
+                    <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
+                         data-field="current_pass_percentage"
+                         style="width: 50px; min-width: 50px; max-width: 50px;"
+                         role="columnheader"
+                         tabindex="-1"
+                         aria-colindex="2"
+                    >
+                      <div class="MuiDataGrid-columnHeaderDraggableContainer"
+                           draggable="false"
+                      >
+                        <div class="MuiDataGrid-columnHeaderTitleContainer">
+                          <div class="MuiDataGrid-columnHeaderTitle"
+                               title
+                          >
+                            Current Period
+                          </div>
+                          <div class="MuiDataGrid-iconButtonContainer">
+                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                                    tabindex="-1"
+                                    type="button"
+                                    aria-label="Sort"
+                                    title="Sort"
+                            >
+                              <span class="MuiIconButton-label">
+                                <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                >
+                                  <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
+                                  </path>
+                                </svg>
+                              </span>
+                              <span class="MuiTouchRipple-root">
+                              </span>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="MuiDataGrid-columnSeparator"
+                           style="min-height: 56px; opacity: 1;"
+                      >
+                        <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
+                             focusable="false"
+                             viewbox="0 0 24 24"
+                             aria-hidden="true"
+                        >
+                          <path d="M11 19V5h2v14z">
+                          </path>
+                        </svg>
+                      </div>
+                    </div>
+                    <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--sorted MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
+                         data-field="net_improvement"
+                         style="width: 50px; min-width: 50px; max-width: 50px;"
+                         role="columnheader"
+                         tabindex="-1"
+                         aria-colindex="3"
+                         aria-sort="ascending"
+                    >
+                      <div class="MuiDataGrid-columnHeaderDraggableContainer"
+                           draggable="false"
+                      >
+                        <div class="MuiDataGrid-columnHeaderTitleContainer">
+                          <div class="MuiDataGrid-columnHeaderTitle"
+                               title
+                          >
+                            Improvement
+                          </div>
+                          <div class="MuiDataGrid-iconButtonContainer">
+                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                                    tabindex="-1"
+                                    type="button"
+                                    aria-label="Sort"
+                                    title="Sort"
+                            >
+                              <span class="MuiIconButton-label">
+                                <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                >
+                                  <path d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z">
+                                  </path>
+                                </svg>
+                              </span>
+                              <span class="MuiTouchRipple-root">
+                              </span>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="MuiDataGrid-columnSeparator"
+                           style="min-height: 56px; opacity: 1;"
+                      >
+                        <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
+                             focusable="false"
+                             viewbox="0 0 24 24"
+                             aria-hidden="true"
+                        >
+                          <path d="M11 19V5h2v14z">
+                          </path>
+                        </svg>
+                      </div>
+                    </div>
+                    <div style="min-width: 50px; max-width: 50px; line-height: 55px; min-height: 56px; max-height: 56px;"
+                         class="MuiDataGrid-cell"
+                    >
+                    </div>
+                  </div>
+                </div>
+                <div style="overflow: visible; width: 0px;">
+                  <div class="MuiDataGrid-windowContainer"
+                       style="width: 0px; height: 556px;"
+                  >
+                    <div class="MuiDataGrid-window"
+                         style="top: 56px; overflow-y: hidden;"
+                    >
+                      <div class="MuiDataGrid-dataContainer"
+                           style="min-width: 200px; min-height: 500px;"
+                      >
+                        <div class="MuiDataGrid-viewport"
+                             style="min-width: 0; max-width: 0; max-height: 500px;"
+                        >
+                          <div class="MuiDataGrid-renderingZone"
+                               style="max-height: 500px; width: 200px; transform: translate3d(-0px, -0px, 0);"
+                          >
+                            <div data-id="25"
+                                 data-rowindex="0"
+                                 role="row"
+                                 class="Mui-even TestTable-row-percent-37-154 MuiDataGrid-row"
+                                 aria-rowindex="2"
+                                 aria-selected="false"
+                                 style="max-height: 100px; min-height: 100px;"
+                            >
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                   role="cell"
+                                   data-value="[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version"
+                                   data-field="name"
+                                   data-rowindex="0"
+                                   data-colindex="0"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="1"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <div class="test-name">
+                                  <a title="[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version"
+                                     class
+                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Binstall%5D%20%5BSuite%3A%20operators%5D%20%5BOSD%5D%20RBAC%20Operator%20Operator%20Upgrade%20should%20upgrade%20from%20the%20replaced%20version%22%7D%5D%7D"
+                                  >
+                                    [install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version
+                                  </a>
+                                </div>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="36.95652173913043"
+                                   data-field="current_pass_percentage"
+                                   data-rowindex="0"
+                                   data-colindex="1"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="2"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <p title="46 runs"
+                                   class
+                                >
+                                  37%
+                                </p>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="-49.83593109105825"
+                                   data-field="net_improvement"
+                                   data-rowindex="0"
+                                   data-colindex="2"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="3"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <svg class="MuiSvgIcon-root"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-49.84%"
+                                >
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                  </path>
+                                </svg>
+                              </div>
+                              <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   class="MuiDataGrid-cell"
+                              >
+                              </div>
+                            </div>
+                            <div data-id="49"
+                                 data-rowindex="1"
+                                 role="row"
+                                 class="Mui-odd TestTable-row-percent-83-200 MuiDataGrid-row"
+                                 aria-rowindex="3"
+                                 aria-selected="false"
+                                 style="max-height: 100px; min-height: 100px;"
+                            >
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                   role="cell"
+                                   data-value="operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test"
+                                   data-field="name"
+                                   data-rowindex="1"
+                                   data-colindex="0"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="1"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <div class="test-name">
+                                  <a title="operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test"
+                                     class
+                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-vsphere-upgrade%20-%20e2e-vsphere-upgrade-ipi-install-install-stableinitial%20container%20test%22%7D%5D%7D"
+                                  >
+                                    operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test
+                                  </a>
+                                </div>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="83.33333333333334"
+                                   data-field="current_pass_percentage"
+                                   data-rowindex="1"
+                                   data-colindex="1"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="2"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <p title="12 runs"
+                                   class
+                                >
+                                  83%
+                                </p>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="-16.666666666666657"
+                                   data-field="net_improvement"
+                                   data-rowindex="1"
+                                   data-colindex="2"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="3"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <svg class="MuiSvgIcon-root"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-16.67%"
+                                >
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                  </path>
+                                </svg>
+                              </div>
+                              <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   class="MuiDataGrid-cell"
+                              >
+                              </div>
+                            </div>
+                            <div data-id="27"
+                                 data-rowindex="2"
+                                 role="row"
+                                 class="Mui-even TestTable-row-percent-50-167 MuiDataGrid-row"
+                                 aria-rowindex="4"
+                                 aria-selected="false"
+                                 style="max-height: 100px; min-height: 100px;"
+                            >
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                   role="cell"
+                                   data-value="operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test"
+                                   data-field="name"
+                                   data-rowindex="2"
+                                   data-colindex="0"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="1"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <div class="test-name">
+                                  <a title="operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test"
+                                     class
+                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-aws-proxy%20-%20e2e-aws-proxy-ipi-install-install%20container%20test%22%7D%5D%7D"
+                                  >
+                                    operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test
+                                  </a>
+                                </div>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="50"
+                                   data-field="current_pass_percentage"
+                                   data-rowindex="2"
+                                   data-colindex="1"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="2"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <p title="16 runs"
+                                   class
+                                >
+                                  50%
+                                </p>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="-12.5"
+                                   data-field="net_improvement"
+                                   data-rowindex="2"
+                                   data-colindex="2"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="3"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <svg class="MuiSvgIcon-root"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-12.50%"
+                                >
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                  </path>
+                                </svg>
+                              </div>
+                              <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   class="MuiDataGrid-cell"
+                              >
+                              </div>
+                            </div>
+                            <div data-id="48"
+                                 data-rowindex="3"
+                                 role="row"
+                                 class="Mui-odd TestTable-row-percent-83-200 MuiDataGrid-row"
+                                 aria-rowindex="5"
+                                 aria-selected="false"
+                                 style="max-height: 100px; min-height: 100px;"
+                            >
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                   role="cell"
+                                   data-value="operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test"
+                                   data-field="name"
+                                   data-rowindex="3"
+                                   data-colindex="0"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="1"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <div class="test-name">
+                                  <a title="operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test"
+                                     class
+                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-gcp-upgrade%20-%20e2e-gcp-upgrade-ipi-install-install-stableinitial%20container%20test%22%7D%5D%7D"
+                                  >
+                                    operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test
+                                  </a>
+                                </div>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="83.33333333333334"
+                                   data-field="current_pass_percentage"
+                                   data-rowindex="3"
+                                   data-colindex="1"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="2"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <p title="48 runs"
+                                   class
+                                >
+                                  83%
+                                </p>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="-12.12121212121211"
+                                   data-field="net_improvement"
+                                   data-rowindex="3"
+                                   data-colindex="2"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="3"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <svg class="MuiSvgIcon-root"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-12.12%"
+                                >
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                  </path>
+                                </svg>
+                              </div>
+                              <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   class="MuiDataGrid-cell"
+                              >
+                              </div>
+                            </div>
+                            <div data-id="55"
+                                 data-rowindex="4"
+                                 role="row"
+                                 class="Mui-even TestTable-row-percent-89-206 MuiDataGrid-row"
+                                 aria-rowindex="6"
+                                 aria-selected="false"
+                                 style="max-height: 100px; min-height: 100px;"
+                            >
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                   role="cell"
+                                   data-value="operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test"
+                                   data-field="name"
+                                   data-rowindex="4"
+                                   data-colindex="0"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="1"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <div class="test-name">
+                                  <a title="operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test"
+                                     class
+                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-gcp%20-%20e2e-gcp-ipi-install-install%20container%20test%22%7D%5D%7D"
+                                  >
+                                    operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test
+                                  </a>
+                                </div>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="89.1891891891892"
+                                   data-field="current_pass_percentage"
+                                   data-rowindex="4"
+                                   data-colindex="1"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="2"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <p title="37 runs"
+                                   class
+                                >
+                                  89%
+                                </p>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="-10.810810810810807"
+                                   data-field="net_improvement"
+                                   data-rowindex="4"
+                                   data-colindex="2"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="3"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <svg class="MuiSvgIcon-root"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-10.81%"
+                                >
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                  </path>
+                                </svg>
+                              </div>
+                              <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   class="MuiDataGrid-cell"
+                              >
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="Mui-resizeTriggers">
+                  <div class="expand-trigger">
+                    <div style="width: 1px; height: 1px;">
+                    </div>
+                  </div>
+                  <div class="contract-trigger">
+                  </div>
+                </div>
+              </div>
+              <div>
+                <div class="MuiDataGrid-footerContainer">
+                  <div>
+                  </div>
+                  <div class="MuiTablePagination-root">
+                    <div class="MuiToolbar-root MuiToolbar-regular MuiTablePagination-toolbar MuiToolbar-gutters">
+                      <div class="MuiTablePagination-spacer">
+                      </div>
+                      <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-269 MuiTypography-body2 MuiTypography-colorInherit">
+                        Rows per page:
+                      </p>
+                      <div class="MuiInputBase-root MuiTablePagination-input makeStyles-input-270 MuiTablePagination-selectRoot">
+                        <div class="MuiSelect-root MuiSelect-select MuiTablePagination-select MuiSelect-selectMenu MuiInputBase-input"
+                             tabindex="0"
+                             role="button"
+                             aria-haspopup="listbox"
+                        >
+                          5
+                        </div>
+                        <input aria-hidden="true"
+                               tabindex="-1"
+                               class="MuiSelect-nativeInput"
+                               value="5"
+                        >
+                        <svg class="MuiSvgIcon-root MuiSelect-icon MuiTablePagination-selectIcon"
+                             focusable="false"
+                             viewbox="0 0 24 24"
+                             aria-hidden="true"
+                        >
+                          <path d="M7 10l5 5 5-5z">
+                          </path>
+                        </svg>
+                      </div>
+                      <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-269 MuiTypography-body2 MuiTypography-colorInherit">
+                        1-5 of 10
+                      </p>
+                      <div class="MuiTablePagination-actions">
+                        <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
+                                tabindex="-1"
+                                type="button"
+                                disabled
+                                title="Previous page"
+                                aria-label="Previous page"
+                        >
+                          <span class="MuiIconButton-label">
+                            <svg class="MuiSvgIcon-root"
+                                 focusable="false"
+                                 viewbox="0 0 24 24"
+                                 aria-hidden="true"
+                            >
+                              <path d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z">
+                              </path>
+                            </svg>
+                          </span>
+                        </button>
+                        <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+                                tabindex="0"
+                                type="button"
+                                title="Next page"
+                                aria-label="Next page"
+                        >
+                          <span class="MuiIconButton-label">
+                            <svg class="MuiSvgIcon-root"
+                                 focusable="false"
+                                 viewbox="0 0 24 24"
+                                 aria-hidden="true"
+                            >
+                              <path d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z">
+                              </path>
+                            </svg>
+                          </span>
+                          <span class="MuiTouchRipple-root">
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-12 MuiGrid-grid-md-6">
+        <div class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
+             enhancement="5"
+             style="text-align: center;"
+        >
+          <a class="MuiTypography-root MuiTypography-h5"
+             style="text-align: center;"
+             href="/tests/4.8?period=twoDay&amp;sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%221%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
+          >
+            Most regressed tests (two day)
+            <svg class="MuiSvgIcon-root"
+                 focusable="false"
+                 viewbox="0 0 24 24"
+                 aria-hidden="true"
+                 title="Shows the last 2 days compared to the last 7 days, sorted by most regressed."
+            >
+              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z">
+              </path>
+            </svg>
+          </a>
+          <div class="MuiContainer-root MuiContainer-maxWidthLg">
+            <div class="MuiDataGrid-root MuiDataGrid-root MuiDataGrid-autoHeight"
+                 role="grid"
+                 aria-colcount="4"
+                 aria-rowcount="10"
+                 aria-multiselectable="false"
+            >
+              <div>
+                <div>
+                </div>
+              </div>
+              <div class="MuiDataGrid-main">
+                <div class="MuiDataGrid-columnsContainer"
+                     style="min-height: 56px; max-height: 56px; line-height: 56px;"
+                >
+                  <div class="MuiDataGrid-columnHeaderWrapper scroll"
+                       aria-rowindex="1"
+                       role="row"
+                       style="transform: translate3d(-0px, 0, 0); min-width: 200px;"
+                  >
+                    <div class="MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader"
+                         data-field="name"
+                         style="width: 50px; min-width: 50px; max-width: 50px;"
+                         role="columnheader"
+                         tabindex="0"
+                         aria-colindex="1"
+                    >
+                      <div class="MuiDataGrid-columnHeaderDraggableContainer"
+                           draggable="false"
+                      >
+                        <div class="MuiDataGrid-columnHeaderTitleContainer">
+                          <div class="MuiDataGrid-columnHeaderTitle"
+                               title
+                          >
+                            Name
+                          </div>
+                          <div class="MuiDataGrid-iconButtonContainer">
+                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                                    tabindex="-1"
+                                    type="button"
+                                    aria-label="Sort"
+                                    title="Sort"
+                            >
+                              <span class="MuiIconButton-label">
+                                <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                >
+                                  <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
+                                  </path>
+                                </svg>
+                              </span>
+                              <span class="MuiTouchRipple-root">
+                              </span>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="MuiDataGrid-columnSeparator"
+                           style="min-height: 56px; opacity: 1;"
+                      >
+                        <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
+                             focusable="false"
+                             viewbox="0 0 24 24"
+                             aria-hidden="true"
+                        >
+                          <path d="M11 19V5h2v14z">
+                          </path>
+                        </svg>
+                      </div>
+                    </div>
+                    <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
+                         data-field="current_pass_percentage"
+                         style="width: 50px; min-width: 50px; max-width: 50px;"
+                         role="columnheader"
+                         tabindex="-1"
+                         aria-colindex="2"
+                    >
+                      <div class="MuiDataGrid-columnHeaderDraggableContainer"
+                           draggable="false"
+                      >
+                        <div class="MuiDataGrid-columnHeaderTitleContainer">
+                          <div class="MuiDataGrid-columnHeaderTitle"
+                               title
+                          >
+                            Current Period
+                          </div>
+                          <div class="MuiDataGrid-iconButtonContainer">
+                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                                    tabindex="-1"
+                                    type="button"
+                                    aria-label="Sort"
+                                    title="Sort"
+                            >
+                              <span class="MuiIconButton-label">
+                                <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                >
+                                  <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z">
+                                  </path>
+                                </svg>
+                              </span>
+                              <span class="MuiTouchRipple-root">
+                              </span>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="MuiDataGrid-columnSeparator"
+                           style="min-height: 56px; opacity: 1;"
+                      >
+                        <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
+                             focusable="false"
+                             viewbox="0 0 24 24"
+                             aria-hidden="true"
+                        >
+                          <path d="M11 19V5h2v14z">
+                          </path>
+                        </svg>
+                      </div>
+                    </div>
+                    <div class="MuiDataGrid-columnHeader--alignRight MuiDataGrid-columnHeader--sortable MuiDataGrid-columnHeader--sorted MuiDataGrid-columnHeader--numeric MuiDataGrid-columnHeader"
+                         data-field="net_improvement"
+                         style="width: 50px; min-width: 50px; max-width: 50px;"
+                         role="columnheader"
+                         tabindex="-1"
+                         aria-colindex="3"
+                         aria-sort="ascending"
+                    >
+                      <div class="MuiDataGrid-columnHeaderDraggableContainer"
+                           draggable="false"
+                      >
+                        <div class="MuiDataGrid-columnHeaderTitleContainer">
+                          <div class="MuiDataGrid-columnHeaderTitle"
+                               title
+                          >
+                            Improvement
+                          </div>
+                          <div class="MuiDataGrid-iconButtonContainer">
+                            <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                                    tabindex="-1"
+                                    type="button"
+                                    aria-label="Sort"
+                                    title="Sort"
+                            >
+                              <span class="MuiIconButton-label">
+                                <svg class="MuiSvgIcon-root MuiDataGrid-sortIcon MuiSvgIcon-fontSizeSmall"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                >
+                                  <path d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z">
+                                  </path>
+                                </svg>
+                              </span>
+                              <span class="MuiTouchRipple-root">
+                              </span>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="MuiDataGrid-columnSeparator"
+                           style="min-height: 56px; opacity: 1;"
+                      >
+                        <svg class="MuiSvgIcon-root MuiDataGrid-iconSeparator"
+                             focusable="false"
+                             viewbox="0 0 24 24"
+                             aria-hidden="true"
+                        >
+                          <path d="M11 19V5h2v14z">
+                          </path>
+                        </svg>
+                      </div>
+                    </div>
+                    <div style="min-width: 50px; max-width: 50px; line-height: 55px; min-height: 56px; max-height: 56px;"
+                         class="MuiDataGrid-cell"
+                    >
+                    </div>
+                  </div>
+                </div>
+                <div style="overflow: visible; width: 0px;">
+                  <div class="MuiDataGrid-windowContainer"
+                       style="width: 0px; height: 556px;"
+                  >
+                    <div class="MuiDataGrid-window"
+                         style="top: 56px; overflow-y: hidden;"
+                    >
+                      <div class="MuiDataGrid-dataContainer"
+                           style="min-width: 200px; min-height: 500px;"
+                      >
+                        <div class="MuiDataGrid-viewport"
+                             style="min-width: 0; max-width: 0; max-height: 500px;"
+                        >
+                          <div class="MuiDataGrid-renderingZone"
+                               style="max-height: 500px; width: 200px; transform: translate3d(-0px, -0px, 0);"
+                          >
+                            <div data-id="6"
+                                 data-rowindex="0"
+                                 role="row"
+                                 class="Mui-even TestTable-row-percent-50-167 MuiDataGrid-row"
+                                 aria-rowindex="2"
+                                 aria-selected="false"
+                                 style="max-height: 100px; min-height: 100px;"
+                            >
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                   role="cell"
+                                   data-value="operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test"
+                                   data-field="name"
+                                   data-rowindex="0"
+                                   data-colindex="0"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="1"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <div class="test-name">
+                                  <a title="operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test"
+                                     class
+                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-metal-assisted%20-%20e2e-metal-assisted-baremetalds-assisted-setup%20container%20test%22%7D%5D%7D"
+                                  >
+                                    operator.Run multi-stage test e2e-metal-assisted - e2e-metal-assisted-baremetalds-assisted-setup container test
+                                  </a>
+                                </div>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="50"
+                                   data-field="current_pass_percentage"
+                                   data-rowindex="0"
+                                   data-colindex="1"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="2"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <p title="2 runs"
+                                   class
+                                >
+                                  50%
+                                </p>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="-42.85714285714286"
+                                   data-field="net_improvement"
+                                   data-rowindex="0"
+                                   data-colindex="2"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="3"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <svg class="MuiSvgIcon-root"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-42.86%"
+                                >
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                  </path>
+                                </svg>
+                              </div>
+                              <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   class="MuiDataGrid-cell"
+                              >
+                              </div>
+                            </div>
+                            <div data-id="7"
+                                 data-rowindex="1"
+                                 role="row"
+                                 class="Mui-odd TestTable-row-percent-50-167 MuiDataGrid-row"
+                                 aria-rowindex="3"
+                                 aria-selected="false"
+                                 style="max-height: 100px; min-height: 100px;"
+                            >
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                   role="cell"
+                                   data-value="operator.Run multi-stage test e2e-metal-ipi-virtualmedia - e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup container test"
+                                   data-field="name"
+                                   data-rowindex="1"
+                                   data-colindex="0"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="1"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <div class="test-name">
+                                  <a title="operator.Run multi-stage test e2e-metal-ipi-virtualmedia - e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup container test"
+                                     class
+                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-metal-ipi-virtualmedia%20-%20e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup%20container%20test%22%7D%5D%7D"
+                                  >
+                                    operator.Run multi-stage test e2e-metal-ipi-virtualmedia - e2e-metal-ipi-virtualmedia-baremetalds-devscripts-setup container test
+                                  </a>
+                                </div>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="50"
+                                   data-field="current_pass_percentage"
+                                   data-rowindex="1"
+                                   data-colindex="1"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="2"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <p title="2 runs"
+                                   class
+                                >
+                                  50%
+                                </p>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="-42.85714285714286"
+                                   data-field="net_improvement"
+                                   data-rowindex="1"
+                                   data-colindex="2"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="3"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <svg class="MuiSvgIcon-root"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-42.86%"
+                                >
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                  </path>
+                                </svg>
+                              </div>
+                              <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   class="MuiDataGrid-cell"
+                              >
+                              </div>
+                            </div>
+                            <div data-id="5"
+                                 data-rowindex="2"
+                                 role="row"
+                                 class="Mui-even TestTable-row-percent-50-167 MuiDataGrid-row"
+                                 aria-rowindex="4"
+                                 aria-selected="false"
+                                 style="max-height: 100px; min-height: 100px;"
+                            >
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                   role="cell"
+                                   data-value="operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test"
+                                   data-field="name"
+                                   data-rowindex="2"
+                                   data-colindex="0"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="1"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <div class="test-name">
+                                  <a title="operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test"
+                                     class
+                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-aws-fips%20-%20e2e-aws-fips-ipi-install-install%20container%20test%22%7D%5D%7D"
+                                  >
+                                    operator.Run multi-stage test e2e-aws-fips - e2e-aws-fips-ipi-install-install container test
+                                  </a>
+                                </div>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="50"
+                                   data-field="current_pass_percentage"
+                                   data-rowindex="2"
+                                   data-colindex="1"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="2"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <p title="2 runs"
+                                   class
+                                >
+                                  50%
+                                </p>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="-42.30769230769231"
+                                   data-field="net_improvement"
+                                   data-rowindex="2"
+                                   data-colindex="2"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="3"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <svg class="MuiSvgIcon-root"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-42.31%"
+                                >
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                  </path>
+                                </svg>
+                              </div>
+                              <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   class="MuiDataGrid-cell"
+                              >
+                              </div>
+                            </div>
+                            <div data-id="12"
+                                 data-rowindex="3"
+                                 role="row"
+                                 class="Mui-odd TestTable-row-percent-75-192 MuiDataGrid-row"
+                                 aria-rowindex="5"
+                                 aria-selected="false"
+                                 style="max-height: 100px; min-height: 100px;"
+                            >
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                   role="cell"
+                                   data-value="TestInstall_test_install.start_install_and_wait_for_installed(openshift_version=4.8)"
+                                   data-field="name"
+                                   data-rowindex="3"
+                                   data-colindex="0"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="1"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <div class="test-name">
+                                  <a title="TestInstall_test_install.start_install_and_wait_for_installed(openshift_version=4.8)"
+                                     class
+                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22TestInstall_test_install.start_install_and_wait_for_installed(openshift_version%3D4.8)%22%7D%5D%7D"
+                                  >
+                                    TestInstall_test_install.start_install_and_wait_for_installed(openshift_version=4.8)
+                                  </a>
+                                </div>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="75"
+                                   data-field="current_pass_percentage"
+                                   data-rowindex="3"
+                                   data-colindex="1"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="2"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <p title="4 runs"
+                                   class
+                                >
+                                  75%
+                                </p>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="-21.15384615384616"
+                                   data-field="net_improvement"
+                                   data-rowindex="3"
+                                   data-colindex="2"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="3"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <svg class="MuiSvgIcon-root"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-21.15%"
+                                >
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                  </path>
+                                </svg>
+                              </div>
+                              <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   class="MuiDataGrid-cell"
+                              >
+                              </div>
+                            </div>
+                            <div data-id="13"
+                                 data-rowindex="4"
+                                 role="row"
+                                 class="Mui-even TestTable-row-percent-75-192 MuiDataGrid-row"
+                                 aria-rowindex="6"
+                                 aria-selected="false"
+                                 style="max-height: 100px; min-height: 100px;"
+                            >
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
+                                   role="cell"
+                                   data-value="operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test"
+                                   data-field="name"
+                                   data-rowindex="4"
+                                   data-colindex="0"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="1"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <div class="test-name">
+                                  <a title="operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test"
+                                     class
+                                     href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-metal-ipi-ovn-ipv6%20-%20e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup%20container%20test%22%7D%5D%7D"
+                                  >
+                                    operator.Run multi-stage test e2e-metal-ipi-ovn-ipv6 - e2e-metal-ipi-ovn-ipv6-baremetalds-devscripts-setup container test
+                                  </a>
+                                </div>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="75"
+                                   data-field="current_pass_percentage"
+                                   data-rowindex="4"
+                                   data-colindex="1"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="2"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <p title="8 runs"
+                                   class
+                                >
+                                  75%
+                                </p>
+                              </div>
+                              <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
+                                   role="cell"
+                                   data-value="-17.85714285714286"
+                                   data-field="net_improvement"
+                                   data-rowindex="4"
+                                   data-colindex="2"
+                                   data-rowselected="false"
+                                   data-editable="false"
+                                   data-mode="view"
+                                   aria-colindex="3"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   tabindex="-1"
+                              >
+                                <svg class="MuiSvgIcon-root"
+                                     focusable="false"
+                                     viewbox="0 0 24 24"
+                                     aria-hidden="true"
+                                     data-icon="ArrowDownwardRoundedIcon"
+                                     style="stroke: darkred; stroke-width: 3; color: darkred;"
+                                     title="-17.86%"
+                                >
+                                  <path d="M11 5v11.17l-4.88-4.88c-.39-.39-1.03-.39-1.42 0-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41a.9959.9959 0 00-1.41 0L13 16.17V5c0-.55-.45-1-1-1s-1 .45-1 1z">
+                                  </path>
+                                </svg>
+                              </div>
+                              <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
+                                   class="MuiDataGrid-cell"
+                              >
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="Mui-resizeTriggers">
+                  <div class="expand-trigger">
+                    <div style="width: 1px; height: 1px;">
+                    </div>
+                  </div>
+                  <div class="contract-trigger">
+                  </div>
+                </div>
+              </div>
+              <div>
+                <div class="MuiDataGrid-footerContainer">
+                  <div>
+                  </div>
+                  <div class="MuiTablePagination-root">
+                    <div class="MuiToolbar-root MuiToolbar-regular MuiTablePagination-toolbar MuiToolbar-gutters">
+                      <div class="MuiTablePagination-spacer">
+                      </div>
+                      <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-269 MuiTypography-body2 MuiTypography-colorInherit">
+                        Rows per page:
+                      </p>
+                      <div class="MuiInputBase-root MuiTablePagination-input makeStyles-input-270 MuiTablePagination-selectRoot">
+                        <div class="MuiSelect-root MuiSelect-select MuiTablePagination-select MuiSelect-selectMenu MuiInputBase-input"
+                             tabindex="0"
+                             role="button"
+                             aria-haspopup="listbox"
+                        >
+                          5
+                        </div>
+                        <input aria-hidden="true"
+                               tabindex="-1"
+                               class="MuiSelect-nativeInput"
+                               value="5"
+                        >
+                        <svg class="MuiSvgIcon-root MuiSelect-icon MuiTablePagination-selectIcon"
+                             focusable="false"
+                             viewbox="0 0 24 24"
+                             aria-hidden="true"
+                        >
+                          <path d="M7 10l5 5 5-5z">
+                          </path>
+                        </svg>
+                      </div>
+                      <p class="MuiTypography-root MuiTablePagination-caption makeStyles-caption-269 MuiTypography-body2 MuiTypography-colorInherit">
+                        1-5 of 10
+                      </p>
+                      <div class="MuiTablePagination-actions">
+                        <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
+                                tabindex="-1"
+                                type="button"
+                                disabled
+                                title="Previous page"
+                                aria-label="Previous page"
+                        >
+                          <span class="MuiIconButton-label">
+                            <svg class="MuiSvgIcon-root"
+                                 focusable="false"
+                                 viewbox="0 0 24 24"
+                                 aria-hidden="true"
+                            >
+                              <path d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z">
+                              </path>
+                            </svg>
+                          </span>
+                        </button>
+                        <button class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+                                tabindex="0"
+                                type="button"
+                                title="Next page"
+                                aria-label="Next page"
+                        >
+                          <span class="MuiIconButton-label">
+                            <svg class="MuiSvgIcon-root"
+                                 focusable="false"
+                                 viewbox="0 0 24 24"
+                                 aria-hidden="true"
+                            >
+                              <path d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z">
+                              </path>
+                            </svg>
+                          </span>
+                          <span class="MuiTouchRipple-root">
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-12 MuiGrid-grid-md-6">
+        <div class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
+             enhancement="5"
+             style="text-align: center;"
+        >
+          <a class="MuiTypography-root MuiTypography-h5"
+             style="text-align: center;"
+             href="/tests/4.8?sortField=net_improvement&amp;sort=asc&amp;filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%2C%7B%22id%22%3A5%2C%22columnField%22%3A%22bugs%22%2C%22operatorValue%22%3A%22%3D%22%2C%22value%22%3A%220%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D"
           >
             Top failing tests without a bug
             <svg class="MuiSvgIcon-root"
@@ -4196,27 +4195,27 @@ exports[`release-overview should render correctly 1`] = `
                 </div>
                 <div style="overflow: visible; width: 0px;">
                   <div class="MuiDataGrid-windowContainer"
-                       style="width: 0px; height: 316px;"
+                       style="width: 0px; height: 556px;"
                   >
                     <div class="MuiDataGrid-window"
                          style="top: 56px; overflow-y: hidden;"
                     >
                       <div class="MuiDataGrid-dataContainer"
-                           style="min-width: 200px; min-height: 260px;"
+                           style="min-width: 200px; min-height: 500px;"
                       >
                         <div class="MuiDataGrid-viewport"
-                             style="min-width: 0; max-width: 0; max-height: 260px;"
+                             style="min-width: 0; max-width: 0; max-height: 500px;"
                         >
                           <div class="MuiDataGrid-renderingZone"
-                               style="max-height: 260px; width: 200px; transform: translate3d(-0px, -0px, 0);"
+                               style="max-height: 500px; width: 200px; transform: translate3d(-0px, -0px, 0);"
                           >
                             <div data-id="25"
                                  data-rowindex="0"
                                  role="row"
-                                 class="Mui-even TestTable-row-percent-37-53 MuiDataGrid-row"
+                                 class="Mui-even TestTable-row-percent-37-154 MuiDataGrid-row"
                                  aria-rowindex="2"
                                  aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
+                                 style="max-height: 100px; min-height: 100px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
@@ -4228,10 +4227,10 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    tabindex="-1"
                               >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                <div class="test-name">
                                   <a title="[install] [Suite: operators] [OSD] RBAC Operator Operator Upgrade should upgrade from the replaced version"
                                      class
                                      href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Binstall%5D%20%5BSuite%3A%20operators%5D%20%5BOSD%5D%20RBAC%20Operator%20Operator%20Upgrade%20should%20upgrade%20from%20the%20replaced%20version%22%7D%5D%7D"
@@ -4250,13 +4249,13 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    tabindex="-1"
                               >
                                 <p title="46 runs"
                                    class
                                 >
-                                  36.96%
+                                  37%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4269,7 +4268,7 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    tabindex="-1"
                               >
                                 <svg class="MuiSvgIcon-root"
@@ -4284,7 +4283,7 @@ exports[`release-overview should render correctly 1`] = `
                                   </path>
                                 </svg>
                               </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                              <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    class="MuiDataGrid-cell"
                               >
                               </div>
@@ -4292,10 +4291,10 @@ exports[`release-overview should render correctly 1`] = `
                             <div data-id="49"
                                  data-rowindex="1"
                                  role="row"
-                                 class="Mui-odd TestTable-row-percent-83-99 MuiDataGrid-row"
+                                 class="Mui-odd TestTable-row-percent-83-200 MuiDataGrid-row"
                                  aria-rowindex="3"
                                  aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
+                                 style="max-height: 100px; min-height: 100px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
@@ -4307,10 +4306,10 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    tabindex="-1"
                               >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                <div class="test-name">
                                   <a title="operator.Run multi-stage test e2e-vsphere-upgrade - e2e-vsphere-upgrade-ipi-install-install-stableinitial container test"
                                      class
                                      href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-vsphere-upgrade%20-%20e2e-vsphere-upgrade-ipi-install-install-stableinitial%20container%20test%22%7D%5D%7D"
@@ -4329,13 +4328,13 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    tabindex="-1"
                               >
                                 <p title="12 runs"
                                    class
                                 >
-                                  83.33%
+                                  83%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4348,7 +4347,7 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    tabindex="-1"
                               >
                                 <svg class="MuiSvgIcon-root"
@@ -4363,7 +4362,7 @@ exports[`release-overview should render correctly 1`] = `
                                   </path>
                                 </svg>
                               </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                              <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    class="MuiDataGrid-cell"
                               >
                               </div>
@@ -4371,10 +4370,10 @@ exports[`release-overview should render correctly 1`] = `
                             <div data-id="27"
                                  data-rowindex="2"
                                  role="row"
-                                 class="Mui-even TestTable-row-percent-50-66 MuiDataGrid-row"
+                                 class="Mui-even TestTable-row-percent-50-167 MuiDataGrid-row"
                                  aria-rowindex="4"
                                  aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
+                                 style="max-height: 100px; min-height: 100px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
@@ -4386,10 +4385,10 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    tabindex="-1"
                               >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                <div class="test-name">
                                   <a title="operator.Run multi-stage test e2e-aws-proxy - e2e-aws-proxy-ipi-install-install container test"
                                      class
                                      href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-aws-proxy%20-%20e2e-aws-proxy-ipi-install-install%20container%20test%22%7D%5D%7D"
@@ -4408,13 +4407,13 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    tabindex="-1"
                               >
                                 <p title="16 runs"
                                    class
                                 >
-                                  50.00%
+                                  50%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4427,7 +4426,7 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    tabindex="-1"
                               >
                                 <svg class="MuiSvgIcon-root"
@@ -4442,7 +4441,7 @@ exports[`release-overview should render correctly 1`] = `
                                   </path>
                                 </svg>
                               </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                              <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    class="MuiDataGrid-cell"
                               >
                               </div>
@@ -4450,10 +4449,10 @@ exports[`release-overview should render correctly 1`] = `
                             <div data-id="48"
                                  data-rowindex="3"
                                  role="row"
-                                 class="Mui-odd TestTable-row-percent-83-99 MuiDataGrid-row"
+                                 class="Mui-odd TestTable-row-percent-83-200 MuiDataGrid-row"
                                  aria-rowindex="5"
                                  aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
+                                 style="max-height: 100px; min-height: 100px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
@@ -4465,10 +4464,10 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    tabindex="-1"
                               >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                <div class="test-name">
                                   <a title="operator.Run multi-stage test e2e-gcp-upgrade - e2e-gcp-upgrade-ipi-install-install-stableinitial container test"
                                      class
                                      href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-gcp-upgrade%20-%20e2e-gcp-upgrade-ipi-install-install-stableinitial%20container%20test%22%7D%5D%7D"
@@ -4487,13 +4486,13 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    tabindex="-1"
                               >
                                 <p title="48 runs"
                                    class
                                 >
-                                  83.33%
+                                  83%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4506,7 +4505,7 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    tabindex="-1"
                               >
                                 <svg class="MuiSvgIcon-root"
@@ -4521,7 +4520,7 @@ exports[`release-overview should render correctly 1`] = `
                                   </path>
                                 </svg>
                               </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                              <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    class="MuiDataGrid-cell"
                               >
                               </div>
@@ -4529,10 +4528,10 @@ exports[`release-overview should render correctly 1`] = `
                             <div data-id="55"
                                  data-rowindex="4"
                                  role="row"
-                                 class="Mui-even TestTable-row-percent-89-105 MuiDataGrid-row"
+                                 class="Mui-even TestTable-row-percent-89-206 MuiDataGrid-row"
                                  aria-rowindex="6"
                                  aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
+                                 style="max-height: 100px; min-height: 100px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
@@ -4544,10 +4543,10 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    tabindex="-1"
                               >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                <div class="test-name">
                                   <a title="operator.Run multi-stage test e2e-gcp - e2e-gcp-ipi-install-install container test"
                                      class
                                      href="/tests/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22operator.Run%20multi-stage%20test%20e2e-gcp%20-%20e2e-gcp-ipi-install-install%20container%20test%22%7D%5D%7D"
@@ -4566,13 +4565,13 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    tabindex="-1"
                               >
                                 <p title="37 runs"
                                    class
                                 >
-                                  89.19%
+                                  89%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4585,7 +4584,7 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    tabindex="-1"
                               >
                                 <svg class="MuiSvgIcon-root"
@@ -4600,7 +4599,7 @@ exports[`release-overview should render correctly 1`] = `
                                   </path>
                                 </svg>
                               </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                              <div style="min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;"
                                    class="MuiDataGrid-cell"
                               >
                               </div>
@@ -4913,7 +4912,7 @@ exports[`release-overview should render correctly 1`] = `
                 </div>
                 <div style="overflow: visible; width: 0px;">
                   <div class="MuiDataGrid-windowContainer"
-                       style="width: 0px; height: 160px;"
+                       style="width: 0px; height: 256px;"
                   >
                     <div class="MuiDataGrid-window"
                          style="top: 56px; overflow-y: hidden;"

--- a/sippy-ng/src/tests/TestByVariantTable.css
+++ b/sippy-ng/src/tests/TestByVariantTable.css
@@ -28,10 +28,10 @@
 }
 
 .cell-name {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-    word-break: break-all;
+    display: block;
+    line-height: normal;
+    white-space: break-spaces;
+    word-wrap: break-word;
 }
 
 .col-result {
@@ -41,6 +41,9 @@
     width: 100px;
     min-width: 100px;
     max-width: 100px;
+    word-wrap: break-word;
+    white-space: break-spaces;
+    display: block;
 }
 
 .col-result-full {

--- a/sippy-ng/src/tests/TestTable.css
+++ b/sippy-ng/src/tests/TestTable.css
@@ -1,0 +1,12 @@
+.test-name {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+
+    font-family: sans-serif;
+    line-height: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: break-spaces;
+    word-wrap: break-word;
+}

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -14,6 +14,7 @@ import { BOOKMARKS, TEST_THRESHOLDS } from '../constants'
 import GridToolbar from '../datagrid/GridToolbar'
 import { generateClasses } from '../datagrid/utils'
 import { pathForExactTest, pathForJobRunsWithTestFailure, withSort } from '../helpers'
+import './TestTable.css'
 
 const bookmarks = [
   {
@@ -57,11 +58,13 @@ function TestTable (props) {
     {
       field: 'name',
       headerName: 'Name',
-      flex: 3,
+      flex: 4,
       renderCell: (params) => (
-        <div style={{ display: 'block', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+        <div className="test-name">
           <Tooltip title={params.value}>
-            <Link to={props.briefTable ? pathForExactTest(props.release, params.value) : '/tests/' + props.release + '/details?test=' + params.row.name}>{params.value}</Link>
+            <Link to={props.briefTable ? pathForExactTest(props.release, params.value) : '/tests/' + props.release + '/details?test=' + params.row.name}>
+              {params.value}
+            </Link>
           </Tooltip>
         </div>
       )
@@ -70,11 +73,11 @@ function TestTable (props) {
       field: 'current_pass_percentage',
       headerName: 'Current Period',
       type: 'number',
-      flex: 1,
+      flex: 0.5,
       renderCell: (params) => (
         <Tooltip title={params.row.current_runs + ' runs'}>
           <p>
-            {Number(params.value).toFixed(2).toLocaleString()}%
+            {Number(params.value).toFixed(0).toLocaleString()}%
           </p>
         </Tooltip>
       )
@@ -91,12 +94,12 @@ function TestTable (props) {
     {
       field: 'previous_pass_percentage',
       headerName: 'Previous Period',
-      flex: 1,
+      flex: 0.5,
       type: 'number',
       renderCell: (params) => (
         <Tooltip title={params.row.previous_runs + ' runs'}>
           <p>
-            {Number(params.value).toFixed(2).toLocaleString()}%
+            {Number(params.value).toFixed(0).toLocaleString()}%
           </p>
         </Tooltip>
       )
@@ -305,6 +308,7 @@ function TestTable (props) {
         rows={rows}
         columns={columns}
         autoHeight={true}
+        rowHeight={100}
         disableColumnFilter={props.briefTable}
         disableColumnMenu={true}
         pageSize={props.pageSize}

--- a/sippy-ng/src/tests/__snapshots__/TestTable.test.js.snap
+++ b/sippy-ng/src/tests/__snapshots__/TestTable.test.js.snap
@@ -310,19 +310,19 @@ exports[`TestTable should render correctly 1`] = `
       </div>
       <div style=\\"overflow: visible; width: 0px;\\">
         <div class=\\"MuiDataGrid-windowContainer\\"
-             style=\\"width: 0px; height: 1356px;\\"
+             style=\\"width: 0px; height: 2556px;\\"
         >
           <div class=\\"MuiDataGrid-window\\"
                style=\\"top: 56px; overflow-y: hidden;\\"
           >
             <div class=\\"MuiDataGrid-dataContainer\\"
-                 style=\\"min-width: 400px; min-height: 1300px;\\"
+                 style=\\"min-width: 400px; min-height: 2500px;\\"
             >
               <div class=\\"MuiDataGrid-viewport\\"
-                   style=\\"min-width: 0; max-width: 0; max-height: 1300px;\\"
+                   style=\\"min-width: 0; max-width: 0; max-height: 2500px;\\"
               >
                 <div class=\\"MuiDataGrid-renderingZone\\"
-                     style=\\"max-height: 1300px; width: 400px; transform: translate3d(-0px, -0px, 0);\\"
+                     style=\\"max-height: 2500px; width: 400px; transform: translate3d(-0px, -0px, 0);\\"
                 >
                   <div data-id=\\"24\\"
                        data-rowindex=\\"0\\"
@@ -330,7 +330,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-even TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"2\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -342,7 +342,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -379,10 +379,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
                            class
                            href=\\"/tests/4.8/details?test=[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
@@ -401,16 +401,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -421,7 +421,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-odd TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"3\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -433,7 +433,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -470,10 +470,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[ClusterLogging] event router e2e test.hack/testing-olm/test-040-eventrouter.sh:109: executing 'oc -n openshift-logging get clusterloggings/instance -o jsonpath={.status.logStore.elasticsearchStatus[0].cluster.status}' expecting any result and text 'green'; re-trying every 10s until completion or 300.000s\\"
                            class
                            href=\\"/tests/4.8/details?test=[ClusterLogging] event router e2e test.hack/testing-olm/test-040-eventrouter.sh:109: executing 'oc -n openshift-logging get clusterloggings/instance -o jsonpath={.status.logStore.elasticsearchStatus[0].cluster.status}' expecting any result and text 'green'; re-trying every 10s until completion or 300.000s\\"
@@ -492,16 +492,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"3 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -512,7 +512,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-even TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"4\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -524,7 +524,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -561,10 +561,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[Elasticsearch] Index Management Block Auto-Create For Write Suffix.hack/testing-olm/test-657-im-block-autocreate-for-write-suffix.sh:64: executing 'oc -n e2e-test-28323 get deployment -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}'' expecting success; re-trying every 0.2s until completion or 120.000s\\"
                            class
                            href=\\"/tests/4.8/details?test=[Elasticsearch] Index Management Block Auto-Create For Write Suffix.hack/testing-olm/test-657-im-block-autocreate-for-write-suffix.sh:64: executing 'oc -n e2e-test-28323 get deployment -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}'' expecting success; re-trying every 0.2s until completion or 120.000s\\"
@@ -583,16 +583,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -603,7 +603,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-odd TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"5\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -615,7 +615,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -652,10 +652,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[Elasticsearch] Index Management Block Auto-Create For Write Suffix.hack/testing-olm/test-657-im-block-autocreate-for-write-suffix.sh:64: executing 'oc -n e2e-test-29522 get deployment -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}'' expecting success; re-trying every 0.2s until completion or 120.000s\\"
                            class
                            href=\\"/tests/4.8/details?test=[Elasticsearch] Index Management Block Auto-Create For Write Suffix.hack/testing-olm/test-657-im-block-autocreate-for-write-suffix.sh:64: executing 'oc -n e2e-test-29522 get deployment -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}'' expecting success; re-trying every 0.2s until completion or 120.000s\\"
@@ -674,16 +674,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -694,7 +694,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-even TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"6\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -706,7 +706,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -743,10 +743,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[Elasticsearch] Index Management Block Auto-Create For Write Suffix.hack/testing-olm/test-657-im-block-autocreate-for-write-suffix.sh:64: executing 'oc -n e2e-test-436 get deployment -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}'' expecting success; re-trying every 0.2s until completion or 120.000s\\"
                            class
                            href=\\"/tests/4.8/details?test=[Elasticsearch] Index Management Block Auto-Create For Write Suffix.hack/testing-olm/test-657-im-block-autocreate-for-write-suffix.sh:64: executing 'oc -n e2e-test-436 get deployment -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}'' expecting success; re-trying every 0.2s until completion or 120.000s\\"
@@ -765,16 +765,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -785,7 +785,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-odd TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"7\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -797,7 +797,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -834,10 +834,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[Elasticsearch] Verify Metrics Access.hack/testing-olm/test-200-verify-es-metrics-access.sh:70: executing 'oc -n e2e-test-2207 get deployment -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}'' expecting success; re-trying every 0.2s until completion or 120.000s\\"
                            class
                            href=\\"/tests/4.8/details?test=[Elasticsearch] Verify Metrics Access.hack/testing-olm/test-200-verify-es-metrics-access.sh:70: executing 'oc -n e2e-test-2207 get deployment -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}'' expecting success; re-trying every 0.2s until completion or 120.000s\\"
@@ -856,16 +856,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -876,7 +876,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-even TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"8\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -888,7 +888,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -925,10 +925,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[Elasticsearch] Verify Metrics Access.hack/testing-olm/test-200-verify-es-metrics-access.sh:70: executing 'oc -n e2e-test-27200 get deployment -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}'' expecting success; re-trying every 0.2s until completion or 120.000s\\"
                            class
                            href=\\"/tests/4.8/details?test=[Elasticsearch] Verify Metrics Access.hack/testing-olm/test-200-verify-es-metrics-access.sh:70: executing 'oc -n e2e-test-27200 get deployment -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}'' expecting success; re-trying every 0.2s until completion or 120.000s\\"
@@ -947,16 +947,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -967,7 +967,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-odd TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"9\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -979,7 +979,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -1016,10 +1016,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[Elasticsearch] Verify Metrics Access.hack/testing-olm/test-200-verify-es-metrics-access.sh:70: executing 'oc -n e2e-test-28323 get deployment -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}'' expecting success; re-trying every 0.2s until completion or 120.000s\\"
                            class
                            href=\\"/tests/4.8/details?test=[Elasticsearch] Verify Metrics Access.hack/testing-olm/test-200-verify-es-metrics-access.sh:70: executing 'oc -n e2e-test-28323 get deployment -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}'' expecting success; re-trying every 0.2s until completion or 120.000s\\"
@@ -1038,16 +1038,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1058,7 +1058,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-even TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"10\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -1070,7 +1070,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -1107,10 +1107,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[Elasticsearch] Verify Metrics Access.hack/testing-olm/test-200-verify-es-metrics-access.sh:70: executing 'oc -n e2e-test-436 get deployment -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}'' expecting success; re-trying every 0.2s until completion or 120.000s\\"
                            class
                            href=\\"/tests/4.8/details?test=[Elasticsearch] Verify Metrics Access.hack/testing-olm/test-200-verify-es-metrics-access.sh:70: executing 'oc -n e2e-test-436 get deployment -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}'' expecting success; re-trying every 0.2s until completion or 120.000s\\"
@@ -1129,16 +1129,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1149,7 +1149,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-odd TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"11\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -1161,7 +1161,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -1198,10 +1198,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[Elasticsearch] Verify Metrics Access.hack/testing-olm/test-200-verify-es-metrics-access.sh:70: executing 'oc -n e2e-test-6123 get deployment -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}'' expecting success; re-trying every 0.2s until completion or 120.000s\\"
                            class
                            href=\\"/tests/4.8/details?test=[Elasticsearch] Verify Metrics Access.hack/testing-olm/test-200-verify-es-metrics-access.sh:70: executing 'oc -n e2e-test-6123 get deployment -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}'' expecting success; re-trying every 0.2s until completion or 120.000s\\"
@@ -1220,16 +1220,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1240,7 +1240,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-even TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"12\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -1252,7 +1252,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -1289,10 +1289,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[sig-storage] In-tree Volumes [Driver: hostPath] [Testpattern: Dynamic PV (delayed binding)] topology should fail to schedule a pod which has topologies that conflict with AllowedTopologies [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
                            class
                            href=\\"/tests/4.8/details?test=[sig-storage] In-tree Volumes [Driver: hostPath] [Testpattern: Dynamic PV (delayed binding)] topology should fail to schedule a pod which has topologies that conflict with AllowedTopologies [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
@@ -1311,16 +1311,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1331,7 +1331,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-odd TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"13\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -1343,7 +1343,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -1380,10 +1380,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[sig-arch] Only known images used by tests\\"
                            class
                            href=\\"/tests/4.8/details?test=[sig-arch] Only known images used by tests\\"
@@ -1402,16 +1402,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1422,7 +1422,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-even TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"14\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -1434,7 +1434,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -1471,10 +1471,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[sig-devex][Feature:Templates] templateservicebroker end-to-end test  should pass an end-to-end test [Suite:openshift/conformance/parallel]\\"
                            class
                            href=\\"/tests/4.8/details?test=[sig-devex][Feature:Templates] templateservicebroker end-to-end test  should pass an end-to-end test [Suite:openshift/conformance/parallel]\\"
@@ -1493,16 +1493,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1513,7 +1513,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-odd TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"15\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -1525,7 +1525,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -1562,10 +1562,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[sig-etcd][Feature:DisasterRecovery][Disruptive] [Feature:EtcdRecovery] Cluster should restore itself after quorum loss [Serial]\\"
                            class
                            href=\\"/tests/4.8/details?test=[sig-etcd][Feature:DisasterRecovery][Disruptive] [Feature:EtcdRecovery] Cluster should restore itself after quorum loss [Serial]\\"
@@ -1584,16 +1584,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"2 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1604,7 +1604,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-even TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"16\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -1616,7 +1616,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -1653,10 +1653,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[sig-network] multicast when using one of the plugins 'redhat/openshift-ovs-subnet' should block multicast traffic [Suite:openshift/conformance/parallel]\\"
                            class
                            href=\\"/tests/4.8/details?test=[sig-network] multicast when using one of the plugins 'redhat/openshift-ovs-subnet' should block multicast traffic [Suite:openshift/conformance/parallel]\\"
@@ -1675,16 +1675,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1695,7 +1695,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-odd TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"17\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -1707,7 +1707,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -1744,10 +1744,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[sig-storage] CSI Volumes [Driver: csi-hostpath] [Testpattern: Dynamic PV (default fs)] fsgroupchangepolicy (Always)[LinuxOnly], pod created with an initial fsgroup, volume contents ownership changed in first pod, new pod with same fsgroup applied to the volume contents [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
                            class
                            href=\\"/tests/4.8/details?test=[sig-storage] CSI Volumes [Driver: csi-hostpath] [Testpattern: Dynamic PV (default fs)] fsgroupchangepolicy (Always)[LinuxOnly], pod created with an initial fsgroup, volume contents ownership changed in first pod, new pod with same fsgroup applied to the volume contents [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
@@ -1766,16 +1766,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1786,7 +1786,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-even TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"18\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -1798,7 +1798,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -1835,10 +1835,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[sig-storage] In-tree Volumes [Driver: emptydir] [Testpattern: Dynamic PV (block volmode)] volumes should store data [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
                            class
                            href=\\"/tests/4.8/details?test=[sig-storage] In-tree Volumes [Driver: emptydir] [Testpattern: Dynamic PV (block volmode)] volumes should store data [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
@@ -1857,16 +1857,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1877,7 +1877,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-odd TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"19\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -1889,7 +1889,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -1926,10 +1926,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[sig-storage] In-tree Volumes [Driver: emptydir] [Testpattern: Inline-volume (ext4)] volumes should allow exec of files on the volume [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
                            class
                            href=\\"/tests/4.8/details?test=[sig-storage] In-tree Volumes [Driver: emptydir] [Testpattern: Inline-volume (ext4)] volumes should allow exec of files on the volume [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
@@ -1948,16 +1948,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1968,7 +1968,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-even TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"20\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -1980,7 +1980,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -2017,10 +2017,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"CRD extensions.ConsoleExternalLogLink CRD.displays YAML editor for adding namespaceFilter to the ConsoleExternalLogLink instance\\"
                            class
                            href=\\"/tests/4.8/details?test=CRD extensions.ConsoleExternalLogLink CRD.displays YAML editor for adding namespaceFilter to the ConsoleExternalLogLink instance\\"
@@ -2039,16 +2039,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"3 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -2059,7 +2059,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-odd TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"21\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -2071,7 +2071,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -2108,10 +2108,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (filesystem volmode)] volumeMode should not mount / map unused volumes in a pod [LinuxOnly] [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
                            class
                            href=\\"/tests/4.8/details?test=[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (filesystem volmode)] volumeMode should not mount / map unused volumes in a pod [LinuxOnly] [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
@@ -2130,16 +2130,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -2150,7 +2150,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-even TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"22\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -2162,7 +2162,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -2199,10 +2199,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link] [Testpattern: Dynamic PV (block volmode)] provisioning should provision storage with pvc data source [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
                            class
                            href=\\"/tests/4.8/details?test=[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link] [Testpattern: Dynamic PV (block volmode)] provisioning should provision storage with pvc data source [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
@@ -2221,16 +2221,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -2241,7 +2241,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-odd TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"23\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -2253,7 +2253,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -2290,10 +2290,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir] [Testpattern: Dynamic PV (default fs)] fsgroupchangepolicy (Always)[LinuxOnly], pod created with an initial fsgroup, volume contents ownership changed in first pod, new pod with same fsgroup applied to the volume contents [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
                            class
                            href=\\"/tests/4.8/details?test=[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir] [Testpattern: Dynamic PV (default fs)] fsgroupchangepolicy (Always)[LinuxOnly], pod created with an initial fsgroup, volume contents ownership changed in first pod, new pod with same fsgroup applied to the volume contents [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
@@ -2312,16 +2312,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -2332,7 +2332,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-even TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"24\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -2344,7 +2344,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -2381,10 +2381,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[sig-storage] In-tree Volumes [Driver: nfs] [Testpattern: Dynamic PV (block volmode)(allowExpansion)] volume-expand should resize volume when PVC is edited while pod is using it [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
                            class
                            href=\\"/tests/4.8/details?test=[sig-storage] In-tree Volumes [Driver: nfs] [Testpattern: Dynamic PV (block volmode)(allowExpansion)] volume-expand should resize volume when PVC is edited while pod is using it [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
@@ -2403,16 +2403,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -2423,7 +2423,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-odd TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"25\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -2435,7 +2435,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -2472,10 +2472,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[sig-storage] In-tree Volumes [Driver: windows-gcepd] [Testpattern: Inline-volume (default fs)] subPath should support existing directory [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
                            class
                            href=\\"/tests/4.8/details?test=[sig-storage] In-tree Volumes [Driver: windows-gcepd] [Testpattern: Inline-volume (default fs)] subPath should support existing directory [Suite:openshift/conformance/parallel] [Suite:k8s]\\"
@@ -2494,16 +2494,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -2514,7 +2514,7 @@ exports[`TestTable should render correctly 1`] = `
                        class=\\"Mui-even TestTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"26\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 100px; min-height: 100px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cellCheckbox MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textCenter\\"
                          role=\\"cell\\"
@@ -2526,7 +2526,7 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <span class=\\"MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-107 MuiCheckbox-root MuiCheckbox-colorPrimary MuiDataGrid-checkboxInput MuiIconButton-colorPrimary\\"
@@ -2563,10 +2563,10 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"test-name\\">
                         <a title=\\"[sig-api-machinery][Feature:ClusterResourceQuota] Cluster resource quota should control resource limits across namespaces [Suite:openshift/conformance/parallel]\\"
                            class
                            href=\\"/tests/4.8/details?test=[sig-api-machinery][Feature:ClusterResourceQuota] Cluster resource quota should control resource limits across namespaces [Suite:openshift/conformance/parallel]\\"
@@ -2585,16 +2585,16 @@ exports[`TestTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          tabindex=\\"-1\\"
                     >
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0.00%
+                        0%
                       </p>
                     </div>
-                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>


### PR DESCRIPTION
Data grid tables don't support dynamic row heights, which is why I used
the ellipsis and tooltip, but I realize I don't need dynamic row heights
they can all be the same size, just taller.

This also fixes the test-by-variant table which isn't data grid and can
have dynamic heights.

I also removed the decimal points.

fixes #266 

Release dashboard, compare with [this page](https://sippy.ci.openshift.org/sippy-ng/)
![image](https://user-images.githubusercontent.com/429763/130533758-1643b090-fe72-4b1d-92f5-d93043c5bafb.png)

Test page, compare with [this page](https://sippy.ci.openshift.org/sippy-ng/tests/4.9?sortField=net_improvement&sort=asc&filters=%7B%22items%22%3A%5B%7B%22id%22%3A1%2C%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%2210%22%7D%5D%7D)
![image](https://user-images.githubusercontent.com/429763/130533765-1760d13b-95ca-48c3-b4c8-3850e9946514.png)

Test-by-variant, compare with [this page](https://sippy.ci.openshift.org/sippy-ng/tests/4.9/details?test=API)
![image](https://user-images.githubusercontent.com/429763/130533771-a0965f0f-6116-4185-a64f-d4f5d57e4002.png)
