### PR TITLE
Remove some unused secondary UI tabs on Install/Upgrade/Tests pages.

### DIFF
--- a/pkg/api/job_analysis.go
+++ b/pkg/api/job_analysis.go
@@ -257,6 +257,8 @@ func PrintJobAnalysisJSONFromDB(w http.ResponseWriter, req *http.Request, dbc *d
 	}
 	tr := make([]testResult, 0)
 
+	// Currently 50 million rows in prow_job_run_tests, this query is taking 25s.
+	// Returning 330 rows or so.
 	jr := dbc.DB.Table("prow_job_runs").
 		Select(fmt.Sprintf(`date_trunc('%s', timestamp) as period, tests.name, COUNT(tests.name)`, period)).
 		Joins(`INNER JOIN prow_job_run_tests pjrt on prow_job_runs.id = pjrt.prow_job_run_id`).

--- a/sippy-ng/src/jobs/Jobs.js
+++ b/sippy-ng/src/jobs/Jobs.js
@@ -59,36 +59,16 @@ export default function Jobs(props) {
                     to={url}
                   />
                   <Tab
-                    label="Jobs by variant"
-                    value="variant"
-                    component={Link}
-                    to={url + '/variant'}
-                  />
-                  <Tab
                     label="All job runs"
                     value="runs"
                     component={Link}
                     to={url + '/runs'}
-                  />
-                  <Tab
-                    label="Job run summary"
-                    value="detail"
-                    component={Link}
-                    to={url + '/detail'}
                   />
                 </Tabs>
               </Paper>
             </Grid>
             <Container size="xl">
               <Switch>
-                <Route path={path + '/variant'}>
-                  <Variants release={props.release} />
-                </Route>
-
-                <Route path={path + '/detail'}>
-                  <JobsDetail release={props.release} />
-                </Route>
-
                 <Route path={path + '/runs'}>
                   <JobRunsTable release={props.release} />
                 </Route>

--- a/sippy-ng/src/releases/Install.js
+++ b/sippy-ng/src/releases/Install.js
@@ -75,12 +75,6 @@ export default function Install(props) {
                     component={Link}
                     to={url + '/operators'}
                   />
-                  <Tab
-                    label="Install related tests"
-                    value="tests"
-                    component={Link}
-                    to={url + '/tests'}
-                  />
                 </Tabs>
               </Paper>
             </Grid>
@@ -90,14 +84,6 @@ export default function Install(props) {
                   release={props.release}
                   colorScale={[90, 100]}
                   data={data}
-                />
-              </Route>
-              <Route path={path + '/tests'}>
-                <TestTable
-                  release={props.release}
-                  filterModel={{
-                    items: [BOOKMARKS.INSTALL],
-                  }}
                 />
               </Route>
               <Redirect from="/" to={url + '/operators'} />

--- a/sippy-ng/src/releases/Upgrades.js
+++ b/sippy-ng/src/releases/Upgrades.js
@@ -88,18 +88,6 @@ export default function Upgrades(props) {
                     component={Link}
                     to={url + '/operators'}
                   />
-                  <Tab
-                    label="Upgrade related tests"
-                    value="tests"
-                    component={Link}
-                    to={url + '/tests'}
-                  />
-                  <Tab
-                    label="Upgrade jobs"
-                    value="jobs"
-                    component={Link}
-                    to={url + '/jobs'}
-                  />
                 </Tabs>
               </Paper>
             </Grid>
@@ -110,24 +98,6 @@ export default function Upgrades(props) {
                   colorScale={[90, 100]}
                   data={data}
                 />
-              </Route>
-              <Route path={path + '/tests'}>
-                <TestTable
-                  release={props.release}
-                  filterModel={{
-                    items: [BOOKMARKS.UPGRADE],
-                  }}
-                />
-              </Route>
-              <Route path={path + '/jobs'}>
-                <Container size="xl">
-                  <JobTable
-                    release={props.release}
-                    filterModel={{
-                      items: [BOOKMARKS.UPGRADE],
-                    }}
-                  />
-                </Container>
               </Route>
               <Redirect from="/" to={url + '/operators'} />
             </Switch>

--- a/sippy-ng/src/releases/__snapshots__/Install.test.js.snap
+++ b/sippy-ng/src/releases/__snapshots__/Install.test.js.snap
@@ -47,19 +47,6 @@ exports[`install should render correctly 1`] = `
             <span class="MuiTouchRipple-root">
             </span>
           </a>
-          <a class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary"
-             tabindex="-1"
-             role="tab"
-             aria-disabled="false"
-             aria-selected="false"
-             href="//tests"
-          >
-            <span class="MuiTab-wrapper">
-              Install related tests
-            </span>
-            <span class="MuiTouchRipple-root">
-            </span>
-          </a>
         </div>
         <span class="PrivateTabIndicator-root-1 PrivateTabIndicator-colorPrimary-2 MuiTabs-indicator"
               style="left: 0px; width: 0px;"

--- a/sippy-ng/src/releases/__snapshots__/Upgrades.test.js.snap
+++ b/sippy-ng/src/releases/__snapshots__/Upgrades.test.js.snap
@@ -47,32 +47,6 @@ exports[`upgrades should render correctly 1`] = `
             <span class="MuiTouchRipple-root">
             </span>
           </a>
-          <a class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary"
-             tabindex="-1"
-             role="tab"
-             aria-disabled="false"
-             aria-selected="false"
-             href="//tests"
-          >
-            <span class="MuiTab-wrapper">
-              Upgrade related tests
-            </span>
-            <span class="MuiTouchRipple-root">
-            </span>
-          </a>
-          <a class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary"
-             tabindex="-1"
-             role="tab"
-             aria-disabled="false"
-             aria-selected="false"
-             href="//jobs"
-          >
-            <span class="MuiTab-wrapper">
-              Upgrade jobs
-            </span>
-            <span class="MuiTouchRipple-root">
-            </span>
-          </a>
         </div>
         <span class="PrivateTabIndicator-root-1 PrivateTabIndicator-colorPrimary-2 MuiTabs-indicator"
               style="left: 0px; width: 0px;"

--- a/sippy-ng/src/tests/Tests.js
+++ b/sippy-ng/src/tests/Tests.js
@@ -70,7 +70,6 @@ export default function Tests(props) {
               <Route path={path + '/details'}>
                 <TestDetails release={props.release} />
               </Route>
-
               <Route exact path={path}>
                 <Container size="xl">
                   <TestTable release={props.release} />


### PR DESCRIPTION
We may bring some of these back at some point, but for now they are
unweildy, non-functional, and we suspect largely unused.
