### PR TITLE
Fix filtering for tests with trailing whitespace.

### DIFF
--- a/pkg/api/filterable.go
+++ b/pkg/api/filterable.go
@@ -307,7 +307,8 @@ func filterString(filter FilterItem, item Filterable) (bool, error) {
 	case OperatorContains:
 		return strings.Contains(value, comparison), nil
 	case OperatorEquals:
-		return value == comparison, nil
+		// We've seen tests sneak in with trailing whitespace, handle this for equals comparisons:
+		return strings.TrimSpace(value) == comparison, nil
 	case OperatorStartsWith:
 		return strings.HasPrefix(value, comparison), nil
 	case OperatorEndsWith:


### PR DESCRIPTION
Some have snuck into origin, the whitespace is filtered out when we
build our filter string in the UI, resulting in no response when trying
to load the test details/analysis page in the UI.

Fix by trimming the test names in memory. Will go fix in master for
origin test names as well.
