### PR TITLE
revert speedup

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -191,53 +189,6 @@ func (o *Options) Run() error {
 			dashboards = append(dashboards, dashboardCoordinate.TestGridDashboardNames...)
 		}
 		testgridhelpers.DownloadData(dashboards, o.JobFilter, o.FetchData)
-		/*
-		server := sippyserver.NewServer(
-			o.toTestGridLoadingConfig(),
-			o.toRawJobResultsAnalysisConfig(),
-			o.toDisplayDataConfig(),
-			o.ToTestGridDashboardCoordinates(),
-			o.ListenAddr,
-			o.getSyntheticTestManager(),
-			o.getVariantManager(),
-			o.getBugCache(),
-			sippyNG,
-			static,
-		)
-		*/
-
-		// Generate reports and seralize to disk:
-		trgc := sippyserver.TestReportGeneratorConfig{
-			TestGridLoadingConfig:       o.toTestGridLoadingConfig(),
-			RawJobResultsAnalysisConfig: o.toRawJobResultsAnalysisConfig(),
-			DisplayDataConfig:           o.toDisplayDataConfig(),
-		}
-
-		testReports := map[string]sippyserver.StandardReport{}
-		for _, dashboard := range o.ToTestGridDashboardCoordinates() {
-			testReports[dashboard.ReportName] = trgc.PrepareStandardTestReports(dashboard,
-				o.getSyntheticTestManager(), o.getVariantManager(), o.getBugCache())
-		}
-
-		localData := trgc.TestGridLoadingConfig.LocalData
-		testReportDir := path.Join(localData, "test-reports")
-		err = os.MkdirAll(testReportDir, os.ModePerm)
-		klog.Infof("creating: %s", testReportDir)
-		if err != nil {
-			klog.Errorf("error creating directory: " + err.Error())
-		}
-		klog.Infof("marshalling test report json")
-		jsonBytes, err := json.MarshalIndent(testReports, "", "    ")
-		if err != nil {
-			klog.Errorf("error marshalling data: " + err.Error())
-		}
-		reportsFile := filepath.Join(testReportDir, "current-reports.json")
-		klog.Infof("writing test reports json to: %s", reportsFile)
-		err = ioutil.WriteFile(reportsFile, jsonBytes, 0600)
-		if err != nil {
-			klog.Errorf("error writing data: " + err.Error())
-		}
-
 
 		// Fetch OpenShift PerfScale Data from ElasticSearch:
 		if o.FetchPerfScaleData {

--- a/main.go
+++ b/main.go
@@ -378,10 +378,8 @@ func (o *Options) toTestGridLoadingConfig() sippyserver.TestGridLoadingConfig {
 	}
 
 	return sippyserver.TestGridLoadingConfig{
-		LocalData:    o.LocalData,
-		JobFilter:    jobFilter,
-		ReportLoader: sippyserver.LoadReportsFromDisk,
-		Loader:       testgridhelpers.LoadTestGridDataFromDisk,
+		LocalData: o.LocalData,
+		JobFilter: jobFilter,
 	}
 }
 

