### PR TITLE
Show runs in the percentage cell for job tables

### DIFF
--- a/sippy-ng/src/__snapshots__/App.test.js.snap
+++ b/sippy-ng/src/__snapshots__/App.test.js.snap
@@ -1660,19 +1660,19 @@ exports[`app should render correctly 1`] = `
                     </div>
                     <div style="overflow: visible; width: 0px;">
                       <div class="MuiDataGrid-windowContainer"
-                           style="width: 0px; height: 316px;"
+                           style="width: 0px; height: 406px;"
                       >
                         <div class="MuiDataGrid-window"
                              style="top: 56px; overflow-y: hidden;"
                         >
                           <div class="MuiDataGrid-dataContainer"
-                               style="min-width: 200px; min-height: 260px;"
+                               style="min-width: 200px; min-height: 350px;"
                           >
                             <div class="MuiDataGrid-viewport"
-                                 style="min-width: 0; max-width: 0; max-height: 260px;"
+                                 style="min-width: 0; max-width: 0; max-height: 350px;"
                             >
                               <div class="MuiDataGrid-renderingZone"
-                                   style="max-height: 260px; width: 200px; transform: translate3d(-0px, -0px, 0);"
+                                   style="max-height: 350px; width: 200px; transform: translate3d(-0px, -0px, 0);"
                               >
                                 <div data-id="40"
                                      data-rowindex="0"
@@ -1680,7 +1680,7 @@ exports[`app should render correctly 1`] = `
                                      class="Mui-even JobTable-row-percent-38-92 MuiDataGrid-row"
                                      aria-rowindex="2"
                                      aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
+                                     style="max-height: 70px; min-height: 70px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
@@ -1692,10 +1692,10 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                    <div class="job-name">
                                       <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4"
                                          class
                                          href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4%22%7D%5D%7D"
@@ -1714,13 +1714,15 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div class="MuiBox-root MuiBox-root-307"
-                                         title="13 runs"
-                                    >
+                                    <div class="percentage-cell">
                                       38%
+                                      <br>
+                                      <small>
+                                        (13 runs)
+                                      </small>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -1733,7 +1735,7 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
                                     <svg class="MuiSvgIcon-root"
@@ -1748,7 +1750,7 @@ exports[`app should render correctly 1`] = `
                                       </path>
                                     </svg>
                                   </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        class="MuiDataGrid-cell"
                                   >
                                   </div>
@@ -1759,7 +1761,7 @@ exports[`app should render correctly 1`] = `
                                      class="Mui-odd JobTable-row-percent-69-123 MuiDataGrid-row"
                                      aria-rowindex="3"
                                      aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
+                                     style="max-height: 70px; min-height: 70px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
@@ -1771,10 +1773,10 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                    <div class="job-name">
                                       <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp"
                                          class
                                          href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp%22%7D%5D%7D"
@@ -1793,13 +1795,15 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div class="MuiBox-root MuiBox-root-308"
-                                         title="13 runs"
-                                    >
+                                    <div class="percentage-cell">
                                       69%
+                                      <br>
+                                      <small>
+                                        (13 runs)
+                                      </small>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -1812,7 +1816,7 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
                                     <svg class="MuiSvgIcon-root"
@@ -1827,7 +1831,7 @@ exports[`app should render correctly 1`] = `
                                       </path>
                                     </svg>
                                   </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        class="MuiDataGrid-cell"
                                   >
                                   </div>
@@ -1838,7 +1842,7 @@ exports[`app should render correctly 1`] = `
                                      class="Mui-even JobTable-row-percent-33-87 MuiDataGrid-row"
                                      aria-rowindex="4"
                                      aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
+                                     style="max-height: 70px; min-height: 70px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
@@ -1850,10 +1854,10 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                    <div class="job-name">
                                       <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade"
                                          class
                                          href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade%22%7D%5D%7D"
@@ -1872,13 +1876,15 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div class="MuiBox-root MuiBox-root-309"
-                                         title="15 runs"
-                                    >
+                                    <div class="percentage-cell">
                                       33%
+                                      <br>
+                                      <small>
+                                        (15 runs)
+                                      </small>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -1891,7 +1897,7 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
                                     <svg class="MuiSvgIcon-root"
@@ -1906,7 +1912,7 @@ exports[`app should render correctly 1`] = `
                                       </path>
                                     </svg>
                                   </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        class="MuiDataGrid-cell"
                                   >
                                   </div>
@@ -1917,7 +1923,7 @@ exports[`app should render correctly 1`] = `
                                      class="Mui-odd JobTable-row-percent-31-85 MuiDataGrid-row"
                                      aria-rowindex="5"
                                      aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
+                                     style="max-height: 70px; min-height: 70px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
@@ -1929,10 +1935,10 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                    <div class="job-name">
                                       <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy"
                                          class
                                          href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy%22%7D%5D%7D"
@@ -1951,13 +1957,15 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div class="MuiBox-root MuiBox-root-310"
-                                         title="16 runs"
-                                    >
+                                    <div class="percentage-cell">
                                       31%
+                                      <br>
+                                      <small>
+                                        (16 runs)
+                                      </small>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -1970,7 +1978,7 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
                                     <svg class="MuiSvgIcon-root"
@@ -1985,7 +1993,7 @@ exports[`app should render correctly 1`] = `
                                       </path>
                                     </svg>
                                   </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        class="MuiDataGrid-cell"
                                   >
                                   </div>
@@ -1996,7 +2004,7 @@ exports[`app should render correctly 1`] = `
                                      class="Mui-even JobTable-row-percent-77-131 MuiDataGrid-row"
                                      aria-rowindex="6"
                                      aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
+                                     style="max-height: 70px; min-height: 70px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
@@ -2008,10 +2016,10 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                    <div class="job-name">
                                       <a title="release-openshift-ocp-installer-e2e-aws-ovn-4.8"
                                          class
                                          href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-e2e-aws-ovn-4.8%22%7D%5D%7D"
@@ -2030,13 +2038,15 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div class="MuiBox-root MuiBox-root-311"
-                                         title="13 runs"
-                                    >
+                                    <div class="percentage-cell">
                                       77%
+                                      <br>
+                                      <small>
+                                        (13 runs)
+                                      </small>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2049,7 +2059,7 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
                                     <svg class="MuiSvgIcon-root"
