### PR TITLE
Disable test table name autocomplete.

### DIFF
--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -71,7 +71,6 @@ function TestTable(props) {
   const columns = [
     {
       field: 'name',
-      autocomplete: 'tests',
       headerName: 'Name',
       flex: 3.5,
       renderCell: (params) => {


### PR DESCRIPTION
As with #420, filtering on test substrings is also broken and this is a
fairly useful feature. Disabling as well until it's known how to make it
work for both use cases.
