### PR TITLE
Fix a couple of bugs

### DIFF
--- a/pkg/testgridanalysis/testreportconversion/jobresult.go
+++ b/pkg/testgridanalysis/testreportconversion/jobresult.go
@@ -1,7 +1,6 @@
 package testreportconversion
 
 import (
-	"k8s.io/klog"
 	"math"
 	"sort"
 
@@ -109,8 +108,7 @@ func calculateJobResultStatistics(results []sippyprocessingv1.JobResult) sippypr
 	data := stats.LoadRawData(percentages)
 	mean, _ := stats.Mean(data)
 	sd, _ := stats.StandardDeviation(data)
-	quartiles, err := stats.Quartile(data)
-	klog.V(1).Info(err)
+	quartiles, _ := stats.Quartile(data)
 	p95, _ := stats.Percentile(data, 95)
 
 	jobStatistics.Mean = mean

--- a/sippy-ng/src/datagrid/utils.js
+++ b/sippy-ng/src/datagrid/utils.js
@@ -76,7 +76,9 @@ export function filterTooltip(filter) {
 
     return (
       <li key={`filter-${index}`}>
-        {`${item.columnField} ${item.operatorValue} ${value}`}{' '}
+        {`${item.columnField}${item.not ? ' not ' : ' '}${
+          item.operatorValue
+        } ${value}`}
         {description ? `(${description})` : ''}
       </li>
     )


### PR DESCRIPTION
- The 3.11 page isn't loading because the stats package is returning NaN for the quartiles since we only have one job, and NaN's aren't marshallable to JSON.
- The filter tooltip incorrectly omits "not" when explaining a filter (e.g. name not equals "foo")