### PR TITLE
Allow releases to be non-integer values

### DIFF
--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -519,9 +519,9 @@ func (s *Server) jsonReleasesReportFromDB(w http.ResponseWriter, _ *http.Request
 	var releases []Release
 	// The string_to_array trick ensures releases are sorted in version order, descending
 	res := s.db.DB.Raw(`
-		SELECT DISTINCT(release), string_to_array(release, '.')::int[]
-		FROM prow_jobs
-		ORDER BY string_to_array(release, '.')::int[] desc`).Scan(&releases)
+		SELECT DISTINCT(release), case when position('.' in release) != 0 then string_to_array(release, '.')::int[] end as sortable_release
+                FROM prow_jobs
+                ORDER BY sortable_release desc`).Scan(&releases)
 	if res.Error != nil {
 		klog.Errorf("error querying releases from db: %v", res.Error)
 	}


### PR DESCRIPTION
I had added code to ensure the releases are sorted, but it doesn't
handle alpha releases, like upstream kube uses. This only casts to an
int array if it contains a '.', which is probably a good enough
heruistic to determine if it's a version or branch name.