### PR TITLE
Clarify migration command

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -52,7 +52,7 @@ cd sippy-ng && npm start
 ## Modifying Database Schema
 
 ```bash
-goose -dir dbmigration create test
+goose -dir dbmigration create add_duration_to_test sql
 ```
 
 Edit the resulting file and add your schema to migrate "up" to, and "down" from.


### PR DESCRIPTION
I noticed when I was trying to create a migration for https://github.com/openshift/sippy/pull/379/files#diff-2a6d9a9f885f73e1ce4ac191e98863e8dfb0edbb1ca1881062b74a72c1108e42.

When creating a new migration, you need to specify it is a `sql`
migration. The default is go, and trying to migrate in our current
configuration results in an error:

```
2022/05/18 08:15:37 goose run: ERROR
dbmigration/20220518081530_prow_job_kind.go: failed to run Go migration:
Go functions must be registered and built into a custom binary (see
https://github.com/pressly/goose/tree/master/examples/go-migrations)
```