### PR TITLE
Fix sippy for an upstream testgrid change to Overall test name.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,6 @@ require (
 	github.com/spf13/cobra v0.0.6
 	github.com/valyala/fasttemplate v1.2.1 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
-	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
+	golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef // indirect
 	k8s.io/klog v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 h1:siQdpVirKtzPhKl3lZWozZraC
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e h1:WUoyKPm6nCo1BnNUvPGnFG3T5DUVem42yDJZZ4CNxMA=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef h1:fPxZ3Umkct3LZ8gK9nbk+DWDJ9fstZa2grBn+lWVKPs=
+golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkg/testgridanalysis/testgridconversion/to_raw_data.go
+++ b/pkg/testgridanalysis/testgridconversion/to_raw_data.go
@@ -99,6 +99,12 @@ var testSuitePrefixes = []string{
 // ignoreTestRegex is used to strip o ut tests that don't have predictive or diagnostic value.  We don't want to show these in our data.
 var ignoreTestRegex = regexp.MustCompile(`Run multi-stage test|operator.Import the release payload|operator.Import a release payload|operator.Run template|operator.Build image|Monitor cluster while tests execute|Overall|job.initialize|\[sig-arch\]\[Feature:ClusterUpgrade\] Cluster should remain functional during upgrade`)
 
+// isOverallTest returns true if the given test name qualifies as the "Overall" test. On Oct 4 2021
+// the test name changed from "Overall" to "[jobName].Overall", and for now we need to support both.
+func isOverallTest(testName string, job testgridv1.JobDetails) bool {
+	return testName == overall || testName == fmt.Sprintf("%s.%s", job.Name, overall)
+}
+
 // processTestToJobRunResults adds the tests to the provided jobresult to the provided JobResult and returns the passed, failed, flaked for the test
 //nolint:gocyclo // TODO: Break this function up, see: https://github.com/fzipp/gocyclo
 func processTestToJobRunResults(jobResult testgridanalysisapi.RawJobResult, job testgridv1.JobDetails, test testgridv1.Test, startCol, endCol int) (passed, failed, flaked int) {
@@ -142,7 +148,7 @@ func processTestToJobRunResults(jobResult testgridanalysisapi.RawJobResult, job 
 					}
 				}
 				switch {
-				case test.Name == overall:
+				case isOverallTest(test.Name, job):
 					jrr.Succeeded = true
 					// if the overall job succeeded, setup is always considered successful, even for jobs
 					// that don't have an explicitly defined setup test.
@@ -182,13 +188,14 @@ func processTestToJobRunResults(jobResult testgridanalysisapi.RawJobResult, job 
 				}
 				// only add the failing test and name if it has predictive value.  We excluded all the non-predictive ones above except for these
 				// which we use to set various JobRunResult markers
-				if test.Name != overall && !testidentification.IsSetupContainerEquivalent(test.Name) {
+				if !isOverallTest(test.Name, job) &&
+					!testidentification.IsSetupContainerEquivalent(test.Name) {
 					jrr.FailedTestNames = append(jrr.FailedTestNames, test.Name)
 					jrr.TestFailures++
 				}
 
 				switch {
-				case test.Name == overall:
+				case isOverallTest(test.Name, job):
 					jrr.Failed = true
 				case testidentification.IsOperatorHealthTest(test.Name):
 					jrr.FinalOperatorStates = append(jrr.FinalOperatorStates, testgridanalysisapi.OperatorState{
@@ -237,7 +244,7 @@ func processTest(rawJobResults testgridanalysisapi.RawData, job testgridv1.JobDe
 	// we have to know about overall to be able to set the global success or failure.
 	// we have to know about container setup to be able to set infra failures
 	// TODO stop doing this so we can avoid any filtering. We can filter when preparing to create the data for display
-	if test.Name != overall && !testidentification.IsSetupContainerEquivalent(test.Name) && ignoreTestRegex.MatchString(test.Name) {
+	if !isOverallTest(test.Name, job) && !testidentification.IsSetupContainerEquivalent(test.Name) && ignoreTestRegex.MatchString(test.Name) {
 		return
 	}
 


### PR DESCRIPTION
Fix sippy for an upstream testgrid change to Overall test name.
    
Late yesterday a prod push in testgrid rolled out a change which caused
the Overall test name to change to [jobName].Overall. As a result sippy
could no longer detect jobs completing and assumed everything was still
running.
    
This change adjusts our code to look for both formats when searching for
the Overall test, which is used to determine success/failure.
