### PR TITLE
Sync data to postgres based on timestamps, not artificial ID's

### DIFF
--- a/main.go
+++ b/main.go
@@ -225,17 +225,17 @@ func (o *Options) Run() error {
 		testgridhelpers.DownloadData(dashboards, o.JobFilter, o.FetchData)
 
 		if o.DSN != "" && os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") != "" {
-			bge, err := bigqueryexporter.New(context.Background())
-			if err != nil {
-				return err
-			}
-
 			dbc, err := db.New(o.DSN)
 			if err != nil {
 				return err
 			}
 
-			if err := bge.ExportData(context.Background(), dbc); err != nil {
+			bge, err := bigqueryexporter.New(context.Background(), dbc)
+			if err != nil {
+				return err
+			}
+
+			if err := bge.ExportData(context.Background()); err != nil {
 				return err
 			}
 		}

--- a/pkg/bigqueryexporter/bigquery.go
+++ b/pkg/bigqueryexporter/bigquery.go
@@ -2,6 +2,9 @@ package bigqueryexporter
 
 import (
 	"context"
+	"time"
+
+	"k8s.io/klog"
 
 	"cloud.google.com/go/bigquery"
 	"github.com/openshift/sippy/pkg/db"
@@ -16,53 +19,65 @@ var (
 
 type Client struct {
 	*bigquery.Client
+
+	postgres   *db.DB
+	mostRecent time.Time
 }
 
-func New(ctx context.Context) (*Client, error) {
-	client := &Client{}
+func New(ctx context.Context, postgres *db.DB) (*Client, error) {
+	client := &Client{
+		postgres: postgres,
+	}
+
+	// Fetch most recent release tag stored locally
+	tag := models.ReleaseTag{}
+	postgres.DB.
+		Table("release_tags").
+		Select(`release_tags."releaseTime"`).
+		Order(`release_tags."releaseTime" DESC`).
+		Last(&tag)
+	client.mostRecent = tag.ReleaseTime
+	klog.V(1).Infof("Most recent release tag was from %v", tag.ReleaseTime)
 
 	bqClient, err := bigquery.NewClient(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
 	client.Client = bqClient
-
 	return client, nil
 }
 
-func (client *Client) ExportData(ctx context.Context, dbClient *db.DB) error {
-	if err := client.ExportReleaseTags(ctx, dbClient); err != nil {
+func (client *Client) ExportData(ctx context.Context) error {
+	if err := client.ExportReleaseTags(ctx); err != nil {
 		return err
 	}
 
-	if err := client.ExportPullRequests(ctx, dbClient); err != nil {
+	if err := client.ExportPullRequests(ctx); err != nil {
 		return err
 	}
 
-	if err := client.ExportRepositories(ctx, dbClient); err != nil {
+	if err := client.ExportRepositories(ctx); err != nil {
 		return err
 	}
 
-	if err := client.ExportJobRuns(ctx, dbClient); err != nil { //nolint:if-return
+	if err := client.ExportJobRuns(ctx); err != nil { //nolint:if-return
 		return err
 	}
 
 	return nil
 }
 
-func (client *Client) ExportReleaseTags(ctx context.Context, dbClient *db.DB) error {
+func (client *Client) ExportReleaseTags(ctx context.Context) error {
 	rows := make([]models.ReleaseTag, 0)
 
-	// Note: BigQuery does not support autoincrementing primary keys, so we use
-	// ROW_NUMBER() OVER(...) -- this produces stable ID's if we do not
-	// remove older records. Currently, we use BQ as append-only and for the
-	// foreseeable future will probably maintain release information
-	// indefinitely (it's not a lot of data).
-	query := client.Query(`SELECT * FROM (SELECT ROW_NUMBER() OVER() id, * FROM ` + "`ci_data.ReleaseTags` ORDER BY releaseTag ASC) WHERE id > @lastID")
+	// Note: BigQuery does not support autoincrementing primary keys, so we see
+	// what the newest entry in our postgres db, and look for any release tags
+	// newer than that.
+	query := client.Query(`SELECT * FROM ` + "`ci_data.ReleaseTags`" + `WHERE releaseTime > @releaseTime`)
 	query.Parameters = []bigquery.QueryParameter{
 		{
-			Name:  "lastID",
-			Value: dbClient.LastID("release_tags"),
+			Name:  "releaseTime",
+			Value: client.mostRecent,
 		},
 	}
 	it, err := query.Read(ctx)
@@ -82,22 +97,17 @@ func (client *Client) ExportReleaseTags(ctx context.Context, dbClient *db.DB) er
 		rows = append(rows, row)
 	}
 
-	return dbClient.DB.Clauses(clause.OnConflict{UpdateAll: true}).CreateInBatches(&rows, dbClient.BatchSize).Error
+	return client.postgres.DB.Clauses(clause.OnConflict{UpdateAll: true}).CreateInBatches(&rows, client.postgres.BatchSize).Error
 }
 
-func (client *Client) ExportPullRequests(ctx context.Context, dbClient *db.DB) error {
+func (client *Client) ExportPullRequests(ctx context.Context) error {
 	rows := make([]models.PullRequest, 0)
 
-	// Note: BigQuery does not support autoincrementing primary keys, so we use
-	// ROW_NUMBER() OVER(...) -- this produces stable ID's if we do not
-	// remove older records. Currently, we use BQ as append-only and for the
-	// foreseeable future will probably maintain release information
-	// indefinitely (it's not a lot of data).
-	query := client.Query(`SELECT * FROM (SELECT ROW_NUMBER() OVER() id, * FROM ` + "`ci_data.ReleasePullRequests` ORDER BY releaseTag ASC) WHERE id > @lastID")
+	query := client.Query("SELECT * FROM `ci_data.ReleasePullRequests` AS pullRequests INNER JOIN `ci_data.ReleaseTags` AS releaseTags ON pullRequests.releaseTag = releaseTags.releaseTag WHERE releaseTags.releaseTime > @releaseTime")
 	query.Parameters = []bigquery.QueryParameter{
 		{
-			Name:  "lastID",
-			Value: dbClient.LastID("pull_requests"),
+			Name:  "releaseTime",
+			Value: client.mostRecent,
 		},
 	}
 	it, err := query.Read(ctx)
@@ -116,22 +126,17 @@ func (client *Client) ExportPullRequests(ctx context.Context, dbClient *db.DB) e
 		}
 		rows = append(rows, row)
 	}
-	return dbClient.DB.Clauses(clause.OnConflict{UpdateAll: true}).CreateInBatches(&rows, dbClient.BatchSize).Error
+	return client.postgres.DB.Clauses(clause.OnConflict{UpdateAll: true}).CreateInBatches(&rows, client.postgres.BatchSize).Error
 }
 
-func (client *Client) ExportRepositories(ctx context.Context, dbClient *db.DB) error {
+func (client *Client) ExportRepositories(ctx context.Context) error {
 	rows := make([]models.Repository, 0)
 
-	// Note: BigQuery does not support autoincrementing primary keys, so we use
-	// ROW_NUMBER() OVER(...) -- this produces stable ID's if we do not
-	// remove older records. Currently, we use BQ as append-only and for the
-	// foreseeable future will probably maintain release information
-	// indefinitely (it's not a lot of data).
-	query := client.Query(`SELECT * FROM (SELECT ROW_NUMBER() OVER() id, * FROM ` + "`ci_data.ReleaseRepositories` ORDER BY releaseTag ASC) WHERE id > @lastID")
+	query := client.Query("SELECT * FROM `ci_data.ReleaseRepositories` AS repositories INNER JOIN `ci_data.ReleaseTags` AS releaseTags ON repositories.releaseTag = releaseTags.releaseTag WHERE releaseTags.releaseTime > @releaseTime")
 	query.Parameters = []bigquery.QueryParameter{
 		{
-			Name:  "lastID",
-			Value: dbClient.LastID("repositories"),
+			Name:  "releaseTime",
+			Value: client.mostRecent,
 		},
 	}
 	it, err := query.Read(ctx)
@@ -151,22 +156,17 @@ func (client *Client) ExportRepositories(ctx context.Context, dbClient *db.DB) e
 		rows = append(rows, row)
 	}
 
-	return dbClient.DB.Clauses(clause.OnConflict{UpdateAll: true}).CreateInBatches(&rows, dbClient.BatchSize).Error
+	return client.postgres.DB.Clauses(clause.OnConflict{UpdateAll: true}).CreateInBatches(&rows, client.postgres.BatchSize).Error
 }
 
-func (client *Client) ExportJobRuns(ctx context.Context, dbClient *db.DB) error {
+func (client *Client) ExportJobRuns(ctx context.Context) error {
 	rows := make([]models.JobRun, 0)
 
-	// Note: BigQuery does not support autoincrementing primary keys, so we use
-	// ROW_NUMBER() OVER(...) -- this produces stable ID's if we do not
-	// remove older records. Currently, we use BQ as append-only and for the
-	// foreseeable future will probably maintain release information
-	// indefinitely (it's not a lot of data).
-	query := client.Query(`SELECT * FROM (SELECT ROW_NUMBER() OVER() id, * FROM ` + "`ci_data.ReleaseJobRuns` ORDER BY releaseTag ASC) WHERE id > @lastID")
+	query := client.Query("SELECT * FROM `ci_data.ReleaseJobRuns` AS jobRuns INNER JOIN `ci_data.ReleaseTags` AS releaseTags ON jobRuns.releaseTag = releaseTags.releaseTag WHERE releaseTags.releaseTime > @releaseTime")
 	query.Parameters = []bigquery.QueryParameter{
 		{
-			Name:  "lastID",
-			Value: dbClient.LastID("job_runs"),
+			Name:  "releaseTime",
+			Value: client.mostRecent,
 		},
 	}
 	it, err := query.Read(ctx)
@@ -186,5 +186,5 @@ func (client *Client) ExportJobRuns(ctx context.Context, dbClient *db.DB) error 
 		rows = append(rows, row)
 	}
 
-	return dbClient.DB.Clauses(clause.OnConflict{UpdateAll: true}).CreateInBatches(&rows, dbClient.BatchSize).Error
+	return client.postgres.DB.Clauses(clause.OnConflict{UpdateAll: true}).CreateInBatches(&rows, client.postgres.BatchSize).Error
 }

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -18,7 +18,7 @@ type DB struct {
 
 func New(dsn string) (*DB, error) {
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Info),
+		Logger: logger.Default.LogMode(logger.Warn),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
BigQuery doesn't support auto-incrementing primary keys. I thought that
using ROW_NUMBER OVER() using deterministic ordering would mimic that,
but it appears it's not working reliably.

This changes the fetch from bigquery to be based on the most recent
timestamp of a release tag.

[TRT-78](https://issues.redhat.com/browse/TRT-78)