### PR TITLE
Use ID with our own generated filters

### DIFF
--- a/sippy-ng/src/jobs/JobTable.js
+++ b/sippy-ng/src/jobs/JobTable.js
@@ -327,8 +327,13 @@ function JobTable(props) {
 
     const selectedIDs = new Set(selectedJobs)
     let jobs = rows.filter((row) => selectedIDs.has(row.id))
-    jobs = jobs.map((job) => {
-      return { columnField: 'name', operatorValue: 'equals', value: job.name }
+    jobs = jobs.map((job, id) => {
+      return {
+        id: id,
+        columnField: 'name',
+        operatorValue: 'equals',
+        value: job.name,
+      }
     })
     console.log(jobs)
     return encodeURIComponent(


### PR DESCRIPTION
It figures the first thing I clicked on after the job analysis page
deployed would give me an error. If you go to [this page](https://sippy.ci.openshift.org/sippy-ng/jobs/4.9/analysis?filters={%22items%22%3A[{%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade%22}%2C{%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-upgrade%22}]%2C%22linkOperator%22%3A%22or%22})
and click "View all matching jobs", you'll get a blank page (and an error in the console).

The data grid tables require an `id` with filters on the same field (e.g. `name contains aws` or `name contains gcp`).
