### PR TITLE
Add UI mechanism for customized views

### DIFF
--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -50,8 +50,8 @@ const (
 		previous_flakes * 100.0 / NULLIF(previous_runs, 0) AS previous_flake_percentage,
 		(previous_successes + previous_flakes) * 100.0 / NULLIF(previous_runs, 0) AS previous_working_percentage,
 
-		(previous_failures * 100.0 / NULLIF(previous_runs, 0)) - (current_failures * 100.0 / NULLIF(current_runs, 0)) AS net_failure_improvement,
-		(previous_flakes * 100.0 / NULLIF(previous_runs, 0)) - (current_flakes * 100.0 / NULLIF(current_runs, 0)) AS net_flake_improvement,
+		(current_failures * 100.0 / NULLIF(current_runs, 0) - (previous_failures * 100.0 / NULLIF(previous_runs, 0))) AS net_failure_improvement,
+		(current_flakes * 100.0 / NULLIF(current_runs, 0) - (previous_flakes * 100.0 / NULLIF(previous_runs, 0))) AS net_flake_improvement,
 		((current_successes + current_flakes) * 100.0 / NULLIF(current_runs, 0)) - ((previous_successes + previous_flakes) * 100.0 / NULLIF(previous_runs, 0)) AS net_working_improvement,
 		(current_successes * 100.0 / NULLIF(current_runs, 0)) - (previous_successes * 100.0 / NULLIF(previous_runs, 0)) AS net_improvement`
 )

--- a/sippy-ng/src/components/PassRateIcon.js
+++ b/sippy-ng/src/components/PassRateIcon.js
@@ -23,14 +23,22 @@ export default function PassRateIcon(props) {
     icon = (
       <ArrowUpwardRoundedIcon
         data-icon="ArrowUpwardRoundedIcon"
-        style={{ stroke: 'green', strokeWidth: 3, color: 'green' }}
+        style={{
+          stroke: props.inverted ? 'darkred' : 'green',
+          strokeWidth: 3,
+          color: props.inverted ? 'darkred' : 'green',
+        }}
       />
     )
   } else {
     icon = (
       <ArrowDownwardRoundedIcon
         data-icon="ArrowDownwardRoundedIcon"
-        style={{ stroke: 'darkred', strokeWidth: 3, color: 'darkred' }}
+        style={{
+          stroke: props.inverted ? 'green' : 'darkred',
+          strokeWidth: 3,
+          color: props.inverted ? 'green' : 'darkred',
+        }}
       />
     )
   }
@@ -43,5 +51,6 @@ export default function PassRateIcon(props) {
 }
 
 PassRateIcon.defaultProps = {
+  inverted: false,
   tooltip: false,
 }

--- a/sippy-ng/src/datagrid/GridToolbar.js
+++ b/sippy-ng/src/datagrid/GridToolbar.js
@@ -1,10 +1,12 @@
 import { createTheme } from '@material-ui/core/styles'
 import { GridToolbarDensitySelector } from '@material-ui/data-grid'
+import { GridView } from './GridView'
 import { makeStyles } from '@material-ui/styles'
 import ClearIcon from '@material-ui/icons/Clear'
 import GridToolbarBookmarkMenu from '../datagrid/GridToolbarBookmarkMenu'
 import GridToolbarFilterMenu from './GridToolbarFilterMenu'
 import GridToolbarPeriodSelector from '../datagrid/GridToolbarPeriodSelector'
+import GridToolbarViewSelector from './GridToolbarViewSelector'
 import IconButton from '@material-ui/core/IconButton'
 import PropTypes from 'prop-types'
 import React, { Fragment } from 'react'
@@ -67,6 +69,15 @@ export default function GridToolbar(props) {
         ) : (
           ''
         )}
+        {props.views ? (
+          <GridToolbarViewSelector
+            setView={props.selectView}
+            views={props.views}
+            view={props.view}
+          />
+        ) : (
+          ''
+        )}
         <GridToolbarDensitySelector />
       </div>
       <div>
@@ -115,6 +126,9 @@ GridToolbar.propTypes = {
   period: PropTypes.string,
   selectPeriod: PropTypes.func,
   columns: PropTypes.array,
+  view: PropTypes.string,
+  views: PropTypes.object,
+  selectView: PropTypes.func,
   filterModel: PropTypes.object,
   setFilterModel: PropTypes.func.isRequired,
   addFilters: PropTypes.func.isRequired,

--- a/sippy-ng/src/datagrid/GridToolbarViewSelector.js
+++ b/sippy-ng/src/datagrid/GridToolbarViewSelector.js
@@ -1,0 +1,58 @@
+import { Button, Menu, MenuItem, Tooltip } from '@material-ui/core'
+import { ViewCarousel } from '@material-ui/icons'
+import PropTypes from 'prop-types'
+import React, { Fragment } from 'react'
+
+export default function GridToolbarViewSelector(props) {
+  const [anchor, setAnchor] = React.useState('')
+
+  const handleClick = (event) => {
+    setAnchor(event.currentTarget)
+  }
+
+  const handleClose = () => {
+    setAnchor(null)
+  }
+
+  return (
+    <Fragment>
+      <Button
+        aria-controls="view-menu"
+        aria-haspopup="true"
+        startIcon={<ViewCarousel />}
+        color="primary"
+        onClick={handleClick}
+      >
+        {props.view} View
+      </Button>
+      <Menu
+        id="view-menu"
+        anchorEl={anchor}
+        keepMounted
+        open={Boolean(anchor)}
+        onClose={handleClose}
+      >
+        {Object.entries(props.views).map(([e, v]) => (
+          <MenuItem
+            key={e}
+            style={{
+              fontWeight: props.view === e ? 'bold' : 'normal',
+            }}
+            onClick={() => {
+              props.setView(e)
+              handleClose()
+            }}
+          >
+            {e}
+          </MenuItem>
+        ))}
+      </Menu>
+    </Fragment>
+  )
+}
+
+GridToolbarViewSelector.propTypes = {
+  view: PropTypes.string,
+  views: PropTypes.arrayOf(Object),
+  setView: PropTypes.func.isRequired,
+}

--- a/sippy-ng/src/datagrid/GridView.js
+++ b/sippy-ng/src/datagrid/GridView.js
@@ -1,0 +1,29 @@
+export class GridView {
+  constructor(columns, views, defaultView) {
+    this.allColumns = columns
+    this.filterColumns = Object.entries(columns).map(([_, v]) => v)
+    this.views = views
+    this.setView(defaultView)
+  }
+
+  setView(name) {
+    if (name in this.views) {
+      let columns = []
+      this.view = this.views[name]
+      this.viewName = name
+      this.view.fieldOrder.forEach((e) => {
+        let field = this.allColumns[e.field]
+        if (field === undefined) {
+          console.error(e.field + ' field not found')
+        }
+        field.hide = e.hide !== undefined ? e.hide : false
+        field.flex = e.flex
+        field.headerClassName = e.headerClassName
+        columns.push(field)
+      })
+      this.columns = columns
+    } else {
+      console.error(name + ' is not a known view')
+    }
+  }
+}

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -112,20 +112,34 @@ function TestTable(props) {
         field: 'current_working_percentage',
       },
       fieldOrder: [
-        { field: 'name', flex: 3.5 },
-        { field: 'variants', flex: 1.5, hide: props.collapse },
+        {
+          field: 'name',
+          flex: 3.5,
+        },
+        {
+          field: 'variants',
+          flex: 1.5,
+          hide: props.collapse,
+        },
         {
           field: 'current_working_percentage',
           flex: 0.75,
           headerClassName: props.briefTable ? '' : 'wrapHeader',
         },
-        { field: 'net_working_improvement', flex: 0.5 },
+        {
+          field: 'net_working_improvement',
+          flex: 0.5,
+        },
         {
           field: 'previous_working_percentage',
           flex: 0.75,
           headerClassName: props.briefTable ? '' : 'wrapHeader',
         },
-        { field: 'link', flex: 1.5, hide: props.briefTable },
+        {
+          field: 'link',
+          flex: 1.5,
+          hide: props.briefTable,
+        },
       ],
     },
     Passing: {
@@ -135,19 +149,34 @@ function TestTable(props) {
         field: 'current_pass_percentage',
       },
       fieldOrder: [
-        { field: 'name', flex: 3.5 },
+        {
+          field: 'name',
+          flex: 3.5,
+        },
+        {
+          field: 'variants',
+          flex: 1.5,
+          hide: props.collapse,
+        },
         {
           field: 'current_pass_percentage',
           flex: 0.75,
           headerClassName: 'wrapHeader',
         },
-        { field: 'net_improvement', flex: 0.5 },
+        {
+          field: 'net_improvement',
+          flex: 0.5,
+        },
         {
           field: 'previous_pass_percentage',
           flex: 0.75,
           headerClassName: 'wrapHeader',
         },
-        { field: 'link', flex: 1.5 },
+        {
+          field: 'link',
+          flex: 1.5,
+          hide: props.briefTable,
+        },
       ],
     },
     Flakes: {
@@ -158,19 +187,34 @@ function TestTable(props) {
         inverted: true,
       },
       fieldOrder: [
-        { field: 'name', flex: 3.5 },
+        {
+          field: 'name',
+          flex: 3.5,
+        },
+        {
+          field: 'variants',
+          flex: 1.5,
+          hide: props.collapse,
+        },
         {
           field: 'current_flake_percentage',
           flex: 0.75,
           headerClassName: 'wrapHeader',
         },
-        { field: 'net_flake_improvement', flex: 0.5 },
+        {
+          field: 'net_flake_improvement',
+          flex: 0.5,
+        },
         {
           field: 'previous_flake_percentage',
           flex: 0.75,
           headerClassName: 'wrapHeader',
         },
-        { field: 'link', flex: 1.5 },
+        {
+          field: 'link',
+          flex: 1.5,
+          hide: props.briefTable,
+        },
       ],
     },
   }
@@ -305,7 +349,13 @@ function TestTable(props) {
       headerName: 'Improvement (flake)',
       type: 'number',
       renderCell: (params) => {
-        return <PassRateIcon tooltip={true} improvement={params.value} />
+        return (
+          <PassRateIcon
+            tooltip={true}
+            inverted={true}
+            improvement={params.value}
+          />
+        )
       },
     },
     net_failure_improvement: {


### PR DESCRIPTION
[TRT-301](https://issues.redhat.com//browse/TRT-301)

This adds a "View" toolbar item, that allows customizing which columns
are shown. This lets us on the test page create working and flakes
views, for example.


![sippy-views](https://user-images.githubusercontent.com/429763/174853655-f862dcee-ccdd-4c14-b287-a3167cd5b2dc.gif)
