### PR TITLE
Explicity set mode for synthetic tests

### DIFF
--- a/scripts/fetchdata-kube.sh
+++ b/scripts/fetchdata-kube.sh
@@ -9,7 +9,7 @@ while [ true ]; do
   rm -rf /data/*
   /bin/sippy --fetch-data /data --dashboard=kube-master=sig-release-master-blocking,sig-release-master-informing= --log-level debug
   echo "Loading database"
-  /bin/sippy --load-database --local-data /data --dashboard=kube-master=sig-release-master-blocking,sig-release-master-informing= --log-level debug --variant=kube
+  /bin/sippy --load-database --local-data /data --dashboard=kube-master=sig-release-master-blocking,sig-release-master-informing= --log-level debug --mode=kube
   echo "Done fetching data, refreshing server"
   curl localhost:8080/refresh
   echo "Done refreshing data, sleeping"

--- a/scripts/fetchdata-prow.sh
+++ b/scripts/fetchdata-prow.sh
@@ -5,7 +5,7 @@ echo "Doing initial sleep before fetching prow data"
 while [ true ]; do
   echo "Fetching new prow data"
   echo "Loading database"
-  /bin/sippy --load-database --load-prow=true --load-testgrid=false --skip-bug-lookup --variant=ocp
+  /bin/sippy --load-database --load-prow=true --load-testgrid=false --skip-bug-lookup --mode=ocp
   echo "Done fetching data, refreshing server"
   curl localhost:8080/refresh
   echo "Done refreshing data, sleeping"

--- a/scripts/fetchdata.sh
+++ b/scripts/fetchdata.sh
@@ -10,7 +10,7 @@ while [ true ]; do
   /bin/sippy --log-level debug --fetch-data /data --fetch-openshift-perfscale-data --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10 --release 4.11
   echo "Loading database"
   # Bug lookup skipped, we're struggling with the number of tests, and moving to Jira soon.
-  /bin/sippy --log-level debug --load-database --local-data /data --skip-bug-lookup --arch amd64 --arch arm64 --arch multi --arch s390x --arch ppc64le --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10 --release 4.11
+  /bin/sippy --mode=ocp --log-level debug --load-database --local-data /data --skip-bug-lookup --arch amd64 --arch arm64 --arch multi --arch s390x --arch ppc64le --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10 --release 4.11
   echo "Done fetching data, refreshing server"
   curl localhost:8080/refresh
   echo "Done refreshing data, sleeping"


### PR DESCRIPTION
We try to infer the mode based on the dashboards available, but this
doesn't work in Sippy prow (it did locally for me since I had testgrid
data around...).

This changes --variant to --mode, which selects both the variant and
synthetic test manager.