### PR TITLE
[wip] Add init container for generating reports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ FROM registry.access.redhat.com/ubi8/ubi:latest AS base
 RUN mkdir -p /historical-data
 COPY --from=builder /go/src/sippy/sippy /bin/sippy
 COPY --from=builder /go/src/sippy/scripts/fetchdata.sh /bin/fetchdata.sh
+COPY --from=builder /go/src/sippy/scripts/gen-reports.sh /bin/gen-reports.sh
 COPY --from=builder /go/src/sippy/scripts/fetchdata-kube.sh /bin/fetchdata-kube.sh
 COPY --from=builder /go/src/sippy/historical-data /historical-data/
 ENTRYPOINT ["/bin/sippy"]

--- a/resources/deploymentconfig-historical.yaml
+++ b/resources/deploymentconfig-historical.yaml
@@ -24,6 +24,31 @@ spec:
       labels:
         deploymentconfig: sippy-historical
     spec:
+      initContainers:
+      - args:
+        - --gen-reports
+        - --local-data
+        - /historical-data/common
+        - --release
+        - "4.4"
+        - --release
+        - "4.5"
+        - --release
+        - "4.6"
+        - --release
+        - "4.7"
+        - --release
+        - "4.8"
+        - --release
+        - "4.9"
+        - --server
+        - --start-day
+        - "-1"
+        command:
+        - /bin/sippy
+        image: docker.io/openshift/sippy
+        imagePullPolicy: Always
+        name: sippy-generate
       containers:
       - args:
         - --local-data
@@ -45,7 +70,7 @@ spec:
         - "-1"
         command:
         - /bin/sippy
-        image: image-registry.openshift-image-registry.svc:5000/bparees/sippy@sha256:35df0be865e4820a76f350ae65d077eb83b41c8cacb286291badf65e0654b5b7
+        image: docker.io/openshift/sippy
         imagePullPolicy: Always
         name: sippy
         ports:
@@ -68,7 +93,7 @@ spec:
       automatic: true
       containerNames:
       - sippy
-      - fetchdata
+      - sippy-generate
       from:
         kind: ImageStreamTag
         name: sippy:latest

--- a/resources/deploymentconfig.yaml
+++ b/resources/deploymentconfig.yaml
@@ -16,6 +16,8 @@ spec:
   strategy:
     activeDeadlineSeconds: 21600
     type: Recreate
+    recreateParams:
+      timeoutSeconds: 1200
   template:
     metadata:
       annotations:
@@ -24,6 +26,15 @@ spec:
       labels:
         deploymentconfig: sippy
     spec:
+      initContainers:
+        command:
+        - /bin/gen-reports.sh
+        image: docker.io/openshift/sippy
+        imagePullPolicy: Always
+        name: sippy-generate
+        volumeMounts:
+        - mountPath: /data
+          name: data
       containers:
       - image: docker.io/openshift/sippy
         imagePullPolicy: Always
@@ -91,6 +102,7 @@ spec:
       automatic: true
       containerNames:
       - sippy
+      - sippy-generate
       - fetchdata
       from:
         kind: ImageStreamTag

--- a/scripts/gen-reports.sh
+++ b/scripts/gen-reports.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ ! -f /data/test-reports/current-reports.json ]
+then
+  /bin/sippy -v 4 --gen-reports --local-data /data --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10
+fi


### PR DESCRIPTION
After #313, we write generated reports directly to disk to speed up sippy start, but there's a catch-22 where we don't run the generate reports for the first time until fetch-data runs, so Sippy will fail to start.