### PR TITLE
Don't round percentages in job/test tables

### DIFF
--- a/sippy-ng/src/__snapshots__/App.test.js.snap
+++ b/sippy-ng/src/__snapshots__/App.test.js.snap
@@ -1776,7 +1776,7 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="percentage-cell">
-                                      38%
+                                      38.5%
                                       <br>
                                       <small>
                                         (13 runs)
@@ -1857,7 +1857,7 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="percentage-cell">
-                                      69%
+                                      69.2%
                                       <br>
                                       <small>
                                         (13 runs)
@@ -1938,7 +1938,7 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="percentage-cell">
-                                      33%
+                                      33.3%
                                       <br>
                                       <small>
                                         (15 runs)
@@ -2019,7 +2019,7 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="percentage-cell">
-                                      31%
+                                      31.3%
                                       <br>
                                       <small>
                                         (16 runs)
@@ -2100,7 +2100,7 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="percentage-cell">
-                                      77%
+                                      76.9%
                                       <br>
                                       <small>
                                         (13 runs)
@@ -2496,7 +2496,7 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="percentage-cell">
-                                      0%
+                                      0.0%
                                       <br>
                                       <small>
                                         (1 runs)
@@ -2577,7 +2577,7 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="percentage-cell">
-                                      0%
+                                      0.0%
                                       <br>
                                       <small>
                                         (1 runs)
@@ -2658,7 +2658,7 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="percentage-cell">
-                                      0%
+                                      0.0%
                                       <br>
                                       <small>
                                         (2 runs)
@@ -2739,7 +2739,7 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="percentage-cell">
-                                      50%
+                                      50.0%
                                       <br>
                                       <small>
                                         (2 runs)
@@ -2820,7 +2820,7 @@ exports[`app should render correctly 1`] = `
                                        tabindex="-1"
                                   >
                                     <div class="percentage-cell">
-                                      0%
+                                      0.0%
                                       <br>
                                       <small>
                                         (2 runs)
@@ -3219,7 +3219,7 @@ exports[`app should render correctly 1`] = `
                                     <p title="46 runs"
                                        class
                                     >
-                                      37%
+                                      37.0%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3298,7 +3298,7 @@ exports[`app should render correctly 1`] = `
                                     <p title="12 runs"
                                        class
                                     >
-                                      83%
+                                      83.3%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3377,7 +3377,7 @@ exports[`app should render correctly 1`] = `
                                     <p title="16 runs"
                                        class
                                     >
-                                      50%
+                                      50.0%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3456,7 +3456,7 @@ exports[`app should render correctly 1`] = `
                                     <p title="48 runs"
                                        class
                                     >
-                                      83%
+                                      83.3%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3535,7 +3535,7 @@ exports[`app should render correctly 1`] = `
                                     <p title="37 runs"
                                        class
                                     >
-                                      89%
+                                      89.2%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3930,7 +3930,7 @@ exports[`app should render correctly 1`] = `
                                     <p title="2 runs"
                                        class
                                     >
-                                      50%
+                                      50.0%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4009,7 +4009,7 @@ exports[`app should render correctly 1`] = `
                                     <p title="2 runs"
                                        class
                                     >
-                                      50%
+                                      50.0%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4088,7 +4088,7 @@ exports[`app should render correctly 1`] = `
                                     <p title="2 runs"
                                        class
                                     >
-                                      50%
+                                      50.0%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4167,7 +4167,7 @@ exports[`app should render correctly 1`] = `
                                     <p title="4 runs"
                                        class
                                     >
-                                      75%
+                                      75.0%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4246,7 +4246,7 @@ exports[`app should render correctly 1`] = `
                                     <p title="8 runs"
                                        class
                                     >
-                                      75%
+                                      75.0%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4641,7 +4641,7 @@ exports[`app should render correctly 1`] = `
                                     <p title="46 runs"
                                        class
                                     >
-                                      37%
+                                      37.0%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4720,7 +4720,7 @@ exports[`app should render correctly 1`] = `
                                     <p title="12 runs"
                                        class
                                     >
-                                      83%
+                                      83.3%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4799,7 +4799,7 @@ exports[`app should render correctly 1`] = `
                                     <p title="16 runs"
                                        class
                                     >
-                                      50%
+                                      50.0%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4878,7 +4878,7 @@ exports[`app should render correctly 1`] = `
                                     <p title="48 runs"
                                        class
                                     >
-                                      83%
+                                      83.3%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4957,7 +4957,7 @@ exports[`app should render correctly 1`] = `
                                     <p title="37 runs"
                                        class
                                     >
-                                      89%
+                                      89.2%
                                     </p>
                                   </div>
                                   <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"

