### PR TITLE
Allow filterable to be empty on SQL filtering

### DIFF
--- a/pkg/filter/filterable.go
+++ b/pkg/filter/filterable.go
@@ -65,21 +65,19 @@ func (f FilterItem) orFilterToSQL(db *gorm.DB, filterable Filterable) *gorm.DB {
 	case OperatorContains:
 		// "contains" is an overloaded operator: 1) see if an array field contains an item,
 		// 2) string contains a substring, so we need to know the field type.
-		switch filterable.GetFieldType(f.Field) {
-		case apitype.ColumnTypeArray:
+		if filterable != nil && filterable.GetFieldType(f.Field) == apitype.ColumnTypeArray {
 			if f.Not {
 				db = db.Or(fmt.Sprintf("? != ALL(%s)", f.Field), f.Value)
 			} else {
 				db = db.Or(fmt.Sprintf("? = ANY(%s)", f.Field), f.Value)
 			}
-		default:
+		} else {
 			if f.Not {
 				db = db.Or(fmt.Sprintf("%q NOT LIKE ?", f.Field), fmt.Sprintf("%%%s%%", f.Value))
 			} else {
 				db = db.Or(fmt.Sprintf("%q LIKE ?", f.Field), fmt.Sprintf("%%%s%%", f.Value))
 			}
 		}
-
 	case OperatorEquals, OperatorArithmeticEquals:
 		if f.Not {
 			db = db.Or(fmt.Sprintf("%q != ?", f.Field), f.Value)
@@ -147,14 +145,13 @@ func (f FilterItem) orFilterToSQL(db *gorm.DB, filterable Filterable) *gorm.DB {
 func (f FilterItem) andFilterToSQL(db *gorm.DB, filterable Filterable) *gorm.DB { //nolint
 	switch f.Operator {
 	case OperatorContains:
-		switch filterable.GetFieldType(f.Field) {
-		case apitype.ColumnTypeArray:
+		if filterable != nil && filterable.GetFieldType(f.Field) == apitype.ColumnTypeArray {
 			if f.Not {
 				db = db.Not(fmt.Sprintf("? = ANY(%s)", f.Field), f.Value)
 			} else {
 				db = db.Where(fmt.Sprintf("? = ANY(%s)", f.Field), f.Value)
 			}
-		default:
+		} else {
 			if f.Not {
 				db = db.Not(fmt.Sprintf("%q LIKE ?", f.Field), fmt.Sprintf("%%%s%%", f.Value))
 			} else {


### PR DESCRIPTION
Filtering from the release tag page is broken, since it expects
to get a filterable passed it, but release tag doesn't send one. This
adds a nil check and default value.

See https://sippy.dptools.openshift.org/sippy-ng/release/4.11/tags, and
try to filter by tag name "contains", e.g. :https://sippy.dptools.openshift.org/sippy-ng/release/4.11/tags?filters=%257B%2522items%2522%253A%255B%257B%2522columnField%2522%253A%2522release_tag%2522%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%25222022-05-01%2522%257D%255D%252C%2522linkOperator%2522%253A%2522and%2522%257D