@@ -2064,7 +2074,7 @@ exports[`app should render correctly 1`] = `
                                       </path>
                                     </svg>
                                   </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        class="MuiDataGrid-cell"
                                   >
                                   </div>
@@ -2371,19 +2381,19 @@ exports[`app should render correctly 1`] = `
                     </div>
                     <div style="overflow: visible; width: 0px;">
                       <div class="MuiDataGrid-windowContainer"
-                           style="width: 0px; height: 316px;"
+                           style="width: 0px; height: 406px;"
                       >
                         <div class="MuiDataGrid-window"
                              style="top: 56px; overflow-y: hidden;"
                         >
                           <div class="MuiDataGrid-dataContainer"
-                               style="min-width: 200px; min-height: 260px;"
+                               style="min-width: 200px; min-height: 350px;"
                           >
                             <div class="MuiDataGrid-viewport"
-                                 style="min-width: 0; max-width: 0; max-height: 260px;"
+                                 style="min-width: 0; max-width: 0; max-height: 350px;"
                             >
                               <div class="MuiDataGrid-renderingZone"
-                                   style="max-height: 260px; width: 200px; transform: translate3d(-0px, -0px, 0);"
+                                   style="max-height: 350px; width: 200px; transform: translate3d(-0px, -0px, 0);"
                               >
                                 <div data-id="38"
                                      data-rowindex="0"
@@ -2391,7 +2401,7 @@ exports[`app should render correctly 1`] = `
                                      class="Mui-even JobTable-row-percent-0-54 MuiDataGrid-row"
                                      aria-rowindex="2"
                                      aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
+                                     style="max-height: 70px; min-height: 70px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
@@ -2403,10 +2413,10 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                    <div class="job-name">
                                       <a title="periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade"
                                          class
                                          href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade%22%7D%5D%7D"
@@ -2425,13 +2435,15 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div class="MuiBox-root MuiBox-root-312"
-                                         title="1 runs"
-                                    >
+                                    <div class="percentage-cell">
                                       0%
+                                      <br>
+                                      <small>
+                                        (1 runs)
+                                      </small>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2444,7 +2456,7 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
                                     <svg class="MuiSvgIcon-root"
@@ -2459,7 +2471,7 @@ exports[`app should render correctly 1`] = `
                                       </path>
                                     </svg>
                                   </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        class="MuiDataGrid-cell"
                                   >
                                   </div>
@@ -2470,7 +2482,7 @@ exports[`app should render correctly 1`] = `
                                      class="Mui-odd JobTable-row-percent-0-54 MuiDataGrid-row"
                                      aria-rowindex="3"
                                      aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
+                                     style="max-height: 70px; min-height: 70px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
@@ -2482,10 +2494,10 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                    <div class="job-name">
                                       <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-libvirt-cert-rotation"
                                          class
                                          href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-libvirt-cert-rotation%22%7D%5D%7D"
@@ -2504,13 +2516,15 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div class="MuiBox-root MuiBox-root-313"
-                                         title="1 runs"
-                                    >
+                                    <div class="percentage-cell">
                                       0%
+                                      <br>
+                                      <small>
+                                        (1 runs)
+                                      </small>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2523,7 +2537,7 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
                                     <svg class="MuiSvgIcon-root"
@@ -2538,7 +2552,7 @@ exports[`app should render correctly 1`] = `
                                       </path>
                                     </svg>
                                   </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        class="MuiDataGrid-cell"
                                   >
                                   </div>
@@ -2549,7 +2563,7 @@ exports[`app should render correctly 1`] = `
                                      class="Mui-even JobTable-row-percent-0-54 MuiDataGrid-row"
                                      aria-rowindex="4"
                                      aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
+                                     style="max-height: 70px; min-height: 70px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
@@ -2561,10 +2575,10 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                    <div class="job-name">
                                       <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia"
                                          class
                                          href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia%22%7D%5D%7D"
@@ -2583,13 +2597,15 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div class="MuiBox-root MuiBox-root-314"
-                                         title="2 runs"
-                                    >
+                                    <div class="percentage-cell">
                                       0%
+                                      <br>
+                                      <small>
+                                        (2 runs)
+                                      </small>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2602,7 +2618,7 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
                                     <svg class="MuiSvgIcon-root"
@@ -2617,7 +2633,7 @@ exports[`app should render correctly 1`] = `
                                       </path>
                                     </svg>
                                   </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        class="MuiDataGrid-cell"
                                   >
                                   </div>
@@ -2628,7 +2644,7 @@ exports[`app should render correctly 1`] = `
                                      class="Mui-odd JobTable-row-percent-50-104 MuiDataGrid-row"
                                      aria-rowindex="5"
                                      aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
+                                     style="max-height: 70px; min-height: 70px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
@@ -2640,10 +2656,10 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                    <div class="job-name">
                                       <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted"
                                          class
                                          href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted%22%7D%5D%7D"
@@ -2662,13 +2678,15 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div class="MuiBox-root MuiBox-root-315"
-                                         title="2 runs"
-                                    >
+                                    <div class="percentage-cell">
                                       50%
+                                      <br>
+                                      <small>
+                                        (2 runs)
+                                      </small>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2681,7 +2699,7 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
                                     <svg class="MuiSvgIcon-root"
@@ -2696,7 +2714,7 @@ exports[`app should render correctly 1`] = `
                                       </path>
                                     </svg>
                                   </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        class="MuiDataGrid-cell"
                                   >
                                   </div>
@@ -2707,7 +2725,7 @@ exports[`app should render correctly 1`] = `
                                      class="Mui-even JobTable-row-percent-0-54 MuiDataGrid-row"
                                      aria-rowindex="6"
                                      aria-selected="false"
-                                     style="max-height: 52px; min-height: 52px;"
+                                     style="max-height: 70px; min-height: 70px;"
                                 >
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                        role="cell"
@@ -2719,10 +2737,10 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="1"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                    <div class="job-name">
                                       <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack"
                                          class
                                          href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack%22%7D%5D%7D"
@@ -2741,13 +2759,15 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="2"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
-                                    <div class="MuiBox-root MuiBox-root-316"
-                                         title="2 runs"
-                                    >
+                                    <div class="percentage-cell">
                                       0%
+                                      <br>
+                                      <small>
+                                        (2 runs)
+                                      </small>
                                     </div>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2760,7 +2780,7 @@ exports[`app should render correctly 1`] = `
                                        data-editable="false"
                                        data-mode="view"
                                        aria-colindex="3"
