### PR TITLE
Load only one testgrid job at a time for memory use.

### DIFF
--- a/pkg/db/loader/loader.go
+++ b/pkg/db/loader/loader.go
@@ -1,0 +1,1 @@
+package loader

--- a/pkg/testgridanalysis/testgridconversion/kube_synthetic_tests.go
+++ b/pkg/testgridanalysis/testgridconversion/kube_synthetic_tests.go
@@ -11,20 +11,24 @@ func NewEmptySyntheticTestManager() SyntheticTestManager {
 	return kubeSyntheticManager{}
 }
 
-func (kubeSyntheticManager) CreateSyntheticTests(rawJobResults testgridanalysisapi.RawData) []string {
+func (k kubeSyntheticManager) CreateSyntheticTests(rawJobResults testgridanalysisapi.RawData) []string {
 	warnings := []string{}
 
-	// Kube does not use any synthetic tests, but we do need to populate the job OverallResult for important functionality.
 	for jobName, jobResults := range rawJobResults.JobResults {
-		for jrrKey, jrr := range jobResults.JobRunResults {
-
-			jrr.OverallResult = kubeJobRunStatus(jrr)
-			jobResults.JobRunResults[jrrKey] = jrr
-		}
-
+		newWarnings := k.CreateSyntheticTestsForJob(jobResults)
+		warnings = append(warnings, newWarnings...)
 		rawJobResults.JobResults[jobName] = jobResults
 	}
 	return warnings
+}
+
+func (k kubeSyntheticManager) CreateSyntheticTestsForJob(jobResults testgridanalysisapi.RawJobResult) []string {
+	// Kube does not use any synthetic tests, but we do need to populate the job OverallResult for important functionality.
+	for jrrKey, jrr := range jobResults.JobRunResults {
+		jrr.OverallResult = kubeJobRunStatus(jrr)
+		jobResults.JobRunResults[jrrKey] = jrr
+	}
+	return []string{}
 }
 
 func kubeJobRunStatus(result testgridanalysisapi.RawJobRunResult) sippyprocessingv1.JobOverallResult {

--- a/pkg/testgridanalysis/testgridconversion/ocp_synthetic_tests.go
+++ b/pkg/testgridanalysis/testgridconversion/ocp_synthetic_tests.go
@@ -16,83 +16,154 @@ func NewOpenshiftSyntheticTestManager() SyntheticTestManager {
 	return openshiftSyntheticManager{}
 }
 
+// make a pass to fill in install, upgrade, and infra synthetic tests.
+type syntheticTestResult struct {
+	name string
+	pass int
+	fail int
+}
+
 // CreateSyntheticTests takes the JobRunResult information and produces some pre-analysis by interpreting different types of failures
 // and potentially producing synthetic test results and aggregations to better inform sippy.
 // This needs to be called after all the JobDetails have been processed.
 // returns warnings found in the data. Not failures to process it.
-//nolint:gocyclo // TODO: Break this function up, see: https://github.com/fzipp/gocyclo
-func (openshiftSyntheticManager) CreateSyntheticTests(rawJobResults testgridanalysisapi.RawData) []string {
+// TODO: move away from this func in favor of the per job one below. Avoiding loading all jobs into memory at once.
+func (o openshiftSyntheticManager) CreateSyntheticTests(rawJobResults testgridanalysisapi.RawData) []string {
 	warnings := []string{}
 
-	// make a pass to fill in install, upgrade, and infra synthetic tests.
-	type syntheticTestResult struct {
-		name string
-		pass int
-		fail int
-	}
-
 	for jobName, jobResults := range rawJobResults.JobResults {
-		numsWithoutInstallIndicator := 0
-		for jrrKey, jrr := range jobResults.JobRunResults {
-			if jrr.InstallStatus == "" {
-				numsWithoutInstallIndicator++
-			}
+		newWarnings := o.CreateSyntheticTestsForJob(jobResults)
+		warnings = append(warnings, newWarnings...)
+		rawJobResults.JobResults[jobName] = jobResults
+	}
+	return warnings
+}
 
-			syntheticTests := map[string]*syntheticTestResult{
-				testgridanalysisapi.InstallTestName:             &syntheticTestResult{name: testgridanalysisapi.InstallTestName},
-				testgridanalysisapi.InstallTimeoutTestName:      &syntheticTestResult{name: testgridanalysisapi.InstallTimeoutTestName},
-				testgridanalysisapi.InfrastructureTestName:      &syntheticTestResult{name: testgridanalysisapi.InfrastructureTestName},
-				testgridanalysisapi.FinalOperatorHealthTestName: &syntheticTestResult{name: testgridanalysisapi.FinalOperatorHealthTestName},
-				testgridanalysisapi.OpenShiftTestsName:          &syntheticTestResult{name: testgridanalysisapi.OpenShiftTestsName},
-			}
-			// upgrades should only be indicated on jobs that run upgrades
-			if jrr.UpgradeStarted {
-				syntheticTests[testgridanalysisapi.UpgradeTestName] = &syntheticTestResult{name: testgridanalysisapi.UpgradeTestName}
-			}
+// CreateSyntheticTestsForJob takes the RawJobResult information and produces some pre-analysis by interpreting different types of failures
+// and potentially producing synthetic test results and aggregations to better inform sippy.
+// returns warnings found in the data. Not failures to process it.
+//nolint:gocyclo // TODO: Break this function up, see: https://github.com/fzipp/gocyclo
+func (openshiftSyntheticManager) CreateSyntheticTestsForJob(jobResults testgridanalysisapi.RawJobResult) []string {
+	warnings := []string{}
+	numsWithoutInstallIndicator := 0
+	for jrrKey, jrr := range jobResults.JobRunResults {
+		if jrr.InstallStatus == "" {
+			numsWithoutInstallIndicator++
+		}
 
-			hasFinalOperatorResults := len(jrr.FinalOperatorStates) > 0
-			allOperatorsSuccessfulAtEndOfRun := true
-			for _, operator := range jrr.FinalOperatorStates {
-				if operator.State == testgridanalysisapi.Failure {
-					allOperatorsSuccessfulAtEndOfRun = false
-					break
+		syntheticTests := map[string]*syntheticTestResult{
+			testgridanalysisapi.InstallTestName:             &syntheticTestResult{name: testgridanalysisapi.InstallTestName},
+			testgridanalysisapi.InstallTimeoutTestName:      &syntheticTestResult{name: testgridanalysisapi.InstallTimeoutTestName},
+			testgridanalysisapi.InfrastructureTestName:      &syntheticTestResult{name: testgridanalysisapi.InfrastructureTestName},
+			testgridanalysisapi.FinalOperatorHealthTestName: &syntheticTestResult{name: testgridanalysisapi.FinalOperatorHealthTestName},
+			testgridanalysisapi.OpenShiftTestsName:          &syntheticTestResult{name: testgridanalysisapi.OpenShiftTestsName},
+		}
+		// upgrades should only be indicated on jobs that run upgrades
+		if jrr.UpgradeStarted {
+			syntheticTests[testgridanalysisapi.UpgradeTestName] = &syntheticTestResult{name: testgridanalysisapi.UpgradeTestName}
+		}
+
+		hasFinalOperatorResults := len(jrr.FinalOperatorStates) > 0
+		allOperatorsSuccessfulAtEndOfRun := true
+		for _, operator := range jrr.FinalOperatorStates {
+			if operator.State == testgridanalysisapi.Failure {
+				allOperatorsSuccessfulAtEndOfRun = false
+				break
+			}
+		}
+		installFailed := jrr.Failed && jrr.InstallStatus != testgridanalysisapi.Success
+		installSucceeded := jrr.Succeeded || jrr.InstallStatus == testgridanalysisapi.Success
+
+		switch {
+		case !hasFinalOperatorResults:
+		// without results, there is no run for the tests
+		case allOperatorsSuccessfulAtEndOfRun:
+			syntheticTests[testgridanalysisapi.FinalOperatorHealthTestName].pass = 1
+		default:
+			syntheticTests[testgridanalysisapi.FinalOperatorHealthTestName].fail = 1
+		}
+
+		// set overall installed status
+		switch {
+		case installSucceeded:
+			syntheticTests[testgridanalysisapi.InstallTestName].pass = 1
+			// if the test succeeded, then the operator install tests should all be passes
+			for _, operatorState := range jrr.FinalOperatorStates {
+				testName := "sippy." + testgridanalysisapi.OperatorInstallPrefix + operatorState.Name
+				syntheticTests[testName] = &syntheticTestResult{
+					name: testName,
+					pass: 1,
 				}
 			}
-			installFailed := jrr.Failed && jrr.InstallStatus != testgridanalysisapi.Success
-			installSucceeded := jrr.Succeeded || jrr.InstallStatus == testgridanalysisapi.Success
 
-			switch {
-			case !hasFinalOperatorResults:
-			// without results, there is no run for the tests
-			case allOperatorsSuccessfulAtEndOfRun:
-				syntheticTests[testgridanalysisapi.FinalOperatorHealthTestName].pass = 1
-			default:
-				syntheticTests[testgridanalysisapi.FinalOperatorHealthTestName].fail = 1
+		case !hasFinalOperatorResults:
+			// if we don't have any operator results, then don't count this an install one way or the other.  This was an infra failure
+
+		default:
+			// the installation failed and we have some operator results, which means the install started. This is a failure
+			syntheticTests[testgridanalysisapi.InstallTestName].fail = 1
+
+			// if the test failed, then the operator install tests should match the operator state
+			for _, operatorState := range jrr.FinalOperatorStates {
+				testName := "sippy." + testgridanalysisapi.OperatorInstallPrefix + operatorState.Name
+				syntheticTests[testName] = &syntheticTestResult{
+					name: testName,
+				}
+				if operatorState.State == testgridanalysisapi.Success {
+					syntheticTests[testName].pass = 1
+				} else {
+					syntheticTests[testName].fail = 1
+				}
 			}
+		}
 
-			// set overall installed status
-			switch {
-			case installSucceeded:
-				syntheticTests[testgridanalysisapi.InstallTestName].pass = 1
+		// set overall install timeout status
+		switch {
+		case !installSucceeded && hasFinalOperatorResults && allOperatorsSuccessfulAtEndOfRun:
+			// the install failed and yet all operators were successful in the end.  This means we had a weird problem.  Probably a timeout failure.
+			syntheticTests[testgridanalysisapi.InstallTimeoutTestName].fail = 1
+
+		default:
+			syntheticTests[testgridanalysisapi.InstallTimeoutTestName].pass = 1
+
+		}
+
+		// set the infra status
+		switch {
+		case matchJobRegexList(jobResults.JobName, jobRegexesWithKnownInstallIssues):
+			// do nothing.  If we don't have an install test, we have no way of determining infrastructure
+
+		case installFailed && !hasFinalOperatorResults:
+			// we only count failures as infra if we have no operator results.  If we got any operator working, then CI infra was working.
+			syntheticTests[testgridanalysisapi.InfrastructureTestName].fail = 1
+
+		default:
+			syntheticTests[testgridanalysisapi.InfrastructureTestName].pass = 1
+		}
+
+		// set the update status
+		switch {
+		case installFailed:
+			// do nothing
+		case !jrr.UpgradeStarted:
+		// do nothing
+
+		default:
+			if jrr.UpgradeForOperatorsStatus == testgridanalysisapi.Success && jrr.UpgradeForMachineConfigPoolsStatus == testgridanalysisapi.Success {
+				syntheticTests[testgridanalysisapi.UpgradeTestName].pass = 1
 				// if the test succeeded, then the operator install tests should all be passes
 				for _, operatorState := range jrr.FinalOperatorStates {
-					testName := "sippy." + testgridanalysisapi.OperatorInstallPrefix + operatorState.Name
+					testName := testgridanalysisapi.SippyOperatorUpgradePrefix + operatorState.Name
 					syntheticTests[testName] = &syntheticTestResult{
 						name: testName,
 						pass: 1,
 					}
 				}
-
-			case !hasFinalOperatorResults:
-				// if we don't have any operator results, then don't count this an install one way or the other.  This was an infra failure
-
-			default:
-				// the installation failed and we have some operator results, which means the install started. This is a failure
-				syntheticTests[testgridanalysisapi.InstallTestName].fail = 1
-
-				// if the test failed, then the operator install tests should match the operator state
+			} else {
+				syntheticTests[testgridanalysisapi.UpgradeTestName].fail = 1
+				// if the test failed, then the operator upgrade tests should match the operator state
 				for _, operatorState := range jrr.FinalOperatorStates {
-					testName := "sippy." + testgridanalysisapi.OperatorInstallPrefix + operatorState.Name
+					testName := testgridanalysisapi.SippyOperatorUpgradePrefix + operatorState.Name
 					syntheticTests[testName] = &syntheticTestResult{
 						name: testName,
 					}
@@ -103,105 +174,45 @@ func (openshiftSyntheticManager) CreateSyntheticTests(rawJobResults testgridanal
 					}
 				}
 			}
-
-			// set overall install timeout status
-			switch {
-			case !installSucceeded && hasFinalOperatorResults && allOperatorsSuccessfulAtEndOfRun:
-				// the install failed and yet all operators were successful in the end.  This means we had a weird problem.  Probably a timeout failure.
-				syntheticTests[testgridanalysisapi.InstallTimeoutTestName].fail = 1
-
-			default:
-				syntheticTests[testgridanalysisapi.InstallTimeoutTestName].pass = 1
-
-			}
-
-			// set the infra status
-			switch {
-			case matchJobRegexList(jobName, jobRegexesWithKnownInstallIssues):
-				// do nothing.  If we don't have an install test, we have no way of determining infrastructure
-
-			case installFailed && !hasFinalOperatorResults:
-				// we only count failures as infra if we have no operator results.  If we got any operator working, then CI infra was working.
-				syntheticTests[testgridanalysisapi.InfrastructureTestName].fail = 1
-
-			default:
-				syntheticTests[testgridanalysisapi.InfrastructureTestName].pass = 1
-			}
-
-			// set the update status
-			switch {
-			case installFailed:
-				// do nothing
-			case !jrr.UpgradeStarted:
-			// do nothing
-
-			default:
-				if jrr.UpgradeForOperatorsStatus == testgridanalysisapi.Success && jrr.UpgradeForMachineConfigPoolsStatus == testgridanalysisapi.Success {
-					syntheticTests[testgridanalysisapi.UpgradeTestName].pass = 1
-					// if the test succeeded, then the operator install tests should all be passes
-					for _, operatorState := range jrr.FinalOperatorStates {
-						testName := testgridanalysisapi.SippyOperatorUpgradePrefix + operatorState.Name
-						syntheticTests[testName] = &syntheticTestResult{
-							name: testName,
-							pass: 1,
-						}
-					}
-				} else {
-					syntheticTests[testgridanalysisapi.UpgradeTestName].fail = 1
-					// if the test failed, then the operator upgrade tests should match the operator state
-					for _, operatorState := range jrr.FinalOperatorStates {
-						testName := testgridanalysisapi.SippyOperatorUpgradePrefix + operatorState.Name
-						syntheticTests[testName] = &syntheticTestResult{
-							name: testName,
-						}
-						if operatorState.State == testgridanalysisapi.Success {
-							syntheticTests[testName].pass = 1
-						} else {
-							syntheticTests[testName].fail = 1
-						}
-					}
-				}
-			}
-
-			switch {
-			case jrr.Failed && jrr.OpenShiftTestsStatus == testgridanalysisapi.Failure:
-				syntheticTests[testgridanalysisapi.OpenShiftTestsName].fail = 1
-			case jrr.OpenShiftTestsStatus == testgridanalysisapi.Success:
-				syntheticTests[testgridanalysisapi.OpenShiftTestsName].pass = 1
-			}
-
-			for testName, result := range syntheticTests {
-				// convert the result.pass or .fail to the status value we use for test results:
-				if result.fail > 0 {
-					jrr.TestFailures += result.fail
-					jrr.FailedTestNames = append(jrr.FailedTestNames, testName)
-				} else {
-					// Add successful test results as well.
-					jrr.TestResults = append(jrr.TestResults, testgridanalysisapi.RawJobRunTestResult{
-						Name:   testName,
-						Status: v1.TestStatusSuccess,
-					})
-				}
-				addTestResult(jobResults.TestResults, nil, testName, result.pass, result.fail, 0)
-			}
-
-			if jrr.InstallStatus == "" && matchJobRegexList(jobName, jobRegexesWithKnownInstallIssues) {
-				jrr.InstallStatus = testgridanalysisapi.Unknown
-			}
-
-			jrr.OverallResult = jobRunStatus(jrr)
-			jobResults.JobRunResults[jrrKey] = jrr
 		}
 
-		if numsWithoutInstallIndicator > 0 && numsWithoutInstallIndicator == len(jobResults.JobRunResults) {
-			if !matchJobRegexList(jobName, jobRegexesWithKnownInstallIssues) {
-				warnings = append(warnings, fmt.Sprintf("%q is missing a test install job to indicate successful installs", jobName))
-			}
+		switch {
+		case jrr.Failed && jrr.OpenShiftTestsStatus == testgridanalysisapi.Failure:
+			syntheticTests[testgridanalysisapi.OpenShiftTestsName].fail = 1
+		case jrr.OpenShiftTestsStatus == testgridanalysisapi.Success:
+			syntheticTests[testgridanalysisapi.OpenShiftTestsName].pass = 1
 		}
 
-		rawJobResults.JobResults[jobName] = jobResults
+		for testName, result := range syntheticTests {
+			// convert the result.pass or .fail to the status value we use for test results:
+			if result.fail > 0 {
+				jrr.TestFailures += result.fail
+				jrr.FailedTestNames = append(jrr.FailedTestNames, testName)
+			} else {
+				// Add successful test results as well.
+				jrr.TestResults = append(jrr.TestResults, testgridanalysisapi.RawJobRunTestResult{
+					Name:   testName,
+					Status: v1.TestStatusSuccess,
+				})
+			}
+			addTestResult(jobResults.TestResults, nil, testName, result.pass, result.fail, 0)
+		}
+
+		if jrr.InstallStatus == "" && matchJobRegexList(jobResults.JobName, jobRegexesWithKnownInstallIssues) {
+			jrr.InstallStatus = testgridanalysisapi.Unknown
+		}
+
+		jrr.OverallResult = jobRunStatus(jrr)
+		jobResults.JobRunResults[jrrKey] = jrr
+	}
+
+	if numsWithoutInstallIndicator > 0 && numsWithoutInstallIndicator == len(jobResults.JobRunResults) {
+		if !matchJobRegexList(jobResults.JobName, jobRegexesWithKnownInstallIssues) {
+			warnings = append(warnings, fmt.Sprintf("%q is missing a test install job to indicate successful installs", jobResults.JobName))
+		}
 	}
 	return warnings
+
 }
 
 const failure string = "Failure"


### PR DESCRIPTION
Previously we processed all testgrid job data for a dashboard, then
loaded each into the database. This change adjusts so we read one job at
a time, load it into the db, and then move on to the next.

In local testing this cuts memory use from about 2GB down to about
550MB.