--- a/pkg/sippyserver/analyzer.go
+++ b/pkg/sippyserver/analyzer.go
@@ -20,9 +20,6 @@ import (
 // Allows one to pass in an alternative testgrid loader func for testing.
 type TestGridLoader func(string, []string, *regexp.Regexp) ([]testgridv1.JobDetails, time.Time)
 
-// Allows one to pass in an alternative report loader func for testing.
-type ReportLoader func(localData string) map[string]StandardReport
-
 // TestGridLoadingOptions control the data which is loaded from disk into the testgrid structs
 type TestGridLoadingConfig struct {
 	// LocalData is the directory where the testgrid data is stored
@@ -31,8 +28,6 @@ type TestGridLoadingConfig struct {
 	JobFilter *regexp.Regexp
 	// The function to load TestGrid results from disk, used for testing.
 	Loader TestGridLoader
-	// The function to load report data from disk, used for testing.
-	ReportLoader ReportLoader
 }
 
 func (t TestGridLoadingConfig) loadWithFilter(dashboards []string, jobFilter *regexp.Regexp) ([]testgridv1.JobDetails, time.Time) {

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -572,12 +572,12 @@ func LoadReportsFromDisk(localData string) map[string]StandardReport {
 		klog.Exitf("%s does not exist, must run with --fetch-data first", testReportsFilePath)
 	}
 	klog.V(4).Infof("loading test reports: %s", testReportsFilePath)
-	testReportsJSONFile, err := os.Open(testReportsFilePath)
+	testReportsJsonFile, err := os.Open(testReportsFilePath)
 	if err != nil {
 		klog.Exitf("error opening %s: %v", testReportsFilePath, err)
 	}
-	defer testReportsJSONFile.Close()
-	testReportBytes, err := ioutil.ReadAll(testReportsJSONFile)
+	defer testReportsJsonFile.Close()
+	testReportBytes, err := ioutil.ReadAll(testReportsJsonFile)
 	if err != nil {
 		klog.Exitf("error reading %s: %v", testReportsFilePath, err)
 	}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -97,7 +97,6 @@ func (s *Server) refresh(w http.ResponseWriter, req *http.Request) {
 
 func (s *Server) RefreshData() {
 	klog.Infof("Refreshing data")
-	s.bugCache.Clear()
 
 	s.currTestReports = s.testReportGeneratorConfig.TestGridLoadingConfig.ReportLoader(
 		s.testReportGeneratorConfig.TestGridLoadingConfig.LocalData)

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -26,7 +26,7 @@ import (
 )
 
 func NewServer(
-	testGridLoadingConfig TestGridLoadingConfig,
+	testGridLoadingOptions TestGridLoadingConfig,
 	rawJobResultsAnalysisOptions RawJobResultsAnalysisConfig,
 	displayDataOptions DisplayDataConfig,
 	dashboardCoordinates []TestGridDashboardCoordinates,
@@ -46,7 +46,7 @@ func NewServer(
 		variantManager:       variantManager,
 		bugCache:             bugCache,
 		testReportGeneratorConfig: TestReportGeneratorConfig{
-			TestGridLoadingConfig:       testGridLoadingConfig,
+			TestGridLoadingConfig:       testGridLoadingOptions,
 			RawJobResultsAnalysisConfig: rawJobResultsAnalysisOptions,
 			DisplayDataConfig:           displayDataOptions,
 		},
@@ -98,8 +98,26 @@ func (s *Server) refresh(w http.ResponseWriter, req *http.Request) {
 func (s *Server) RefreshData() {
 	klog.Infof("Refreshing data")
 
-	s.currTestReports = s.testReportGeneratorConfig.TestGridLoadingConfig.ReportLoader(
-		s.testReportGeneratorConfig.TestGridLoadingConfig.LocalData)
+	// Load reports from disk:
+	testReportsFilePath := filepath.Join(s.testReportGeneratorConfig.TestGridLoadingConfig.LocalData,
+		"test-reports", "current-reports.json")
+	if _, err := os.Stat(testReportsFilePath); err != nil {
+		klog.Exitf("%s does not exist, must run with --fetch-data first", testReportsFilePath)
+	}
+	klog.V(4).Infof("loading test reports: %s", testReportsFilePath)
+	testReportsJsonFile, err := os.Open(testReportsFilePath)
+	if err != nil {
+		klog.Exitf("error opening %s: %v", testReportsFilePath, err)
+	}
+	defer testReportsJsonFile.Close()
+	testReportBytes, err := ioutil.ReadAll(testReportsJsonFile)
+	if err != nil {
+		klog.Exitf("error reading %s: %v", testReportsFilePath, err)
+	}
+	err = json.Unmarshal(testReportBytes, &s.currTestReports)
+	if err != nil {
+		klog.Exitf("error parsing json from %s: %v", testReportsFilePath, err)
+	}
 
 	// TODO: skip if not enabled or data does not exist.
 	// Load the scale job reports from disk:
@@ -285,10 +303,9 @@ func (s *Server) detailed(w http.ResponseWriter, req *http.Request) {
 
 	testReportConfig := TestReportGeneratorConfig{
 		TestGridLoadingConfig: TestGridLoadingConfig{
-			LocalData:    s.testReportGeneratorConfig.TestGridLoadingConfig.LocalData,
-			Loader:       s.testReportGeneratorConfig.TestGridLoadingConfig.Loader,
-			ReportLoader: s.testReportGeneratorConfig.TestGridLoadingConfig.ReportLoader,
-			JobFilter:    jobFilter,
+			LocalData: s.testReportGeneratorConfig.TestGridLoadingConfig.LocalData,
+			Loader:    s.testReportGeneratorConfig.TestGridLoadingConfig.Loader,
+			JobFilter: jobFilter,
 		},
 		RawJobResultsAnalysisConfig: RawJobResultsAnalysisConfig{
 			StartDay: startDay,
@@ -562,29 +579,4 @@ func (s *Server) Serve() {
 
 func (s *Server) GetHTTPServer() *http.Server {
 	return s.httpServer
-}
-
-func LoadReportsFromDisk(localData string) map[string]StandardReport {
-	// Load reports from disk:
-	testReportsFilePath := filepath.Join(localData,
-		"test-reports", "current-reports.json")
-	if _, err := os.Stat(testReportsFilePath); err != nil {
-		klog.Exitf("%s does not exist, must run with --fetch-data first", testReportsFilePath)
-	}
-	klog.V(4).Infof("loading test reports: %s", testReportsFilePath)
-	testReportsJsonFile, err := os.Open(testReportsFilePath)
-	if err != nil {
-		klog.Exitf("error opening %s: %v", testReportsFilePath, err)
-	}
-	defer testReportsJsonFile.Close()
-	testReportBytes, err := ioutil.ReadAll(testReportsJsonFile)
-	if err != nil {
-		klog.Exitf("error reading %s: %v", testReportsFilePath, err)
-	}
-	testReports := map[string]StandardReport{}
-	err = json.Unmarshal(testReportBytes, &testReports)
-	if err != nil {
-		klog.Exitf("error parsing json from %s: %v", testReportsFilePath, err)
-	}
-	return testReports
 }

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -570,8 +570,7 @@ func LoadReportsFromDisk(localData string) map[string]StandardReport {
 	testReportsFilePath := filepath.Join(localData,
 		"test-reports", "current-reports.json")
 	if _, err := os.Stat(testReportsFilePath); err != nil {
-		klog.Errorf("%s does not exist, no data to display until sippy --fetch-data is run", testReportsFilePath)
-		return map[string]StandardReport{}
+		klog.Exitf("%s does not exist, must run with --fetch-data first", testReportsFilePath)
 	}
 	klog.V(4).Infof("loading test reports: %s", testReportsFilePath)
 	testReportsJSONFile, err := os.Open(testReportsFilePath)

--- a/pkg/sippyserver/server_test.go
+++ b/pkg/sippyserver/server_test.go
@@ -442,22 +442,6 @@ func configureSippyServer(jobDetails []testgridv1.JobDetails, timestamp time.Tim
 		},
 	}
 
-	trgc := sippyserver.TestReportGeneratorConfig{
-		TestGridLoadingConfig:       loadingConfig,
-		RawJobResultsAnalysisConfig: analysisConfig,
-		DisplayDataConfig:           displayConfig,
-	}
-	testReports := map[string]sippyserver.StandardReport{}
-	for _, dashboard := range dashboardCoordinates {
-		testReports[dashboard.ReportName] = trgc.PrepareStandardTestReports(dashboard,
-			testgridconversion.NewOpenshiftSyntheticTestManager(),
-			testidentification.NewOpenshiftVariantManager(),
-			buganalysis.NewNoOpBugCache())
-	}
-	loadingConfig.ReportLoader = func(_ string) map[string]sippyserver.StandardReport {
-		return testReports
-	}
-
 	listenAddr := fmt.Sprintf(":%d", port)
 
 	// Configure the Sippy server.

--- a/resources/deploymentconfig.yaml
+++ b/resources/deploymentconfig.yaml
@@ -67,7 +67,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            memory: 4G
+            memory: 500M
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         command:

--- a/scripts/fetchdata-kube.sh
+++ b/scripts/fetchdata-kube.sh
@@ -7,9 +7,7 @@ sleep 60 # 1 minutes
 while [ true ]; do
   echo "Fetching new testgrid data"
   rm -rf /data/*
-  /bin/sippy --fetch-data /data
-  echo "Generating reports"
-  /bin/sippy -v 4 --gen-reports --local-data /data --dashboard=kube-master=sig-release-master-blocking,sig-release-master-informing=
+  /bin/sippy --fetch-data /data --dashboard=kube-master=sig-release-master-blocking,sig-release-master-informing= -v 4
   echo "Done fetching data, refreshing server"
   curl localhost:8080/refresh
   echo "Done refreshing data, sleeping"

--- a/scripts/fetchdata.sh
+++ b/scripts/fetchdata.sh
@@ -8,8 +8,6 @@ while [ true ]; do
   echo "Fetching new testgrid data"
   rm -rf /data/*
   /bin/sippy -v 4 --fetch-data /data --fetch-openshift-perfscale-data --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10
-  echo "Generating reports"
-  /bin/sippy -v 4 --gen-reports --local-data /data --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10
   echo "Done fetching data, refreshing server"
   curl localhost:8080/refresh
   echo "Done refreshing data, sleeping"


### PR DESCRIPTION
- Revert "Bump memory for the fetchdata container, which now generates all reporting data."
- Revert "Fix rollout bug when sippy exits with no data."
- Revert "Restore bugCache.Clear()"
- Revert "Lint fix."
- Revert "Fix unit tests for report loading."
- Revert "Break --gen-reports out into a separate invocation for restoring historical testgrid --local-dir."
- Revert "Move report generation to fetch-data scripts."
