### PR TITLE
Show everything in UTC, with local tooltips where possible

### DIFF
--- a/sippy-ng/README.md
+++ b/sippy-ng/README.md
@@ -35,6 +35,18 @@ if they change.
 **If you are prompted to update any snapshots, ensure the changes are
 expected.**
 
+### Managing time
+
+When snapshotting pages that use date or time, the test must mock out
+Date.now() to ensure consistent snapshots.  You can use jest's spy
+functions:
+
+```javascript
+  Date.now = jest
+    .spyOn(Date, 'now')
+    .mockImplementation(() => new Date(1628691480000))
+```
+
 ### Updating snapshots
 
 When changing any of the UI, snapshots will need to be retaken. Run `npm
@@ -56,6 +68,10 @@ And then run:
 ```
 POLLY_MODE=record npm test
 ``````
+
+For some reason (not yet determined), updating Polly recordings and the
+snapshots doesn't work in the same run. First re-record the API results
+(you'll get snapshot errors), then run the snapshot update as above.
 
 If you need to move on to something other than 4.8GA, please update this
 section.

--- a/sippy-ng/package-lock.json
+++ b/sippy-ng/package-lock.json
@@ -5712,6 +5712,11 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-beta.5.tgz",
       "integrity": "sha512-GS5yi964NDFNoja9yOdWFj9T97T67yLrUeJZgddHaVfc/6tHWtX7RXocuubmZkNzrZUZ9BqBOW7jTR5OoWjJ1w=="
     },
+    "date-fns-tz": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.1.6.tgz",
+      "integrity": "sha512-nyy+URfFI3KUY7udEJozcoftju+KduaqkVfwyTIE0traBiVye09QnyWKLZK7drRr5h9B7sPJITmQnS3U6YOdQg=="
+    },
     "debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",

--- a/sippy-ng/package.json
+++ b/sippy-ng/package.json
@@ -20,6 +20,7 @@
     "chroma-js": "^2.1.2",
     "clsx": "^1.1.1",
     "date-fns": "^2.0.0-beta.5",
+    "date-fns-tz": "^1.1.6",
     "npm-install-missing": "^0.1.4",
     "query-string": "^7.0.1",
     "react": "^17.0.2",

