### PR TITLE
Add 4.10 to Sippy

### DIFF
--- a/pkg/testgridanalysis/testidentification/ocp_variants.go
+++ b/pkg/testgridanalysis/testidentification/ocp_variants.go
@@ -78,6 +78,7 @@ var (
 	openshiftJobsNeverStableForVariants = sets.NewString(
 		// Experimental jobs that are under active development
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-hypershift",
+		"periodic-ci-openshift-release-master-ci-4.10-e2e-aws-hypershift",
 
 		// Pending removal - https://github.com/openshift/release/pull/21560
 		// Remove when Sippy no longer has any runs
@@ -85,34 +86,53 @@ var (
 
 		// https://issues.redhat.com/browse/OSD-8071
 		"release-openshift-ocp-osd-aws-nightly-4.9",
+		"release-openshift-ocp-osd-aws-nightly-4.10",
 		"release-openshift-ocp-osd-gcp-nightly-4.9",
+		"release-openshift-ocp-osd-gcp-nightly-4.10",
 
 		// https://bugzilla.redhat.com/show_bug.cgi?id=1999130
 		"periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-assisted-ipv6",
+		"periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-assisted-ipv6",
 
 		// https://bugzilla.redhat.com/show_bug.cgi?id=1979966
 		"periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-workers-rhel7",
+		"periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-workers-rhel7",
 
 		// https://bugzilla.redhat.com/show_bug.cgi?id=1997345
 		"periodic-ci-openshift-multiarch-master-nightly-4.9-ocp-e2e-compact-remote-libvirt-ppc64le",
+		"periodic-ci-openshift-multiarch-master-nightly-4.10-ocp-e2e-compact-remote-libvirt-ppc64le",
 		"periodic-ci-openshift-multiarch-master-nightly-4.9-ocp-e2e-remote-libvirt-ppc64le",
+		"periodic-ci-openshift-multiarch-master-nightly-4.10-ocp-e2e-remote-libvirt-ppc64le",
 		"periodic-ci-openshift-multiarch-master-nightly-4.9-ocp-e2e-remote-libvirt-ppc64le",
+		"periodic-ci-openshift-multiarch-master-nightly-4.10-ocp-e2e-remote-libvirt-ppc64le",
 		"periodic-ci-openshift-multiarch-master-nightly-4.9-ocp-e2e-remote-libvirt-s390x",
+		"periodic-ci-openshift-multiarch-master-nightly-4.10-ocp-e2e-remote-libvirt-s390x",
 
 		// https://bugzilla.redhat.com/show_bug.cgi?id=1989100
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-openstack-ovn",
+		"periodic-ci-openshift-release-master-ci-4.10-e2e-openstack-ovn",
 
 		// https://bugzilla.redhat.com/show_bug.cgi?id=1979962
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-compact",
+		"periodic-ci-openshift-release-master-ci-4.10-e2e-aws-compact",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-compact-upgrade",
+		"periodic-ci-openshift-release-master-ci-4.10-e2e-aws-compact-upgrade",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-network-stress",
+		"periodic-ci-openshift-release-master-ci-4.10-e2e-aws-network-stress",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-ovn-network-stress",
+		"periodic-ci-openshift-release-master-ci-4.10-e2e-aws-ovn-network-stress",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-azure-compact",
+		"periodic-ci-openshift-release-master-ci-4.10-e2e-azure-compact",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-azure-compact-upgrade",
+		"periodic-ci-openshift-release-master-ci-4.10-e2e-azure-compact-upgrade",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-gcp-compact",
+		"periodic-ci-openshift-release-master-ci-4.10-e2e-gcp-compact",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-gcp-compact-upgrade",
+		"periodic-ci-openshift-release-master-ci-4.10-e2e-gcp-compact-upgrade",
 		"release-openshift-ocp-installer-e2e-metal-compact-4.9",
+		"release-openshift-ocp-installer-e2e-metal-compact-4.10",
 		"release-openshift-origin-installer-e2e-aws-sdn-network-stress-4.9",
+		"release-openshift-origin-installer-e2e-aws-sdn-network-stress-4.10",
 	)
 )
 

--- a/pkg/testgridanalysis/testidentification/test_identification.go
+++ b/pkg/testgridanalysis/testidentification/test_identification.go
@@ -70,6 +70,12 @@ func IsSetupContainerEquivalent(testName string) bool {
 // Whoever is running or working on TRT gets freedom to choose 10-20 of these for whatever reason they need.  At the moment,
 // we're chasing problems where pods are not running reliably and we have to track it down.
 var curatedTestSubstrings = map[string][]string{
+	"4.10": []string{
+		"Kubernetes APIs remain available",
+		"OAuth APIs remain available",
+		"OpenShift APIs remain available",
+		"Cluster frontend ingress remain available",
+	},
 	"4.9": []string{
 		"Kubernetes APIs remain available",
 		"OAuth APIs remain available",

--- a/resources/deploymentconfig.yaml
+++ b/resources/deploymentconfig.yaml
@@ -42,6 +42,8 @@ spec:
         - --local-data
         - /data
         - --release
+        - "4.10"
+        - --release
         - "4.9"
         - --release
         - "4.8"

--- a/scripts/fetchdata.sh
+++ b/scripts/fetchdata.sh
@@ -7,7 +7,7 @@ sleep 600 # 10 minutes
 while [ true ]; do
   echo "Fetching new testgrid data"
   rm -rf /data/*
-  /bin/sippy -v 4 --fetch-data /data --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9
+  /bin/sippy -v 4 --fetch-data /data --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10
   echo "Done fetching data, refreshing server"
   curl localhost:8080/refresh
   echo "Done refreshing data, sleeping"

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -4,7 +4,7 @@ export function relativeTime(date) {
   const minute = 1000 * 60 // Milliseconds in a minute
   const hour = 60 * minute // Milliseconds in an hour
   const day = 24 * hour // Milliseconds in a day
-  const millisAgo = date.getTime() - new Date().getTime()
+  const millisAgo = date.getTime() - Date.now()
 
   if (Math.abs(millisAgo) < hour) {
     return Math.round(Math.abs(millisAgo) / minute) + ' minutes ago'

--- a/sippy-ng/src/jobs/__snapshots__/JobRunsTable.test.js.snap
+++ b/sippy-ng/src/jobs/__snapshots__/JobRunsTable.test.js.snap
@@ -391,7 +391,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"41 days ago\\"
+                      <p title=\\"19 days ago\\"
                          class
                       >
                         7/23/2021, 12:30:36 PM
@@ -460,7 +460,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"49 days ago\\"
+                      <p title=\\"27 days ago\\"
                          class
                       >
                         7/15/2021, 6:00:12 PM
@@ -529,7 +529,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"49 days ago\\"
+                      <p title=\\"27 days ago\\"
                          class
                       >
                         7/15/2021, 6:58:56 PM
@@ -598,7 +598,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"44 days ago\\"
+                      <p title=\\"22 days ago\\"
                          class
                       >
                         7/20/2021, 11:40:59 AM
@@ -667,7 +667,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"42 days ago\\"
+                      <p title=\\"19 days ago\\"
                          class
                       >
                         7/23/2021, 4:17:36 AM
@@ -736,7 +736,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"49 days ago\\"
+                      <p title=\\"27 days ago\\"
                          class
                       >
                         7/15/2021, 1:27:00 PM
@@ -805,7 +805,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"50 days ago\\"
+                      <p title=\\"28 days ago\\"
                          class
                       >
                         7/14/2021, 6:00:47 PM
@@ -874,7 +874,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"45 days ago\\"
+                      <p title=\\"23 days ago\\"
                          class
                       >
                         7/19/2021, 7:01:56 AM
@@ -943,7 +943,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"37 days ago\\"
+                      <p title=\\"15 days ago\\"
                          class
                       >
                         7/27/2021, 6:45:10 PM
@@ -1012,7 +1012,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"49 days ago\\"
+                      <p title=\\"27 days ago\\"
                          class
                       >
                         7/15/2021, 3:20:47 PM
@@ -1081,7 +1081,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"42 days ago\\"
+                      <p title=\\"20 days ago\\"
                          class
                       >
                         7/23/2021, 2:00:40 AM
@@ -1150,7 +1150,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"41 days ago\\"
+                      <p title=\\"19 days ago\\"
                          class
                       >
                         7/24/2021, 12:11:20 AM
@@ -1219,7 +1219,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"49 days ago\\"
+                      <p title=\\"27 days ago\\"
                          class
                       >
                         7/15/2021, 2:05:28 PM
@@ -1288,7 +1288,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"37 days ago\\"
+                      <p title=\\"15 days ago\\"
                          class
                       >
                         7/27/2021, 6:45:17 PM
@@ -1357,7 +1357,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"44 days ago\\"
+                      <p title=\\"22 days ago\\"
                          class
                       >
                         7/20/2021, 7:35:09 PM
@@ -1426,7 +1426,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"39 days ago\\"
+                      <p title=\\"16 days ago\\"
                          class
                       >
                         7/26/2021, 3:39:19 AM
@@ -1495,7 +1495,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"40 days ago\\"
+                      <p title=\\"18 days ago\\"
                          class
                       >
                         7/24/2021, 9:19:29 PM
@@ -1564,7 +1564,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"43 days ago\\"
+                      <p title=\\"21 days ago\\"
                          class
                       >
                         7/21/2021, 7:07:08 AM
@@ -1633,7 +1633,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"37 days ago\\"
+                      <p title=\\"14 days ago\\"
                          class
                       >
                         7/28/2021, 4:25:17 AM
@@ -1702,7 +1702,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"46 days ago\\"
+                      <p title=\\"24 days ago\\"
                          class
                       >
                         7/18/2021, 7:26:55 PM
@@ -1771,7 +1771,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"46 days ago\\"
+                      <p title=\\"24 days ago\\"
                          class
                       >
                         7/18/2021, 2:00:55 PM
@@ -1840,7 +1840,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"49 days ago\\"
+                      <p title=\\"27 days ago\\"
                          class
                       >
                         7/15/2021, 3:55:20 PM
@@ -1909,7 +1909,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"46 days ago\\"
+                      <p title=\\"24 days ago\\"
                          class
                       >
                         7/18/2021, 6:00:57 AM
@@ -1978,7 +1978,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"48 days ago\\"
+                      <p title=\\"26 days ago\\"
                          class
                       >
                         7/16/2021, 7:26:33 PM
@@ -2047,7 +2047,7 @@ exports[`JobRunsTable should render correctly 1`] = `
                          style=\\"min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;\\"
                          tabindex=\\"-1\\"
                     >
-                      <p title=\\"41 days ago\\"
+                      <p title=\\"19 days ago\\"
                          class
                       >
                         7/23/2021, 8:14:45 PM

--- a/sippy-ng/src/tests/__snapshots__/TestAnalysis.test.js.snap
+++ b/sippy-ng/src/tests/__snapshots__/TestAnalysis.test.js.snap
@@ -388,7 +388,7 @@ exports[`TestAnalysis should render correctly 1`] = `
                                style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
                                tabindex="-1"
                           >
-                            <p title="37 days ago"
+                            <p title="15 days ago"
                                class
                             >
                               7/27/2021, 8:49:29 AM
@@ -457,7 +457,7 @@ exports[`TestAnalysis should render correctly 1`] = `
                                style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
                                tabindex="-1"
                           >
-                            <p title="44 days ago"
+                            <p title="22 days ago"
                                class
                             >
                               7/20/2021, 4:01:02 PM
@@ -526,7 +526,7 @@ exports[`TestAnalysis should render correctly 1`] = `
                                style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
                                tabindex="-1"
                           >
-                            <p title="46 days ago"
+                            <p title="24 days ago"
                                class
                             >
                               7/18/2021, 4:00:56 PM
@@ -595,7 +595,7 @@ exports[`TestAnalysis should render correctly 1`] = `
                                style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
                                tabindex="-1"
                           >
-                            <p title="46 days ago"
+                            <p title="24 days ago"
                                class
                             >
                               7/18/2021, 4:00:55 PM
@@ -664,7 +664,7 @@ exports[`TestAnalysis should render correctly 1`] = `
                                style="min-width: 50px; max-width: 50px; line-height: 51px; min-height: 52px; max-height: 52px;"
                                tabindex="-1"
                           >
-                            <p title="47 days ago"
+                            <p title="24 days ago"
                                class
                             >
                               7/18/2021, 3:34:55 AM


### PR DESCRIPTION
Also removes 3.11, there doesn't appear to be any data for it for some time.