### PR TITLE
Revert "Load releases to the db serially (separate invocations)"

### DIFF
--- a/scripts/fetchdata.sh
+++ b/scripts/fetchdata.sh
@@ -9,13 +9,7 @@ while [ true ]; do
   rm -rf /data/*
   /bin/sippy -v 4 --fetch-data /data --fetch-openshift-perfscale-data --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10 --release 4.11
   echo "Loading database"
-  /bin/sippy -v 4 --load-database --local-data /data --arch amd64 --arch arm64 --arch s390x --arch ppc64le --release 3.11
-  /bin/sippy -v 4 --load-database --local-data /data --arch amd64 --arch arm64 --arch s390x --arch ppc64le --release 4.6
-  /bin/sippy -v 4 --load-database --local-data /data --arch amd64 --arch arm64 --arch s390x --arch ppc64le --release 4.7
-  /bin/sippy -v 4 --load-database --local-data /data --arch amd64 --arch arm64 --arch s390x --arch ppc64le --release 4.8
-  /bin/sippy -v 4 --load-database --local-data /data --arch amd64 --arch arm64 --arch s390x --arch ppc64le --release 4.9
-  /bin/sippy -v 4 --load-database --local-data /data --arch amd64 --arch arm64 --arch s390x --arch ppc64le --release 4.10
-  /bin/sippy -v 4 --load-database --local-data /data --arch amd64 --arch arm64 --arch s390x --arch ppc64le --release 4.11
+  /bin/sippy -v 4 --load-database --local-data /data --arch amd64 --arch arm64 --arch s390x --arch ppc64le --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10 --release 4.11
   echo "Done fetching data, refreshing server"
   curl localhost:8080/refresh
   echo "Done refreshing data, sleeping"


### PR DESCRIPTION
This reverts commit 5b183e76a37bdb93d6e423bb96e11a143d9ebba1.

This didn't seem to help as we were already largely loading one
dashboard at a time. The issue was that 4.11 alone could still blow
memory as we do load every job within that dashboard at once. This has
now been changed to only ever load one testgrid job from one dashboard
at a time.

This needs reverting as we're now doing the full bugzilla update every
invocation.
