### PR TITLE
Port /api/health to db.

### DIFF
--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -1,20 +1,46 @@
 package api
 
 import (
+	"math"
 	"net/http"
+	"strings"
 	"time"
 
+	"github.com/montanaflynn/stats"
+	apitype "github.com/openshift/sippy/pkg/apis/api"
 	sippyv1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/query"
+	"github.com/openshift/sippy/pkg/filter"
+	"github.com/openshift/sippy/pkg/testgridanalysis/testgridanalysisapi"
+	"github.com/openshift/sippy/pkg/testgridanalysis/testreportconversion"
+	"k8s.io/klog"
 )
+
+type indicator struct {
+	Current  sippyv1.PassRate `json:"current"`
+	Previous sippyv1.PassRate `json:"previous"`
+}
+
+type variants struct {
+	Current  sippyprocessingv1.VariantHealth `json:"current"`
+	Previous sippyprocessingv1.VariantHealth `json:"previous"`
+}
+
+type health struct {
+	Indicators  map[string]indicator         `json:"indicators"`
+	Variants    variants                     `json:"variants"`
+	LastUpdated time.Time                    `json:"last_updated"`
+	Promotions  map[string]time.Time         `json:"promotions"`
+	Warnings    []string                     `json:"warnings"`
+	Current     sippyprocessingv1.Statistics `json:"current_statistics"`
+	Previous    sippyprocessingv1.Statistics `json:"previous_statistics"`
+}
 
 // PrintOverallReleaseHealth gives a summarized status of the overall health, including
 // infrastructure, install, upgrade, and variant success rates.
 func PrintOverallReleaseHealth(w http.ResponseWriter, curr, twoDay, prev sippyprocessingv1.TestReport) {
-	type indicator struct {
-		Current  sippyv1.PassRate `json:"current"`
-		Previous sippyv1.PassRate `json:"previous"`
-	}
 	indicators := make(map[string]indicator)
 
 	// Infrastructure
@@ -105,22 +131,6 @@ func PrintOverallReleaseHealth(w http.ResponseWriter, curr, twoDay, prev sippypr
 		Previous: previousPassRate,
 	}
 
-	type variants struct {
-		Current  sippyprocessingv1.VariantHealth `json:"current"`
-		Previous sippyprocessingv1.VariantHealth `json:"previous"`
-	}
-
-	type health struct {
-		Indicators  map[string]indicator         `json:"indicators"`
-		Variants    variants                     `json:"variants"`
-		LastUpdated time.Time                    `json:"last_updated"`
-		Promotions  map[string]time.Time         `json:"promotions"`
-		Warnings    []string                     `json:"warnings"`
-		Current     sippyprocessingv1.Statistics `json:"current_statistics"`
-		TwoDay      sippyprocessingv1.Statistics `json:"two_day_statistics"`
-		Previous    sippyprocessingv1.Statistics `json:"previous_statistics"`
-	}
-
 	RespondWithJSON(http.StatusOK, w, health{
 		Indicators:  indicators,
 		LastUpdated: curr.Timestamp,
@@ -129,8 +139,184 @@ func PrintOverallReleaseHealth(w http.ResponseWriter, curr, twoDay, prev sippypr
 			Previous: prev.TopLevelIndicators.Variant,
 		},
 		Current:  curr.JobStatistics,
-		TwoDay:   twoDay.JobStatistics,
 		Previous: prev.JobStatistics,
 		Warnings: append(curr.AnalysisWarnings, prev.AnalysisWarnings...),
 	})
+}
+
+// PrintOverallReleaseHealthFromDB gives a summarized status of the overall health, including
+// infrastructure, install, upgrade, and variant success rates.
+func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release string) {
+	indicators := make(map[string]indicator)
+
+	// Infrastructure
+	infraTestName := strings.TrimPrefix(testgridanalysisapi.InfrastructureTestName,
+		testgridanalysisapi.SippySuiteName+".")
+	infraIndicator, err := getIndicatorForTest(dbc, release, infraTestName)
+	if err != nil {
+		klog.Errorf("error querying test report: %s", err)
+		return
+	}
+	indicators["infrastructure"] = infraIndicator
+
+	// Install
+	installTestName := strings.TrimPrefix(testgridanalysisapi.InstallTestName,
+		testgridanalysisapi.SippySuiteName+".")
+	installIndicator, err := getIndicatorForTest(dbc, release, installTestName)
+	if err != nil {
+		klog.Errorf("error querying test report: %s", err)
+		return
+	}
+	indicators["install"] = installIndicator
+
+	// Upgrade
+	upgradeTestName := strings.TrimPrefix(testgridanalysisapi.UpgradeTestName,
+		testgridanalysisapi.SippySuiteName+".")
+	upgradeIndicator, err := getIndicatorForTest(dbc, release, upgradeTestName)
+	if err != nil {
+		klog.Errorf("error querying test report: %s", err)
+		return
+	}
+	indicators["upgrade"] = upgradeIndicator
+
+	// Tests
+	// NOTE: this is not actually representing the percentage of tests that passed, it's representing
+	// the percentage of time that all tests passed. We should probably fix that.
+	testsTestName := strings.TrimPrefix(testgridanalysisapi.OpenShiftTestsName,
+		testgridanalysisapi.SippySuiteName+".")
+	testsIndicator, err := getIndicatorForTest(dbc, release, testsTestName)
+	if err != nil {
+		klog.Errorf("error querying test report: %s", err)
+		return
+	}
+	indicators["tests"] = testsIndicator
+
+	var lastUpdated time.Time
+	r := dbc.DB.Raw("SELECT MAX(created_at) FROM prow_job_runs").Scan(&lastUpdated)
+	if r.Error != nil {
+		klog.Errorf("error querying last update time: %s", r.Error)
+		return
+	}
+	klog.Infof("ran the last update query: %s", lastUpdated)
+
+	// Load all the job reports for this release to calculate statistics:
+	filterOpts := &filter.FilterOptions{
+		Filter:    &filter.Filter{},
+		SortField: "current_pass_percentage",
+		Sort:      apitype.SortDescending,
+		Limit:     0,
+	}
+	start := time.Now().Add(-14 * 24 * time.Hour)
+	boundary := time.Now().Add(-7 * 24 * time.Hour)
+	end := time.Now()
+	jobReports, err := query.JobReports(dbc, filterOpts, release, start, boundary, end)
+	if err != nil {
+		klog.Errorf("error querying job reports: %s", err)
+		return
+	}
+	currStats, prevStats := calculateJobResultStatistics(jobReports)
+
+	RespondWithJSON(http.StatusOK, w, health{
+		Indicators:  indicators,
+		LastUpdated: lastUpdated,
+		Current:     currStats,
+		Previous:    prevStats,
+		/*
+				// NOTE: looks unused in ReleaseOverview and of questionable use in general. This field would show
+				// the number of variants whose jobs fully pass over 80% of the time, 60% of the time, or less than that.
+				// skipping for now.
+					Variants: variants{
+						Current:  curr.TopLevelIndicators.Variant,
+						Previous: prev.TopLevelIndicators.Variant,
+					},
+
+			    // TODO: do we have need of these anymore with the new installer tests coming from junit?
+					Warnings: append(curr.AnalysisWarnings, prev.AnalysisWarnings...),
+		*/
+	})
+}
+
+func getIndicatorForTest(dbc *db.DB, release, testName string) (indicator, error) {
+	testReport, err := query.TestReportExcludeVariants(dbc, release, testName, []string{"never-stable", "techpreview"})
+	if err != nil {
+		klog.Errorf("error querying test report: %s", err)
+		return indicator{}, err
+	}
+	currentPassRate := sippyv1.PassRate{
+		Percentage: testReport[0].CurrentPassPercentage,
+		Runs:       testReport[0].CurrentRuns,
+	}
+	previousPassRate := sippyv1.PassRate{
+		Percentage: testReport[0].PreviousPassPercentage,
+		Runs:       testReport[0].PreviousRuns,
+	}
+	return indicator{
+		Current:  currentPassRate,
+		Previous: previousPassRate,
+	}, nil
+}
+
+func calculateJobResultStatistics(results []apitype.Job) (currStats, prevStats sippyprocessingv1.Statistics) {
+	currPercentages := []float64{}
+	prevPercentages := []float64{}
+	currStats.Histogram = make([]int, 10)
+	prevStats.Histogram = make([]int, 10)
+
+	/* I don't think this is necessary...
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].CurrentPassPercentage > results[j].CurrentPassPercentage
+	})
+	*/
+
+	for _, result := range results {
+		if testreportconversion.IsNeverStableOrTechPreview(result.Variants) {
+			continue
+		}
+
+		index := int(math.Floor(result.CurrentPassPercentage / 10))
+		if index == 10 { // 100% gets bucketed in the 10th bucket
+			index = 9
+		}
+		currStats.Histogram[index]++
+		currPercentages = append(currPercentages, result.CurrentPassPercentage)
+
+		index = int(math.Floor(result.PreviousPassPercentage / 10))
+		if index == 10 { // 100% gets bucketed in the 10th bucket
+			index = 9
+		}
+		prevStats.Histogram[index]++
+		prevPercentages = append(prevPercentages, result.PreviousPassPercentage)
+	}
+
+	data := stats.LoadRawData(currPercentages)
+	mean, _ := stats.Mean(data)
+	sd, _ := stats.StandardDeviation(data)
+	quartiles, _ := stats.Quartile(data)
+	p95, _ := stats.Percentile(data, 95)
+
+	currStats.Mean = mean
+	currStats.StandardDeviation = sd
+	currStats.Quartiles = []float64{
+		testreportconversion.ConvertNaNToZero(quartiles.Q1),
+		testreportconversion.ConvertNaNToZero(quartiles.Q2),
+		testreportconversion.ConvertNaNToZero(quartiles.Q3),
+	}
+	currStats.P95 = p95
+
+	data = stats.LoadRawData(prevPercentages)
+	mean, _ = stats.Mean(data)
+	sd, _ = stats.StandardDeviation(data)
+	quartiles, _ = stats.Quartile(data)
+	p95, _ = stats.Percentile(data, 95)
+
+	prevStats.Mean = mean
+	prevStats.StandardDeviation = sd
+	prevStats.Quartiles = []float64{
+		testreportconversion.ConvertNaNToZero(quartiles.Q1),
+		testreportconversion.ConvertNaNToZero(quartiles.Q2),
+		testreportconversion.ConvertNaNToZero(quartiles.Q3),
+	}
+	prevStats.P95 = p95
+
+	return currStats, prevStats
 }