-                                       style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                       style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        tabindex="-1"
                                   >
                                     <svg class="MuiSvgIcon-root"
@@ -2775,7 +2795,7 @@ exports[`app should render correctly 1`] = `
                                       </path>
                                     </svg>
                                   </div>
-                                  <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                  <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                        class="MuiDataGrid-cell"
                                   >
                                   </div>

--- a/sippy-ng/src/jobs/JobTable.css
+++ b/sippy-ng/src/jobs/JobTable.css
@@ -1,4 +1,9 @@
-.test-name {
+.percentage-cell {
+    line-height: 1.2em;
+    text-align: center;
+}
+
+.job-name {
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 4;

--- a/sippy-ng/src/jobs/JobTable.js
+++ b/sippy-ng/src/jobs/JobTable.js
@@ -1,4 +1,11 @@
-import { Backdrop, Box, Button, CircularProgress, Container, Tooltip, Typography } from '@material-ui/core'
+import {
+  Backdrop,
+  Button,
+  CircularProgress,
+  Container,
+  Tooltip,
+  Typography
+} from '@material-ui/core'
 import { DataGrid } from '@material-ui/data-grid'
 import { BugReport, DirectionsRun, GridOn } from '@material-ui/icons'
 import Alert from '@material-ui/lab/Alert'
@@ -14,6 +21,7 @@ import { BOOKMARKS, JOB_THRESHOLDS } from '../constants'
 import GridToolbar from '../datagrid/GridToolbar'
 import { generateClasses } from '../datagrid/utils'
 import { pathForExactJob, pathForExactJobRuns } from '../helpers'
+import './JobTable.css'
 
 const bookmarks = [
   { name: 'Runs > 10', model: [BOOKMARKS.RUN_10] },
@@ -36,12 +44,19 @@ function JobTable (props) {
   const [isLoaded, setLoaded] = React.useState(false)
   const [rows, setRows] = React.useState([])
 
-  const [period = props.period, setPeriod] = useQueryParam('period', StringParam)
+  const [period = props.period, setPeriod] = useQueryParam(
+    'period',
+    StringParam
+  )
 
   const [filterModel, setFilterModel] = React.useState(props.filterModel)
-  const [filters = JSON.stringify(props.filterModel), setFilters] = useQueryParam('filters', StringParam)
+  const [filters = JSON.stringify(props.filterModel), setFilters] =
+    useQueryParam('filters', StringParam)
 
-  const [sortField = props.sortField, setSortField] = useQueryParam('sortField', StringParam)
+  const [sortField = props.sortField, setSortField] = useQueryParam(
+    'sortField',
+    StringParam
+  )
   const [sort = props.sort, setSort] = useQueryParam('sort', StringParam)
 
   const [isBugzillaDialogOpen, setBugzillaDialogOpen] = React.useState(false)
@@ -51,12 +66,20 @@ function JobTable (props) {
     {
       field: 'name',
       headerName: 'Name',
-      flex: 4,
+      flex: 3.5,
       renderCell: (params) => {
         return (
-          <div style={{ display: 'block', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          <div className="job-name">
             <Tooltip title={params.value}>
-              <Link to={props.briefTable ? pathForExactJob(props.release, params.value) : '/jobs/' + props.release + '/detail?job=' + params.row.name}>
+              <Link
+                to={
+                  props.briefTable
+                    ? pathForExactJob(props.release, params.value)
+                    : '/jobs/' +
+                      props.release +
+                      '/detail?job=' +
+                      params.row.name
+                }>
                 {props.briefTable ? params.row.brief_name : params.value}
               </Link>
             </Tooltip>
@@ -68,13 +91,12 @@ function JobTable (props) {
       field: 'current_pass_percentage',
       headerName: 'Current Period',
       type: 'number',
-      flex: 0.5,
+      flex: 0.75,
       renderCell: (params) => (
-        <Tooltip title={params.row.current_runs + ' runs'}>
-          <Box>
-            {Number(params.value).toFixed(0).toLocaleString()}%
-          </Box>
-        </Tooltip>
+        <div className="percentage-cell">
+          {Number(params.value).toFixed(0).toLocaleString()}%<br />
+          <small>({params.row.current_runs} runs)</small>
+        </div>
       )
     },
     {
@@ -83,32 +105,34 @@ function JobTable (props) {
       type: 'number',
       flex: 0.5,
       renderCell: (params) => {
-        return (
-          <PassRateIcon tooltip={true} improvement={params.value} />
-        )
+        return <PassRateIcon tooltip={true} improvement={params.value} />
       }
     },
     {
       field: 'previous_pass_percentage',
       headerName: 'Previous Period',
-      flex: 0.5,
+      flex: 0.75,
       type: 'number',
       renderCell: (params) => (
-        <Tooltip title={params.row.current_runs + ' runs'}>
-          <Box>
-            {Number(params.value).toFixed(0).toLocaleString()}%
-          </Box>
-        </Tooltip>
+        <div className="percentage-cell">
+          {Number(params.value).toFixed(0).toLocaleString()}%<br />
+          <small>({params.row.previous_runs} runs)</small>
+        </div>
       )
     },
     {
       field: 'test_grid_url',
       headerName: ' ',
-      flex: 0.40,
+      flex: 0.4,
       renderCell: (params) => {
         return (
           <Tooltip title="TestGrid">
-            <Button style={{ justifyContent: 'center' }} target="_blank" startIcon={<GridOn />} href={params.value} />
+            <Button
+              style={{ justifyContent: 'center' }}
+              target="_blank"
+              startIcon={<GridOn />}
+              href={params.value}
+            />
           </Tooltip>
         )
       },
@@ -118,11 +142,16 @@ function JobTable (props) {
     {
       field: 'job_runs',
       headerName: ' ',
-      flex: 0.40,
+      flex: 0.4,
       renderCell: (params) => {
         return (
           <Tooltip title="See all job runs">
-            <Button component={Link} style={{ justifyContent: 'center' }} startIcon={<DirectionsRun />} to={pathForExactJobRuns(props.release, params.row.name)} />
+            <Button
+              component={Link}
+              style={{ justifyContent: 'center' }}
+              startIcon={<DirectionsRun />}
+              to={pathForExactJobRuns(props.release, params.row.name)}
+            />
           </Tooltip>
         )
       },
@@ -132,22 +161,34 @@ function JobTable (props) {
     {
       field: 'bugs',
       headerName: 'Bugs',
-      flex: 0.40,
+      flex: 0.4,
       type: 'number',
       filterable: true,
       renderCell: (params) => {
         return (
-          <Tooltip title={params.value.length + ' linked bugs,' + params.row.associated_bugs.length + ' associated bugs'}>
-            <Button style={{ justifyContent: 'center', color: bugColor(params.row) }} startIcon={<BugReport />} onClick={() => openBugzillaDialog(params.row)} />
+          <Tooltip
+            title={
+              params.value.length +
+              ' linked bugs,' +
+              params.row.associated_bugs.length +
+              ' associated bugs'
+            }>
+            <Button
+              style={{ justifyContent: 'center', color: bugColor(params.row) }}
+              startIcon={<BugReport />}
+              onClick={() => openBugzillaDialog(params.row)}
+            />
           </Tooltip>
         )
       },
       // Weight linked bugs more than associated bugs, but associated bugs are ranked more than not having one at all.
-      sortComparator: (v1, v2, param1, param2) => weightedBugComparator(
-        param1.api.getCellValue(param1.id, 'bugs'),
-        param1.api.getCellValue(param1.id, 'associated_bugs'),
-        param2.api.getCellValue(param2.id, 'bugs'),
-        param2.api.getCellValue(param2.id, 'associated_bugs')),
+      sortComparator: (v1, v2, param1, param2) =>
+        weightedBugComparator(
+          param1.api.getCellValue(param1.id, 'bugs'),
+          param1.api.getCellValue(param1.id, 'associated_bugs'),
+          param2.api.getCellValue(param2.id, 'bugs'),
+          param2.api.getCellValue(param2.id, 'associated_bugs')
+        ),
       hide: props.briefTable
     },
     // These are here just to allow filtering
@@ -179,7 +220,6 @@ function JobTable (props) {
       headerName: 'Tags',
       hide: true
     }
-
   ]
 
   const openBugzillaDialog = (job) => {
@@ -208,25 +248,38 @@ function JobTable (props) {
     queryString += '&sortField=' + encodeURIComponent(sortField)
     queryString += '&sort=' + encodeURIComponent(sort)
 
-    fetch(process.env.REACT_APP_API_URL + '/api/jobs?release=' + props.release + queryString)
+    fetch(
+      process.env.REACT_APP_API_URL +
+        '/api/jobs?release=' +
+        props.release +
+        queryString
+    )
       .then((response) => {
         if (response.status !== 200) {
           throw new Error('server returned ' + response.status)
         }
         return response.json()
       })
-      .then(json => {
+      .then((json) => {
         setRows(json)
         setLoaded(true)
-      }).catch(error => {
+      })
+      .catch((error) => {
         setFetchError('Could not retrieve jobs ' + props.release + ', ' + error)
       })
   }
 
   const requestSearch = (searchValue) => {
     const currentFilters = filterModel
-    currentFilters.items = currentFilters.items.filter((f) => f.columnField !== 'name')
-    currentFilters.items.push({ id: 99, columnField: 'name', operatorValue: 'contains', value: searchValue })
+    currentFilters.items = currentFilters.items.filter(
+      (f) => f.columnField !== 'name'
+    )
+    currentFilters.items.push({
+      id: 99,
+      columnField: 'name',
+      operatorValue: 'contains',
+      value: searchValue
+    })
     setFilters(JSON.stringify(currentFilters))
   }
 
@@ -292,26 +345,30 @@ function JobTable (props) {
         rows={rows}
         columns={columns}
         autoHeight={true}
-
+        rowHeight={70}
         // Filtering:
         filterMode="server"
         filterModel={filterModel}
         onFilterModelChange={(m) => setFilters(JSON.stringify(m))}
         sortingOrder={['desc', 'asc']}
-        sortModel={[{
-          field: sortField,
-          sort: sort
-        }]}
-
+        sortModel={[
+          {
+            field: sortField,
+            sort: sort
+          }
+        ]}
         // Sorting:
         onSortModelChange={(m) => updateSortModel(m)}
         sortingMode="server"
         pageSize={props.pageSize}
         disableColumnFilter={props.briefTable}
         disableColumnMenu={true}
-
         rowsPerPageOptions={[5, 10, 25, 50]}
-        getRowClassName={(params) => classes['row-percent-' + Math.round(params.row.current_pass_percentage)]}
+        getRowClassName={(params) =>
+          classes[
+            'row-percent-' + Math.round(params.row.current_pass_percentage)
+          ]
+        }
         componentsProps={{
           toolbar: {
             bookmarks: bookmarks,
@@ -322,9 +379,12 @@ function JobTable (props) {
             setFilterModel: (m) => addFilters(m)
           }
         }}
-
       />
-      <BugzillaDialog item={jobDetails} isOpen={isBugzillaDialogOpen} close={closeBugzillaDialog} />
+      <BugzillaDialog
+        item={jobDetails}
+        isOpen={isBugzillaDialogOpen}
+        close={closeBugzillaDialog}
+      />
     </Container>
   )
 }

--- a/sippy-ng/src/jobs/__snapshots__/JobTable.test.js.snap
+++ b/sippy-ng/src/jobs/__snapshots__/JobTable.test.js.snap
@@ -313,19 +313,19 @@ exports[`JobTable should render correctly 1`] = `
       </div>
       <div style=\\"overflow: visible; width: 0px;\\">
         <div class=\\"MuiDataGrid-windowContainer\\"