--- a/sippy-ng/src/__snapshots__/App.test.js.snap
+++ b/sippy-ng/src/__snapshots__/App.test.js.snap
@@ -517,7 +517,7 @@ exports[`app should render correctly 1`] = `
                  style="padding: 20px; height: 100%;"
             >
               <h6 class="MuiTypography-root MuiTypography-h6">
-                <a href="/jobs/4.8&amp;sortField=current_pass_percentage&amp;sort=asc">
+                <a href="/jobs/4.8?sortField=current_pass_percentage&amp;sort=asc">
                   Job histogram
                 </a>
                 <svg class="MuiSvgIcon-root"

--- a/sippy-ng/src/datagrid/GridToolbarFilterDateUtils.js
+++ b/sippy-ng/src/datagrid/GridToolbarFilterDateUtils.js
@@ -1,0 +1,14 @@
+import { format, utcToZonedTime } from 'date-fns-tz'
+import DateFnsUtils from '@date-io/date-fns'
+export class GridToolbarFilterDateUtils extends DateFnsUtils {
+  constructor() {
+    super()
+  }
+
+  format(date, formatString) {
+    return `${format(utcToZonedTime(date, 'UTC'), formatString, {
+      timeZone: 'Etc/UTC',
+      locale: this.locale,
+    })}`
+  }
+}

--- a/sippy-ng/src/datagrid/GridToolbarFilterItem.js
+++ b/sippy-ng/src/datagrid/GridToolbarFilterItem.js
@@ -11,10 +11,10 @@ import {
 } from '@material-ui/core'
 import { Close } from '@material-ui/icons'
 import { DateTimePicker, MuiPickersUtilsProvider } from '@material-ui/pickers'
+import { GridToolbarFilterDateUtils } from './GridToolbarFilterDateUtils'
 import { makeStyles } from '@material-ui/core/styles'
-import DateFnsUtils from '@date-io/date-fns'
 import PropTypes from 'prop-types'
-import React, { Fragment, useEffect } from 'react'
+import React, { Fragment } from 'react'
 
 const useStyles = makeStyles((theme) => ({
   filterMenu: {
@@ -144,12 +144,18 @@ export default function GridToolbarFilterItem(props) {
       <FormControl>
         {columnType === 'date' ? (
           <Fragment>
-            <MuiPickersUtilsProvider utils={DateFnsUtils}>
+            <MuiPickersUtilsProvider utils={GridToolbarFilterDateUtils}>
               <DateTimePicker
                 showTodayButton
                 disableFuture
                 label="Value"
-                value={new Date(parseInt(props.filterModel.value))}
+                format="yyyy-MM-dd HH:mm 'UTC'"
+                ampm={false}
+                value={
+                  props.filterModel.value === ''
+                    ? null
+                    : new Date(parseInt(props.filterModel.value))
+                }
                 onChange={(e) => {
                   props.setFilterModel({
                     columnField: props.filterModel.columnField,

--- a/sippy-ng/src/datagrid/GridToolbarFilterMenu.js
+++ b/sippy-ng/src/datagrid/GridToolbarFilterMenu.js
@@ -12,7 +12,7 @@ import {
   Select,
   Tooltip,
 } from '@material-ui/core'
-import { explainFilter } from '../helpers'
+import { filterTooltip } from './utils'
 import { makeStyles } from '@material-ui/core/styles'
 import Divider from '@material-ui/core/Divider'
 import GridToolbarFilterItem from './GridToolbarFilterItem'
@@ -169,27 +169,9 @@ export default function GridToolbarFilterMenu(props) {
     </FormControl>
   )
 
-  const tooltip = (
-    <Fragment>
-      {filterItems === 0 ? (
-        'No filters applied'
-      ) : (
-        <div style={{ padding: 10 }}>
-          Currently filtered by:
-          <ul>
-            {explainFilter(props.filterModel).map((item, index) => (
-              <li key={`filter-${index}`}>{item}</li>
-            ))}
-          </ul>
-          Link operator: {props.filterModel.linkOperator || 'and'}
-        </div>
-      )}
-    </Fragment>
-  )
-
   return (
     <Fragment>
-      <Tooltip title={tooltip}>
+      <Tooltip title={filterTooltip(props.filterModel)}>
         <Button
           aria-describedby={id}
           color={props.standalone ? 'default' : 'primary'}

--- a/sippy-ng/src/datagrid/utils.js
+++ b/sippy-ng/src/datagrid/utils.js
@@ -1,8 +1,21 @@
-import { createTheme } from '@material-ui/core'
+import { Close } from '@material-ui/icons'
+import {
+  createTheme,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Tooltip,
+} from '@material-ui/core'
+import { format, utcToZonedTime } from 'date-fns-tz'
+import { Link } from 'react-router-dom'
 import { scale } from 'chroma-js'
+import List from '@material-ui/core/List'
+import React, { Fragment } from 'react'
 
 const theme = createTheme()
 
+// DataGrid tables can only be customized by specifying a classname, so this
+// creates the classes needed for creating background color gradient.
 export function generateClasses(threshold) {
   const colors = scale([
     theme.palette.error.light,
@@ -19,17 +32,105 @@ export function generateClasses(threshold) {
   return classes
 }
 
-export const ROW_STYLES = {
-  rowSuccess: {
-    backgroundColor: theme.palette.success.light,
-    color: 'black',
-  },
-  rowWarning: {
-    backgroundColor: theme.palette.warning.light,
-    color: 'black',
-  },
-  rowError: {
-    backgroundColor: theme.palette.error.light,
-    color: 'black',
-  },
+export function filterRemoveItem(filter, index) {
+  if (!filter || filter.items.length === 0) {
+    return
+  }
+  let currentItems = filter.items
+  currentItems.splice(index, 1)
+  return {
+    items: currentItems,
+    linkOperator: filter.linkOperator,
+  }
+}
+
+export function filterIsEmpty(filter) {
+  return (
+    !filter ||
+    filter.items.length === 0 ||
+    (filter.items.length === 1 && filter.items[0].columnField === '')
+  )
+}
+
+export function filterItemRenderValue(item) {
+  let value = item.value
+  let tooltip = null
+  if (item.columnField === 'timestamp' && item.value !== '') {
+    let date = new Date(parseInt(item.value))
+    value = format(utcToZonedTime(date, 'UTC'), "yyyy-MM-dd HH:mm 'UTC'", {
+      timeZone: 'Etc/UTC',
+    })
+    tooltip = date.toLocaleString()
+  }
+
+  return { value: value, description: tooltip }
+}
+
+export function filterTooltip(filter) {
+  if (filterIsEmpty(filter)) {
+    return 'Showing all results'
+  }
+
+  const items = filter.items.map((item, index) => {
+    let { value, description } = filterItemRenderValue(item)
+
+    return (
+      <li key={`filter-${index}`}>
+        {`${item.columnField} ${item.operatorValue} ${value}`}{' '}
+        {description ? `(${description})` : ''}
+      </li>
+    )
+  })
+
+  return (
+    <Fragment>
+      Current filters:
+      <ul>{items}</ul>
+      Link operator: {filter.linkOperator}
+    </Fragment>
+  )
+}
+
+export function filterList(filter, setFilter) {
+  let originalFilters = filter
+  if (filterIsEmpty(filter)) {
+    return 'Showing all results'
+  }
+
+  const explanations = []
+  filter.items.forEach((item, idx) => {
+    let { value, description } = filterItemRenderValue(item)
+    let listItem = (
+      <ListItemText>
+        {`${item.columnField} ${item.not ? 'not ' : ''} ${item.operatorValue} `}
+        {value}
+      </ListItemText>
+    )
+
+    if (description && description !== '') {
+      listItem = <Tooltip title={description}>{listItem}</Tooltip>
+    }
+
+    explanations.push(
+      <ListItem
+        button={Boolean(setFilter)}
+        onClick={
+          setFilter
+            ? () => setFilter(filterRemoveItem(originalFilters, idx))
+            : null
+        }
+      >
+        {setFilter ? (
+          <ListItemIcon component={Link}>
+            <Close />
+          </ListItemIcon>
+        ) : (
+          ''
+        )}
+        {listItem}
+      </ListItem>
+    )
+  })
+
+  return <List>{explanations}</List>
 }

--- a/sippy-ng/src/jobs/JobAnalysis.js
+++ b/sippy-ng/src/jobs/JobAnalysis.js
@@ -19,17 +19,17 @@ import {
   Typography,
 } from '@material-ui/core'
 import { DataGrid } from '@material-ui/data-grid'
-import {
-  explainFilter,
-  pathForJobRunsWithFilter,
-  pathForJobsWithFilter,
-  withSort,
-} from '../helpers'
+import { filterList } from '../datagrid/utils'
 import { getColumns } from './JobTable'
 import { hourFilter, JobStackedChart } from './JobStackedChart'
 import { JOB_THRESHOLDS } from '../constants'
 import { Line } from 'react-chartjs-2'
 import { Link } from 'react-router-dom'
+import {
+  pathForJobRunsWithFilter,
+  pathForJobsWithFilter,
+  withSort,
+} from '../helpers'
 import { scale } from 'chroma-js'
 import Alert from '@material-ui/lab/Alert'
 import Divider from '@material-ui/core/Divider'
@@ -351,13 +351,7 @@ export function JobAnalysis(props) {
             >
               <strong>Current filter</strong>
               <br />
-              <ul>
-                {filterModel && filterModel.items.length > 0
-                  ? explainFilter(filterModel).map((item, index) => (
-                      <li key={`filter-${index}`}>{item}</li>
-                    ))
-                  : 'Showing all'}
-              </ul>
+              {filterList(filterModel, setFilterModel)}
               <br />
               <Divider style={{ marginBottom: 20 }} />
               <Grid container justifyContent="space-between">

--- a/sippy-ng/src/jobs/__snapshots__/JobAnalysis.test.js.snap
+++ b/sippy-ng/src/jobs/__snapshots__/JobAnalysis.test.js.snap
@@ -75,9 +75,7 @@ exports[`JobAnalysis should render correctly 1`] = `
           Current filter
         </strong>
         <br>
