### PR TITLE
Skip bad junits instead of failing the whole import

### DIFF
--- a/pkg/prowloader/gcs/gcs_jobrun.go
+++ b/pkg/prowloader/gcs/gcs_jobrun.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/storage"
+	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
 
 	"github.com/openshift/sippy/pkg/apis/junit"
@@ -75,7 +76,8 @@ func (j *GCSJobRun) GetCombinedJUnitTestSuites(ctx context.Context) (*junit.Test
 
 		currTestSuite := &junit.TestSuite{}
 		if testSuiteErr := xml.Unmarshal(junitContent, currTestSuite); testSuiteErr != nil {
-			return nil, fmt.Errorf("error parsing content for jobrun %w in file %s path %s", testSuitesErr, junitFile, j.gcsProwJobPath)
+			log.WithError(testSuiteErr).Warningf("error parsing content for jobrun in file %s path %s", junitFile, j.gcsProwJobPath)
+			continue
 		}
 		testSuites.Suites = append(testSuites.Suites, currTestSuite)
 	}


### PR DESCRIPTION
I have an example of the Prow censor finding a secret integer value in
the `time` field of a junit test, which makes it unparsable:

```
time="2022-05-31T18:09:14.954Z" level=warning msg="failed to get junit
test suites: error parsing content for jobrun strconv.ParseFloat:
parsing \"0.0XXXXX687\": invalid syntax in file
pr-logs/pull/openshift_installer/5951/pull-ci-openshift-installer-master-e2e-crc/1531677474260258816/artifacts/junit_operator.xml
path
pr-logs/pull/openshift_installer/5951/pull-ci-openshift-installer-master-e2e-crc/1531677474260258816"
```

This error is fatal and causes the prow importer to stop. This makes it
non-fatal. We log it but continue on.