### PR TITLE
Result should be overall result

### DIFF
--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/lib/pq"
+
 	"github.com/openshift/sippy/pkg/db/models"
 
 	bugsv1 "github.com/openshift/sippy/pkg/apis/bugs/v1"
@@ -162,7 +163,7 @@ type JobRun struct {
 	KnownFailure          bool                `json:"known_failure"`
 	Succeeded             bool                `json:"succeeded"`
 	Timestamp             int                 `json:"timestamp"`
-	OverallResult         v1.JobOverallResult `json:"result"`
+	OverallResult         v1.JobOverallResult `json:"overall_result"`
 }
 
 func (run JobRun) GetFieldType(param string) ColumnType {
@@ -173,7 +174,7 @@ func (run JobRun) GetFieldType(param string) ColumnType {
 		return ColumnTypeArray
 	case "job":
 		return ColumnTypeString
-	case "result":
+	case "overall_result":
 		return ColumnTypeString
 	case "failed_test_names":
 		return ColumnTypeArray
@@ -194,7 +195,7 @@ func (run JobRun) GetStringValue(param string) (string, error) {
 	switch param {
 	case "job", "name":
 		return run.Job, nil
-	case "result":
+	case "overall_result":
 		return string(run.OverallResult), nil
 	case "test_grid_url":
 		return run.TestGridURL, nil

--- a/sippy-ng/src/jobs/JobRunsTable.js
+++ b/sippy-ng/src/jobs/JobRunsTable.js
@@ -113,7 +113,7 @@ export default function JobRunsTable(props) {
       flex: 0.6,
     },
     {
-      field: 'result',
+      field: 'overall_result',
       headerName: 'Result',
       flex: 0.5,
       renderCell: (params) => {


### PR DESCRIPTION
The DB columns are all named overall_result, but we were returning
`result` in the JSON.  They need to match for filtering to work,
and this is the least invasive way to fix it.  This has been broken for
a while so I don't think many people use this filtering. I doubt
we're breaking any URL's in the wild by changing this.