-             style=\\"width: 0px; height: 1356px;\\"
+             style=\\"width: 0px; height: 1806px;\\"
         >
           <div class=\\"MuiDataGrid-window\\"
                style=\\"top: 56px; overflow-y: hidden;\\"
           >
             <div class=\\"MuiDataGrid-dataContainer\\"
-                 style=\\"min-width: 350px; min-height: 1300px;\\"
+                 style=\\"min-width: 350px; min-height: 1750px;\\"
             >
               <div class=\\"MuiDataGrid-viewport\\"
-                   style=\\"min-width: 0; max-width: 0; max-height: 1300px;\\"
+                   style=\\"min-width: 0; max-width: 0; max-height: 1750px;\\"
               >
                 <div class=\\"MuiDataGrid-renderingZone\\"
-                     style=\\"max-height: 1300px; width: 350px; transform: translate3d(-0px, -0px, 0);\\"
+                     style=\\"max-height: 1750px; width: 350px; transform: translate3d(-0px, -0px, 0);\\"
                 >
                   <div data-id=\\"19\\"
                        data-rowindex=\\"0\\"
@@ -333,7 +333,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-even JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"2\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -345,10 +345,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-ovirt-upgrade\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-ovirt-upgrade\\"
@@ -367,13 +367,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-107\\"
-                           title=\\"3 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (3 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -386,7 +388,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -401,7 +403,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -412,7 +414,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-odd JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"3\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -424,10 +426,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-ovn-upgrade\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-ovn-upgrade\\"
@@ -446,13 +448,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-108\\"
-                           title=\\"3 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (3 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -465,7 +469,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -480,7 +484,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -491,7 +495,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-even JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"4\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -503,10 +507,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-ovn-upgrade-rollback\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-ovn-upgrade-rollback\\"
@@ -525,13 +529,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-109\\"
-                           title=\\"6 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (6 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -544,7 +550,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -559,7 +565,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -570,7 +576,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-odd JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"5\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -582,10 +588,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-openstack-upgrade\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-openstack-upgrade\\"
@@ -604,13 +610,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-110\\"
-                           title=\\"3 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (3 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -623,7 +631,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -638,7 +646,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -649,7 +657,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-even JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"6\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -661,10 +669,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-e2e-aws-compact-upgrade\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-ci-4.8-e2e-aws-compact-upgrade\\"
@@ -683,13 +691,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-111\\"
-                           title=\\"3 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (3 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -702,7 +712,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -717,7 +727,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -728,7 +738,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-odd JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"7\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -740,10 +750,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8\\"
                            class
                            href=\\"/jobs/4.8/detail?job=release-openshift-ocp-installer-upgrade-remote-libvirt-s390x-4.7-to-4.8\\"