-        <ul>
-          Showing all
-        </ul>
+        Showing all results
         <br>
         <hr class="MuiDivider-root"
             style="margin-bottom: 20px;"
@@ -86,6 +84,7 @@ exports[`JobAnalysis should render correctly 1`] = `
           <button class="MuiButtonBase-root MuiButton-root MuiButton-contained"
                   tabindex="0"
                   type="button"
+                  title="Showing all results"
           >
             <span class="MuiButton-label">
               <span class="MuiBadge-root">
@@ -133,7 +132,7 @@ exports[`JobAnalysis should render correctly 1`] = `
              tabindex="0"
              role="button"
              aria-disabled="false"
-             href="/jobs/4.8/runs&amp;sortField=timestamp&amp;sort=desc"
+             href="/jobs/4.8/runs?sortField=timestamp&amp;sort=desc"
           >
             <span class="MuiButton-label">
               View matching job runs

--- a/sippy-ng/src/jobs/__snapshots__/JobRunsTable.test.js.snap
+++ b/sippy-ng/src/jobs/__snapshots__/JobRunsTable.test.js.snap
@@ -86,6 +86,7 @@ exports[`JobRunsTable should render correctly 1`] = `
             <button class=\\"MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary\\"
                     tabindex=\\"0\\"
                     type=\\"button\\"
+                    title=\\"Showing all results\\"
             >
               <span class=\\"MuiButton-label\\">
                 <span class=\\"MuiBadge-root\\">

--- a/sippy-ng/src/jobs/__snapshots__/JobTable.test.js.snap
+++ b/sippy-ng/src/jobs/__snapshots__/JobTable.test.js.snap
@@ -16,6 +16,7 @@ exports[`JobTable should render correctly 1`] = `
             <button class=\\"MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary\\"
                     tabindex=\\"0\\"
                     type=\\"button\\"
