### PR TITLE
Add some missing indexes on ID's

### DIFF
--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -53,9 +53,9 @@ type ProwJobRun struct {
 	// KnownFailure is true if the job run failed, but we found a bug that is likely related already filed.
 	KnownFailure  bool
 	Succeeded     bool
-	Timestamp     time.Time
+	Timestamp     time.Time `gorm:"index"`
 	Duration      time.Duration
-	OverallResult v1.JobOverallResult
+	OverallResult v1.JobOverallResult `gorm:"index"`
 }
 
 type Test struct {

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -38,7 +38,7 @@ type ProwJobRun struct {
 
 	// ProwJob is a link to the prow job this run belongs to.
 	ProwJob   ProwJob
-	ProwJobID uint
+	ProwJobID uint `gorm:"index"`
 
 	// Cluster is the cluster where the prow job was run.
 	Cluster string
@@ -67,13 +67,13 @@ type Test struct {
 // that execution.
 type ProwJobRunTest struct {
 	gorm.Model
-	ProwJobRunID uint
+	ProwJobRunID uint `gorm:"index"`
 	ProwJobRun   ProwJobRun
-	TestID       uint
+	TestID       uint `gorm:"index"`
 	Test         Test
 	// SuiteID may be nil if no suite name could be parsed from the testgrid test name.
-	SuiteID   *uint
-	Status    int // would like to use smallint here, but gorm auto-migrate breaks trying to change the type every start
+	SuiteID   *uint `gorm:"index"`
+	Status    int   // would like to use smallint here, but gorm auto-migrate breaks trying to change the type every start
 	Duration  float64
 	CreatedAt time.Time
 	DeletedAt gorm.DeletedAt


### PR DESCRIPTION
I tried to do some direct queries on prow_job_run_tests by test_id and
wow is it slow.

We should merge this early morning or at the end of the day, takes about 30 minutes to run.
