### PR TITLE
Save PR data for prow imported job runs

### DIFF
--- a/pkg/apis/prow/prow.go
+++ b/pkg/apis/prow/prow.go
@@ -21,10 +21,49 @@ const (
 	ErrorState ProwJobState = "error"
 )
 
+type Refs struct {
+	// Org is something like kubernetes or k8s.io
+	Org string `json:"org"`
+	// Repo is something like test-infra
+	Repo string `json:"repo"`
+	// RepoLink links to the source for Repo.
+	RepoLink string `json:"repo_link,omitempty"`
+
+	BaseRef string `json:"base_ref,omitempty"`
+	BaseSHA string `json:"base_sha,omitempty"`
+	// BaseLink is a link to the commit identified by BaseSHA.
+	BaseLink string `json:"base_link,omitempty"`
+
+	Pulls []Pull `json:"pulls,omitempty"`
+}
+
+// Pull describes a pull request at a particular point in time.
+type Pull struct {
+	Number int    `json:"number"`
+	Author string `json:"author"`
+	SHA    string `json:"sha"`
+	Title  string `json:"title,omitempty"`
+
+	// Ref is git ref can be checked out for a change
+	// for example,
+	// github: pull/123/head
+	// gerrit: refs/changes/00/123/1
+	Ref string `json:"ref,omitempty"`
+	// Link links to the pull request itself.
+	Link string `json:"link,omitempty"`
+	// CommitLink links to the commit identified by the SHA.
+	CommitLink string `json:"commit_link,omitempty"`
+	// AuthorLink links to the author of the pull request.
+	AuthorLink string `json:"author_link,omitempty"`
+}
+
 type ProwJobSpec struct {
 	Type    string `json:"type,omitempty"`
 	Cluster string `json:"cluster,omitempty"`
 	Job     string `json:"job,omitempty"`
+
+	// Refs is the code under test, determined at runtime by Prow itself
+	Refs *Refs `json:"refs,omitempty"`
 }
 
 type ProwJobStatus struct {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -4,11 +4,12 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 
-	"github.com/openshift/sippy/pkg/db/models"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
+
+	"github.com/openshift/sippy/pkg/db/models"
 )
 
 type SchemaHashType string
@@ -72,6 +73,10 @@ func New(dsn string) (*DB, error) {
 	}
 
 	if err := db.AutoMigrate(&models.Bug{}); err != nil {
+		return nil, err
+	}
+
+	if err := db.AutoMigrate(&models.ProwPullRequest{}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -120,7 +120,10 @@ type Bug struct {
 	Jobs           []ProwJob `gorm:"many2many:bug_jobs;"`
 }
 
-// ProwPullRequest represents a GitHub pull request.
+// ProwPullRequest represents a GitHub pull request, there can be multiple entries
+// for a pull request, if it was tested with different HEADs (SHA). This lets us
+// track jobs at a more granular level, allowing us differentiate between code pushes
+// and retests.
 type ProwPullRequest struct {
 	Model
 
@@ -131,9 +134,10 @@ type ProwPullRequest struct {
 
 	Number int    `json:"number"`
 	Author string `json:"author"`
-	SHA    string `json:"sha"`
 	Title  string `json:"title,omitempty"`
 
+	// SHA is the specific commit at HEAD.
+	SHA string `json:"sha" gorm:"index:pr_link_sha,unique"`
 	// Link links to the pull request itself.
-	Link string `json:"link,omitempty" gorm:"unique"`
+	Link string `json:"link,omitempty" gorm:"index:pr_link_sha,unique"`
 }

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -46,6 +46,7 @@ type ProwJobRun struct {
 	URL          string
 	TestFailures int
 	Tests        []ProwJobRunTest
+	PullRequests []ProwPullRequest `gorm:"many2many:prow_job_run_prow_pull_requests;"`
 	Failed       bool
 	// InfrastructureFailure is true if the job run failed, for reasons which appear to be related to test/CI infra.
 	InfrastructureFailure bool
@@ -117,4 +118,22 @@ type Bug struct {
 	FlakeCount     int
 	Tests          []Test    `gorm:"many2many:bug_tests;"`
 	Jobs           []ProwJob `gorm:"many2many:bug_jobs;"`
+}
+
+// ProwPullRequest represents a GitHub pull request.
+type ProwPullRequest struct {
+	Model
+
+	// Org is something like kubernetes or k8s.io
+	Org string `json:"org"`
+	// Repo is something like test-infra
+	Repo string `json:"repo"`
+
+	Number int    `json:"number"`
+	Author string `json:"author"`
+	SHA    string `json:"sha"`
+	Title  string `json:"title,omitempty"`
+
+	// Link links to the pull request itself.
+	Link string `json:"link,omitempty" gorm:"unique"`
 }

--- a/pkg/prowloader/prow.go
+++ b/pkg/prowloader/prow.go
@@ -229,7 +229,6 @@ func (pl *ProwLoader) findOrAddPullRequests(refs *prow.Refs) []models.ProwPullRe
 		}
 
 		pull := models.ProwPullRequest{}
-		log.Infof("%+v", pr)
 		res := pl.dbc.DB.Where("link = ? and sha = ?", pr.Link, pr.SHA).First(&pull)
 		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
 			pull.Org = refs.Org


### PR DESCRIPTION
[TRT-278](https://issues.redhat.com//browse/TRT-278)

This saves the PR data for a prow job run.  This will eventually allow
us to do analysis on how many retests  it takes to land certain PR's.
It also lets us know which org/repo is linked to a presubmit job.