### PR TITLE
Skip assisted jobs for time being.

### DIFF
--- a/pkg/sippyserver/dbloader.go
+++ b/pkg/sippyserver/dbloader.go
@@ -117,6 +117,12 @@ func (a TestReportGeneratorConfig) LoadDatabase(
 		jobResultCtr++
 		jr := rawJobResults.JobResults[i]
 		jobStatus := fmt.Sprintf("%d/%d", jobResultCtr, len(rawJobResults.JobResults))
+
+		if strings.Contains(jr.JobName, "assisted") {
+			klog.Warningf("Skipping assisted job due to known issue with test names containing random strings: %s", jr.JobName)
+			continue
+		}
+
 		err := LoadJob(dbc, prowJobCache, prowJobCacheLock, suiteCache, testCache, testCacheLock, jr, jobStatus)
 		if err != nil {
 			return err


### PR DESCRIPTION
These jobs are using randomized test names such as:

assisted-service-64996486bb-lnsms_minikube."github.com/openshift/assisted-service/internal/bminventory.(*bareMetalInventory).V2PostStepReply"

Team is notified, we will manually clean dbs, for now we skip processing
them.
