### PR TITLE
Use custom serializer for use-query-params

### DIFF
--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -2,6 +2,19 @@
 // and not supported in all browsers, and it's not in node yet.
 import React from 'react'
 
+export const SafeJSONParam = {
+  encode: (j) => {
+    return safeEncodeURIComponent(JSON.stringify(j))
+  },
+  decode: (j) => {
+    try {
+      return JSON.parse(decodeURIComponent(j))
+    } catch (e) {
+      // return undefined
+    }
+  },
+}
+
 // safeEncodeURIComponent wraps the library function, and additionally encodes
 // square brackets.  Square brackets are NOT unsafe per RFC1738, but Google and
 // others mishandle them.

--- a/sippy-ng/src/jobs/JobAnalysis.js
+++ b/sippy-ng/src/jobs/JobAnalysis.js
@@ -1,7 +1,6 @@
 import './JobAnalysis.css'
 import {
   ArrayParam,
-  JsonParam,
   NumberParam,
   StringParam,
   useQueryParam,
@@ -29,6 +28,7 @@ import {
   pathForJobRunsWithFilter,
   pathForJobsWithFilter,
   safeEncodeURIComponent,
+  SafeJSONParam,
   withSort,
 } from '../helpers'
 import { scale } from 'chroma-js'
@@ -46,7 +46,7 @@ export function JobAnalysis(props) {
   const [isLoaded, setLoaded] = React.useState(false)
   const [analysis, setAnalysis] = React.useState({ by_period: {} })
 
-  const [filterModel, setFilterModel] = useQueryParam('filters', JsonParam)
+  const [filterModel, setFilterModel] = useQueryParam('filters', SafeJSONParam)
   const [period, setPeriod] = useQueryParam('period', StringParam)
   const [dayOffset = 1, setDayOffset] = useQueryParam('dayOffset', NumberParam)
 
@@ -60,7 +60,7 @@ export function JobAnalysis(props) {
   )
   const [testFilter, setTestFilter] = useQueryParam(
     'testFilters',
-    withDefault(JsonParam, { items: [] })
+    withDefault(SafeJSONParam, { items: [] })
   )
 
   const [testSelectionDialog, setTestSelectionDialog] = React.useState(false)

--- a/sippy-ng/src/jobs/JobRunsTable.js
+++ b/sippy-ng/src/jobs/JobRunsTable.js
@@ -8,13 +8,14 @@ import {
 } from '@material-ui/core'
 import { DataGrid } from '@material-ui/data-grid'
 import { DirectionsBoat } from '@material-ui/icons'
-import { JsonParam, StringParam, useQueryParam } from 'use-query-params'
 import { Link } from 'react-router-dom'
 import {
   pathForExactJob,
   relativeTime,
   safeEncodeURIComponent,
+  SafeJSONParam,
 } from '../helpers'
+import { StringParam, useQueryParam } from 'use-query-params'
 import Alert from '@material-ui/lab/Alert'
 import GridToolbar from '../datagrid/GridToolbar'
 import PropTypes from 'prop-types'
@@ -30,7 +31,7 @@ export default function JobRunsTable(props) {
 
   const [filterModel = props.filterModel, setFilterModel] = useQueryParam(
     'filters',
-    JsonParam
+    SafeJSONParam
   )
 
   const [sortField = props.sortField, setSortField] = useQueryParam(

--- a/sippy-ng/src/jobs/JobTable.js
+++ b/sippy-ng/src/jobs/JobTable.js
@@ -8,10 +8,11 @@ import {
   pathForExactJobAnalysis,
   pathForExactJobRuns,
   safeEncodeURIComponent,
+  SafeJSONParam,
 } from '../helpers'
 import { generateClasses } from '../datagrid/utils'
-import { JsonParam, StringParam, useQueryParam } from 'use-query-params'
 import { Link } from 'react-router-dom'
+import { StringParam, useQueryParam } from 'use-query-params'
 import { withStyles } from '@material-ui/styles'
 import Alert from '@material-ui/lab/Alert'
 import BugzillaDialog from '../bugzilla/BugzillaDialog'
@@ -181,7 +182,7 @@ function JobTable(props) {
 
   const [filterModel = props.filterModel, setFilterModel] = useQueryParam(
     'filters',
-    JsonParam
+    SafeJSONParam
   )
 
   const [sortField = props.sortField, setSortField] = useQueryParam(

--- a/sippy-ng/src/releases/ReleasePayloadJobRuns.js
+++ b/sippy-ng/src/releases/ReleasePayloadJobRuns.js
@@ -2,8 +2,8 @@ import { Button, Tooltip } from '@material-ui/core'
 import { Check, DirectionsBoat, Error } from '@material-ui/icons'
 import { createTheme, makeStyles } from '@material-ui/core/styles'
 import { DataGrid } from '@material-ui/data-grid'
-import { JsonParam, StringParam, useQueryParam } from 'use-query-params'
-import { safeEncodeURIComponent } from '../helpers'
+import { safeEncodeURIComponent, SafeJSONParam } from '../helpers'
+import { StringParam, useQueryParam } from 'use-query-params'
 import Alert from '@material-ui/lab/Alert'
 import GridToolbar from '../datagrid/GridToolbar'
 import PropTypes from 'prop-types'
@@ -88,7 +88,7 @@ function ReleasePayloadJobRuns(props) {
 
   const [filterModel = props.filterModel, setFilterModel] = useQueryParam(
     'filters',
-    JsonParam
+    SafeJSONParam
   )
 
   const [sortField = props.sortField, setSortField] = useQueryParam(

--- a/sippy-ng/src/releases/ReleasePayloadPullRequests.js
+++ b/sippy-ng/src/releases/ReleasePayloadPullRequests.js
@@ -1,8 +1,8 @@
 import { createTheme, makeStyles } from '@material-ui/core/styles'
 import { DataGrid } from '@material-ui/data-grid'
 import { Error } from '@material-ui/icons'
-import { JsonParam, StringParam, useQueryParam } from 'use-query-params'
-import { safeEncodeURIComponent } from '../helpers'
+import { safeEncodeURIComponent, SafeJSONParam } from '../helpers'
+import { StringParam, useQueryParam } from 'use-query-params'
 import Alert from '@material-ui/lab/Alert'
 import GridToolbar from '../datagrid/GridToolbar'
 import PropTypes from 'prop-types'
@@ -66,7 +66,7 @@ function ReleasePayloadPullRequests(props) {
 
   const [filterModel = props.filterModel, setFilterModel] = useQueryParam(
     'filters',
-    JsonParam
+    SafeJSONParam
   )
 
   const [sortField = props.sortField, setSortField] = useQueryParam(

--- a/sippy-ng/src/releases/ReleasePayloadTable.js
+++ b/sippy-ng/src/releases/ReleasePayloadTable.js
@@ -3,9 +3,9 @@ import { Box, Button, Container, Tooltip, Typography } from '@material-ui/core'
 import { CheckCircle, CompareArrows, Error, Help } from '@material-ui/icons'
 import { createTheme, makeStyles } from '@material-ui/core/styles'
 import { DataGrid } from '@material-ui/data-grid'
-import { JsonParam, StringParam, useQueryParam } from 'use-query-params'
 import { Link } from 'react-router-dom'
-import { relativeTime, safeEncodeURIComponent } from '../helpers'
+import { relativeTime, safeEncodeURIComponent, SafeJSONParam } from '../helpers'
+import { StringParam, useQueryParam } from 'use-query-params'
 import Alert from '@material-ui/lab/Alert'
 import GridToolbar from '../datagrid/GridToolbar'
 import PropTypes from 'prop-types'
@@ -187,7 +187,7 @@ function ReleasePayloadTable(props) {
 
   const [filterModel = props.filterModel, setFilterModel] = useQueryParam(
     'filters',
-    JsonParam
+    SafeJSONParam
   )
 
   const [sortField = props.sortField, setSortField] = useQueryParam(

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -14,12 +14,13 @@ import {
   pathForJobRunsWithTestFailure,
   pathForJobRunsWithTestFlake,
   safeEncodeURIComponent,
+  SafeJSONParam,
   withSort,
 } from '../helpers'
 import { generateClasses } from '../datagrid/utils'
-import { JsonParam, StringParam, useQueryParam } from 'use-query-params'
 import { Link } from 'react-router-dom'
 import { makeStyles } from '@material-ui/core/styles'
+import { StringParam, useQueryParam } from 'use-query-params'
 import { withStyles } from '@material-ui/styles'
 import Alert from '@material-ui/lab/Alert'
 import BugzillaDialog from '../bugzilla/BugzillaDialog'
@@ -360,7 +361,7 @@ function TestTable(props) {
 
   const [filterModel = props.filterModel, setFilterModel] = useQueryParam(
     'filters',
-    JsonParam
+    SafeJSONParam
   )
 
   const [sortField = props.sortField, setSortField] = useQueryParam(

--- a/sippy-ng/src/workloadmetrics/WorkloadMetricsTable.js
+++ b/sippy-ng/src/workloadmetrics/WorkloadMetricsTable.js
@@ -2,7 +2,8 @@
 import '../jobs/JobTable.css'
 import { DataGrid } from '@material-ui/data-grid'
 import { Grid } from '@material-ui/core'
-import { JsonParam, useQueryParam } from 'use-query-params'
+import { SafeJSONParam } from '../helpers'
+import { useQueryParam } from 'use-query-params'
 import Alert from '@material-ui/lab/Alert'
 import GridToolbar from '../datagrid/GridToolbar'
 import PropTypes from 'prop-types'
@@ -158,7 +159,7 @@ function WorkloadMetricsTable(props) {
 
   const [filterModel = props.filterModel, setFilterModel] = useQueryParam(
     'filters',
-    JsonParam
+    SafeJSONParam
   )
 
   useEffect(() => {


### PR DESCRIPTION
A follow-up to ensure square brackets are quoted in JSON encoded
URI params.