### PR TITLE
Add download and copy names link

### DIFF
--- a/sippy-ng/src/datagrid/GridToolbar.js
+++ b/sippy-ng/src/datagrid/GridToolbar.js
@@ -1,9 +1,9 @@
 import { createTheme } from '@material-ui/core/styles'
 import { GridToolbarDensitySelector } from '@material-ui/data-grid'
-import { GridView } from './GridView'
 import { makeStyles } from '@material-ui/styles'
 import ClearIcon from '@material-ui/icons/Clear'
 import GridToolbarBookmarkMenu from '../datagrid/GridToolbarBookmarkMenu'
+import GridToolbarDownload from './GridToolbarDownload'
 import GridToolbarFilterMenu from './GridToolbarFilterMenu'
 import GridToolbarPeriodSelector from '../datagrid/GridToolbarPeriodSelector'
 import GridToolbarViewSelector from './GridToolbarViewSelector'
@@ -79,6 +79,14 @@ export default function GridToolbar(props) {
           ''
         )}
         <GridToolbarDensitySelector />
+        {props.downloadDataFunc ? (
+          <GridToolbarDownload
+            getData={props.downloadDataFunc}
+            filePrefix={props.downloadFilePrefix}
+          />
+        ) : (
+          ''
+        )}
       </div>
       <div>
         <TextField
@@ -133,4 +141,6 @@ GridToolbar.propTypes = {
   setFilterModel: PropTypes.func.isRequired,
   addFilters: PropTypes.func.isRequired,
   value: PropTypes.string,
+  downloadDataFunc: PropTypes.func,
+  downloadFilePrefix: PropTypes.string,
 }

--- a/sippy-ng/src/datagrid/GridToolbarDownload.js
+++ b/sippy-ng/src/datagrid/GridToolbarDownload.js
@@ -1,0 +1,40 @@
+import { Button, Menu, MenuItem, Tooltip } from '@material-ui/core'
+import { GetApp } from '@material-ui/icons'
+import PropTypes from 'prop-types'
+import React, { Fragment } from 'react'
+
+export default function GridToolbarDownload(props) {
+  let handleClick = () => {
+    const dataStr =
+      'data:text/json;charset=utf-8,' +
+      encodeURIComponent(JSON.stringify(props.getData(), null, 2))
+    const a = document.createElement('a')
+    a.href = dataStr
+    a.download =
+      (props.filePrefix === '' ? 'data-' : props.filePrefix + '-') +
+      new Date().toISOString() +
+      '.json'
+    a.click()
+  }
+
+  return (
+    <Fragment>
+      <Tooltip title="Download the raw data">
+        <Button
+          aria-controls="download-menu"
+          aria-haspopup="true"
+          startIcon={<GetApp />}
+          color="primary"
+          onClick={handleClick}
+        >
+          Download
+        </Button>
+      </Tooltip>
+    </Fragment>
+  )
+}
+
+GridToolbarDownload.propTypes = {
+  filePrefix: PropTypes.string,
+  getData: PropTypes.func.isRequired,
+}

--- a/sippy-ng/src/jobs/JobTable.js
+++ b/sippy-ng/src/jobs/JobTable.js
@@ -1,6 +1,6 @@
 import './JobTable.css'
 import { BOOKMARKS, JOB_THRESHOLDS } from '../constants'
-import { BugReport, DirectionsRun, GridOn, Search } from '@material-ui/icons'
+import { BugReport, DirectionsRun, GridOn } from '@material-ui/icons'
 import { Button, Container, Tooltip, Typography } from '@material-ui/core'
 import { DataGrid } from '@material-ui/data-grid'
 import {
@@ -307,6 +307,15 @@ function JobTable(props) {
     }
   }
 
+  const selectedJobNames = () => {
+    let jobs = rows
+    if (selectedJobs.length !== 0) {
+      const selectedIDs = new Set(selectedJobs)
+      jobs = rows.filter((row) => selectedIDs.has(row.id))
+    }
+    return jobs.map((job) => job.name).join('\n')
+  }
+
   const createFilter = () => {
     if (selectedJobs.length === rows.length || selectedJobs.length === 0) {
       return safeEncodeURIComponent(JSON.stringify(filterModel))
@@ -322,7 +331,6 @@ function JobTable(props) {
         value: job.name,
       }
     })
-    console.log(jobs)
     return safeEncodeURIComponent(
       JSON.stringify({ items: jobs, linkOperator: 'or' })
     )
@@ -337,6 +345,17 @@ function JobTable(props) {
       style={{ margin: 10 }}
     >
       Analyze
+    </Button>
+  )
+
+  const copyButton = (
+    <Button
+      onClick={() => navigator.clipboard.writeText(selectedJobNames())}
+      variant="contained"
+      color="secondary"
+      style={{ margin: 10 }}
+    >
+      Copy names
     </Button>
   )
 
@@ -384,10 +403,15 @@ function JobTable(props) {
             setFilterModel: setFilterModel,
             columns: columns,
             addFilters: (m) => addFilters(m),
+            downloadDataFunc: () => {
+              return rows
+            },
+            downloadFilePrefix: 'jobs',
           },
         }}
       />
       {props.briefTable ? '' : detailsButton}
+      {props.briefTable ? '' : copyButton}
       <BugzillaDialog
         release={props.release}
         item={jobDetails}

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -732,6 +732,10 @@ function TestTable(props) {
             addFilters: addFilters,
             filterModel: filterModel,
             setFilterModel: setFilterModel,
+            downloadDataFunc: () => {
+              return rows
+            },
+            downloadFilePrefix: 'tests',
           },
         }}
       />


### PR DESCRIPTION
This adds two features:

1. Download

Enabled for both the jobs and tests page.

In the grid toolbar, a "Download" link is present that will give you the
raw JSON for the table rows.

2. Copy names

On the jobs table, add a "Copy names" button next to the analyzer button
to copy the selected job names (or all). This makes it easier to take a
filtered list of jobs and copy the names -- something I do manually
row-by-row by updating lists like never-stable.