@@ -762,13 +772,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-112\\"
-                           title=\\"13 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (13 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -781,7 +793,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -796,7 +808,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -807,7 +819,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-even JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"8\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -819,10 +831,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-ovn-upgrade\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-ovn-upgrade\\"
@@ -841,13 +853,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-113\\"
-                           title=\\"3 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (3 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -860,7 +874,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -875,7 +889,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -886,7 +900,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-odd JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"9\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -898,10 +912,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"release-openshift-ocp-installer-cluster-logging-operator-e2e-4.8\\"
                            class
                            href=\\"/jobs/4.8/detail?job=release-openshift-ocp-installer-cluster-logging-operator-e2e-4.8\\"
@@ -920,13 +934,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-114\\"
-                           title=\\"3 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (3 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -939,7 +955,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -954,7 +970,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -965,7 +981,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-even JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"10\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -977,10 +993,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade-rollback\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade-rollback\\"
@@ -999,13 +1015,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-115\\"
-                           title=\\"3 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (3 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1018,7 +1036,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -1033,7 +1051,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1044,7 +1062,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-odd JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"11\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -1056,10 +1074,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-e2e-azure-compact-upgrade\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-ci-4.8-e2e-azure-compact-upgrade\\"
@@ -1078,13 +1096,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-116\\"
-                           title=\\"3 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (3 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1097,7 +1117,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -1112,7 +1132,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1123,7 +1143,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-even JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"12\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -1135,10 +1155,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-nightly-4.8-openshift-ipi-azure-arcconformance\\"
@@ -1157,13 +1177,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-117\\"
-                           title=\\"40 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (40 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1176,7 +1198,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -1191,7 +1213,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1202,7 +1224,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-odd JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"13\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -1214,10 +1236,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"release-openshift-origin-installer-e2e-aws-disruptive-4.8\\"
                            class
                            href=\\"/jobs/4.8/detail?job=release-openshift-origin-installer-e2e-aws-disruptive-4.8\\"
@@ -1236,13 +1258,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-118\\"
-                           title=\\"3 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (3 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1255,7 +1279,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -1270,7 +1294,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1281,7 +1305,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-even JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"14\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -1293,10 +1317,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-e2e-azure-cilium\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-ci-4.8-e2e-azure-cilium\\"
@@ -1315,13 +1339,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-119\\"
-                           title=\\"3 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (3 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1334,7 +1360,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -1349,7 +1375,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1360,7 +1386,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-odd JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"15\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -1372,10 +1398,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-from-stable-4.7-from-stable-4.6-e2e-aws-upgrade\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-ci-4.8-upgrade-from-from-stable-4.7-from-stable-4.6-e2e-aws-upgrade\\"
@@ -1394,13 +1420,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-120\\"
-                           title=\\"3 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (3 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1413,7 +1441,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -1428,7 +1456,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1439,7 +1467,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-even JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"16\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -1451,10 +1479,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"release-openshift-origin-installer-old-rhcos-e2e-aws-4.8\\"
                            class
                            href=\\"/jobs/4.8/detail?job=release-openshift-origin-installer-old-rhcos-e2e-aws-4.8\\"
@@ -1473,13 +1501,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-121\\"
-                           title=\\"3 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (3 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1492,7 +1522,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -1507,7 +1537,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1518,7 +1548,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-odd JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"17\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -1530,10 +1560,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8\\"
                            class
                            href=\\"/jobs/4.8/detail?job=release-openshift-ocp-installer-elasticsearch-operator-e2e-4.8\\"
