### PR TITLE
job runs: fix sort by timestamp

### DIFF
--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -149,7 +149,8 @@ func PrintJobsRunsReportFromDB(w http.ResponseWriter, req *http.Request,
 		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": "Error building job run report:" + err.Error()})
 		return
 	}
-	q = rf.Where(q)
+
+	q = q.Where(rf)
 
 	jobsResult := make([]apitype.JobRun, 0)
 	q.Table("prow_job_runs_report_matview").Scan(&jobsResult)


### PR DESCRIPTION
Ordering of release vs filtered results query was reversed, making ORDER
BY apply to the wrong subquery.

e.g., try to sort by timestamp here (it won't work):

https://sippy.dptools.openshift.org/sippy-ng/jobs/4.11/runs?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22failed_test_names%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22%5Bsig-network%5D%20services%20external%20ip%20ensures%20policy%20is%20configured%20correctly%20on%20the%20cluster%20%5BSerial%5D%20%5BSuite%3Aopenshift%2Fconformance%2Fserial%5D%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22techpreview%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D&sortField=timestamp&sort=desc

