### PR TITLE
Bump fetchdata memory limit to 3G.

### DIFF
--- a/resources/deploymentconfig.yaml
+++ b/resources/deploymentconfig.yaml
@@ -92,7 +92,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            memory: 500M
+            memory: 3G
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         command:


### PR DESCRIPTION
The new load-database command does the same in-memory computation as the
API server does today, and with a limit of 500M is getting killed before
it can complete. As such our postgres db is likely not being populated
with testgrid data right now. Rest of the script is functioning as
before so no impact to sippy right now.
