### PR TITLE
Order releases with unsortable releases last

### DIFF
--- a/pkg/db/query/release_queries.go
+++ b/pkg/db/query/release_queries.go
@@ -15,7 +15,7 @@ func ReleasesFromDB(dbClient *db.DB) ([]Release, error) {
 	res := dbClient.DB.Raw(`
 		SELECT DISTINCT(release), case when position('.' in release) != 0 then string_to_array(release, '.')::int[] end as sortable_release
                 FROM prow_jobs
-                ORDER BY sortable_release desc`).Scan(&releases)
+                ORDER BY sortable_release desc NULLS LAST`).Scan(&releases)
 	if res.Error != nil {
 		log.Errorf("error querying releases from db: %v", res.Error)
 		return releases, res.Error


### PR DESCRIPTION
Releases are sorted in version order.  For releases that can't be sorted
by version order, they are currently placed first. On [prow-sippy](http://sippy-prow.dptools.openshift.org/sippy-ng/), I want
presubmits to be last instead of first on the list of releases, so the
release under active development is first.