### PR TITLE
Update never-stable jobs

### DIFF
--- a/pkg/testgridanalysis/testidentification/ocp_variants.go
+++ b/pkg/testgridanalysis/testidentification/ocp_variants.go
@@ -88,13 +88,7 @@ var (
 
 		// https://issues.redhat.com/browse/OSD-8071
 		"release-openshift-ocp-osd-aws-nightly-4.9",
-		"release-openshift-ocp-osd-aws-nightly-4.10",
 		"release-openshift-ocp-osd-gcp-nightly-4.9",
-		"release-openshift-ocp-osd-gcp-nightly-4.10",
-
-		// https://bugzilla.redhat.com/show_bug.cgi?id=1999130
-		"periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-assisted-ipv6",
-		"periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-assisted-ipv6",
 
 		// https://bugzilla.redhat.com/show_bug.cgi?id=1979966
 		"periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-workers-rhel7",
@@ -116,9 +110,7 @@ var (
 
 		// https://bugzilla.redhat.com/show_bug.cgi?id=1979962
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-compact",
-		"periodic-ci-openshift-release-master-ci-4.10-e2e-aws-compact",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-compact-upgrade",
-		"periodic-ci-openshift-release-master-ci-4.10-e2e-aws-compact-upgrade",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-network-stress",
 		"periodic-ci-openshift-release-master-ci-4.10-e2e-aws-network-stress",
 		"periodic-ci-openshift-release-master-ci-4.9-e2e-aws-ovn-network-stress",


### PR DESCRIPTION
- Assisted IPv6 is passing again
- aws-compact* is passing
- OSD 4.10 is passing (but not 4.9)