--- a/sippy-ng/src/jobs/JobTable.js
+++ b/sippy-ng/src/jobs/JobTable.js
@@ -51,7 +51,7 @@ export const getColumns = (config, openBugzillaDialog) => {
       flex: 0.75,
       renderCell: (params) => (
         <div className="percentage-cell">
-          {Number(params.value).toFixed(0).toLocaleString()}%<br />
+          {Number(params.value).toFixed(1).toLocaleString()}%<br />
           <small>({params.row.current_runs} runs)</small>
         </div>
       ),
@@ -72,7 +72,7 @@ export const getColumns = (config, openBugzillaDialog) => {
       type: 'number',
       renderCell: (params) => (
         <div className="percentage-cell">
-          {Number(params.value).toFixed(0).toLocaleString()}%<br />
+          {Number(params.value).toFixed(1).toLocaleString()}%<br />
           <small>({params.row.previous_runs} runs)</small>
         </div>
       ),

--- a/sippy-ng/src/jobs/__snapshots__/JobTable.test.js.snap
+++ b/sippy-ng/src/jobs/__snapshots__/JobTable.test.js.snap
@@ -402,7 +402,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (3 runs)
@@ -495,7 +495,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (6 runs)
@@ -588,7 +588,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (3 runs)
@@ -681,7 +681,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (6 runs)
@@ -774,7 +774,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (3 runs)
@@ -867,7 +867,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (3 runs)
@@ -960,7 +960,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (3 runs)
@@ -1053,7 +1053,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (3 runs)
@@ -1146,7 +1146,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (40 runs)
@@ -1239,7 +1239,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (3 runs)
@@ -1332,7 +1332,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (3 runs)
@@ -1425,7 +1425,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (3 runs)
@@ -1518,7 +1518,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (6 runs)
@@ -1611,7 +1611,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (3 runs)
@@ -1704,7 +1704,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (3 runs)
@@ -1797,7 +1797,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (13 runs)
@@ -1890,7 +1890,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (6 runs)
@@ -1983,7 +1983,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (3 runs)
@@ -2076,7 +2076,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (6 runs)
@@ -2169,7 +2169,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        0%
+                        0.0%
                         <br>
                         <small>
                           (3 runs)
@@ -2262,7 +2262,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        15%
+                        15.4%
                         <br>
                         <small>
                           (13 runs)
@@ -2355,7 +2355,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        17%
+                        16.7%
                         <br>
                         <small>
                           (6 runs)
@@ -2448,7 +2448,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        23%
+                        23.1%
                         <br>
                         <small>
                           (13 runs)
@@ -2541,7 +2541,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        25%
+                        25.0%
                         <br>
                         <small>
                           (4 runs)
@@ -2634,7 +2634,7 @@ exports[`JobTable should render correctly 1`] = `
                          tabindex=\\"-1\\"
                     >
                       <div class=\\"percentage-cell\\">
-                        25%
+                        25.0%
                         <br>
                         <small>
                           (24 runs)

--- a/sippy-ng/src/releases/__snapshots__/ReleaseOverview.test.js.snap
+++ b/sippy-ng/src/releases/__snapshots__/ReleaseOverview.test.js.snap
@@ -1545,7 +1545,7 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="percentage-cell">
-                                  38%
+                                  38.5%
                                   <br>
                                   <small>
                                     (13 runs)
@@ -1626,7 +1626,7 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="percentage-cell">
-                                  69%
+                                  69.2%
                                   <br>
                                   <small>
                                     (13 runs)
@@ -1707,7 +1707,7 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="percentage-cell">
-                                  33%
+                                  33.3%
                                   <br>
                                   <small>
                                     (15 runs)
@@ -1788,7 +1788,7 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="percentage-cell">
-                                  31%
+                                  31.3%
                                   <br>
                                   <small>
                                     (16 runs)
@@ -1869,7 +1869,7 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="percentage-cell">
-                                  77%
+                                  76.9%
                                   <br>
                                   <small>
                                     (13 runs)
@@ -2265,7 +2265,7 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="percentage-cell">
-                                  0%
+                                  0.0%
                                   <br>
                                   <small>
                                     (1 runs)
@@ -2346,7 +2346,7 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="percentage-cell">
-                                  0%
+                                  0.0%
                                   <br>
                                   <small>
                                     (1 runs)
@@ -2427,7 +2427,7 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="percentage-cell">
-                                  0%
+                                  0.0%
                                   <br>
                                   <small>
                                     (2 runs)
@@ -2508,7 +2508,7 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="percentage-cell">
-                                  50%
+                                  50.0%
                                   <br>
                                   <small>
                                     (2 runs)
@@ -2589,7 +2589,7 @@ exports[`release-overview should render correctly 1`] = `
                                    tabindex="-1"
                               >
                                 <div class="percentage-cell">
-                                  0%
+                                  0.0%
                                   <br>
                                   <small>
                                     (2 runs)
@@ -2988,7 +2988,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <p title="46 runs"
                                    class
                                 >
-                                  37%
+                                  37.0%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3067,7 +3067,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <p title="12 runs"
                                    class
                                 >
-                                  83%
+                                  83.3%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3146,7 +3146,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <p title="16 runs"
                                    class
                                 >
-                                  50%
+                                  50.0%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3225,7 +3225,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <p title="48 runs"
                                    class
                                 >
-                                  83%
+                                  83.3%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3304,7 +3304,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <p title="37 runs"
                                    class
                                 >
-                                  89%
+                                  89.2%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3699,7 +3699,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <p title="2 runs"
                                    class
                                 >
-                                  50%
+                                  50.0%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3778,7 +3778,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <p title="2 runs"
                                    class
                                 >
-                                  50%
+                                  50.0%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3857,7 +3857,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <p title="2 runs"
                                    class
                                 >
-                                  50%
+                                  50.0%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -3936,7 +3936,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <p title="4 runs"
                                    class
                                 >
-                                  75%
+                                  75.0%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4015,7 +4015,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <p title="8 runs"
                                    class
                                 >
-                                  75%
+                                  75.0%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4410,7 +4410,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <p title="46 runs"
                                    class
                                 >
-                                  37%
+                                  37.0%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4489,7 +4489,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <p title="12 runs"
                                    class
                                 >
-                                  83%
+                                  83.3%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4568,7 +4568,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <p title="16 runs"
                                    class
                                 >
-                                  50%
+                                  50.0%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4647,7 +4647,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <p title="48 runs"
                                    class
                                 >
-                                  83%
+                                  83.3%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"
@@ -4726,7 +4726,7 @@ exports[`release-overview should render correctly 1`] = `
                                 <p title="37 runs"
                                    class
                                 >
-                                  89%
+                                  89.2%
                                 </p>
                               </div>
                               <div class="MuiDataGrid-cell MuiDataGrid-cell--withRenderer MuiDataGrid-cell--textRight"

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -4,10 +4,14 @@ import { bugColor, weightedBugComparator } from '../bugzilla/BugzillaUtils'
 import { BugReport, DirectionsRun, Search } from '@material-ui/icons'
 import { Button, Container, Tooltip } from '@material-ui/core'
 import { DataGrid } from '@material-ui/data-grid'
+import {
+  escapeRegex,
+  pathForJobRunsWithTestFailure,
+  withSort,
+} from '../helpers'
 import { generateClasses } from '../datagrid/utils'
 import { JsonParam, StringParam, useQueryParam } from 'use-query-params'
 import { Link } from 'react-router-dom'
-import { pathForJobRunsWithTestFailure, withSort } from '../helpers'
 import { withStyles } from '@material-ui/styles'
 import Alert from '@material-ui/lab/Alert'
 import BugzillaDialog from '../bugzilla/BugzillaDialog'
@@ -80,7 +84,7 @@ function TestTable(props) {
       flex: 0.5,
       renderCell: (params) => (
         <Tooltip title={params.row.current_runs + ' runs'}>
-          <p>{Number(params.value).toFixed(0).toLocaleString()}%</p>
+          <p>{Number(params.value).toFixed(1).toLocaleString()}%</p>
         </Tooltip>
       ),
     },
@@ -100,7 +104,7 @@ function TestTable(props) {
       type: 'number',
       renderCell: (params) => (
         <Tooltip title={params.row.previous_runs + ' runs'}>
-          <p>{Number(params.value).toFixed(0).toLocaleString()}%</p>
+          <p>{Number(params.value).toFixed(1).toLocaleString()}%</p>
         </Tooltip>
       ),
     },
@@ -117,7 +121,7 @@ function TestTable(props) {
               startIcon={<Search />}
               href={
                 'https://search.ci.openshift.org/?search=' +
-                encodeURIComponent(params.row.name) +
+                encodeURIComponent(escapeRegex(params.row.name)) +
                 '&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job'
               }
             />

--- a/sippy-ng/src/tests/__snapshots__/TestTable.test.js.snap
+++ b/sippy-ng/src/tests/__snapshots__/TestTable.test.js.snap
@@ -404,7 +404,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -495,7 +495,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"3 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -586,7 +586,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -677,7 +677,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -768,7 +768,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -859,7 +859,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -950,7 +950,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -1041,7 +1041,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -1132,7 +1132,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -1223,7 +1223,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -1314,7 +1314,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -1405,7 +1405,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -1496,7 +1496,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -1587,7 +1587,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"2 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -1678,7 +1678,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -1769,7 +1769,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -1860,7 +1860,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -1951,7 +1951,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -2042,7 +2042,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"3 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -2133,7 +2133,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -2224,7 +2224,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -2315,7 +2315,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -2406,7 +2406,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -2497,7 +2497,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"
@@ -2588,7 +2588,7 @@ exports[`TestTable should render correctly 1`] = `
                       <p title=\\"1 runs\\"
                          class
                       >
-                        0%
+                        0.0%
                       </p>
                     </div>
                     <div style=\\"min-width: 250px; max-width: 250px; line-height: 99px; min-height: 100px; max-height: 100px;\\"


### PR DESCRIPTION
This change keeps 1 digit after the decimal point, so values that were
being rounded to 100% will now correctly show something like 99.7%.

fixes #291 