### PR TITLE
Show UTC consistently on job analysis

### DIFF
--- a/pkg/api/job_analysis.go
+++ b/pkg/api/job_analysis.go
@@ -235,7 +235,7 @@ func PrintJobAnalysisJSONFromDB(w http.ResponseWriter, req *http.Request, dbc *d
 	}
 
 	for _, sum := range sums {
-		results.ByPeriod[sum.Period.Format(formatter)] = analysisResult{
+		results.ByPeriod[sum.Period.UTC().Format(formatter)] = analysisResult{
 			TotalRuns: sum.TotalRuns,
 			ResultCount: map[v1sippyprocessing.JobOverallResult]int{
 				v1sippyprocessing.JobSucceeded:             sum.Success,

--- a/sippy-ng/src/datagrid/GridToolbarFilterDateUtils.js
+++ b/sippy-ng/src/datagrid/GridToolbarFilterDateUtils.js
@@ -5,6 +5,14 @@ export class GridToolbarFilterDateUtils extends DateFnsUtils {
     super()
   }
 
+  getHours(date) {
+    return date.getUTCHours()
+  }
+
+  getMinutes(date) {
+    return date.getUTCMinutes()
+  }
+
   format(date, formatString) {
     return `${format(utcToZonedTime(date, 'UTC'), formatString, {
       timeZone: 'Etc/UTC',


### PR DESCRIPTION
When adjusting time in the filters dialog, the clock shows local time
but the field shows UTC. This fixes it so everything is correctly in
UTC.