### PR TITLE
Move start/boundary/end param handler to util function

### DIFF
--- a/pkg/api/jobs.go
+++ b/pkg/api/jobs.go
@@ -10,8 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/sippy/pkg/db/query"
 	"gorm.io/gorm"
+
+	"github.com/openshift/sippy/pkg/db/query"
 
 	"k8s.io/klog"
 
@@ -162,58 +163,11 @@ func PrintJobsReportFromDB(w http.ResponseWriter, req *http.Request,
 		}
 	}
 
-	// Preferred method of slicing is with start->boundary->end query params in the format ?start=2021-12-02&boundary=2021-12-07.
-	// 'end' can be specified if you wish to view historical reports rather than now, which is assumed if end param is absent.
-	var start time.Time
-	var boundary time.Time
-	var end time.Time
-	var err error
-
-	startParam := req.URL.Query().Get("start")
-	if startParam != "" {
-		start, err = time.Parse("2006-01-02", startParam)
-		if err != nil {
-			RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": fmt.Sprintf("Error decoding start param: %s", err.Error())})
-			return
-		}
-	} else if req.URL.Query().Get("period") == periodTwoDay {
-		// twoDay report period starts 9 days ago, (comparing last 2 days vs previous 7)
-		start = time.Now().Add(-9 * 24 * time.Hour)
-	} else {
-		// Default start to 14 days ago
-		start = time.Now().Add(-14 * 24 * time.Hour)
+	start, boundary, end, err := getTimeParams(w, req)
+	if err != nil {
+		RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": err.Error()})
+		return
 	}
-
-	// TODO: currently we're assuming dates use the 00:00:00, is it more logical to add 23:23 for boundary and end? or
-	// for callers to know to specify one day beyond.
-	boundaryParam := req.URL.Query().Get("boundary")
-	if boundaryParam != "" {
-		boundary, err = time.Parse("2006-01-02", boundaryParam)
-		if err != nil {
-			RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": fmt.Sprintf("Error decoding boundary param: %s", err.Error())})
-			return
-		}
-	} else if req.URL.Query().Get("period") == periodTwoDay {
-		boundary = time.Now().Add(-2 * 24 * time.Hour)
-	} else {
-		// Default boundary to 7 days ago
-		boundary = time.Now().Add(-7 * 24 * time.Hour)
-
-	}
-
-	endParam := req.URL.Query().Get("end")
-	if endParam != "" {
-		end, err = time.Parse("2006-01-02", endParam)
-		if err != nil {
-			RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": fmt.Sprintf("Error decoding end param: %s", err.Error())})
-			return
-		}
-	} else {
-		// Default end to now
-		end = time.Now()
-	}
-
-	klog.V(4).Infof("Querying between %s -> %s -> %s", start.Format(time.RFC3339), boundary.Format(time.RFC3339), end.Format(time.RFC3339))
 
 	filterOpts, err := filter.FilterOptionsFromRequest(req, "current_pass_percentage", apitype.SortDescending)
 	if err != nil {

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"k8s.io/klog"
+)
+
+func getTimeParams(w http.ResponseWriter, req *http.Request) (start, boundary, end time.Time, err error) {
+	startParam := req.URL.Query().Get("start")
+	if startParam != "" {
+		start, err = time.Parse("2006-01-02", startParam)
+		if err != nil {
+			err = fmt.Errorf("error decoding start param: %s", err.Error())
+			return
+		}
+	} else if req.URL.Query().Get("period") == periodTwoDay {
+		// twoDay report period starts 9 days ago, (comparing last 2 days vs previous 7)
+		start = time.Now().Add(-9 * 24 * time.Hour)
+	} else {
+		// Default start to 14 days ago
+		start = time.Now().Add(-14 * 24 * time.Hour)
+	}
+
+	boundaryParam := req.URL.Query().Get("boundary")
+	if boundaryParam != "" {
+		boundary, err = time.Parse("2006-01-02", boundaryParam)
+		if err != nil {
+			err = fmt.Errorf("error decoding boundary param: %s", err.Error())
+			return
+		}
+	} else if req.URL.Query().Get("period") == periodTwoDay {
+		boundary = time.Now().Add(-2 * 24 * time.Hour)
+	} else {
+		// Default boundary to 7 days ago
+		boundary = time.Now().Add(-7 * 24 * time.Hour)
+
+	}
+
+	endParam := req.URL.Query().Get("end")
+	if endParam != "" {
+		end, err = time.Parse("2006-01-02", endParam)
+		if err != nil {
+			err = fmt.Errorf("error decoding end param: %s", err.Error())
+			return
+		}
+	} else {
+		end = time.Now()
+	}
+
+	klog.V(4).Infof("Querying between %s -> %s -> %s", start.Format(time.RFC3339), boundary.Format(time.RFC3339), end.Format(time.RFC3339))
+	return start, boundary, end, nil
+}

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -31,12 +31,13 @@ func getTimeParams(w http.ResponseWriter, req *http.Request) (start, boundary, e
 			err = fmt.Errorf("error decoding boundary param: %s", err.Error())
 			return
 		}
+		// We want the boundary to include the entire day specified
+		boundary = boundary.Add(24 * time.Hour)
 	} else if req.URL.Query().Get("period") == periodTwoDay {
 		boundary = time.Now().Add(-2 * 24 * time.Hour)
 	} else {
 		// Default boundary to 7 days ago
 		boundary = time.Now().Add(-7 * 24 * time.Hour)
-
 	}
 
 	endParam := req.URL.Query().Get("end")
@@ -46,6 +47,8 @@ func getTimeParams(w http.ResponseWriter, req *http.Request) (start, boundary, e
 			err = fmt.Errorf("error decoding end param: %s", err.Error())
 			return
 		}
+		// We want the end date to include the entire day specified
+		end = end.Add(24 * time.Hour)
 	} else {
 		end = time.Now()
 	}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -556,7 +556,7 @@ func (s *Server) jsonHealthReport(w http.ResponseWriter, req *http.Request) {
 func (s *Server) jsonHealthReportFromDB(w http.ResponseWriter, req *http.Request) {
 	release := s.getReleaseOrFail(w, req)
 	if release != "" {
-		api.PrintOverallReleaseHealthFromDB(w, s.db, release)
+		api.PrintOverallReleaseHealthFromDB(w, req, s.db, release)
 	}
 }
 


### PR DESCRIPTION
Move this to a function we can use in multiple API's, and also adds +24 hours to boundary and end params to make them inclusive of the entire day.