@@ -1552,13 +1582,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-122\\"
-                           title=\\"6 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (6 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1571,7 +1603,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -1586,7 +1618,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1597,7 +1629,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-even JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"18\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -1609,10 +1641,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-azure-ovn-upgrade\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-azure-ovn-upgrade\\"
@@ -1631,13 +1663,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-123\\"
-                           title=\\"6 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (6 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1650,7 +1684,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -1665,7 +1699,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1676,7 +1710,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-odd JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"19\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -1688,10 +1722,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-ci-4.8-e2e-aws-hypershift\\"
@@ -1710,13 +1744,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-124\\"
-                           title=\\"6 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (6 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1729,7 +1765,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -1744,7 +1780,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1755,7 +1791,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-even JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"20\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -1767,10 +1803,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-upgrade-rollback\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-upgrade-rollback\\"
@@ -1789,13 +1825,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-125\\"
-                           title=\\"3 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (3 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1808,7 +1846,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -1823,7 +1861,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1834,7 +1872,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-odd JobTable-row-percent-0-1 MuiDataGrid-row\\"
                        aria-rowindex=\\"21\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -1846,10 +1884,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"release-openshift-origin-installer-e2e-aws-upgrade-4.5-to-4.6-to-4.7-to-4.8-ci\\"
                            class
                            href=\\"/jobs/4.8/detail?job=release-openshift-origin-installer-e2e-aws-upgrade-4.5-to-4.6-to-4.7-to-4.8-ci\\"
