### PR TITLE
Fix crash in fetchdata container.

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,8 +210,6 @@ func (o *Options) Run() error {
 			if err := bge.ExportData(context.Background(), dbc); err != nil {
 				return err
 			}
-		} else {
-			klog.V(1).Infof("")
 		}
 
 		// Fetch OpenShift PerfScale Data from ElasticSearch:


### PR DESCRIPTION
Apparently this empty log line is worthy of a panic.

Job periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-rt has bad status FLAKY
panic: runtime error: index out of range [-1]

goroutine 1 [running]:
k8s.io/klog.(*loggingT).printf(0x1dac200, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/go/src/sippy/vendor/k8s.io/klog/klog.go:704 +0x17a
k8s.io/klog.Verbose.Infof(...)
	/go/src/sippy/vendor/k8s.io/klog/klog.go:1176
main.(*Options).Run(0xc0001e2000, 0x0, 0x0)
	/go/src/sippy/main.go:214 +0x545
main.main.func1(0xc0001e8000, 0xc0001f2000, 0x0, 0x11)
	/go/src/sippy/main.go:77 +0xd7
github.com/spf13/cobra.(*Command).execute(0xc0001e8000, 0xc000138010, 0x11, 0x11, 0xc0001e8000, 0xc000138010)
	/go/src/sippy/vendor/github.com/spf13/cobra/command.go:844 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0xc0001e8000, 0xc0001e41c0, 0x142506c, 0xc)
	/go/src/sippy/vendor/github.com/spf13/cobra/command.go:945 +0x336
github.com/spf13/cobra.(*Command).Execute(...)
	/go/src/sippy/vendor/github.com/spf13/cobra/command.go:885
main.main()
	/go/src/sippy/main.go:106 +0x913
