### PR TITLE
Fix error when tests are null

### DIFF
--- a/pkg/api/jobs.go
+++ b/pkg/api/jobs.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/sippy/pkg/db/query"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
+
+	"github.com/openshift/sippy/pkg/db/query"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/db"
@@ -361,7 +362,7 @@ func PrintJobDetailsReportFromDB(w http.ResponseWriter, req *http.Request, dbc *
 	// TODO: 14 days matches orig API behavior, may want to add query params in future to control.
 	since := time.Now().Add(-14 * 24 * time.Hour)
 
-	prowJobRuns := []*models.ProwJobRun{}
+	prowJobRuns := make([]*models.ProwJobRun, 0)
 	res := dbc.DB.Joins("ProwJob").
 		Where("name LIKE ?", "%"+jobSearchStr+"%").
 		Where("timestamp > ?", since).

--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -224,7 +224,7 @@ func BuildTestsResults(dbc *db.DB, release, period string, fil *filter.Filter) (
 		rawQuery = rawFilter.ToSQL(rawQuery, apitype.Test{})
 	}
 
-	var testReports []apitype.Test
+	testReports := make([]apitype.Test, 0)
 	// FIXME: Add test id to matview, for now generate with ROW_NUMBER OVER
 	processedResults := dbc.DB.Table("(?) as results", rawQuery).Select(
 		`ROW_NUMBER() OVER() as id,

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -400,7 +400,11 @@ function TestTable(props) {
         return response.json()
       })
       .then((json) => {
-        setRows(json)
+        if (json != null) {
+          setRows(json)
+        } else {
+          setRows([])
+        }
         setLoaded(true)
       })
       .catch((error) => {


### PR DESCRIPTION
If not tests are found, we return null instead of `[]`, which breaks the
UI. This fixes it so the API returns `[]`, and the UI can handle a null
result from the API.