### PR TITLE
Store build cluster and duration from prow job

### DIFF
--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -40,6 +40,9 @@ type ProwJobRun struct {
 	ProwJob   ProwJob
 	ProwJobID uint
 
+	// Cluster is the cluster where the prow job was run.
+	Cluster string
+
 	URL          string
 	TestFailures int
 	Tests        []ProwJobRunTest
@@ -50,6 +53,7 @@ type ProwJobRun struct {
 	KnownFailure  bool
 	Succeeded     bool
 	Timestamp     time.Time
+	Duration      time.Duration
 	OverallResult v1.JobOverallResult
 }
 

--- a/pkg/prowloader/prow.go
+++ b/pkg/prowloader/prow.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/pkg/errors"
@@ -181,10 +182,17 @@ func (pl *ProwLoader) prowJobToJobRun(pj prow.ProwJob) error {
 				return err
 			}
 
+			var duration time.Duration
+			if pj.Status.CompletionTime != nil {
+				duration = (*pj.Status.CompletionTime).Sub(pj.Status.StartTime)
+			}
+
 			err = pl.dbc.DB.Create(&models.ProwJobRun{
 				Model: gorm.Model{
 					ID: uint(id),
 				},
+				Cluster:       pj.Spec.Cluster,
+				Duration:      duration,
 				ProwJob:       *dbProwJob,
 				ProwJobID:     dbProwJob.ID,
 				URL:           pj.Status.URL,


### PR DESCRIPTION
TRT-325

This stores the duration of the job, and the build cluster it was run
on, in the DB for prow sippy.