+                    title=\\"Showing all results\\"
             >
               <span class=\\"MuiButton-label\\">
                 <span class=\\"MuiBadge-root\\">

--- a/sippy-ng/src/releases/__snapshots__/ReleaseOverview.test.js.snap
+++ b/sippy-ng/src/releases/__snapshots__/ReleaseOverview.test.js.snap
@@ -286,7 +286,7 @@ exports[`release-overview should render correctly 1`] = `
              style="padding: 20px; height: 100%;"
         >
           <h6 class="MuiTypography-root MuiTypography-h6">
-            <a href="/jobs/4.8&amp;sortField=current_pass_percentage&amp;sort=asc">
+            <a href="/jobs/4.8?sortField=current_pass_percentage&amp;sort=asc">
               Job histogram
             </a>
             <svg class="MuiSvgIcon-root"

--- a/sippy-ng/src/setupTests.js
+++ b/sippy-ng/src/setupTests.js
@@ -35,7 +35,7 @@ if (!process.env.POLLY_MODE) {
 }
 
 export const setupDefaultPolly = () => {
-  const context = setupPolly({
+  return setupPolly({
     mode: process.env.POLLY_MODE,
     adapters: [require('@pollyjs/adapter-node-http')],
     persister: require('@pollyjs/persister-fs'),
@@ -45,7 +45,6 @@ export const setupDefaultPolly = () => {
       },
     },
   })
-  return context
 }
 
 export const expectLoadingPage = (wrapper) =>

--- a/sippy-ng/src/tests/__snapshots__/TestTable.test.js.snap
+++ b/sippy-ng/src/tests/__snapshots__/TestTable.test.js.snap
@@ -16,6 +16,7 @@ exports[`TestTable should render correctly 1`] = `
             <button class=\\"MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary\\"
                     tabindex=\\"0\\"
                     type=\\"button\\"
+                    title=\\"Showing all results\\"
             >
               <span class=\\"MuiButton-label\\">
                 <span class=\\"MuiBadge-root\\">


### PR DESCRIPTION
When I added the date/time filtering, I couldn't figure out how to get the picker in UTC, but I found [this issue](https://github.com/mui-org/material-ui-pickers/issues/2098#issuecomment-695360012) which showed extending DateFnUtils and forcing a specific time zone. With this change, the entire UI should be consistently in UTC. 

Where it's possible to add them, there are tooltips showing the local time (via `toLocaleString()`).

This also updates the docs to include some information about the test snapshots and how time is handled.
