### PR TITLE
Hookup -start-day and --num-days for load-database, improve help.

### DIFF
--- a/pkg/sippyserver/dbloader.go
+++ b/pkg/sippyserver/dbloader.go
@@ -27,14 +27,14 @@ func (a TestReportGeneratorConfig) LoadDatabase(
 	dbc *db.DB,
 	dashboard TestGridDashboardCoordinates,
 	variantManager testidentification.VariantManager,
-	syntheticTestManager testgridconversion.SyntheticTestManager) error {
+	syntheticTestManager testgridconversion.SyntheticTestManager,
+	startDay, numDays int) error {
 
 	testGridJobDetails, _ := a.TestGridLoadingConfig.load(dashboard.TestGridDashboardNames)
 	rawJobResultOptions := testgridconversion.ProcessingOptions{
 		SyntheticTestManager: syntheticTestManager,
-		// Load the last 14 days of data.
-		StartDay: 0,
-		NumDays:  14,
+		StartDay:             startDay,
+		NumDays:              numDays,
 	}
 
 	// Load all job and test results into database:

--- a/pkg/testgridanalysis/testgridconversion/to_raw_data.go
+++ b/pkg/testgridanalysis/testgridconversion/to_raw_data.go
@@ -79,6 +79,8 @@ func processJobDetails(job testgridv1.JobDetails, startCol, endCol int) *testgri
 }
 
 func computeLookback(startDay, numDays int, timestamps []int) (int, int) {
+	// WARNING: this is modelled as it is in testgrid where we read newest results to oldest left to right.
+	// Thus startTs is the newest timestamp, stopTs is the oldest.
 	stopTs := time.Now().Add(time.Duration(-1*(startDay+numDays)*24)*time.Hour).Unix() * 1000
 	startTs := time.Now().Add(time.Duration(-1*startDay*24)*time.Hour).Unix() * 1000
 	if startDay <= -1 { // find the most recent startTime

--- a/resources/deploymentconfig.yaml
+++ b/resources/deploymentconfig.yaml
@@ -59,8 +59,6 @@ spec:
         - "4.6"
         - --release
         - "3.11"
-        - --end-day
-        - "7"
         - --server
         env:
           - name: SIPPY_DATABASE_DSN


### PR DESCRIPTION
Also drops --end-day which was can be accomplished with --num-days.

This change makes it possible to load historical data into the sippy db, even if we can't yet view the UI once done.
