### PR TITLE
Improve default test table filters.

### DIFF
--- a/sippy-ng/src/components/Sidebar.js
+++ b/sippy-ng/src/components/Sidebar.js
@@ -141,7 +141,7 @@ export default function Sidebar(props) {
                   to={withSort(
                     pathForTestsWithFilter(release, {
                       items: [
-                        BOOKMARKS.RUN_1,
+                        BOOKMARKS.RUN_7,
                         BOOKMARKS.NO_NEVER_STABLE,
                         BOOKMARKS.NO_TECHPREVIEW,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,

--- a/sippy-ng/src/components/Sidebar.js
+++ b/sippy-ng/src/components/Sidebar.js
@@ -146,6 +146,7 @@ export default function Sidebar(props) {
                         BOOKMARKS.NO_TECHPREVIEW,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                         BOOKMARKS.NO_STEP_GRAPH,
+                        BOOKMARKS.NO_OPENSHIFT_TESTS_SHOULD_WORK,
                       ],
                       linkOperator: 'and',
                     }),

--- a/sippy-ng/src/constants.js
+++ b/sippy-ng/src/constants.js
@@ -46,6 +46,16 @@ export const BOOKMARKS = {
     operatorValue: '>=',
     value: '1',
   },
+  RUN_2: {
+    columnField: 'current_runs',
+    operatorValue: '>=',
+    value: '2',
+  },
+  RUN_7: {
+    columnField: 'current_runs',
+    operatorValue: '>=',
+    value: '7',
+  },
   RUN_10: {
     columnField: 'current_runs',
     operatorValue: '>=',

--- a/sippy-ng/src/constants.js
+++ b/sippy-ng/src/constants.js
@@ -79,6 +79,12 @@ export const BOOKMARKS = {
     operatorValue: 'contains',
     value: 'step graph.',
   },
+  NO_OPENSHIFT_TESTS_SHOULD_WORK: {
+    columnField: 'name',
+    not: true,
+    operatorValue: 'contains',
+    value: 'openshift-tests should work',
+  },
   WITHOUT_OVERALL_JOB_RESULT: {
     columnField: 'name',
     not: true,

--- a/sippy-ng/src/releases/ReleaseOverview.js
+++ b/sippy-ng/src/releases/ReleaseOverview.js
@@ -266,7 +266,7 @@ export default function ReleaseOverview(props) {
                   to={`/jobs/${
                     props.release
                   }?sortField=net_improvement&sort=asc&${queryForBookmark(
-                    BOOKMARKS.RUN_10,
+                    BOOKMARKS.RUN_7,
                     BOOKMARKS.NO_STEP_GRAPH,
                     ...withoutUnstable()
                   )}`}
@@ -287,7 +287,7 @@ export default function ReleaseOverview(props) {
                   rowsPerPageOptions={[5]}
                   filterModel={{
                     items: [
-                      BOOKMARKS.RUN_10,
+                      BOOKMARKS.RUN_7,
                       BOOKMARKS.NO_NEVER_STABLE,
                       BOOKMARKS.NO_TECHPREVIEW,
                       BOOKMARKS.NO_STEP_GRAPH,
@@ -306,7 +306,7 @@ export default function ReleaseOverview(props) {
                   to={`/jobs/${
                     props.release
                   }?period=twoDay&sortField=net_improvement&sort=asc&${queryForBookmark(
-                    BOOKMARKS.RUN_1,
+                    BOOKMARKS.RUN_2,
                     ...withoutUnstable()
                   )}`}
                   variant="h5"
@@ -324,7 +324,7 @@ export default function ReleaseOverview(props) {
                   limit={10}
                   rowsPerPageOptions={[5]}
                   filterModel={{
-                    items: [BOOKMARKS.RUN_1, ...withoutUnstable()],
+                    items: [BOOKMARKS.RUN_2, ...withoutUnstable()],
                   }}
                   pageSize={5}
                   period="twoDay"
@@ -339,7 +339,7 @@ export default function ReleaseOverview(props) {
                 <Typography
                   component={Link}
                   to={`/tests/${props.release}?${queryForBookmark(
-                    BOOKMARKS.RUN_10,
+                    BOOKMARKS.RUN_7,
                     BOOKMARKS.NO_NEVER_STABLE,
                     BOOKMARKS.NO_TECHPREVIEW,
                     BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
@@ -363,7 +363,7 @@ export default function ReleaseOverview(props) {
                     rowsPerPageOptions={[5]}
                     filterModel={{
                       items: [
-                        BOOKMARKS.RUN_10,
+                        BOOKMARKS.RUN_7,
                         BOOKMARKS.NO_NEVER_STABLE,
                         BOOKMARKS.NO_TECHPREVIEW,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
@@ -385,7 +385,7 @@ export default function ReleaseOverview(props) {
                   to={`/tests/${
                     props.release
                   }?period=twoDay&sortField=net_working_improvement&sort=asc&${queryForBookmark(
-                    BOOKMARKS.RUN_1,
+                    BOOKMARKS.RUN_2,
                     BOOKMARKS.NO_NEVER_STABLE,
                     BOOKMARKS.NO_TECHPREVIEW,
                     BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
@@ -408,7 +408,7 @@ export default function ReleaseOverview(props) {
                     rowsPerPageOptions={[5]}
                     filterModel={{
                       items: [
-                        BOOKMARKS.RUN_1,
+                        BOOKMARKS.RUN_2,
                         BOOKMARKS.NO_NEVER_STABLE,
                         BOOKMARKS.NO_TECHPREVIEW,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
@@ -429,7 +429,7 @@ export default function ReleaseOverview(props) {
                 <Typography
                   component={Link}
                   to={`/tests/${props.release}?${queryForBookmark(
-                    BOOKMARKS.RUN_10,
+                    BOOKMARKS.RUN_7,
                     BOOKMARKS.NO_NEVER_STABLE,
                     BOOKMARKS.NO_TECHPREVIEW,
                     BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
@@ -453,7 +453,7 @@ export default function ReleaseOverview(props) {
                     rowsPerPageOptions={[5]}
                     filterModel={{
                       items: [
-                        BOOKMARKS.RUN_10,
+                        BOOKMARKS.RUN_7,
                         BOOKMARKS.NO_NEVER_STABLE,
                         BOOKMARKS.NO_TECHPREVIEW,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,


### PR DESCRIPTION
Bumps the >= 1 current runs filter up to roughly once per day for both tests and jobs on the overview, and the tests sidebar link.

Also filters out openshift-tests should work, I'm less sure about this one but looking by variant, it does fill up the results and hide the actual tests we'd go after. It's somewhat interesting, but I think more interesting is what tests are causing the overall tests should work to change it's pass rate.