### PR TITLE
Add script for fetching prow data, and some adjustments to sippy arguments

### DIFF
--- a/scripts/fetchdata-prow.sh
+++ b/scripts/fetchdata-prow.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# sleep before fetching so that if we're in some sort of fast crashloop/reschedule mode
+echo "Doing initial sleep before fetching prow data"
+while [ true ]; do
+  echo "Fetching new prow data"
+  echo "Loading database"
+  ./sippy --load-database --load-prow=true --load-testgrid=false --skip-bug-lookup
+  echo "Done fetching data, refreshing server"
+  curl localhost:8080/refresh
+  echo "Done refreshing data, sleeping"
+  sleep 3600  # 1 hour
+done


### PR DESCRIPTION
This adds a script to sync prow data, and also makes some small changes
to the main.go for using env var for google credentials, and not
requiring a data dir when operating in Prow-only mode.