### PR TITLE
No longer consider techpreview unstable

### DIFF
--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -68,7 +68,7 @@ func useNewInstallTest(release string) bool {
 // PrintOverallReleaseHealthFromDB gives a summarized status of the overall health, including
 // infrastructure, install, upgrade, and variant success rates.
 func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release string) {
-	excludedVariants := []string{"never-stable", "techpreview"}
+	excludedVariants := []string{"never-stable"}
 	// Minor upgrades install a previous version and should not be counted against the current version's install stat.
 	excludedInstallVariants := append(excludedVariants, "upgrade-minor")
 
@@ -209,7 +209,7 @@ func calculateJobResultStatistics(results []apitype.Job) (currStats, prevStats s
 	prevStats.Histogram = make([]int, 10)
 
 	for _, result := range results {
-		if testreportconversion.IsNeverStableOrTechPreview(result.Variants) {
+		if testreportconversion.IsNeverStable(result.Variants) {
 			continue
 		}
 

--- a/pkg/testgridanalysis/testreportconversion/jobresult.go
+++ b/pkg/testgridanalysis/testreportconversion/jobresult.go
@@ -4,9 +4,9 @@ import (
 	"math"
 )
 
-func IsNeverStableOrTechPreview(variants []string) bool {
+func IsNeverStable(variants []string) bool {
 	for _, variant := range variants {
-		if variant == "never-stable" || variant == "techpreview" {
+		if variant == "never-stable" {
 			return true
 		}
 	}

--- a/pkg/testidentification/ocp_variants.go
+++ b/pkg/testidentification/ocp_variants.go
@@ -233,9 +233,6 @@ func (v openshiftVariants) IdentifyVariants(jobName string) []string { //nolint:
 	if v.IsJobNeverStable(jobName) {
 		return []string{"never-stable"}
 	}
-	if techpreview.MatchString(jobName) {
-		return []string{"techpreview"}
-	}
 	if promoteRegex.MatchString(jobName) {
 		variants = append(variants, "promote")
 		return variants
@@ -336,6 +333,9 @@ func (v openshiftVariants) IdentifyVariants(jobName string) []string { //nolint:
 	}
 	if fipsRegex.MatchString(jobName) {
 		variants = append(variants, "fips")
+	}
+	if techpreview.MatchString(jobName) {
+		variants = append(variants, "techpreview")
 	}
 	if rtRegex.MatchString(jobName) {
 		variants = append(variants, "realtime")

--- a/sippy-ng/src/components/Sidebar.js
+++ b/sippy-ng/src/components/Sidebar.js
@@ -36,7 +36,6 @@ import PropTypes from 'prop-types'
 import React, { Fragment, useEffect } from 'react'
 import SearchIcon from '@material-ui/icons/Search'
 import SippyLogo from './SippyLogo'
-import TableChartIcon from '@material-ui/icons/TableChart'
 
 export default function Sidebar(props) {
   const classes = useTheme()
@@ -162,7 +161,6 @@ export default function Sidebar(props) {
                       items: [
                         BOOKMARKS.RUN_7,
                         BOOKMARKS.NO_NEVER_STABLE,
-                        BOOKMARKS.NO_TECHPREVIEW,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                         BOOKMARKS.NO_STEP_GRAPH,
                         BOOKMARKS.NO_OPENSHIFT_TESTS_SHOULD_WORK,

--- a/sippy-ng/src/constants.js
+++ b/sippy-ng/src/constants.js
@@ -91,12 +91,6 @@ export const BOOKMARKS = {
     operatorValue: 'contains',
     value: 'never-stable',
   },
-  NO_TECHPREVIEW: {
-    columnField: 'variants',
-    not: true,
-    operatorValue: 'contains',
-    value: 'techpreview',
-  },
   NO_STEP_GRAPH: {
     columnField: 'name',
     not: true,

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -218,10 +218,7 @@ export function filterFor(column, operator, value) {
 }
 
 export function withoutUnstable() {
-  return [
-    not(filterFor('variants', 'contains', 'never-stable')),
-    not(filterFor('variants', 'contains', 'techpreview')),
-  ]
+  return [not(filterFor('variants', 'contains', 'never-stable'))]
 }
 
 export function multiple(...filters) {

--- a/sippy-ng/src/releases/ReleaseOverview.js
+++ b/sippy-ng/src/releases/ReleaseOverview.js
@@ -1,7 +1,6 @@
-import { ArrowBack, ArrowForward } from '@material-ui/icons'
 import { BOOKMARKS } from '../constants'
-import { Button, Card, Container, Tooltip, Typography } from '@material-ui/core'
 import { CapabilitiesContext } from '../App'
+import { Card, Container, Tooltip, Typography } from '@material-ui/core'
 import { createTheme, makeStyles } from '@material-ui/core/styles'
 import { dayFilter, JobStackedChart } from '../jobs/JobStackedChart'
 import { Link } from 'react-router-dom'
@@ -27,9 +26,9 @@ import TopLevelIndicators from './TopLevelIndicators'
 import VariantCards from '../jobs/VariantCards'
 
 export const REGRESSED_TOOLTIP =
-  'Shows the most regressed items this week vs. last week, for those with more than 10 runs, excluding never-stable and techpreview.'
+  'Shows the most regressed items this week vs. last week, for those with more than 10 runs, excluding never-stable.'
 export const TWODAY_WARNING =
-  'Shows the last 2 days compared to the last 7 days, sorted by most regressed, excluding never-stable and techpreview.'
+  'Shows the last 2 days compared to the last 7 days, sorted by most regressed, excluding never-stable.'
 export const TOP_FAILERS_TOOLTIP =
   'Shows the list of tests ordered by their failure percentage.'
 
@@ -289,7 +288,6 @@ export default function ReleaseOverview(props) {
                     items: [
                       BOOKMARKS.RUN_7,
                       BOOKMARKS.NO_NEVER_STABLE,
-                      BOOKMARKS.NO_TECHPREVIEW,
                       BOOKMARKS.NO_STEP_GRAPH,
                     ],
                   }}
@@ -341,7 +339,6 @@ export default function ReleaseOverview(props) {
                   to={`/tests/${props.release}?${queryForBookmark(
                     BOOKMARKS.RUN_7,
                     BOOKMARKS.NO_NEVER_STABLE,
-                    BOOKMARKS.NO_TECHPREVIEW,
                     BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                     BOOKMARKS.NO_STEP_GRAPH
                   )}&sortField=net_working_improvement&sort=asc`}
@@ -365,7 +362,6 @@ export default function ReleaseOverview(props) {
                       items: [
                         BOOKMARKS.RUN_7,
                         BOOKMARKS.NO_NEVER_STABLE,
-                        BOOKMARKS.NO_TECHPREVIEW,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                         BOOKMARKS.NO_STEP_GRAPH,
                       ],
@@ -387,7 +383,6 @@ export default function ReleaseOverview(props) {
                   }?period=twoDay&sortField=net_working_improvement&sort=asc&${queryForBookmark(
                     BOOKMARKS.RUN_2,
                     BOOKMARKS.NO_NEVER_STABLE,
-                    BOOKMARKS.NO_TECHPREVIEW,
                     BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                     BOOKMARKS.NO_STEP_GRAPH
                   )}`}
@@ -410,7 +405,6 @@ export default function ReleaseOverview(props) {
                       items: [
                         BOOKMARKS.RUN_2,
                         BOOKMARKS.NO_NEVER_STABLE,
-                        BOOKMARKS.NO_TECHPREVIEW,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                         BOOKMARKS.NO_STEP_GRAPH,
                       ],
@@ -431,7 +425,6 @@ export default function ReleaseOverview(props) {
                   to={`/tests/${props.release}?${queryForBookmark(
                     BOOKMARKS.RUN_7,
                     BOOKMARKS.NO_NEVER_STABLE,
-                    BOOKMARKS.NO_TECHPREVIEW,
                     BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                     BOOKMARKS.NO_STEP_GRAPH
                   )}&sortField=current_working_percentage&sort=asc`}
@@ -455,7 +448,6 @@ export default function ReleaseOverview(props) {
                       items: [
                         BOOKMARKS.RUN_7,
                         BOOKMARKS.NO_NEVER_STABLE,
-                        BOOKMARKS.NO_TECHPREVIEW,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                         BOOKMARKS.NO_STEP_GRAPH,
                       ],

--- a/sippy-ng/src/tests/TestAnalysis.js
+++ b/sippy-ng/src/tests/TestAnalysis.js
@@ -48,7 +48,6 @@ export function TestAnalysis(props) {
       items: [
         filterFor('name', 'equals', testName),
         not(filterFor('variants', 'contains', 'never-stable')),
-        not(filterFor('variants', 'contains', 'techpreview')),
       ],
     },
     setFilterModel,


### PR DESCRIPTION
[TRT-404](https://issues.redhat.com//browse/TRT-404)

When the first techpreview jobs got added they were nearly always
failing so it was added to our default filters along with never-stable.
That's no longer the case, so this changes makes it get treated like any
other variant.