### PR TITLE
Fix a crash in some situations due to missing UTC() usage.

### DIFF
--- a/pkg/api/job_analysis.go
+++ b/pkg/api/job_analysis.go
@@ -8,9 +8,8 @@ import (
 	"time"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
-	"github.com/openshift/sippy/pkg/db"
-
 	v1sippyprocessing "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/filter"
 	"github.com/openshift/sippy/pkg/util"
 )
@@ -264,7 +263,8 @@ func PrintJobAnalysisJSONFromDB(w http.ResponseWriter, req *http.Request, dbc *d
 	jobRunsFilter.ToSQL(jr, apitype.JobRun{}).Scan(&tr)
 
 	for _, t := range tr {
-		results.ByPeriod[t.Period.Format(formatter)].TestFailureCount[t.TestName] = t.Count
+		dateKey := t.Period.UTC().Format(formatter)
+		results.ByPeriod[dateKey].TestFailureCount[t.TestName] = t.Count
 	}
 
 	RespondWithJSON(http.StatusOK, w, results)


### PR DESCRIPTION
This surfaced when I was working locally with a backup of the prod db,
not sure why it doesn't show up in prod initially but it looks like this
can crash in some cases due to the missing UTC in key.
