### PR TITLE
Allow searching job runs by flakes

### DIFF
--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -142,11 +142,14 @@ func PrintJobsRunsReportFromDB(w http.ResponseWriter, req *http.Request,
 		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": "Error building job run report:" + err.Error()})
 		return
 	}
-	q, err := filter.FilterableDBResult(releaseFilter(req, dbc), filterOpts, apitype.JobRun{})
+
+	rf := releaseFilter(req, dbc.DB)
+	q, err := filter.FilterableDBResult(dbc.DB, filterOpts, apitype.JobRun{})
 	if err != nil {
 		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": "Error building job run report:" + err.Error()})
 		return
 	}
+	q = rf.Where(q)
 
 	jobsResult := make([]apitype.JobRun, 0)
 	q.Table("prow_job_runs_report_matview").Scan(&jobsResult)

--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -8,6 +8,7 @@ import (
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/filter"
 	log "github.com/sirupsen/logrus"
+
 	"gorm.io/gorm"
 
 	"github.com/openshift/sippy/pkg/db"
@@ -19,7 +20,7 @@ func PrintPullRequestsReport(w http.ResponseWriter, req *http.Request, dbClient 
 		RespondWithJSON(http.StatusOK, w, []struct{}{})
 	}
 
-	q := releaseFilter(req, dbClient)
+	q := releaseFilter(req, dbClient.DB)
 	q = q.Joins(`INNER JOIN release_tag_pull_requests ON release_tag_pull_requests.release_pull_request_id = release_pull_requests.id JOIN release_tags on release_tags.id = release_tag_pull_requests.release_tag_id`)
 	filterOpts, err := filter.FilterOptionsFromRequest(req, "id", apitype.SortDescending)
 	if err != nil {
@@ -45,7 +46,7 @@ func PrintReleaseJobRunsReport(w http.ResponseWriter, req *http.Request, dbClien
 		RespondWithJSON(http.StatusOK, w, []struct{}{})
 	}
 
-	q := releaseFilter(req, dbClient)
+	q := releaseFilter(req, dbClient.DB)
 	q = q.Joins(`JOIN release_tags on release_tags.id = release_job_runs.release_tag_id`)
 	filterOpts, err := filter.FilterOptionsFromRequest(req, "id", apitype.SortDescending)
 	if err != nil {
@@ -82,7 +83,7 @@ func PrintReleasesReport(w http.ResponseWriter, req *http.Request, dbClient *db.
 		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": "Error building job run report:" + err.Error()})
 		return
 	}
-	q, err := filter.FilterableDBResult(releaseFilter(req, dbClient), filterOpts, nil)
+	q, err := filter.FilterableDBResult(releaseFilter(req, dbClient.DB), filterOpts, nil)
 	if err != nil {
 		RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{
 			"code":    http.StatusBadRequest,
@@ -160,11 +161,11 @@ func PrintReleaseHealthReport(w http.ResponseWriter, req *http.Request, dbClient
 	RespondWithJSON(http.StatusOK, w, apiResults)
 }
 
-func releaseFilter(req *http.Request, dbClient *db.DB) *gorm.DB {
+func releaseFilter(req *http.Request, db *gorm.DB) *gorm.DB {
 	releaseFilter := req.URL.Query().Get("release")
 	if releaseFilter != "" {
-		return dbClient.DB.Where("release = ?", releaseFilter)
+		return db.Where("release = ?", releaseFilter)
 	}
 
-	return dbClient.DB
+	return db
 }

--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -5,9 +5,10 @@ import (
 	"net/http"
 
 	"github.com/lib/pq"
+	log "github.com/sirupsen/logrus"
+
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/filter"
-	log "github.com/sirupsen/logrus"
 
 	"gorm.io/gorm"
 
@@ -161,11 +162,11 @@ func PrintReleaseHealthReport(w http.ResponseWriter, req *http.Request, dbClient
 	RespondWithJSON(http.StatusOK, w, apiResults)
 }
 
-func releaseFilter(req *http.Request, db *gorm.DB) *gorm.DB {
+func releaseFilter(req *http.Request, dbc *gorm.DB) *gorm.DB {
 	releaseFilter := req.URL.Query().Get("release")
 	if releaseFilter != "" {
-		return db.Where("release = ?", releaseFilter)
+		return dbc.Where("release = ?", releaseFilter)
 	}
 
-	return db
+	return dbc
 }

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -152,6 +152,8 @@ type JobRun struct {
 	ProwID                uint                `json:"prow_id"`
 	Job                   string              `json:"job"`
 	URL                   string              `json:"url"`
+	TestFlakes            int                 `json:"test_flakes"`
+	FlakedTestNames       pq.StringArray      `json:"flaked_test_names" gorm:"type:text[]"`
 	TestFailures          int                 `json:"test_failures"`
 	FailedTestNames       pq.StringArray      `json:"failed_test_names" gorm:"type:text[]"`
 	Failed                bool                `json:"failed"`
@@ -173,6 +175,8 @@ func (run JobRun) GetFieldType(param string) ColumnType {
 	case "result":
 		return ColumnTypeString
 	case "failed_test_names":
+		return ColumnTypeArray
+	case "flaked_test_names":
 		return ColumnTypeArray
 	case "variants":
 		return ColumnTypeArray
@@ -215,6 +219,8 @@ func (run JobRun) GetArrayValue(param string) ([]string, error) {
 	switch param {
 	case "failed_test_names":
 		return run.FailedTestNames, nil
+	case "flaked_test_names":
+		return run.FlakedTestNames, nil
 	case "tags":
 		return run.Tags, nil
 	case "variants":

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -80,8 +80,9 @@ export function pathForVariantsWithTestFailure(release, variant, test) {
 }
 
 export function pathForJobRunsWithTestFailure(release, test) {
-  return `/jobs/${release}/runs?${single(
-    filterFor('failed_test_names', 'contains', test)
+  return `/jobs/${release}/runs?${multiple_or(
+    filterFor('failed_test_names', 'contains', test),
+    filterFor('flaked_test_names', 'contains', test)
   )}`
 }
 
@@ -133,6 +134,12 @@ export function withoutUnstable() {
 export function multiple(...filters) {
   return `filters=${encodeURIComponent(
     JSON.stringify({ items: filters, linkOperator: 'and' })
+  )}`
+}
+
+export function multiple_or(...filters) {
+  return `filters=${encodeURIComponent(
+    JSON.stringify({ items: filters, linkOperator: 'or' })
   )}`
 }
 

--- a/sippy-ng/src/jobs/JobRunsTable.js
+++ b/sippy-ng/src/jobs/JobRunsTable.js
@@ -95,15 +95,15 @@ export default function JobRunsTable(props) {
     },
     {
       field: 'test_failures',
-      headerName: 'Test Failures',
+      headerName: 'Failures',
       type: 'number',
-      flex: 0.5,
+      flex: 0.6,
     },
     {
       field: 'test_flakes',
-      headerName: 'Test Flakes',
+      headerName: 'Flakes',
       type: 'number',
-      flex: 0.5,
+      flex: 0.6,
     },
     {
       field: 'result',

--- a/sippy-ng/src/jobs/JobRunsTable.js
+++ b/sippy-ng/src/jobs/JobRunsTable.js
@@ -100,6 +100,12 @@ export default function JobRunsTable(props) {
       flex: 0.5,
     },
     {
+      field: 'test_flakes',
+      headerName: 'Test Flakes',
+      type: 'number',
+      flex: 0.5,
+    },
+    {
       field: 'result',
       headerName: 'Result',
       flex: 0.5,
@@ -144,7 +150,11 @@ export default function JobRunsTable(props) {
       headerName: 'Failed tests',
       hide: true,
     },
-
+    {
+      field: 'flaked_test_names',
+      headerName: 'Flaked tests',
+      hide: true,
+    },
     // These are fields on the job, not the run - but we can
     // filter by them.
     {


### PR DESCRIPTION
*NOTE*: This requires dropping the job runs materialized view to update it.

If you look at tests that mostly flake -- https://sippy.dptools.openshift.org/sippy-ng/tests/4.11/analysis?test=[sig-arch][Late]%20clients%20should%20not%20use%20APIs%20that%20are%20removed%20in%20upcoming%20releases%20[Suite:openshift/conformance/parallel] is a good example, clicking on "All job runs" doesn't show any results (or at least, very few).

We're definitely interested to see jobs where tests flaked, so this adds that option.

For the above test, we now get results like this:

![image](https://user-images.githubusercontent.com/429763/165389726-87a6d90e-e1f5-4541-aca0-f9ede78d51a6.png)