@@ -1868,13 +1906,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-126\\"
-                           title=\\"6 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         0%
+                        <br>
+                        <small>
+                          (6 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1887,7 +1927,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -1902,7 +1942,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1913,7 +1953,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-even JobTable-row-percent-15-16 MuiDataGrid-row\\"
                        aria-rowindex=\\"22\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -1925,10 +1965,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\\"
                            class
                            href=\\"/jobs/4.8/detail?job=release-openshift-ocp-installer-upgrade-remote-libvirt-ppc64le-4.7-to-4.8\\"
@@ -1947,13 +1987,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-127\\"
-                           title=\\"13 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         15%
+                        <br>
+                        <small>
+                          (13 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -1966,7 +2008,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -1981,7 +2023,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -1992,7 +2034,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-odd JobTable-row-percent-17-18 MuiDataGrid-row\\"
                        aria-rowindex=\\"23\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -2004,10 +2046,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-ovn\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-ovn\\"
@@ -2026,13 +2068,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-128\\"
-                           title=\\"6 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         17%
+                        <br>
+                        <small>
+                          (6 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -2045,7 +2089,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -2060,7 +2104,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -2071,7 +2115,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-even JobTable-row-percent-23-24 MuiDataGrid-row\\"
                        aria-rowindex=\\"24\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -2083,10 +2127,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade\\"
@@ -2105,13 +2149,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-129\\"
-                           title=\\"13 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         23%
+                        <br>
+                        <small>
+                          (13 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -2124,7 +2170,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -2139,7 +2185,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -2150,7 +2196,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-odd JobTable-row-percent-25-26 MuiDataGrid-row\\"
                        aria-rowindex=\\"25\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -2162,10 +2208,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-e2e-azure-compact-serial\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-ci-4.8-e2e-azure-compact-serial\\"
@@ -2184,13 +2230,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-130\\"
-                           title=\\"4 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         25%
+                        <br>
+                        <small>
+                          (4 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -2203,7 +2251,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -2218,7 +2266,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>
@@ -2229,7 +2277,7 @@ exports[`JobTable should render correctly 1`] = `
                        class=\\"Mui-even JobTable-row-percent-25-26 MuiDataGrid-row\\"
                        aria-rowindex=\\"26\\"
                        aria-selected=\\"false\\"
-                       style=\\"max-height: 52px; min-height: 52px;\\"
+                       style=\\"max-height: 70px; min-height: 70px;\\"
                   >
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft\\"
                          role=\\"cell\\"
@@ -2241,10 +2289,10 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"1\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div style=\\"display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\\">
+                      <div class=\\"job-name\\">
                         <a title=\\"periodic-ci-openshift-release-master-ci-4.8-e2e-azure-compact\\"
                            class
                            href=\\"/jobs/4.8/detail?job=periodic-ci-openshift-release-master-ci-4.8-e2e-azure-compact\\"
@@ -2263,13 +2311,15 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"2\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <div class=\\"MuiBox-root MuiBox-root-131\\"
-                           title=\\"4 runs\\"
-                      >
+                      <div class=\\"percentage-cell\\">
                         25%
+                        <br>
+                        <small>
+                          (4 runs)
+                        </small>
                       </div>
                     </div>
                     <div class=\\"MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight\\"
@@ -2282,7 +2332,7 @@ exports[`JobTable should render correctly 1`] = `
                          data-editable=\\"false\\"
                          data-mode=\\"view\\"
                          aria-colindex=\\"3\\"
-                         style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                         style=\\"min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          tabindex=\\"-1\\"
                     >
                       <svg class=\\"MuiSvgIcon-root\\"
@@ -2297,7 +2347,7 @@ exports[`JobTable should render correctly 1`] = `
                         </path>
                       </svg>
                     </div>
-                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
+                    <div style=\\"min-width: 200px; max-width: 200px; line-height: 69px; min-height: 70px; max-height: 70px;\\"
                          class=\\"MuiDataGrid-cell\\"
                     >
                     </div>

--- a/sippy-ng/src/releases/__snapshots__/ReleaseOverview.test.js.snap
+++ b/sippy-ng/src/releases/__snapshots__/ReleaseOverview.test.js.snap
@@ -1452,19 +1452,19 @@ exports[`release-overview should render correctly 1`] = `
                 </div>
                 <div style="overflow: visible; width: 0px;">
                   <div class="MuiDataGrid-windowContainer"
-                       style="width: 0px; height: 316px;"
+                       style="width: 0px; height: 406px;"
                   >
                     <div class="MuiDataGrid-window"
                          style="top: 56px; overflow-y: hidden;"
                     >
                       <div class="MuiDataGrid-dataContainer"
-                           style="min-width: 200px; min-height: 260px;"
+                           style="min-width: 200px; min-height: 350px;"
                       >
                         <div class="MuiDataGrid-viewport"
-                             style="min-width: 0; max-width: 0; max-height: 260px;"
+                             style="min-width: 0; max-width: 0; max-height: 350px;"
                         >
                           <div class="MuiDataGrid-renderingZone"
-                               style="max-height: 260px; width: 200px; transform: translate3d(-0px, -0px, 0);"
+                               style="max-height: 350px; width: 200px; transform: translate3d(-0px, -0px, 0);"
                           >
                             <div data-id="38"
                                  data-rowindex="0"
@@ -1472,7 +1472,7 @@ exports[`release-overview should render correctly 1`] = `
                                  class="Mui-even JobTable-row-percent-38-54 MuiDataGrid-row"
                                  aria-rowindex="2"
                                  aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
+                                 style="max-height: 70px; min-height: 70px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
@@ -1484,10 +1484,10 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                <div class="job-name">
                                   <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4"
                                      class
                                      href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4%22%7D%5D%7D"
@@ -1506,13 +1506,15 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div class="MuiBox-root MuiBox-root-271"
-                                     title="13 runs"
-                                >
+                                <div class="percentage-cell">
                                   38%
+                                  <br>
+                                  <small>
+                                    (13 runs)
+                                  </small>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -1525,7 +1527,7 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
                                 <svg class="MuiSvgIcon-root"
@@ -1540,7 +1542,7 @@ exports[`release-overview should render correctly 1`] = `
                                   </path>
                                 </svg>
                               </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                              <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    class="MuiDataGrid-cell"
                               >
                               </div>
@@ -1551,7 +1553,7 @@ exports[`release-overview should render correctly 1`] = `
                                  class="Mui-odd JobTable-row-percent-69-85 MuiDataGrid-row"
                                  aria-rowindex="3"
                                  aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
+                                 style="max-height: 70px; min-height: 70px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
@@ -1563,10 +1565,10 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                <div class="job-name">
                                   <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp"
                                      class
                                      href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp%22%7D%5D%7D"
@@ -1585,13 +1587,15 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div class="MuiBox-root MuiBox-root-272"
-                                     title="13 runs"
-                                >
+                                <div class="percentage-cell">
                                   69%
+                                  <br>
+                                  <small>
+                                    (13 runs)
+                                  </small>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -1604,7 +1608,7 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
                                 <svg class="MuiSvgIcon-root"
@@ -1619,7 +1623,7 @@ exports[`release-overview should render correctly 1`] = `
                                   </path>
                                 </svg>
                               </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                              <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    class="MuiDataGrid-cell"
                               >
                               </div>
@@ -1630,7 +1634,7 @@ exports[`release-overview should render correctly 1`] = `
                                  class="Mui-even JobTable-row-percent-33-49 MuiDataGrid-row"
                                  aria-rowindex="4"
                                  aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
+                                 style="max-height: 70px; min-height: 70px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
@@ -1642,10 +1646,10 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                <div class="job-name">
                                   <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade"
                                      class
                                      href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade%22%7D%5D%7D"
@@ -1664,13 +1668,15 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div class="MuiBox-root MuiBox-root-273"
-                                     title="15 runs"
-                                >
+                                <div class="percentage-cell">
                                   33%
+                                  <br>
+                                  <small>
+                                    (15 runs)
+                                  </small>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -1683,7 +1689,7 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
                                 <svg class="MuiSvgIcon-root"
@@ -1698,7 +1704,7 @@ exports[`release-overview should render correctly 1`] = `
                                   </path>
                                 </svg>
                               </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                              <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    class="MuiDataGrid-cell"
                               >
                               </div>
@@ -1709,7 +1715,7 @@ exports[`release-overview should render correctly 1`] = `
                                  class="Mui-odd JobTable-row-percent-31-47 MuiDataGrid-row"
                                  aria-rowindex="5"
                                  aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
+                                 style="max-height: 70px; min-height: 70px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
@@ -1721,10 +1727,10 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                <div class="job-name">
                                   <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy"
                                      class
                                      href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy%22%7D%5D%7D"
@@ -1743,13 +1749,15 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div class="MuiBox-root MuiBox-root-274"
-                                     title="16 runs"
-                                >
+                                <div class="percentage-cell">
                                   31%
+                                  <br>
+                                  <small>
+                                    (16 runs)
+                                  </small>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -1762,7 +1770,7 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
                                 <svg class="MuiSvgIcon-root"
@@ -1777,7 +1785,7 @@ exports[`release-overview should render correctly 1`] = `
                                   </path>
                                 </svg>
                               </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                              <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    class="MuiDataGrid-cell"
                               >
                               </div>
@@ -1788,7 +1796,7 @@ exports[`release-overview should render correctly 1`] = `
                                  class="Mui-even JobTable-row-percent-77-93 MuiDataGrid-row"
                                  aria-rowindex="6"
                                  aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
+                                 style="max-height: 70px; min-height: 70px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
@@ -1800,10 +1808,10 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                <div class="job-name">
                                   <a title="release-openshift-ocp-installer-e2e-aws-ovn-4.8"
                                      class
                                      href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22release-openshift-ocp-installer-e2e-aws-ovn-4.8%22%7D%5D%7D"
@@ -1822,13 +1830,15 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div class="MuiBox-root MuiBox-root-275"
-                                     title="13 runs"
-                                >
+                                <div class="percentage-cell">
                                   77%
+                                  <br>
+                                  <small>
+                                    (13 runs)
+                                  </small>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -1841,7 +1851,7 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
                                 <svg class="MuiSvgIcon-root"
@@ -1856,7 +1866,7 @@ exports[`release-overview should render correctly 1`] = `
                                   </path>
                                 </svg>
                               </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                              <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    class="MuiDataGrid-cell"
                               >
                               </div>
@@ -2163,19 +2173,19 @@ exports[`release-overview should render correctly 1`] = `
                 </div>
                 <div style="overflow: visible; width: 0px;">
                   <div class="MuiDataGrid-windowContainer"
-                       style="width: 0px; height: 316px;"
+                       style="width: 0px; height: 406px;"
                   >
                     <div class="MuiDataGrid-window"
                          style="top: 56px; overflow-y: hidden;"
                     >
                       <div class="MuiDataGrid-dataContainer"
-                           style="min-width: 200px; min-height: 260px;"
+                           style="min-width: 200px; min-height: 350px;"
                       >
                         <div class="MuiDataGrid-viewport"
-                             style="min-width: 0; max-width: 0; max-height: 260px;"
+                             style="min-width: 0; max-width: 0; max-height: 350px;"
                         >
                           <div class="MuiDataGrid-renderingZone"
-                               style="max-height: 260px; width: 200px; transform: translate3d(-0px, -0px, 0);"
+                               style="max-height: 350px; width: 200px; transform: translate3d(-0px, -0px, 0);"
                           >
                             <div data-id="16"
                                  data-rowindex="0"
@@ -2183,7 +2193,7 @@ exports[`release-overview should render correctly 1`] = `
                                  class="Mui-even JobTable-row-percent-0-16 MuiDataGrid-row"
                                  aria-rowindex="2"
                                  aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
+                                 style="max-height: 70px; min-height: 70px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
@@ -2195,10 +2205,10 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                <div class="job-name">
                                   <a title="periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade"
                                      class
                                      href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade%22%7D%5D%7D"
@@ -2217,13 +2227,15 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div class="MuiBox-root MuiBox-root-276"
-                                     title="1 runs"
-                                >
+                                <div class="percentage-cell">
                                   0%
+                                  <br>
+                                  <small>
+                                    (1 runs)
+                                  </small>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2236,7 +2248,7 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
                                 <svg class="MuiSvgIcon-root"
@@ -2251,7 +2263,7 @@ exports[`release-overview should render correctly 1`] = `
                                   </path>
                                 </svg>
                               </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                              <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    class="MuiDataGrid-cell"
                               >
                               </div>
@@ -2262,7 +2274,7 @@ exports[`release-overview should render correctly 1`] = `
                                  class="Mui-odd JobTable-row-percent-0-16 MuiDataGrid-row"
                                  aria-rowindex="3"
                                  aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
+                                 style="max-height: 70px; min-height: 70px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
@@ -2274,10 +2286,10 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                <div class="job-name">
                                   <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-libvirt-cert-rotation"
                                      class
                                      href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-libvirt-cert-rotation%22%7D%5D%7D"
@@ -2296,13 +2308,15 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div class="MuiBox-root MuiBox-root-277"
-                                     title="1 runs"
-                                >
+                                <div class="percentage-cell">
                                   0%
+                                  <br>
+                                  <small>
+                                    (1 runs)
+                                  </small>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2315,7 +2329,7 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
                                 <svg class="MuiSvgIcon-root"
@@ -2330,7 +2344,7 @@ exports[`release-overview should render correctly 1`] = `
                                   </path>
                                 </svg>
                               </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                              <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    class="MuiDataGrid-cell"
                               >
                               </div>
@@ -2341,7 +2355,7 @@ exports[`release-overview should render correctly 1`] = `
                                  class="Mui-even JobTable-row-percent-0-16 MuiDataGrid-row"
                                  aria-rowindex="4"
                                  aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
+                                 style="max-height: 70px; min-height: 70px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
@@ -2353,10 +2367,10 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                <div class="job-name">
                                   <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia"
                                      class
                                      href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia%22%7D%5D%7D"
@@ -2375,13 +2389,15 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div class="MuiBox-root MuiBox-root-278"
-                                     title="2 runs"
-                                >
+                                <div class="percentage-cell">
                                   0%
+                                  <br>
+                                  <small>
+                                    (2 runs)
+                                  </small>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2394,7 +2410,7 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
                                 <svg class="MuiSvgIcon-root"
@@ -2409,7 +2425,7 @@ exports[`release-overview should render correctly 1`] = `
                                   </path>
                                 </svg>
                               </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                              <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    class="MuiDataGrid-cell"
                               >
                               </div>
@@ -2420,7 +2436,7 @@ exports[`release-overview should render correctly 1`] = `
                                  class="Mui-odd JobTable-row-percent-50-66 MuiDataGrid-row"
                                  aria-rowindex="5"
                                  aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
+                                 style="max-height: 70px; min-height: 70px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
@@ -2432,10 +2448,10 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                <div class="job-name">
                                   <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted"
                                      class
                                      href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted%22%7D%5D%7D"
@@ -2454,13 +2470,15 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div class="MuiBox-root MuiBox-root-279"
-                                     title="2 runs"
-                                >
+                                <div class="percentage-cell">
                                   50%
+                                  <br>
+                                  <small>
+                                    (2 runs)
+                                  </small>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2473,7 +2491,7 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
                                 <svg class="MuiSvgIcon-root"
@@ -2488,7 +2506,7 @@ exports[`release-overview should render correctly 1`] = `
                                   </path>
                                 </svg>
                               </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                              <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    class="MuiDataGrid-cell"
                               >
                               </div>
@@ -2499,7 +2517,7 @@ exports[`release-overview should render correctly 1`] = `
                                  class="Mui-even JobTable-row-percent-0-16 MuiDataGrid-row"
                                  aria-rowindex="6"
                                  aria-selected="false"
-                                 style="max-height: 52px; min-height: 52px;"
+                                 style="max-height: 70px; min-height: 70px;"
                             >
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textLeft"
                                    role="cell"
@@ -2511,10 +2529,10 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="1"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                <div class="job-name">
                                   <a title="periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack"
                                      class
                                      href="/jobs/4.8?filters=%7B%22items%22%3A%5B%7B%22id%22%3A99%2C%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack%22%7D%5D%7D"
@@ -2533,13 +2551,15 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="2"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
-                                <div class="MuiBox-root MuiBox-root-280"
-                                     title="2 runs"
-                                >
+                                <div class="percentage-cell">
                                   0%
+                                  <br>
+                                  <small>
+                                    (2 runs)
+                                  </small>
                                 </div>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -2552,7 +2572,7 @@ exports[`release-overview should render correctly 1`] = `
                                    data-editable="false"
                                    data-mode="view"
                                    aria-colindex="3"
-                                   style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                                   style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    tabindex="-1"
                               >
                                 <svg class="MuiSvgIcon-root"
@@ -2567,7 +2587,7 @@ exports[`release-overview should render correctly 1`] = `
                                   </path>
                                 </svg>
                               </div>
-                              <div style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
+                              <div style="min-width: 50px; max-width: 50px; line-height: 69px; min-height: 70px; max-height: 70px;"
                                    class="MuiDataGrid-cell"
                               >
                               </div>


### PR DESCRIPTION
This shows the number of runs in the cell that contains the percentage,
this was previously in a tooltip but some people didn't find it, so I
guess that's not very discoverable.

![image](https://user-images.githubusercontent.com/429763/130802058-5d13f87b-3031-46eb-bc65-1e742f14ed40.png)

![image](https://user-images.githubusercontent.com/429763/130802106-fb8a249c-d5d2-4a61-9af0-849cc7cad0ce.png)
