### PR TITLE
Add install setup test step for openstack proxy jobs

### DIFF
--- a/pkg/testgridanalysis/testidentification/test_identification.go
+++ b/pkg/testgridanalysis/testidentification/test_identification.go
@@ -29,6 +29,7 @@ var customJobSetupContainers = sets.NewString(
 	"e2e-metal-ipi-ovn-dualstack-local-gateway-baremetalds-devscripts-setup",
 	"e2e-metal-ipi-upgrade-baremetalds-devscripts-setup container test",
 	"e2e-metal-single-node-live-iso-baremetalds-packet-setup",
+	"e2e-openshift-proxy-ipi-install-install",
 	"e2e-openstack-upgrade-ipi-install",
 	"e2e-ovirt-ipi-install-install container test",
 	"e2e-vsphere-ipi-install-vsphere",


### PR DESCRIPTION
Sippy is complaining, see https://sippy.ci.openshift.org/sippy-ng/release/4.9

Not sure about periodic-ci-openshift-multiarch-master-nightly-4.9-ocp-e2e-serial-remote-libvirt-s390x yet -- it's using ipi-install-libvirt-install, which is already listed.
