### PR TITLE
Open sidebar and expand first release by default.

### DIFF
--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -110,7 +110,7 @@ export default function App(props) {
   const theme = useTheme()
 
   const [lastUpdated, setLastUpdated] = React.useState(null)
-  const [drawerOpen, setDrawerOpen] = React.useState(false)
+  const [drawerOpen, setDrawerOpen] = React.useState(true)
   const [isLoaded, setLoaded] = React.useState(false)
   const [releases, setReleases] = React.useState([])
   const [capabilities, setCapabilities] = React.useState([])

--- a/sippy-ng/src/components/Sidebar.js
+++ b/sippy-ng/src/components/Sidebar.js
@@ -34,7 +34,7 @@ export default function Sidebar(props) {
   const classes = useTheme()
 
   const [bugzillaOpen, setBugzillaOpen] = React.useState(false)
-  const [open, setOpen] = React.useState({})
+  const [open, setOpen] = React.useState({ 0: true })
 
   const handleBugzillaOpen = () => {
     setBugzillaOpen(true)


### PR DESCRIPTION
Opening these is a very common first two clicks that are probably not
necessary and we can spare the real estate by default.
