### PR TITLE
Fix upstream kube job processing.

### DIFF
--- a/pkg/testgridanalysis/testreportconversion/jobresult.go
+++ b/pkg/testgridanalysis/testreportconversion/jobresult.go
@@ -199,7 +199,8 @@ func convertRawJobResultToProcessedJobResult(
 	// we should make it clear this is an invalid value.
 	// TODO wire a warning. This is strictly better than nothing at the moment though.
 	if job.InfrastructureFailures > job.Failures {
-		klog.V(1).Infof("WARNING: detected more infra failures than failures which should not be possible, for job: %s", job.Name)
+		klog.V(1).Infof("WARNING: detected more infra failures (%d) than failures (%d) which should not be possible, for job: %s",
+			job.InfrastructureFailures, job.Failures, job.Name)
 		job.PassPercentageWithoutInfrastructureFailures = -1
 	}
 
@@ -211,7 +212,7 @@ func convertRawToJobRunResult(jrr testgridanalysisapi.RawJobRunResult, testResul
 	prowID, _ := strconv.ParseUint(tokens[len(tokens)-1], 10, 64)
 	knownFailure := jrr.Failed && areAllFailuresKnown(jrr, testResults)
 
-	// success - we saw the install/infra test result, it succeeded (or the whole job succeeeded)
+	// success - we saw the install/infra test result, it succeeded (or the whole job succeeded)
 	// failure - we saw the test result, it failed
 	// unknown - we know this job doesn't have an install test, and the job didn't succeed, so we don't know if it
 	//           failed due to infra issues or not.  probably not infra.


### PR DESCRIPTION
We updated for testgrid change in Oct from displaying "Overall" to what
we thought was "jobname.Overall". This is generally consistent but it
turns out prow jobs can specify a testgrid-tab-name annotation, which
changes the test name to that value.Overall, causing sippy to think it
has mass infrastructure failures.

Fix by just looking for suffix ".Overall", this looks consistent across
all our tests.