--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -262,12 +262,6 @@ func calculateJobResultStatistics(results []apitype.Job) (currStats, prevStats s
 	currStats.Histogram = make([]int, 10)
 	prevStats.Histogram = make([]int, 10)
 
-	/* I don't think this is necessary...
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].CurrentPassPercentage > results[j].CurrentPassPercentage
-	})
-	*/
-
 	for _, result := range results {
 		if testreportconversion.IsNeverStableOrTechPreview(result.Variants) {
 			continue

--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -242,6 +242,12 @@ func getIndicatorForTest(dbc *db.DB, release, testName string) (indicator, error
 		klog.Errorf("error querying test report: %s", err)
 		return indicator{}, err
 	}
+
+	// Can happen if the materialized views have not been refreshed yet.
+	if len(testReport) == 0 {
+		return indicator{}, nil
+	}
+
 	currentPassRate := sippyv1.PassRate{
 		Percentage: testReport[0].CurrentPassPercentage,
 		Runs:       testReport[0].CurrentRuns,

--- a/pkg/api/job_analysis.go
+++ b/pkg/api/job_analysis.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift/sippy/pkg/db"
 
 	v1sippyprocessing "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
-	filter2 "github.com/openshift/sippy/pkg/filter"
+	"github.com/openshift/sippy/pkg/filter"
 	"github.com/openshift/sippy/pkg/util"
 )
 
@@ -29,12 +29,12 @@ type apiJobAnalysisResult struct {
 }
 
 func PrintJobAnalysisJSON(w http.ResponseWriter, req *http.Request, curr, prev v1sippyprocessing.TestReport) {
-	var filter *filter2.Filter
+	var fil *filter.Filter
 
 	queryFilter := req.URL.Query().Get("filter")
 	if queryFilter != "" {
-		filter = &filter2.Filter{}
-		if err := json.Unmarshal([]byte(queryFilter), filter); err != nil {
+		fil = &filter.Filter{}
+		if err := json.Unmarshal([]byte(queryFilter), fil); err != nil {
 			RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": "Could not marshal query:" + err.Error()})
 			return
 		}
@@ -53,29 +53,29 @@ func PrintJobAnalysisJSON(w http.ResponseWriter, req *http.Request, curr, prev v
 	}
 
 	allJobs := append(curr.ByJob, prev.ByJob...)
-	var timestampFilter *filter2.Filter
+	var timestampFilter *filter.Filter
 	for index, job := range allJobs {
 		prevJob := util.FindJobResultForJobName(job.Name, prev.ByJob)
-		if filter != nil {
-			newItems := make([]filter2.FilterItem, 0)
-			timestampItems := make([]filter2.FilterItem, 0)
-			for _, item := range filter.Items {
+		if fil != nil {
+			newItems := make([]filter.FilterItem, 0)
+			timestampItems := make([]filter.FilterItem, 0)
+			for _, item := range fil.Items {
 				if item.Field != "timestamp" {
 					newItems = append(newItems, item)
 				} else {
 					timestampItems = append(timestampItems, item)
 				}
-				filter.Items = newItems
+				fil.Items = newItems
 
 				if len(timestampItems) > 0 {
-					timestampFilter = &filter2.Filter{
+					timestampFilter = &filter.Filter{
 						Items:        timestampItems,
-						LinkOperator: filter.LinkOperator,
+						LinkOperator: fil.LinkOperator,
 					}
 				}
 			}
 
-			include, err := filter.Filter(jobResultToAPI(index, &allJobs[index], prevJob))
+			include, err := fil.Filter(jobResultToAPI(index, &allJobs[index], prevJob))
 			if err != nil {
 				RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": "Filter error:" + err.Error()})
 				return
@@ -142,7 +142,7 @@ func PrintJobAnalysisJSON(w http.ResponseWriter, req *http.Request, curr, prev v
 }
 
 func PrintJobAnalysisJSONFromDB(w http.ResponseWriter, req *http.Request, dbc *db.DB, release string) {
-	filter, err := filter2.ExtractFilters(req)
+	fil, err := filter.ExtractFilters(req)
 	if err != nil {
 		RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": "Could not marshal query:" + err.Error()})
 		return
@@ -150,14 +150,14 @@ func PrintJobAnalysisJSONFromDB(w http.ResponseWriter, req *http.Request, dbc *d
 
 	// This API is a bit special, since we are largely interested in filtering the jobs list,
 	// but there's a case for filtering by the time stamp on a job run.
-	jobRunsFilter := &filter2.Filter{
-		LinkOperator: filter.LinkOperator,
+	jobRunsFilter := &filter.Filter{
+		LinkOperator: fil.LinkOperator,
 	}
-	jobFilter := &filter2.Filter{
-		LinkOperator: filter.LinkOperator,
+	jobFilter := &filter.Filter{
+		LinkOperator: fil.LinkOperator,
 	}
 
-	for _, f := range filter.Items {
+	for _, f := range fil.Items {
 		if f.Field == "timestamp" {
 			ms, err := strconv.ParseInt(f.Value, 0, 64)
 			if err != nil {
@@ -183,7 +183,7 @@ func PrintJobAnalysisJSONFromDB(w http.ResponseWriter, req *http.Request, dbc *d
 		return
 	}
 
-	q, err := filter2.ApplyFilters(req, jobFilter, "name", table, apitype.Job{})
+	q, err := filter.ApplyFilters(req, jobFilter, "name", table, apitype.Job{})
 	if err != nil {
 		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": "Error building job run report:" + err.Error()})
 		return

--- a/pkg/api/job_analysis.go
+++ b/pkg/api/job_analysis.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	v1sippyprocessing "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+	filter2 "github.com/openshift/sippy/pkg/filter"
 	"github.com/openshift/sippy/pkg/util"
 )
 
@@ -20,11 +21,11 @@ type apiJobAnalysisResult struct {
 }
 
 func PrintJobAnalysisJSON(w http.ResponseWriter, req *http.Request, curr, prev v1sippyprocessing.TestReport) {
-	var filter *Filter
+	var filter *filter2.Filter
 
 	queryFilter := req.URL.Query().Get("filter")
 	if queryFilter != "" {
-		filter = &Filter{}
+		filter = &filter2.Filter{}
 		if err := json.Unmarshal([]byte(queryFilter), filter); err != nil {
 			RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": "Could not marshal query:" + err.Error()})
 			return
@@ -41,12 +42,12 @@ func PrintJobAnalysisJSON(w http.ResponseWriter, req *http.Request, curr, prev v
 	}
 
 	allJobs := append(curr.ByJob, prev.ByJob...)
-	var timestampFilter *Filter
+	var timestampFilter *filter2.Filter
 	for index, job := range allJobs {
 		prevJob := util.FindJobResultForJobName(job.Name, prev.ByJob)
 		if filter != nil {
-			newItems := make([]FilterItem, 0)
-			timestampItems := make([]FilterItem, 0)
+			newItems := make([]filter2.FilterItem, 0)
+			timestampItems := make([]filter2.FilterItem, 0)
 			for _, item := range filter.Items {
 				if item.Field != "timestamp" {
 					newItems = append(newItems, item)
@@ -56,7 +57,7 @@ func PrintJobAnalysisJSON(w http.ResponseWriter, req *http.Request, curr, prev v
 				filter.Items = newItems
 
 				if len(timestampItems) > 0 {
-					timestampFilter = &Filter{
+					timestampFilter = &filter2.Filter{
 						Items:        timestampItems,
 						LinkOperator: filter.LinkOperator,
 					}

--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	v1 "github.com/openshift/sippy/pkg/apis/bugs/v1"
-	filter2 "github.com/openshift/sippy/pkg/filter"
+	"github.com/openshift/sippy/pkg/filter"
 	"k8s.io/klog"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
@@ -55,9 +55,9 @@ func (tests testsAPIResult) sort(req *http.Request) testsAPIResult {
 
 	gosort.Slice(tests, func(i, j int) bool {
 		if sort == "asc" {
-			return filter2.Compare(tests[i], tests[j], sortField)
+			return filter.Compare(tests[i], tests[j], sortField)
 		}
-		return filter2.Compare(tests[j], tests[i], sortField)
+		return filter.Compare(tests[j], tests[i], sortField)
 	})
 
 	return tests
@@ -75,12 +75,12 @@ func (tests testsAPIResult) limit(req *http.Request) testsAPIResult {
 // PrintTestsJSON renders the list of matching tests.
 func PrintTestsJSON(release string, w http.ResponseWriter, req *http.Request, currentPeriod, twoDayPeriod, previousPeriod []v1sippyprocessing.FailingTestResult) {
 	tests := testsAPIResult{}
-	var filter *filter2.Filter
+	var fil *filter.Filter
 
 	queryFilter := req.URL.Query().Get("filter")
 	if queryFilter != "" {
-		filter = &filter2.Filter{}
-		if err := json.Unmarshal([]byte(queryFilter), filter); err != nil {
+		fil = &filter.Filter{}
+		if err := json.Unmarshal([]byte(queryFilter), fil); err != nil {
 			RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": "Could not marshal query:" + err.Error()})
 			return
 		}
@@ -141,8 +141,8 @@ func PrintTestsJSON(release string, w http.ResponseWriter, req *http.Request, cu
 			row.Tags = append(row.Tags, "upgrade")
 		}
 
-		if filter != nil {
-			include, err := filter.Filter(row)
+		if fil != nil {
+			include, err := fil.Filter(row)
 			if err != nil {
 				RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": "Filter error:" + err.Error()})
 				return
@@ -162,12 +162,12 @@ func PrintTestsJSON(release string, w http.ResponseWriter, req *http.Request, cu
 }
 
 func PrintTestsJSONFromDB(release string, w http.ResponseWriter, req *http.Request, dbc *db.DB) {
-	var filter *filter2.Filter
+	var fil *filter.Filter
 
 	queryFilter := req.URL.Query().Get("filter")
 	if queryFilter != "" {
-		filter = &filter2.Filter{}
-		if err := json.Unmarshal([]byte(queryFilter), filter); err != nil {
+		fil = &filter.Filter{}
+		if err := json.Unmarshal([]byte(queryFilter), fil); err != nil {
 			RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": "Could not marshal query:" + err.Error()})
 			return
 		}
@@ -181,7 +181,7 @@ func PrintTestsJSONFromDB(release string, w http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	testsResult, err := BuildTestsResults(dbc, release, period, filter)
+	testsResult, err := BuildTestsResults(dbc, release, period, fil)
 	if err != nil {
 		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": "Error building job report:" + err.Error()})
 		return
@@ -192,7 +192,7 @@ func PrintTestsJSONFromDB(release string, w http.ResponseWriter, req *http.Reque
 		limit(req))
 }
 
-func BuildTestsResults(dbc *db.DB, release, period string, filter *filter2.Filter) (testsAPIResult, error) {
+func BuildTestsResults(dbc *db.DB, release, period string, fil *filter.Filter) (testsAPIResult, error) {
 	now := time.Now()
 
 	var testReports []apitype.Test
@@ -235,8 +235,8 @@ FROM results;
 	filteredReports := make([]apitype.Test, 0, len(testReports))
 	fakeIDCtr := 1
 	for _, testReport := range testReports {
-		if filter != nil {
-			include, err := filter.Filter(testReport)
+		if fil != nil {
+			include, err := fil.Filter(testReport)
 			if err != nil {
 				return []apitype.Test{}, err
 			}

--- a/pkg/db/query/job_queries.go
+++ b/pkg/db/query/job_queries.go
@@ -1,0 +1,44 @@
+package query
+
+import (
+	"time"
+
+	apitype "github.com/openshift/sippy/pkg/apis/api"
+	bugsv1 "github.com/openshift/sippy/pkg/apis/bugs/v1"
+	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/filter"
+	"k8s.io/klog"
+)
+
+func JobReports(dbc *db.DB, filterOpts *filter.FilterOptions, release string, start, boundary, end time.Time) ([]apitype.Job, error) {
+	now := time.Now()
+	jobReports := make([]apitype.Job, 0)
+
+	table := dbc.DB.Table("job_results(?, ?, ?, ?)", release, start, boundary, end)
+	if table.Error != nil {
+		return jobReports, table.Error
+	}
+
+	q, err := filter.FilterableDBResult(table, filterOpts, apitype.Job{})
+	if err != nil {
+		return jobReports, err
+	}
+
+	q.Scan(&jobReports)
+	elapsed := time.Since(now)
+	klog.Infof("BuildJobResult completed in %s with %d results from db", elapsed, len(jobReports))
+
+	// FIXME(stbenjam): There's a UI bug where the jobs page won't load if either bugs filled is "null"
+	// instead of empty array. Quick hack to make this work.
+	for i, j := range jobReports {
+		if len(j.Bugs) == 0 {
+			jobReports[i].Bugs = make([]bugsv1.Bug, 0)
+		}
+
+		if len(j.AssociatedBugs) == 0 {
+			jobReports[i].AssociatedBugs = make([]bugsv1.Bug, 0)
+		}
+	}
+
+	return jobReports, nil
+}

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -1,0 +1,117 @@
+package query
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openshift/sippy/pkg/apis/api"
+	"github.com/openshift/sippy/pkg/db"
+	"k8s.io/klog"
+)
+
+// TestReportsByVariant returns a test report for every test in the db matching the given substrings, separated by variant.
+func TestReportsByVariant(
+	dbc *db.DB,
+	release string,
+	testSubStrings []string,
+) ([]api.Test, error) {
+	now := time.Now()
+
+	testSubstringFilter := strings.Join(testSubStrings, "|")
+
+	// Query and group by variant:
+	var testReports []api.Test
+	q := `
+WITH results AS (
+    SELECT name,
+           release,
+           sum(current_runs)       AS current_runs,
+           sum(current_successes)  AS current_successes,
+           sum(current_failures)   AS current_failures,
+           sum(current_flakes)     AS current_flakes,
+           sum(previous_runs)      AS previous_runs,
+           sum(previous_successes) AS previous_successes,
+           sum(previous_failures)  AS previous_failures,
+           sum(previous_flakes)    AS previous_flakes,
+           unnest(variants)        AS variant
+    FROM prow_test_report_7d_matview
+	WHERE release = @release AND name ~* @testsubstrings
+    GROUP BY name, release, variant
+)
+SELECT *,
+       current_successes * 100.0 / NULLIF(current_runs, 0) AS current_pass_percentage,
+       current_failures * 100.0 / NULLIF(current_runs, 0) AS current_failure_percentage,
+       previous_successes * 100.0 / NULLIF(previous_runs, 0) AS previous_pass_percentage,
+       previous_failures * 100.0 / NULLIF(previous_runs, 0) AS previous_failure_percentage,
+       (current_successes * 100.0 / NULLIF(current_runs, 0)) - (previous_successes * 100.0 / NULLIF(previous_runs, 0)) AS net_improvement
+FROM results;
+`
+	r := dbc.DB.Raw(q,
+		sql.Named("release", release),
+		sql.Named("testsubstrings", testSubstringFilter)).Scan(&testReports)
+	if r.Error != nil {
+		klog.Error(r.Error)
+		return testReports, r.Error
+	}
+
+	elapsed := time.Since(now)
+	klog.Infof("TestReportsByVariant completed in %s with %d results from db", elapsed, len(testReports))
+	return testReports, nil
+}
+
+// TestReportExcludeVariants returns a single test report the given test name in the db,
+// all variants collapsed, optionally with some excluded.
+func TestReportExcludeVariants(
+	dbc *db.DB,
+	release string,
+	testName string,
+	excludeVariants []string,
+) ([]api.Test, error) {
+	now := time.Now()
+
+	excludeVariantsQuery := ""
+	for _, ev := range excludeVariants {
+		excludeVariantsQuery += fmt.Sprintf(" AND NOT ('%s'=any(variants))", ev)
+	}
+
+	// Query and group by variant:
+	var testReports []api.Test
+	q := `
+WITH results AS (
+    SELECT name,
+           release,
+           sum(current_runs)       AS current_runs,
+           sum(current_successes)  AS current_successes,
+           sum(current_failures)   AS current_failures,
+           sum(current_flakes)     AS current_flakes,
+           sum(previous_runs)      AS previous_runs,
+           sum(previous_successes) AS previous_successes,
+           sum(previous_failures)  AS previous_failures,
+           sum(previous_flakes)    AS previous_flakes
+    FROM prow_test_report_7d_matview
+    WHERE release = @release AND name = @testname %s
+    GROUP BY name, release
+)
+SELECT *,
+       current_successes * 100.0 / NULLIF(current_runs, 0) AS current_pass_percentage,
+       current_failures * 100.0 / NULLIF(current_runs, 0) AS current_failure_percentage,
+       previous_successes * 100.0 / NULLIF(previous_runs, 0) AS previous_pass_percentage,
+       previous_failures * 100.0 / NULLIF(previous_runs, 0) AS previous_failure_percentage,
+       (current_successes * 100.0 / NULLIF(current_runs, 0)) - (previous_successes * 100.0 / NULLIF(previous_runs, 0)) AS net_improvement
+FROM results;
+`
+	q = fmt.Sprintf(q, excludeVariantsQuery)
+	r := dbc.DB.Raw(q,
+		sql.Named("release", release),
+		sql.Named("testname", testName)).Scan(&testReports)
+	if r.Error != nil {
+		klog.Error(r.Error)
+		return testReports, r.Error
+	}
+
+	elapsed := time.Since(now)
+	klog.Infof("TestReportExcludeVariants completed in %s with %d results from db", elapsed, len(testReports))
+	return testReports, nil
+}

--- a/pkg/filter/filterable.go
+++ b/pkg/filter/filterable.go
@@ -304,9 +304,9 @@ func ApplyFilters(req *http.Request, filter *Filter, defaultSortField string, db
 		sortField = defaultSortField
 	}
 	if sort == "" {
-		sort = "desc"
+		sort = apitype.SortDescending
 	}
-	q.Order(clause.OrderByColumn{Column: clause.Column{Name: sortField}, Desc: sort == "desc"})
+	q.Order(clause.OrderByColumn{Column: clause.Column{Name: sortField}, Desc: sort == apitype.SortDescending})
 
 	return q, nil
 }
@@ -317,7 +317,7 @@ func FilterableDBResult(dbClient *gorm.DB, filterOpts *FilterOptions, filterable
 		q = q.Limit(filterOpts.Limit)
 	}
 
-	q.Order(clause.OrderByColumn{Column: clause.Column{Name: filterOpts.SortField}, Desc: filterOpts.Sort == "desc"})
+	q.Order(clause.OrderByColumn{Column: clause.Column{Name: filterOpts.SortField}, Desc: filterOpts.Sort == apitype.SortDescending})
 
 	return q, nil
 }

--- a/pkg/filter/filterable_test.go
+++ b/pkg/filter/filterable_test.go
@@ -1,4 +1,4 @@
-package api
+package filter
 
 import (
 	"testing"

--- a/pkg/html/installhtml/install_by_operators.go
+++ b/pkg/html/installhtml/install_by_operators.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/testgridanalysis/testidentification"
 	"github.com/openshift/sippy/pkg/util"
 	"github.com/openshift/sippy/pkg/util/sets"
@@ -64,7 +65,7 @@ func InstallOperatorTestsFromDB(dbc *db.DB, release string) (string, error) {
 		"install should work",                     // TODO: would prefer exact matching on the full InstallTestName const
 	}
 
-	testReports, err := queryTestReports(dbc, release, testSubstrings)
+	testReports, err := query.TestReportsByVariant(dbc, release, testSubstrings)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/html/installhtml/util.go
+++ b/pkg/html/installhtml/util.go
@@ -1,16 +1,12 @@
 package installhtml
 
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
-	"strings"
-	"time"
 
 	api "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/db"
-	"k8s.io/klog"
-
+	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/testgridanalysis/testidentification"
 
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
@@ -151,7 +147,7 @@ func getDataForTestsByVariantFromDB(dbc *db.DB, release string, testSubStrings [
 		aggregationToOverallTestResult: map[string]*currPrevTestResult{}, // may not be used in output in our first use case
 	}
 
-	testReports, err := queryTestReports(dbc, release, testSubStrings)
+	testReports, err := query.TestReportsByVariant(dbc, release, testSubStrings)
 	if err != nil {
 		return ret, err
 	}
@@ -190,56 +186,6 @@ func getDataForTestsByVariantFromDB(dbc *db.DB, release string, testSubStrings [
 	}
 
 	return ret, nil
-}
-
-// queryTestReports returns a test report for every test in the db matching the given substrings.
-func queryTestReports(
-	dbc *db.DB,
-	release string,
-	testSubStrings []string,
-) ([]api.Test, error) {
-	now := time.Now()
-
-	testSubstringFilter := strings.Join(testSubStrings, "|")
-
-	// Query and group by variant:
-	var testReports []api.Test
-	q := `
-WITH results AS (
-    SELECT name,
-           release,
-           sum(current_runs)       AS current_runs,
-           sum(current_successes)  AS current_successes,
-           sum(current_failures)   AS current_failures,
-           sum(current_flakes)     AS current_flakes,
-           sum(previous_runs)      AS previous_runs,
-           sum(previous_successes) AS previous_successes,
-           sum(previous_failures)  AS previous_failures,
-           sum(previous_flakes)    AS previous_flakes,
-           unnest(variants)        AS variant
-    FROM prow_test_report_7d_matview
-	WHERE release = @release AND name ~* @testsubstrings
-    GROUP BY name, release, variant
-)
-SELECT *,
-       current_successes * 100.0 / NULLIF(current_runs, 0) AS current_pass_percentage,
-       current_failures * 100.0 / NULLIF(current_runs, 0) AS current_failure_percentage,
-       previous_successes * 100.0 / NULLIF(previous_runs, 0) AS previous_pass_percentage,
-       previous_failures * 100.0 / NULLIF(previous_runs, 0) AS previous_failure_percentage,
-       (current_successes * 100.0 / NULLIF(current_runs, 0)) - (previous_successes * 100.0 / NULLIF(previous_runs, 0)) AS net_improvement
-FROM results;
-`
-	r := dbc.DB.Raw(q,
-		sql.Named("release", release),
-		sql.Named("testsubstrings", testSubstringFilter)).Scan(&testReports)
-	if r.Error != nil {
-		klog.Error(r.Error)
-		return testReports, r.Error
-	}
-
-	elapsed := time.Since(now)
-	klog.Infof("BuildTestsResult completed in %s with %d results from db", elapsed, len(testReports))
-	return testReports, nil
 }
 
 //nolint:goconst

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -549,6 +549,13 @@ func (s *Server) jsonHealthReport(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
+func (s *Server) jsonHealthReportFromDB(w http.ResponseWriter, req *http.Request) {
+	release := s.getReleaseOrFail(w, req)
+	if release != "" {
+		api.PrintOverallReleaseHealthFromDB(w, s.db, release)
+	}
+}
+
 func (s *Server) variantsReport(w http.ResponseWriter, req *http.Request) (*sippyprocessingv1.VariantResults, *sippyprocessingv1.VariantResults) {
 	release := req.URL.Query().Get("release")
 	variant := req.URL.Query().Get("variant")
@@ -727,6 +734,7 @@ func (s *Server) Serve() {
 		serveMux.HandleFunc("/api/tests/analysis", s.jsonTestAnalysisReportFromDB)
 		serveMux.HandleFunc("/api/install", s.jsonInstallReportFromDB)
 		serveMux.HandleFunc("/api/releases", s.jsonReleasesReportFromDB)
+		serveMux.HandleFunc("/api/health", s.jsonHealthReportFromDB)
 	} else {
 		// Preserve old sippy at /legacy for now
 		serveMux.HandleFunc("/legacy", s.printHTMLReport)
@@ -753,7 +761,7 @@ func (s *Server) Serve() {
 		serveMux.HandleFunc("/api/releases/health", s.jsonReleaseHealthReport) // TODO: port to db
 		serveMux.HandleFunc("/api/releases", s.jsonReleasesReport)
 
-		serveMux.HandleFunc("/api/health", s.jsonHealthReport) // TODO: port to db
+		serveMux.HandleFunc("/api/health", s.jsonHealthReport)
 		serveMux.HandleFunc("/api/install", s.jsonInstallReport)
 		serveMux.HandleFunc("/api/upgrade", s.jsonUpgradeReport) // TODO: port to db
 	}

--- a/pkg/testgridanalysis/testgridanalysisapi/types.go
+++ b/pkg/testgridanalysis/testgridanalysisapi/types.go
@@ -91,8 +91,18 @@ type OperatorState struct {
 }
 
 const (
-	OperatorUpgradePrefix       = "sippy.[sig-sippy] operator upgrade "
-	OperatorFinalHealthPrefix   = "sippy.[sig-sippy] operator conditions "
+	// OperatorUpgradePrefix is used to detect tests in the junit which signal an operator's upgrade status.
+	// TODO: what writes these initially?
+	OperatorUpgradePrefix = "Cluster upgrade.Operator upgrade "
+
+	// SippyOperatorUpgradePrefix is the test name sippy prefix adds to signal operator upgrade success. It added based on
+	// the above OperatorUpgradePrefix.
+	// TODO: why do we add a test when there already is one? It looks like it may have been to converge a legacy test name under the same name as a new test name.
+	SippyOperatorUpgradePrefix = "sippy.[sig-sippy] operator upgrade "
+
+	// OperatorFinalHealthPrefix is used to detect tests in the junit which signal an operator's install status.
+	OperatorFinalHealthPrefix = "Operator results.operator conditions "
+
 	FinalOperatorHealthTestName = "sippy.[sig-sippy] tests should finish with healthy operators"
 
 	SippySuiteName         = "sippy"
@@ -109,6 +119,9 @@ const (
 
 var (
 	// TODO: add [sig-sippy] here as well so we can more clearly identify and substring search
-	OperatorInstallPrefix          = "operator install "
-	OperatorConditionsTestCaseName = regexp.MustCompile("^operator install (?P<operator>.*)")
+	// OperatorInstallPrefix is used when sippy adds synthetic tests to report if each operator installed correct.
+	OperatorInstallPrefix = "operator install "
+
+	// TODO: is this even used anymore?
+	OperatorConditionsTestCaseName = regexp.MustCompile(`Operator results.*operator install (?P<operator>.*)`)
 )

--- a/pkg/testgridanalysis/testgridanalysisapi/types.go
+++ b/pkg/testgridanalysis/testgridanalysisapi/types.go
@@ -95,6 +95,7 @@ const (
 	OperatorFinalHealthPrefix   = "sippy.[sig-sippy] operator conditions "
 	FinalOperatorHealthTestName = "sippy.[sig-sippy] tests should finish with healthy operators"
 
+	SippySuiteName         = "sippy"
 	InfrastructureTestName = `sippy.[sig-sippy] infrastructure should work`
 	InstallTestName        = `sippy.[sig-sippy] install should work`
 	InstallTimeoutTestName = `sippy.[sig-sippy] install should not timeout`

--- a/pkg/testgridanalysis/testgridconversion/ocp_synthetic_tests.go
+++ b/pkg/testgridanalysis/testgridconversion/ocp_synthetic_tests.go
@@ -140,7 +140,7 @@ func (openshiftSyntheticManager) CreateSyntheticTests(rawJobResults testgridanal
 					syntheticTests[testgridanalysisapi.UpgradeTestName].pass = 1
 					// if the test succeeded, then the operator install tests should all be passes
 					for _, operatorState := range jrr.FinalOperatorStates {
-						testName := testgridanalysisapi.OperatorUpgradePrefix + operatorState.Name
+						testName := testgridanalysisapi.SippyOperatorUpgradePrefix + operatorState.Name
 						syntheticTests[testName] = &syntheticTestResult{
 							name: testName,
 							pass: 1,
@@ -150,7 +150,7 @@ func (openshiftSyntheticManager) CreateSyntheticTests(rawJobResults testgridanal
 					syntheticTests[testgridanalysisapi.UpgradeTestName].fail = 1
 					// if the test failed, then the operator upgrade tests should match the operator state
 					for _, operatorState := range jrr.FinalOperatorStates {
-						testName := testgridanalysisapi.OperatorUpgradePrefix + operatorState.Name
+						testName := testgridanalysisapi.SippyOperatorUpgradePrefix + operatorState.Name
 						syntheticTests[testName] = &syntheticTestResult{
 							name: testName,
 						}

--- a/pkg/testgridanalysis/testreportconversion/jobresult.go
+++ b/pkg/testgridanalysis/testreportconversion/jobresult.go
@@ -66,8 +66,8 @@ func filterPertinentInfrequentJobResults(
 	return filtered
 }
 
-func isNeverStableOrTechPreview(result sippyprocessingv1.JobResult) bool {
-	for _, variant := range result.Variants {
+func IsNeverStableOrTechPreview(variants []string) bool {
+	for _, variant := range variants {
 		if variant == "never-stable" || variant == "techpreview" {
 			return true
 		}
@@ -76,9 +76,8 @@ func isNeverStableOrTechPreview(result sippyprocessingv1.JobResult) bool {
 	return false
 }
 
-// The zero-value of a float64 in go is NaN, however you cannot marshal that
-// value to JSON. This converts a NaN to zero.
-func convertNaNToZero(f float64) float64 {
+// ConvertNaNToZero prevents attempts to marshal the NaN zero-value of a float64 in go by converting to 0.
+func ConvertNaNToZero(f float64) float64 {
 	if math.IsNaN(f) {
 		return 0.0
 	}
@@ -96,7 +95,7 @@ func calculateJobResultStatistics(results []sippyprocessingv1.JobResult) sippypr
 	})
 
 	for _, result := range results {
-		if isNeverStableOrTechPreview(result) {
+		if IsNeverStableOrTechPreview(result.Variants) {
 			continue
 		}
 		index := int(math.Floor(result.PassPercentage / 10))
@@ -117,9 +116,9 @@ func calculateJobResultStatistics(results []sippyprocessingv1.JobResult) sippypr
 	jobStatistics.Mean = mean
 	jobStatistics.StandardDeviation = sd
 	jobStatistics.Quartiles = []float64{
-		convertNaNToZero(quartiles.Q1),
-		convertNaNToZero(quartiles.Q2),
-		convertNaNToZero(quartiles.Q3),
+		ConvertNaNToZero(quartiles.Q1),
+		ConvertNaNToZero(quartiles.Q2),
+		ConvertNaNToZero(quartiles.Q3),
 	}
 	jobStatistics.P95 = p95
 


### PR DESCRIPTION
Skipped two portions of this that appear unused, the two day statistics,
and the variant health (number of variants whose jobs fully pass over
80%, 60%, or less (fail)).

Refactored filtering out to it's own package due to cyclical imports.

Trending towards moving DB query functions to the db package.

Refactored job report query to be more usable without an http request.
