### PR TITLE
Disable autocomplete on job names

### DIFF
--- a/sippy-ng/src/jobs/JobTable.js
+++ b/sippy-ng/src/jobs/JobTable.js
@@ -31,8 +31,6 @@ export const getColumns = (config, openBugzillaDialog) => {
   return [
     {
       field: 'name',
-      autocomplete: 'jobs',
-      release: config.release,
       headerName: 'Name',
       flex: 3.5,
       renderCell: (params) => {


### PR DESCRIPTION
The autocomplete I added last week requires you to enter the full name
of a job to work.  So, you can't easily filter on a substring (e.g. name
contains aws), this disables it until I figure out how I get it to
behave correctly.