### PR TITLE
Distinguish between no payload and rejected payloads

### DIFF
--- a/pkg/db/models/release_tag.go
+++ b/pkg/db/models/release_tag.go
@@ -75,3 +75,49 @@ func GetLastAcceptedByArchitectureAndStream(db *gorm.DB, release string) ([]Rele
 
 	return results, nil
 }
+
+// GetLastPayloadStatus returns the most recent payload status for an architecture/stream combination,
+// as well as the count of how many of the last payloads had that status (e.g., when this returns
+// Rejected, 5 -- it means the last 5 payloads were rejected.
+func GetLastPayloadStatus(db *gorm.DB, architecture, stream, release string) (string, int, error) {
+	count := struct {
+		Phase string `gorm:"column:phase"`
+		Count int    `gorm:"column:count"`
+	}{}
+
+	result := db.Raw(`
+		WITH releases AS
+			(
+				SELECT
+					ROW_NUMBER() OVER(ORDER BY "releaseTime" desc) AS id,
+					phase
+				FROM
+					release_tags
+				WHERE
+					architecture = ? AND stream = ? AND release = ?
+			),
+		changes AS
+			(
+				SELECT
+					*,
+					CASE WHEN LAG(phase) OVER(ORDER BY id) = phase THEN 0 ELSE 1 END AS change
+				FROM
+					releases
+			),
+		groups AS
+			(
+				SELECT
+					*,
+					SUM(change) OVER(ORDER BY id) AS group FROM changes
+			)
+		SELECT
+			phase, COUNT(phase)
+		FROM
+			groups
+		WHERE
+			groups.group = 1
+		GROUP BY
+			phase`, architecture, stream, release).Scan(&count)
+
+	return count.Phase, count.Count, result.Error
+}

--- a/sippy-ng/src/releases/ReleasePayloadAcceptance.js
+++ b/sippy-ng/src/releases/ReleasePayloadAcceptance.js
@@ -1,5 +1,12 @@
-import { Box, Card, CardContent, Grid, Typography } from '@material-ui/core'
-import { CheckCircle, Error, Help } from '@material-ui/icons'
+import {
+  Box,
+  Card,
+  CardContent,
+  Grid,
+  Tooltip,
+  Typography,
+} from '@material-ui/core'
+import { CheckCircle, Error, Help, Warning } from '@material-ui/icons'
 import { createTheme, makeStyles } from '@material-ui/core/styles'
 import { filterFor, relativeTime } from '../helpers'
 import { Link } from 'react-router-dom'
@@ -66,15 +73,25 @@ function ReleasePayloadAcceptance(props) {
     let bgColor = theme.palette.grey.A100
     let icon = <Help />
     let text = 'Unknown'
+    let tooltip = 'No information is available.'
     if (row.releaseTime && row.releaseTime != '') {
+      tooltip = `The last ${row.count} releases were ${row.lastPhase}`
       text = relativeTime(new Date(row.releaseTime))
       const when = new Date().getTime() - new Date(row.releaseTime).getTime()
-      if (when <= 24 * 60 * 60 * 1000) {
+
+      if (row.lastPhase === 'Accepted' && when <= 24 * 60 * 60 * 1000) {
+        // If we had an accepted release in the last 24 hours, we're green
         bgColor = theme.palette.success.light
         icon = <CheckCircle style={{ fill: 'green' }} />
-      } else {
+      } else if (row.lastPhase === 'Rejected') {
+        // If the last payload was rejected, we are red.
         bgColor = theme.palette.error.light
         icon = <Error style={{ fill: 'maroon' }} />
+      } else {
+        // Otherwise we are yellow -- e.g., last release payload was accepted
+        // but it's been several days.
+        bgColor = theme.palette.warning.light
+        icon = <Warning style={{ fill: 'goldenrod' }} />
       }
     }
 
@@ -92,27 +109,29 @@ function ReleasePayloadAcceptance(props) {
           JSON.stringify(filter)
         )}`}
       >
-        <Card
-          elevation={5}
-          style={{ backgroundColor: bgColor, margin: 20, width: 200 }}
-        >
-          <CardContent
-            className={`${classes.cardContent}`}
-            style={{ textAlign: 'center' }}
+        <Tooltip title={tooltip}>
+          <Card
+            elevation={5}
+            style={{ backgroundColor: bgColor, margin: 20, width: 200 }}
           >
-            <Typography variant="h6">
-              {row.architecture} {row.stream}
-            </Typography>
-            <Grid
-              container
-              direction="row"
-              alignItems="center"
-              style={{ margin: 20, textAlign: 'center' }}
+            <CardContent
+              className={`${classes.cardContent}`}
+              style={{ textAlign: 'center' }}
             >
-              {icon}&nbsp;{text}
-            </Grid>
-          </CardContent>
-        </Card>
+              <Typography variant="h6">
+                {row.architecture} {row.stream}
+              </Typography>
+              <Grid
+                container
+                direction="row"
+                alignItems="center"
+                style={{ margin: 20, textAlign: 'center' }}
+              >
+                {icon}&nbsp;{text}
+              </Grid>
+            </CardContent>
+          </Card>
+        </Tooltip>
       </Box>
     )
   })


### PR DESCRIPTION
This distinguishes between no payload, and rejected payloads.

- Rejected payloads are red.
- Accepted payloads in the last 24 hours are green.
- When we haven't had a payload in several days, but the most recent one
  was accepted, we mark it as a warning.

A tooltip also now tells you how many of the most recent payloads
had that status (e.g. The last 9 payloads were rejected.)

![image](https://user-images.githubusercontent.com/429763/142744506-bf85b546-4990-4f74-bf53-5f856ef3aa7f.png)
