### PR TITLE
Include test failures in api job run result

### DIFF
--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -56,6 +56,7 @@ func jobRunToAPIJobRun(id int, job v1sippyprocessing.JobResult, result v1sippypr
 		Job:                   result.Job,
 		URL:                   result.URL,
 		TestFailures:          result.TestFailures,
+		FailedTestNames:       result.FailedTestNames,
 		Failed:                result.Failed,
 		InfrastructureFailure: result.InfrastructureFailure,
 		KnownFailure:          result.KnownFailure,


### PR DESCRIPTION
I missed this last week when fixing this API.