### PR TITLE
rhcos ver check

### DIFF
--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -214,9 +214,7 @@ func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release 
 	if err != nil {
 		warnings = append(warnings, fmt.Sprintf("error checking release health, see logs: %v", err))
 	} else {
-		for _, rw := range releaseWarnings {
-			warnings = append(warnings, rw)
-		}
+		warnings = append(warnings, releaseWarnings...)
 	}
 
 	RespondWithJSON(http.StatusOK, w, health{

--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"math"
 	"net/http"
 	"time"
@@ -209,13 +208,7 @@ func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release 
 	}
 	currStats, prevStats := calculateJobResultStatistics(jobReports)
 
-	warnings := make([]string, 0)
-	releaseWarnings, err := ScanReleaseHealth(dbc, release)
-	if err != nil {
-		warnings = append(warnings, fmt.Sprintf("error checking release health, see logs: %v", err))
-	} else {
-		warnings = append(warnings, releaseWarnings...)
-	}
+	warnings := ScanForReleaseWarnings(dbc, release)
 
 	RespondWithJSON(http.StatusOK, w, health{
 		Indicators:  indicators,

--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -147,14 +147,15 @@ func ReleaseHealthReports(dbClient *db.DB, release string) ([]apitype.ReleaseHea
 	return apiResults, nil
 }
 
-// ScanReleaseHealth looks for problems in current release health and returns them to the user.
-func ScanReleaseHealth(dbClient *db.DB, release string) ([]string, error) {
+// ScanForReleaseWarnings looks for problems in current release health and returns them to the user.
+func ScanForReleaseWarnings(dbClient *db.DB, release string) []string {
 	payloadHealth, err := ReleaseHealthReports(dbClient, release)
 	if err != nil {
-		return []string{}, err
+		// treat the error as a warning itself
+		return []string{fmt.Sprintf("error checking release health, see logs: %v", err)}
 	}
 	// May add more release health checks in future
-	return ScanReleaseHealthForRHCOSVersionMisMatches(payloadHealth), nil
+	return ScanReleaseHealthForRHCOSVersionMisMatches(payloadHealth)
 }
 
 func ScanReleaseHealthForRHCOSVersionMisMatches(payloadHealth []apitype.ReleaseHealthReport) []string {

--- a/pkg/api/releases_test.go
+++ b/pkg/api/releases_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"testing"
 
-	"github.com/openshift/sippy/pkg/apis/api"
+	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/stretchr/testify/assert"
 )
@@ -11,19 +11,19 @@ import (
 func TestScanReleaseHealthForRHCOSVersionMisMatches(t *testing.T) {
 	tests := []struct {
 		name             string
-		releaseHealth    []api.ReleaseHealthReport
+		releaseHealth    []apitype.ReleaseHealthReport
 		expectedWarnings []string
 	}{
 		{
 			name: "single stream os version match",
-			releaseHealth: []api.ReleaseHealthReport{
-				buildFakeReleaseHealthReport("4.11", "411.85.202203212232-0"),
+			releaseHealth: []apitype.ReleaseHealthReport{
+				buildFakeReleaseHealthReport("411.85.202203212232-0"),
 			},
 		},
 		{
 			name: "single stream os version mismatch",
-			releaseHealth: []api.ReleaseHealthReport{
-				buildFakeReleaseHealthReport("4.11", "410.85.202203212232-0"),
+			releaseHealth: []apitype.ReleaseHealthReport{
+				buildFakeReleaseHealthReport("410.85.202203212232-0"),
 			},
 			expectedWarnings: []string{
 				"OS version 410.85.202203212232-0 does not match OpenShift release 4.11",
@@ -31,8 +31,8 @@ func TestScanReleaseHealthForRHCOSVersionMisMatches(t *testing.T) {
 		},
 		{
 			name: "single stream os version parse error",
-			releaseHealth: []api.ReleaseHealthReport{
-				buildFakeReleaseHealthReport("4.11", "foobar"),
+			releaseHealth: []apitype.ReleaseHealthReport{
+				buildFakeReleaseHealthReport("foobar"),
 			},
 			expectedWarnings: []string{
 				"unable to parse OpenShift version from OS version foobar",
@@ -40,11 +40,11 @@ func TestScanReleaseHealthForRHCOSVersionMisMatches(t *testing.T) {
 		},
 		{
 			name: "multi stream os version mismatch",
-			releaseHealth: []api.ReleaseHealthReport{
-				buildFakeReleaseHealthReport("4.11", "411.85.202203212232-0"), // one good
-				buildFakeReleaseHealthReport("4.11", "410.85.202203212232-0"),
-				buildFakeReleaseHealthReport("4.11", "412.85.202203212232-0"),
-				buildFakeReleaseHealthReport("4.11", "413.85.202203212232-0"),
+			releaseHealth: []apitype.ReleaseHealthReport{
+				buildFakeReleaseHealthReport("411.85.202203212232-0"), // one good
+				buildFakeReleaseHealthReport("410.85.202203212232-0"),
+				buildFakeReleaseHealthReport("412.85.202203212232-0"),
+				buildFakeReleaseHealthReport("413.85.202203212232-0"),
 			},
 			expectedWarnings: []string{
 				"OS version 410.85.202203212232-0 does not match OpenShift release 4.11",
@@ -61,10 +61,10 @@ func TestScanReleaseHealthForRHCOSVersionMisMatches(t *testing.T) {
 	}
 }
 
-func buildFakeReleaseHealthReport(release, osVersion string) api.ReleaseHealthReport {
-	return api.ReleaseHealthReport{
+func buildFakeReleaseHealthReport(osVersion string) apitype.ReleaseHealthReport {
+	return apitype.ReleaseHealthReport{
 		ReleaseTag: models.ReleaseTag{
-			Release:          release,
+			Release:          "4.11",
 			CurrentOSVersion: osVersion,
 		},
 	}

--- a/pkg/api/releases_test.go
+++ b/pkg/api/releases_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/openshift/sippy/pkg/apis/api"
+	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScanReleaseHealthForRHCOSVersionMisMatches(t *testing.T) {
+	tests := []struct {
+		name             string
+		releaseHealth    []api.ReleaseHealthReport
+		expectedWarnings []string
+	}{
+		{
+			name: "single stream os version match",
+			releaseHealth: []api.ReleaseHealthReport{
+				buildFakeReleaseHealthReport("4.11", "411.85.202203212232-0"),
+			},
+		},
+		{
+			name: "single stream os version mismatch",
+			releaseHealth: []api.ReleaseHealthReport{
+				buildFakeReleaseHealthReport("4.11", "410.85.202203212232-0"),
+			},
+			expectedWarnings: []string{
+				"OS version 410.85.202203212232-0 does not match OpenShift release 4.11",
+			},
+		},
+		{
+			name: "single stream os version parse error",
+			releaseHealth: []api.ReleaseHealthReport{
+				buildFakeReleaseHealthReport("4.11", "foobar"),
+			},
+			expectedWarnings: []string{
+				"unable to parse OpenShift version from OS version foobar",
+			},
+		},
+		{
+			name: "multi stream os version mismatch",
+			releaseHealth: []api.ReleaseHealthReport{
+				buildFakeReleaseHealthReport("4.11", "411.85.202203212232-0"), // one good
+				buildFakeReleaseHealthReport("4.11", "410.85.202203212232-0"),
+				buildFakeReleaseHealthReport("4.11", "412.85.202203212232-0"),
+				buildFakeReleaseHealthReport("4.11", "413.85.202203212232-0"),
+			},
+			expectedWarnings: []string{
+				"OS version 410.85.202203212232-0 does not match OpenShift release 4.11",
+				"OS version 412.85.202203212232-0 does not match OpenShift release 4.11",
+				"OS version 413.85.202203212232-0 does not match OpenShift release 4.11",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			warnings := ScanReleaseHealthForRHCOSVersionMisMatches(tc.releaseHealth)
+			assert.ElementsMatch(t, tc.expectedWarnings, warnings, "unexpected warnings")
+		})
+	}
+}
+
+func buildFakeReleaseHealthReport(release, osVersion string) api.ReleaseHealthReport {
+	return api.ReleaseHealthReport{
+		ReleaseTag: models.ReleaseTag{
+			Release:          release,
+			CurrentOSVersion: osVersion,
+		},
+	}
+}

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/lib/pq"
+	"github.com/openshift/sippy/pkg/db/models"
 
 	bugsv1 "github.com/openshift/sippy/pkg/apis/bugs/v1"
 	v1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
@@ -354,4 +355,11 @@ func (test Test) GetArrayValue(param string) ([]string, error) {
 	default:
 		return nil, fmt.Errorf("unknown array value field %s", param)
 	}
+}
+
+// ReleaseHealthReport contains information about the latest health of release payloads for a specific tag.
+type ReleaseHealthReport struct {
+	models.ReleaseTag
+	LastPhase string `json:"last_phase"`
+	Count     int    `json:"count"`
 }

--- a/pkg/apis/sippy/v1/types.go
+++ b/pkg/apis/sippy/v1/types.go
@@ -11,13 +11,6 @@ type PassRate struct {
 	Runs                int     `json:"runs"`
 }
 
-// SummaryAcrossAllJobs describes the category summaryacrossalljobs
-// valid keys are latest and prev
-type SummaryAcrossAllJobs struct {
-	TestExecutions     map[string]int     `json:"testExecutions"`
-	TestPassPercentage map[string]float64 `json:"testPassPercentage"`
-}
-
 // FailureGroups describes the category failuregroups
 // valid keys are latest and prev
 type FailureGroups struct {

--- a/pkg/db/models/releases.go
+++ b/pkg/db/models/releases.go
@@ -2,8 +2,6 @@ package models
 
 import (
 	"time"
-
-	"gorm.io/gorm"
 )
 
 type ReleaseTag struct {
@@ -115,74 +113,4 @@ type ReleaseJobRun struct {
 	UpgradesFrom   string     `json:"upgrades_from" gorm:"column:upgrades_from"`
 	UpgradesTo     string     `json:"upgrades_to" gorm:"column:upgrades_to"`
 	Upgrade        bool       `json:"upgrade" gorm:"column:upgrade"`
-}
-
-// GetLastAcceptedByArchitectureAndStream returns the last accepted payload for each architecture/stream combo.
-func GetLastAcceptedByArchitectureAndStream(db *gorm.DB, release string) ([]ReleaseTag, error) {
-	results := make([]ReleaseTag, 0)
-
-	result := db.Raw(`SELECT
-						DISTINCT ON
-							(architecture, stream)
-							*
-						FROM
-							release_tags
-						WHERE
-							release = ?
-						AND
-							phase = 'Accepted'
-						ORDER BY
-							architecture, stream, release_time desc`, release).Scan(&results)
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	return results, nil
-}
-
-// GetLastPayloadStatus returns the most recent payload status for an architecture/stream combination,
-// as well as the count of how many of the last payloads had that status (e.g., when this returns
-// Rejected, 5 -- it means the last 5 payloads were rejected.
-func GetLastPayloadStatus(db *gorm.DB, architecture, stream, release string) (string, int, error) {
-	count := struct {
-		Phase string `gorm:"column:phase"`
-		Count int    `gorm:"column:count"`
-	}{}
-
-	result := db.Raw(`
-		WITH releases AS
-			(
-				SELECT
-					ROW_NUMBER() OVER(ORDER BY release_time desc) AS id,
-					phase
-				FROM
-					release_tags
-				WHERE
-					architecture = ? AND stream = ? AND release = ?
-			),
-		changes AS
-			(
-				SELECT
-					*,
-					CASE WHEN LAG(phase) OVER(ORDER BY id) = phase THEN 0 ELSE 1 END AS change
-				FROM
-					releases
-			),
-		groups AS
-			(
-				SELECT
-					*,
-					SUM(change) OVER(ORDER BY id) AS group FROM changes
-			)
-		SELECT
-			phase, COUNT(phase)
-		FROM
-			groups
-		WHERE
-			groups.group = 1
-		GROUP BY
-			phase`, architecture, stream, release).Scan(&count)
-
-	return count.Phase, count.Count, result.Error
 }

--- a/pkg/db/query/payload_queries.go
+++ b/pkg/db/query/payload_queries.go
@@ -1,0 +1,77 @@
+package query
+
+import (
+	"gorm.io/gorm"
+
+	"github.com/openshift/sippy/pkg/db/models"
+)
+
+// GetLastAcceptedByArchitectureAndStream returns the last accepted payload for each architecture/stream combo.
+func GetLastAcceptedByArchitectureAndStream(db *gorm.DB, release string) ([]models.ReleaseTag, error) {
+	results := make([]models.ReleaseTag, 0)
+
+	result := db.Raw(`SELECT
+						DISTINCT ON
+							(architecture, stream)
+							*
+						FROM
+							release_tags
+						WHERE
+							release = ?
+						AND
+							phase = 'Accepted'
+						ORDER BY
+							architecture, stream, release_time desc`, release).Scan(&results)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return results, nil
+}
+
+// GetLastPayloadStatus returns the most recent payload status for an architecture/stream combination,
+// as well as the count of how many of the last payloads had that status (e.g., when this returns
+// Rejected, 5 -- it means the last 5 payloads were rejected.
+func GetLastPayloadStatus(db *gorm.DB, architecture, stream, release string) (string, int, error) {
+	count := struct {
+		Phase string `gorm:"column:phase"`
+		Count int    `gorm:"column:count"`
+	}{}
+
+	result := db.Raw(`
+		WITH releases AS
+			(
+				SELECT
+					ROW_NUMBER() OVER(ORDER BY release_time desc) AS id,
+					phase
+				FROM
+					release_tags
+				WHERE
+					architecture = ? AND stream = ? AND release = ?
+			),
+		changes AS
+			(
+				SELECT
+					*,
+					CASE WHEN LAG(phase) OVER(ORDER BY id) = phase THEN 0 ELSE 1 END AS change
+				FROM
+					releases
+			),
+		groups AS
+			(
+				SELECT
+					*,
+					SUM(change) OVER(ORDER BY id) AS group FROM changes
+			)
+		SELECT
+			phase, COUNT(phase)
+		FROM
+			groups
+		WHERE
+			groups.group = 1
+		GROUP BY
+			phase`, architecture, stream, release).Scan(&count)
+
+	return count.Phase, count.Count, result.Error
+}

--- a/pkg/db/query/release_queries.go
+++ b/pkg/db/query/release_queries.go
@@ -9,7 +9,7 @@ type Release struct {
 	Release string
 }
 
-func ReleasesFromDB(dbClient *db.DB) []Release {
+func ReleasesFromDB(dbClient *db.DB) ([]Release, error) {
 	var releases []Release
 	// The string_to_array trick ensures releases are sorted in version order, descending
 	res := dbClient.DB.Raw(`
@@ -18,7 +18,7 @@ func ReleasesFromDB(dbClient *db.DB) []Release {
                 ORDER BY sortable_release desc`).Scan(&releases)
 	if res.Error != nil {
 		log.Errorf("error querying releases from db: %v", res.Error)
-		return nil
+		return releases, res.Error
 	}
-	return releases
+	return releases, nil
 }

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -455,7 +455,26 @@ func (s *Server) jsonReleaseJobRunsReport(w http.ResponseWriter, req *http.Reque
 }
 
 func (s *Server) jsonReleaseHealthReport(w http.ResponseWriter, req *http.Request) {
-	api.PrintReleaseHealthReport(w, req, s.db)
+	release := req.URL.Query().Get("release")
+	if release == "" {
+		api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{
+			"code":    http.StatusBadRequest,
+			"message": fmt.Errorf(`"release" is required`),
+		})
+		return
+	}
+
+	results, err := api.ReleaseHealthReports(s.db, release)
+	if err != nil {
+		api.RespondWithJSON(http.StatusInternalServerError, w, err)
+		api.RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{
+			"code":    http.StatusInternalServerError,
+			"message": err.Error(),
+		})
+		return
+	}
+
+	api.RespondWithJSON(http.StatusOK, w, results)
 }
 
 func (s *Server) jsonJobAnalysisReport(w http.ResponseWriter, req *http.Request) {

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -183,26 +183,20 @@ func (s *Server) refreshMetricsDB() error {
 
 		if err != nil {
 			return errors.Wrapf(err, "error refreshing prom report type %s - %s", pType.period, pType.release)
-		} else {
-			for _, jobResult := range jobsResult {
-				jobPassRatioMetric.WithLabelValues(pType.release, pType.period, jobResult.Name).Set(jobResult.CurrentPassPercentage / 100)
-			}
+		}
+		for _, jobResult := range jobsResult {
+			jobPassRatioMetric.WithLabelValues(pType.release, pType.period, jobResult.Name).Set(jobResult.CurrentPassPercentage / 100)
 		}
 	}
 
 	// Add a metric for any warnings for each release. We can't convey exact details with prom, but we can
 	// tell you x warnings are present and link you to the overview in the alert.
 	for _, release := range releases {
-		warnings := make([]string, 0)
 		releaseWarnings, err := api.ScanReleaseHealth(s.db, release.Release)
 		if err != nil {
 			return err
-		} else {
-			for _, rw := range releaseWarnings {
-				warnings = append(warnings, rw)
-			}
 		}
-		releaseWarningsMetric.WithLabelValues(release.Release).Set(float64(len(warnings)))
+		releaseWarningsMetric.WithLabelValues(release.Release).Set(float64(len(releaseWarnings)))
 	}
 
 	return nil

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -124,7 +124,7 @@ var (
 
 	releaseWarningsMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "sippy_release_warnings",
-		Help: "Number of current warnings for a release",
+		Help: "Number of current warnings for a release, see overview page in UI for details",
 	}, []string{"release"})
 )
 
@@ -192,10 +192,7 @@ func (s *Server) refreshMetricsDB() error {
 	// Add a metric for any warnings for each release. We can't convey exact details with prom, but we can
 	// tell you x warnings are present and link you to the overview in the alert.
 	for _, release := range releases {
-		releaseWarnings, err := api.ScanReleaseHealth(s.db, release.Release)
-		if err != nil {
-			return err
-		}
+		releaseWarnings := api.ScanForReleaseWarnings(s.db, release.Release)
 		releaseWarningsMetric.WithLabelValues(release.Release).Set(float64(len(releaseWarnings)))
 	}
 


### PR DESCRIPTION
Refactor for release health query re-use.

Display warnings on releaes overview pages if we detect an RHCOS version that doesn't seem to match the release it's in a payload for. (i.e. release 4.11 should match RHCOS version 411.86.202205030351-0)

Adds a gauge metric for the count of warnings per release. It won't tell you what's wrong, but it will tell you something is and can link you to the overview where you get the details easily.
