### PR TITLE
Remove golangci-lint rpm from buildroot

### DIFF
--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -4,14 +4,9 @@
 # [1] https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image
 #
 FROM registry.access.redhat.com/ubi8/ubi:latest
-ARG GOLANGCI_LINT_VERSION="1.41.1"
-RUN curl -Lso /tmp/golangci-lint.rpm \
-          "https://github.com/golangci/golangci-lint/releases/download/v1.41.1/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64.rpm" && \
-      dnf module enable nodejs:16 -y && \
+RUN dnf module enable nodejs:16 -y && \
       dnf install -y \
         git \
         go \
         make \
-        npm \
-        /tmp/golangci-lint.rpm && \
-      rm /tmp/golangci-lint.rpm
+        npm

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
 export PATH := ${HOME}/go/bin:/go/bin:${PATH}
 
 DEPS = npm go
-CHECK := $(foreach dep,$(DEPS),\
-        $(if $(shell which $(dep)),"$(dep) found",$(error "Missing $(exec) in PATH")))
 
 all: test build
 
-build: clean npm
+build: clean check npm
 	cd sippy-ng; npm run build
 	go build -mod=vendor .
 
-test: npm
+check:
+	$(foreach dep,$(DEPS),$(if $(shell which $(dep)),,$(error "Missing $(dep) in PATH")))
+
+test: check npm
 	go test -v ./...
 	LANG=en_US.utf-8 LC_ALL=en_US.utf-8 cd sippy-ng; CI=true npm test -- --coverage
 


### PR DESCRIPTION
https://github.com/openshift/release/pull/29517 changes us to use the golangci-lint container we already have available. We're being throttled by GitHub, so we can drop the curl after that PR is merged.