### PR TITLE
Add Pass Rate By Variant to test analysis page.

### DIFF
--- a/sippy-ng/src/tests/TestAnalysis.test.js
+++ b/sippy-ng/src/tests/TestAnalysis.test.js
@@ -48,7 +48,8 @@ describe('TestAnalysis', () => {
       expectLoadingPage(wrapper).toBeFalsy()
     })
 
-    expect(wrapper.text()).toContain('Pass rate')
+    expect(wrapper.text()).toContain('Pass Rate By Job')
+    expect(wrapper.text()).toContain('Pass Rate By Variant')
     expect(wrapper.exists()).toBe(true)
     expect(withoutMuiID(wrapper)).toMatchSnapshot()
     expect(fetchSpy).toHaveBeenCalledTimes(3)


### PR DESCRIPTION
This will allow us to see trends by variant instead of just by job
previously.
