### PR TITLE
Update never-stable with jobs that have new bugs

### DIFF
--- a/pkg/testgridanalysis/testidentification/ocp_variants.go
+++ b/pkg/testgridanalysis/testidentification/ocp_variants.go
@@ -79,20 +79,34 @@ var (
 		// Experimental jobs that are under active development
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-hypershift",
 
+		// Pending removal - https://github.com/openshift/release/pull/21560
+		// Remove when Sippy no longer has any runs
+		"release-openshift-ocp-installer-elasticsearch-operator-e2e-4.9",
+
 		// https://issues.redhat.com/browse/OSD-8071
 		"release-openshift-ocp-osd-aws-nightly-4.9",
 		"release-openshift-ocp-osd-gcp-nightly-4.9",
+
+		// https://bugzilla.redhat.com/show_bug.cgi?id=1999130
+		"periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-assisted-ipv6",
 
 		// https://bugzilla.redhat.com/show_bug.cgi?id=1979966
 		"periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-workers-rhel7",
 
 		// https://bugzilla.redhat.com/show_bug.cgi?id=1997345
-		"periodic-ci-openshift-multiarch-master-nightly-4.9-ocp-e2e-remote-libvirt-ppc64le",
 		"periodic-ci-openshift-multiarch-master-nightly-4.9-ocp-e2e-compact-remote-libvirt-ppc64le",
+		"periodic-ci-openshift-multiarch-master-nightly-4.9-ocp-e2e-remote-libvirt-ppc64le",
+		"periodic-ci-openshift-multiarch-master-nightly-4.9-ocp-e2e-remote-libvirt-ppc64le",
+		"periodic-ci-openshift-multiarch-master-nightly-4.9-ocp-e2e-remote-libvirt-s390x",
+
+		// https://bugzilla.redhat.com/show_bug.cgi?id=1989100
+		"periodic-ci-openshift-release-master-ci-4.9-e2e-openstack-ovn",
 
 		// https://bugzilla.redhat.com/show_bug.cgi?id=1979962
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-compact",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-compact-upgrade",
+		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-network-stress",
+		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-ovn-network-stress",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-azure-compact",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-azure-compact-upgrade",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-gcp-compact",


### PR DESCRIPTION
This adds a few jobs to never-stable that have been investigated,
failed for a long period of time (~2 weeks), and have a bug.