### PR TITLE
Fix metrics port for sippy.

### DIFF
--- a/resources/deploymentconfig.yaml
+++ b/resources/deploymentconfig.yaml
@@ -29,7 +29,11 @@ spec:
         imagePullPolicy: Always
         name: sippy
         ports:
-        - containerPort: 8080
+        - name: www
+          containerPort: 8080
+          protocol: TCP
+        - name: metrics
+          containerPort: 2112
           protocol: TCP
         resources:
           limits:
@@ -64,9 +68,6 @@ spec:
         name: fetchdata
         ports:
         - containerPort: 8080
-          protocol: TCP
-        - name: metrics
-          containerPort: 2112
           protocol: TCP
         resources:
           limits:


### PR DESCRIPTION
Accidentally added to fetchdata container, not the API.
