### PR TITLE
Fix addition of synthetic tests for every job run.

### DIFF
--- a/pkg/testgridanalysis/testgridconversion/ocp_synthetic_tests.go
+++ b/pkg/testgridanalysis/testgridconversion/ocp_synthetic_tests.go
@@ -188,7 +188,7 @@ func (openshiftSyntheticManager) CreateSyntheticTestsForJob(jobResults testgrida
 			if result.fail > 0 {
 				jrr.TestFailures += result.fail
 				jrr.FailedTestNames = append(jrr.FailedTestNames, testName)
-			} else {
+			} else if result.pass > 0 {
 				// Add successful test results as well.
 				jrr.TestResults = append(jrr.TestResults, testgridanalysisapi.RawJobRunTestResult{
 					Name:   testName,


### PR DESCRIPTION
Previously this was only added in some cases, openshift-tests should
work would be added only if we ran a test that looked like it came from
that suite. This code was new in the postgres work and made the
assumption that if we didn't mark the syntehtic test a fail, it must
have been a pass, when in fact it was intended to have a third didn't
run state.
