### PR TITLE
Add name to sippy service

### DIFF
--- a/resources/service-historical.yaml
+++ b/resources/service-historical.yaml
@@ -6,7 +6,8 @@ metadata:
   name: sippy-historical
 spec:
   ports:
-  - port: 8080
+  - name: www
+    port: 8080
     protocol: TCP
     targetPort: 8080
   selector:

--- a/resources/service.yaml
+++ b/resources/service.yaml
@@ -8,7 +8,8 @@ metadata:
   name: sippy
 spec:
   ports:
-  - port: 8080
+  - name: www
+    port: 8080
     protocol: TCP
     targetPort: 8080
   - name: metrics


### PR DESCRIPTION
oc apply is complaining:

  The Service "sippy" is invalid: spec.ports[0].name: Required value