### PR TITLE
Disable bugzilla syncing.

### DIFF
--- a/scripts/fetchdata.sh
+++ b/scripts/fetchdata.sh
@@ -9,7 +9,8 @@ while [ true ]; do
   rm -rf /data/*
   /bin/sippy -v 4 --fetch-data /data --fetch-openshift-perfscale-data --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10 --release 4.11
   echo "Loading database"
-  /bin/sippy -v 4 --load-database --local-data /data --arch amd64 --arch arm64 --arch s390x --arch ppc64le --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10 --release 4.11
+  # Bug lookup skipped, we're struggling with the number of tests, and moving to Jira soon.
+  /bin/sippy -v 4 --load-database --local-data /data --skip-bug-lookup --arch amd64 --arch arm64 --arch s390x --arch ppc64le --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10 --release 4.11
   echo "Done fetching data, refreshing server"
   curl localhost:8080/refresh
   echo "Done refreshing data, sleeping"


### PR DESCRIPTION
We're spending 20 minutes every hour doing this due to the increase in
number of tests. We'll be moving to Jira soon regardless, so no point
investing in this right now.
