### PR TITLE
Show flake % in tool tip and link to runs/flakes separately

### DIFF
--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -238,18 +238,22 @@ type Test struct {
 	Variant  string         `json:"variant,omitempty"`
 	Variants pq.StringArray `json:"variants" gorm:"type:text[]"`
 
-	CurrentSuccesses      int     `json:"current_successes"`
-	CurrentFailures       int     `json:"current_failures"`
-	CurrentFlakes         int     `json:"current_flakes"`
-	CurrentPassPercentage float64 `json:"current_pass_percentage"`
-	CurrentRuns           int     `json:"current_runs"`
+	CurrentSuccesses         int     `json:"current_successes"`
+	CurrentFailures          int     `json:"current_failures"`
+	CurrentFlakes            int     `json:"current_flakes"`
+	CurrentPassPercentage    float64 `json:"current_pass_percentage"`
+	CurrentFailurePercentage float64 `json:"current_failure_percentage"`
+	CurrentFlakePercentage   float64 `json:"current_flake_percentage"`
+	CurrentRuns              int     `json:"current_runs"`
 
-	PreviousSuccesses      int     `json:"previous_successes"`
-	PreviousFailures       int     `json:"previous_failures"`
-	PreviousFlakes         int     `json:"previous_flakes"`
-	PreviousPassPercentage float64 `json:"previous_pass_percentage"`
-	PreviousRuns           int     `json:"previous_runs"`
-	NetImprovement         float64 `json:"net_improvement"`
+	PreviousSuccesses         int     `json:"previous_successes"`
+	PreviousFailures          int     `json:"previous_failures"`
+	PreviousFlakes            int     `json:"previous_flakes"`
+	PreviousPassPercentage    float64 `json:"previous_pass_percentage"`
+	PreviousFailurePercentage float64 `json:"previous_failure_percentage"`
+	PreviousFlakePercentage   float64 `json:"previous_flake_percentage"`
+	PreviousRuns              int     `json:"previous_runs"`
+	NetImprovement            float64 `json:"net_improvement"`
 
 	Tags           []string     `json:"tags"`
 	Bugs           []bugsv1.Bug `json:"bugs"`

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -79,11 +79,32 @@ export function pathForVariantsWithTestFailure(release, variant, test) {
   )}`
 }
 
-export function pathForJobRunsWithTestFailure(release, test) {
-  return `/jobs/${release}/runs?${multiple_or(
-    filterFor('failed_test_names', 'contains', test),
-    filterFor('flaked_test_names', 'contains', test)
-  )}`
+export function pathForJobRunsWithTestFailure(release, test, filter) {
+  let filters = []
+  filters.push(filterFor('failed_test_names', 'contains', test))
+  if (filter && filter.items) {
+    filter.items.forEach((item) => {
+      if (item.columnField === 'variants') {
+        filters.push(item)
+      }
+    })
+  }
+
+  return `/jobs/${release}/runs?${multiple(...filters)}`
+}
+
+export function pathForJobRunsWithTestFlake(release, test, filter) {
+  let filters = []
+  filters.push(filterFor('flaked_test_names', 'contains', test))
+  if (filter && filter.items) {
+    filter.items.forEach((item) => {
+      if (item.columnField === 'variants') {
+        filters.push(item)
+      }
+    })
+  }
+
+  return `/jobs/${release}/runs?${multiple(...filters)}`
 }
 
 export function pathForJobRunsWithFilter(release, filter) {


### PR DESCRIPTION
This show the flake % in a tool tip, and link to runs/flakes separately. I *think* this is better than the current view (click image below to embiggen). 


![Peek 2022-04-27 11-41](https://user-images.githubusercontent.com/429763/165558670-424bd086-920b-49ee-b1dd-8dbfbfa8a178.gif)
