### PR TITLE
Speedup sippy API startup by pre-generating reports

### DIFF
--- a/main.go
+++ b/main.go
@@ -378,8 +378,10 @@ func (o *Options) toTestGridLoadingConfig() sippyserver.TestGridLoadingConfig {
 	}
 
 	return sippyserver.TestGridLoadingConfig{
-		LocalData: o.LocalData,
-		JobFilter: jobFilter,
+		LocalData:    o.LocalData,
+		JobFilter:    jobFilter,
+		ReportLoader: sippyserver.LoadReportsFromDisk,
+		Loader:       testgridhelpers.LoadTestGridDataFromDisk,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	v1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 	"github.com/openshift/sippy/pkg/perfscaleanalysis"
@@ -42,6 +43,7 @@ type Options struct {
 	FailureClusterThreshold int
 	FetchData               string
 	FetchPerfScaleData      bool
+	GenReports              bool
 	ListenAddr              string
 	Server                  bool
 	SkipBugLookup           bool
@@ -88,6 +90,7 @@ func main() {
 	flags.Float64Var(&opt.TestSuccessThreshold, "test-success-threshold", opt.TestSuccessThreshold, "Filter results for tests that are more than this percent successful")
 	flags.StringVar(&opt.JobFilter, "job-filter", opt.JobFilter, "Only analyze jobs that match this regex")
 	flags.StringVar(&opt.FetchData, "fetch-data", opt.FetchData, "Download testgrid data to directory specified for future use with --local-data")
+	flags.BoolVar(&opt.GenReports, "gen-reports", opt.GenReports, "Generate reports from testgrid data in --local-data, required for --server")
 	flags.BoolVar(&opt.FetchPerfScaleData, "fetch-openshift-perfscale-data", opt.FetchPerfScaleData, "Download ElasticSearch data for workload CPU/memory use from jobs run by the OpenShift perfscale team. Will be stored in 'perfscale-metrics/' subdirectory beneath the --fetch-data dir.")
 	flags.IntVar(&opt.MinTestRuns, "min-test-runs", opt.MinTestRuns, "Ignore tests with less than this number of runs")
 	flags.IntVar(&opt.FailureClusterThreshold, "failure-cluster-threshold", opt.FailureClusterThreshold, "Include separate report on job runs with more than N test failures, -1 to disable")
@@ -175,11 +178,28 @@ func (o *Options) Validate() error {
 		return fmt.Errorf("must specify --fetch-data with --fetch-openshift-perfscale-data")
 	}
 
+	if o.Server && o.FetchData != "" {
+		return fmt.Errorf("cannot specify --server with --fetch-data")
+	}
+
+	if o.Server && o.GenReports {
+		return fmt.Errorf("cannot specify --server with --gen-reports")
+	}
+
+	if o.GenReports && o.FetchData != "" {
+		return fmt.Errorf("cannot specify --gen-reports with --fetch-data")
+	}
+
+	if o.GenReports && o.LocalData == "" {
+		return fmt.Errorf("must specify --local-data with --gen-reports")
+	}
+
 	return nil
 }
 
 func (o *Options) Run() error {
 	if o.FetchData != "" {
+		start := time.Now()
 		err := os.MkdirAll(o.FetchData, os.ModePerm)
 		if err != nil {
 			return err
@@ -191,22 +211,29 @@ func (o *Options) Run() error {
 			dashboards = append(dashboards, dashboardCoordinate.TestGridDashboardNames...)
 		}
 		testgridhelpers.DownloadData(dashboards, o.JobFilter, o.FetchData)
-		/*
-		server := sippyserver.NewServer(
-			o.toTestGridLoadingConfig(),
-			o.toRawJobResultsAnalysisConfig(),
-			o.toDisplayDataConfig(),
-			o.ToTestGridDashboardCoordinates(),
-			o.ListenAddr,
-			o.getSyntheticTestManager(),
-			o.getVariantManager(),
-			o.getBugCache(),
-			sippyNG,
-			static,
-		)
-		*/
 
-		// Generate reports and seralize to disk:
+		// Fetch OpenShift PerfScale Data from ElasticSearch:
+		if o.FetchPerfScaleData {
+			scaleJobsDir := path.Join(o.FetchData, perfscaleanalysis.ScaleJobsSubDir)
+			err := os.MkdirAll(scaleJobsDir, os.ModePerm)
+			if err != nil {
+				return err
+			}
+			err = perfscaleanalysis.DownloadPerfScaleData(scaleJobsDir)
+			if err != nil {
+				return err
+			}
+		}
+
+		elapsed := time.Since(start)
+		klog.Infof("Testgrid data fetched in: %s", elapsed)
+
+		return nil
+	}
+
+	if o.GenReports {
+		start := time.Now()
+		// Generate reports and serialize to disk:
 		trgc := sippyserver.TestReportGeneratorConfig{
 			TestGridLoadingConfig:       o.toTestGridLoadingConfig(),
 			RawJobResultsAnalysisConfig: o.toRawJobResultsAnalysisConfig(),
@@ -221,7 +248,7 @@ func (o *Options) Run() error {
 
 		localData := trgc.TestGridLoadingConfig.LocalData
 		testReportDir := path.Join(localData, "test-reports")
-		err = os.MkdirAll(testReportDir, os.ModePerm)
+		err := os.MkdirAll(testReportDir, os.ModePerm)
 		klog.Infof("creating: %s", testReportDir)
 		if err != nil {
 			klog.Errorf("error creating directory: " + err.Error())
@@ -237,21 +264,8 @@ func (o *Options) Run() error {
 		if err != nil {
 			klog.Errorf("error writing data: " + err.Error())
 		}
-
-
-		// Fetch OpenShift PerfScale Data from ElasticSearch:
-		if o.FetchPerfScaleData {
-			scaleJobsDir := path.Join(o.FetchData, perfscaleanalysis.ScaleJobsSubDir)
-			err := os.MkdirAll(scaleJobsDir, os.ModePerm)
-			if err != nil {
-				return err
-			}
-			err = perfscaleanalysis.DownloadPerfScaleData(scaleJobsDir)
-			if err != nil {
-				return err
-			}
-		}
-
+		elapsed := time.Since(start)
+		klog.Infof("Reports generated in: %s", elapsed)
 		return nil
 	}
 

--- a/pkg/sippyserver/analyzer.go
+++ b/pkg/sippyserver/analyzer.go
@@ -20,6 +20,9 @@ import (
 // Allows one to pass in an alternative testgrid loader func for testing.
 type TestGridLoader func(string, []string, *regexp.Regexp) ([]testgridv1.JobDetails, time.Time)
 
+// Allows one to pass in an alternative report loader func for testing.
+type ReportLoader func(localData string) map[string]StandardReport
+
 // TestGridLoadingOptions control the data which is loaded from disk into the testgrid structs
 type TestGridLoadingConfig struct {
 	// LocalData is the directory where the testgrid data is stored
@@ -28,6 +31,8 @@ type TestGridLoadingConfig struct {
 	JobFilter *regexp.Regexp
 	// The function to load TestGrid results from disk, used for testing.
 	Loader TestGridLoader
+	// The function to load report data from disk, used for testing.
+	ReportLoader ReportLoader
 }
 
 func (t TestGridLoadingConfig) loadWithFilter(dashboards []string, jobFilter *regexp.Regexp) ([]testgridv1.JobDetails, time.Time) {

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -97,6 +97,7 @@ func (s *Server) refresh(w http.ResponseWriter, req *http.Request) {
 
 func (s *Server) RefreshData() {
 	klog.Infof("Refreshing data")
+	s.bugCache.Clear()
 
 	s.currTestReports = s.testReportGeneratorConfig.TestGridLoadingConfig.ReportLoader(
 		s.testReportGeneratorConfig.TestGridLoadingConfig.LocalData)

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -97,9 +97,26 @@ func (s *Server) refresh(w http.ResponseWriter, req *http.Request) {
 
 func (s *Server) RefreshData() {
 	klog.Infof("Refreshing data")
-	s.bugCache.Clear()
-	for _, dashboard := range s.dashboardCoordinates {
-		s.currTestReports[dashboard.ReportName] = s.testReportGeneratorConfig.PrepareStandardTestReports(dashboard, s.syntheticTestManager, s.variantManager, s.bugCache)
+
+	// Load reports from disk:
+	testReportsFilePath := filepath.Join(s.testReportGeneratorConfig.TestGridLoadingConfig.LocalData,
+		"test-reports", "current-reports.json")
+	if _, err := os.Stat(testReportsFilePath); err != nil {
+		klog.Exitf("%s does not exist, must run with --fetch-data first", testReportsFilePath)
+	}
+	klog.V(4).Infof("loading test reports: %s", testReportsFilePath)
+	testReportsJsonFile, err := os.Open(testReportsFilePath)
+	if err != nil {
+		klog.Exitf("error opening %s: %v", testReportsFilePath, err)
+	}
+	defer testReportsJsonFile.Close()
+	testReportBytes, err := ioutil.ReadAll(testReportsJsonFile)
+	if err != nil {
+		klog.Exitf("error reading %s: %v", testReportsFilePath, err)
+	}
+	err = json.Unmarshal(testReportBytes, &s.currTestReports)
+	if err != nil {
+		klog.Exitf("error parsing json from %s: %v", testReportsFilePath, err)
 	}
 
 	// TODO: skip if not enabled or data does not exist.
@@ -122,6 +139,7 @@ func (s *Server) RefreshData() {
 			klog.Errorf("error parsing json from %s: %v", scaleJobsFilePath, err)
 		}
 	}
+
 	klog.Infof("Refresh complete")
 }
 

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -572,12 +572,12 @@ func LoadReportsFromDisk(localData string) map[string]StandardReport {
 		klog.Exitf("%s does not exist, must run with --fetch-data first", testReportsFilePath)
 	}
 	klog.V(4).Infof("loading test reports: %s", testReportsFilePath)
-	testReportsJsonFile, err := os.Open(testReportsFilePath)
+	testReportsJSONFile, err := os.Open(testReportsFilePath)
 	if err != nil {
 		klog.Exitf("error opening %s: %v", testReportsFilePath, err)
 	}
-	defer testReportsJsonFile.Close()
-	testReportBytes, err := ioutil.ReadAll(testReportsJsonFile)
+	defer testReportsJSONFile.Close()
+	testReportBytes, err := ioutil.ReadAll(testReportsJSONFile)
 	if err != nil {
 		klog.Exitf("error reading %s: %v", testReportsFilePath, err)
 	}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -26,7 +26,7 @@ import (
 )
 
 func NewServer(
-	testGridLoadingOptions TestGridLoadingConfig,
+	testGridLoadingConfig TestGridLoadingConfig,
 	rawJobResultsAnalysisOptions RawJobResultsAnalysisConfig,
 	displayDataOptions DisplayDataConfig,
 	dashboardCoordinates []TestGridDashboardCoordinates,
@@ -46,7 +46,7 @@ func NewServer(
 		variantManager:       variantManager,
 		bugCache:             bugCache,
 		testReportGeneratorConfig: TestReportGeneratorConfig{
-			TestGridLoadingConfig:       testGridLoadingOptions,
+			TestGridLoadingConfig:       testGridLoadingConfig,
 			RawJobResultsAnalysisConfig: rawJobResultsAnalysisOptions,
 			DisplayDataConfig:           displayDataOptions,
 		},
@@ -98,26 +98,8 @@ func (s *Server) refresh(w http.ResponseWriter, req *http.Request) {
 func (s *Server) RefreshData() {
 	klog.Infof("Refreshing data")
 
-	// Load reports from disk:
-	testReportsFilePath := filepath.Join(s.testReportGeneratorConfig.TestGridLoadingConfig.LocalData,
-		"test-reports", "current-reports.json")
-	if _, err := os.Stat(testReportsFilePath); err != nil {
-		klog.Exitf("%s does not exist, must run with --fetch-data first", testReportsFilePath)
-	}
-	klog.V(4).Infof("loading test reports: %s", testReportsFilePath)
-	testReportsJsonFile, err := os.Open(testReportsFilePath)
-	if err != nil {
-		klog.Exitf("error opening %s: %v", testReportsFilePath, err)
-	}
-	defer testReportsJsonFile.Close()
-	testReportBytes, err := ioutil.ReadAll(testReportsJsonFile)
-	if err != nil {
-		klog.Exitf("error reading %s: %v", testReportsFilePath, err)
-	}
-	err = json.Unmarshal(testReportBytes, &s.currTestReports)
-	if err != nil {
-		klog.Exitf("error parsing json from %s: %v", testReportsFilePath, err)
-	}
+	s.currTestReports = s.testReportGeneratorConfig.TestGridLoadingConfig.ReportLoader(
+		s.testReportGeneratorConfig.TestGridLoadingConfig.LocalData)
 
 	// TODO: skip if not enabled or data does not exist.
 	// Load the scale job reports from disk:
@@ -303,9 +285,10 @@ func (s *Server) detailed(w http.ResponseWriter, req *http.Request) {
 
 	testReportConfig := TestReportGeneratorConfig{
 		TestGridLoadingConfig: TestGridLoadingConfig{
-			LocalData: s.testReportGeneratorConfig.TestGridLoadingConfig.LocalData,
-			Loader:    s.testReportGeneratorConfig.TestGridLoadingConfig.Loader,
-			JobFilter: jobFilter,
+			LocalData:    s.testReportGeneratorConfig.TestGridLoadingConfig.LocalData,
+			Loader:       s.testReportGeneratorConfig.TestGridLoadingConfig.Loader,
+			ReportLoader: s.testReportGeneratorConfig.TestGridLoadingConfig.ReportLoader,
+			JobFilter:    jobFilter,
 		},
 		RawJobResultsAnalysisConfig: RawJobResultsAnalysisConfig{
 			StartDay: startDay,
@@ -579,4 +562,29 @@ func (s *Server) Serve() {
 
 func (s *Server) GetHTTPServer() *http.Server {
 	return s.httpServer
+}
+
+func LoadReportsFromDisk(localData string) map[string]StandardReport {
+	// Load reports from disk:
+	testReportsFilePath := filepath.Join(localData,
+		"test-reports", "current-reports.json")
+	if _, err := os.Stat(testReportsFilePath); err != nil {
+		klog.Exitf("%s does not exist, must run with --fetch-data first", testReportsFilePath)
+	}
+	klog.V(4).Infof("loading test reports: %s", testReportsFilePath)
+	testReportsJsonFile, err := os.Open(testReportsFilePath)
+	if err != nil {
+		klog.Exitf("error opening %s: %v", testReportsFilePath, err)
+	}
+	defer testReportsJsonFile.Close()
+	testReportBytes, err := ioutil.ReadAll(testReportsJsonFile)
+	if err != nil {
+		klog.Exitf("error reading %s: %v", testReportsFilePath, err)
+	}
+	testReports := map[string]StandardReport{}
+	err = json.Unmarshal(testReportBytes, &testReports)
+	if err != nil {
+		klog.Exitf("error parsing json from %s: %v", testReportsFilePath, err)
+	}
+	return testReports
 }

--- a/pkg/sippyserver/server_test.go
+++ b/pkg/sippyserver/server_test.go
@@ -442,6 +442,22 @@ func configureSippyServer(jobDetails []testgridv1.JobDetails, timestamp time.Tim
 		},
 	}
 
+	trgc := sippyserver.TestReportGeneratorConfig{
+		TestGridLoadingConfig:       loadingConfig,
+		RawJobResultsAnalysisConfig: analysisConfig,
+		DisplayDataConfig:           displayConfig,
+	}
+	testReports := map[string]sippyserver.StandardReport{}
+	for _, dashboard := range dashboardCoordinates {
+		testReports[dashboard.ReportName] = trgc.PrepareStandardTestReports(dashboard,
+			testgridconversion.NewOpenshiftSyntheticTestManager(),
+			testidentification.NewOpenshiftVariantManager(),
+			buganalysis.NewNoOpBugCache())
+	}
+	loadingConfig.ReportLoader = func(_ string) map[string]sippyserver.StandardReport {
+		return testReports
+	}
+
 	listenAddr := fmt.Sprintf(":%d", port)
 
 	// Configure the Sippy server.

--- a/scripts/fetchdata-kube.sh
+++ b/scripts/fetchdata-kube.sh
@@ -7,7 +7,9 @@ sleep 60 # 1 minutes
 while [ true ]; do
   echo "Fetching new testgrid data"
   rm -rf /data/*
-  /bin/sippy --fetch-data /data --dashboard=kube-master=sig-release-master-blocking,sig-release-master-informing= -v 4
+  /bin/sippy --fetch-data /data
+  echo "Generating reports"
+  /bin/sippy -v 4 --gen-reports --local-data /data --dashboard=kube-master=sig-release-master-blocking,sig-release-master-informing=
   echo "Done fetching data, refreshing server"
   curl localhost:8080/refresh
   echo "Done refreshing data, sleeping"

--- a/scripts/fetchdata.sh
+++ b/scripts/fetchdata.sh
@@ -8,6 +8,8 @@ while [ true ]; do
   echo "Fetching new testgrid data"
   rm -rf /data/*
   /bin/sippy -v 4 --fetch-data /data --fetch-openshift-perfscale-data --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10
+  echo "Generating reports"
+  /bin/sippy -v 4 --gen-reports --local-data /data --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10
   echo "Done fetching data, refreshing server"
   curl localhost:8080/refresh
   echo "Done refreshing data, sleeping"


### PR DESCRIPTION
Goal is to move the expensive report generation from server startup, where we're stuck waiting roughly 2 minutes per --release with sippy down entirely, to the slower fetchdata scripts. This wait is extremely painful for developing on sippy.

Adds a new --gen-reports command which is to be run separately from --fetch-data, as we may want to run it against a snapshot of historical restored testgrid data.

With this change and using just --release 4.10, sippy api server startup time goes from 2m to 9s.