### PR TITLE
db sync: batch insertions and only fetch what is needed from bigquery

### DIFF
--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -53,12 +53,12 @@ func PrintReleaseJobRunsReport(w http.ResponseWriter, req *http.Request, dbClien
 	RespondWithJSON(http.StatusOK, w, jobRuns)
 }
 
-type apiReleaseTag struct {
-	models.ReleaseTag
-	FailedJobNames pq.StringArray `gorm:"type:text[];column:failedJobNames" json:"failedJobNames,omitempty"`
-}
-
 func PrintReleasesReport(w http.ResponseWriter, req *http.Request, dbClient *db.DB) {
+	type apiReleaseTag struct {
+		models.ReleaseTag
+		FailedJobNames pq.StringArray `gorm:"type:text[];column:failedJobNames" json:"failedJobNames,omitempty"`
+	}
+
 	if dbClient == nil || dbClient.DB == nil {
 		RespondWithJSON(http.StatusOK, w, []struct{}{})
 	}

--- a/pkg/bigqueryexporter/bigquery.go
+++ b/pkg/bigqueryexporter/bigquery.go
@@ -52,10 +52,13 @@ func (client *Client) ExportData(ctx context.Context, dbClient *db.DB) error {
 
 func (client *Client) ExportReleaseTags(ctx context.Context, dbClient *db.DB) error {
 	rows := make([]models.ReleaseTag, 0)
-	query := client.Query(`
-		SELECT
-			ROW_NUMBER() OVER() id, *
-		FROM ` + "`ci_data.ReleaseTags`")
+	query := client.Query(`SELECT * FROM (SELECT ROW_NUMBER() OVER() id, * FROM ` + "`ci_data.ReleaseTags`) WHERE id > @lastID)")
+	query.Parameters = []bigquery.QueryParameter{
+		{
+			Name:  "lastID",
+			Value: dbClient.LastID("release_tags"),
+		},
+	}
 	it, err := query.Read(ctx)
 	if err != nil {
 		return err
@@ -73,15 +76,18 @@ func (client *Client) ExportReleaseTags(ctx context.Context, dbClient *db.DB) er
 		rows = append(rows, row)
 	}
 
-	return dbClient.DB.Clauses(clause.OnConflict{UpdateAll: true}).Create(&rows).Error
+	return dbClient.DB.Clauses(clause.OnConflict{UpdateAll: true}).CreateInBatches(&rows, dbClient.BatchSize).Error
 }
 
 func (client *Client) ExportPullRequests(ctx context.Context, dbClient *db.DB) error {
 	rows := make([]models.PullRequest, 0)
-	query := client.Query(`
-		SELECT
-			ROW_NUMBER() OVER() id, *
-		FROM ` + "`ci_data.ReleasePullRequests`")
+	query := client.Query(`SELECT * FROM (SELECT ROW_NUMBER() OVER() id, * FROM ` + "`ci_data.ReleasePullRequests`) WHERE id > @lastID")
+	query.Parameters = []bigquery.QueryParameter{
+		{
+			Name:  "lastID",
+			Value: dbClient.LastID("pull_requests"),
+		},
+	}
 	it, err := query.Read(ctx)
 	if err != nil {
 		return err
@@ -98,15 +104,18 @@ func (client *Client) ExportPullRequests(ctx context.Context, dbClient *db.DB) e
 		}
 		rows = append(rows, row)
 	}
-	return dbClient.DB.Clauses(clause.OnConflict{UpdateAll: true}).Create(&rows).Error
+	return dbClient.DB.Clauses(clause.OnConflict{UpdateAll: true}).CreateInBatches(&rows, dbClient.BatchSize).Error
 }
 
 func (client *Client) ExportRepositories(ctx context.Context, dbClient *db.DB) error {
 	rows := make([]models.Repository, 0)
-	query := client.Query(`
-		SELECT
-			ROW_NUMBER() OVER() id, *
-		FROM ` + "`ci_data.ReleaseRepositories`")
+	query := client.Query(`SELECT * FROM (SELECT ROW_NUMBER() OVER() id, * FROM ` + "`ci_data.ReleaseRepositories`) WHERE id > @lastID")
+	query.Parameters = []bigquery.QueryParameter{
+		{
+			Name:  "lastID",
+			Value: dbClient.LastID("repositories"),
+		},
+	}
 	it, err := query.Read(ctx)
 	if err != nil {
 		return err
@@ -124,15 +133,18 @@ func (client *Client) ExportRepositories(ctx context.Context, dbClient *db.DB) e
 		rows = append(rows, row)
 	}
 
-	return dbClient.DB.Clauses(clause.OnConflict{UpdateAll: true}).Create(&rows).Error
+	return dbClient.DB.Clauses(clause.OnConflict{UpdateAll: true}).CreateInBatches(&rows, dbClient.BatchSize).Error
 }
 
 func (client *Client) ExportJobRuns(ctx context.Context, dbClient *db.DB) error {
 	rows := make([]models.JobRun, 0)
-	query := client.Query(`
-		SELECT
-			ROW_NUMBER() OVER() id, *
-		FROM ` + "`ci_data.ReleaseJobRuns`")
+	query := client.Query(`SELECT * FROM (SELECT ROW_NUMBER() OVER() id, * FROM ` + "`ci_data.ReleaseJobRuns`) WHERE id > @lastID")
+	query.Parameters = []bigquery.QueryParameter{
+		{
+			Name:  "lastID",
+			Value: dbClient.LastID("job_runs"),
+		},
+	}
 	it, err := query.Read(ctx)
 	if err != nil {
 		return err
@@ -150,5 +162,5 @@ func (client *Client) ExportJobRuns(ctx context.Context, dbClient *db.DB) error 
 		rows = append(rows, row)
 	}
 
-	return dbClient.DB.Clauses(clause.OnConflict{UpdateAll: true}).Create(&rows).Error
+	return dbClient.DB.Clauses(clause.OnConflict{UpdateAll: true}).CreateInBatches(&rows, dbClient.BatchSize).Error
 }

--- a/pkg/bigqueryexporter/bigquery.go
+++ b/pkg/bigqueryexporter/bigquery.go
@@ -52,7 +52,13 @@ func (client *Client) ExportData(ctx context.Context, dbClient *db.DB) error {
 
 func (client *Client) ExportReleaseTags(ctx context.Context, dbClient *db.DB) error {
 	rows := make([]models.ReleaseTag, 0)
-	query := client.Query(`SELECT * FROM (SELECT ROW_NUMBER() OVER() id, * FROM ` + "`ci_data.ReleaseTags`) WHERE id > @lastID)")
+
+	// Note: BigQuery does not support autoincrementing primary keys, so we use
+	// ROW_NUMBER() OVER(...) -- this produces stable ID's if we do not
+	// remove older records. Currently, we use BQ as append-only and for the
+	// foreseeable future will probably maintain release information
+	// indefinitely (it's not a lot of data).
+	query := client.Query(`SELECT * FROM (SELECT ROW_NUMBER() OVER() id, * FROM ` + "`ci_data.ReleaseTags` ORDER BY releaseTag ASC) WHERE id > @lastID")
 	query.Parameters = []bigquery.QueryParameter{
 		{
 			Name:  "lastID",
@@ -81,7 +87,13 @@ func (client *Client) ExportReleaseTags(ctx context.Context, dbClient *db.DB) er
 
 func (client *Client) ExportPullRequests(ctx context.Context, dbClient *db.DB) error {
 	rows := make([]models.PullRequest, 0)
-	query := client.Query(`SELECT * FROM (SELECT ROW_NUMBER() OVER() id, * FROM ` + "`ci_data.ReleasePullRequests`) WHERE id > @lastID")
+
+	// Note: BigQuery does not support autoincrementing primary keys, so we use
+	// ROW_NUMBER() OVER(...) -- this produces stable ID's if we do not
+	// remove older records. Currently, we use BQ as append-only and for the
+	// foreseeable future will probably maintain release information
+	// indefinitely (it's not a lot of data).
+	query := client.Query(`SELECT * FROM (SELECT ROW_NUMBER() OVER() id, * FROM ` + "`ci_data.ReleasePullRequests` ORDER BY releaseTag ASC) WHERE id > @lastID")
 	query.Parameters = []bigquery.QueryParameter{
 		{
 			Name:  "lastID",
@@ -109,7 +121,13 @@ func (client *Client) ExportPullRequests(ctx context.Context, dbClient *db.DB) e
 
 func (client *Client) ExportRepositories(ctx context.Context, dbClient *db.DB) error {
 	rows := make([]models.Repository, 0)
-	query := client.Query(`SELECT * FROM (SELECT ROW_NUMBER() OVER() id, * FROM ` + "`ci_data.ReleaseRepositories`) WHERE id > @lastID")
+
+	// Note: BigQuery does not support autoincrementing primary keys, so we use
+	// ROW_NUMBER() OVER(...) -- this produces stable ID's if we do not
+	// remove older records. Currently, we use BQ as append-only and for the
+	// foreseeable future will probably maintain release information
+	// indefinitely (it's not a lot of data).
+	query := client.Query(`SELECT * FROM (SELECT ROW_NUMBER() OVER() id, * FROM ` + "`ci_data.ReleaseRepositories` ORDER BY releaseTag ASC) WHERE id > @lastID")
 	query.Parameters = []bigquery.QueryParameter{
 		{
 			Name:  "lastID",
@@ -138,7 +156,13 @@ func (client *Client) ExportRepositories(ctx context.Context, dbClient *db.DB) e
 
 func (client *Client) ExportJobRuns(ctx context.Context, dbClient *db.DB) error {
 	rows := make([]models.JobRun, 0)
-	query := client.Query(`SELECT * FROM (SELECT ROW_NUMBER() OVER() id, * FROM ` + "`ci_data.ReleaseJobRuns`) WHERE id > @lastID")
+
+	// Note: BigQuery does not support autoincrementing primary keys, so we use
+	// ROW_NUMBER() OVER(...) -- this produces stable ID's if we do not
+	// remove older records. Currently, we use BQ as append-only and for the
+	// foreseeable future will probably maintain release information
+	// indefinitely (it's not a lot of data).
+	query := client.Query(`SELECT * FROM (SELECT ROW_NUMBER() OVER() id, * FROM ` + "`ci_data.ReleaseJobRuns` ORDER BY releaseTag ASC) WHERE id > @lastID")
 	query.Parameters = []bigquery.QueryParameter{
 		{
 			Name:  "lastID",

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -5,10 +5,15 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
+	"k8s.io/klog"
 )
 
 type DB struct {
 	DB *gorm.DB
+
+	// BatchSize is used for how many insertions we should do at once. Postgres supports
+	// a maximum of 2^16 records per insert.
+	BatchSize int
 }
 
 func New(dsn string) (*DB, error) {
@@ -36,6 +41,20 @@ func New(dsn string) (*DB, error) {
 	}
 
 	return &DB{
-		DB: db,
+		DB:        db,
+		BatchSize: 1024,
 	}, nil
+}
+
+// LastID returns the last ID (highest) from a table.
+func (db *DB) LastID(table string) int {
+	var lastID int
+	if res := db.DB.Table(table).Order("id desc").Limit(1).Select("id").Scan(&lastID); res.Error != nil {
+		klog.V(1).Infof("error retrieving last id from %q: %s", table, res.Error)
+		lastID = 0
+	} else {
+		klog.V(1).Infof("retrieved last id of %d from %q", lastID, table)
+	}
+
+	return lastID
 }


### PR DESCRIPTION
We're failing to insert job runs because the size of the insert is now
greater than 65,535 (max of int16). This changes the insert to go in
batches.

More importantly, we also only fetch what is exactly needed from
BigQuery.  If our DB is already populated, there's no need to pull
everything from BQ - this gets the highest ID from postgres, and fetches
only the newer records from BQ.

Note: BigQuery does not support autoincrementing primary keys, so we use
`ROW_NUMBER() OVER(...)` -- this produces stable ID's if we do not
remove older records. Currently, we use BQ as append-only and for the
foreseeable future will probably maintain release information
indefinitely (it's not a lot of data).