### PR TITLE
Ensure we don't add duplicate PR's

### DIFF
--- a/pkg/releasesync/changelog_parser.go
+++ b/pkg/releasesync/changelog_parser.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 
 	"github.com/anaskhan96/soup"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/openshift/sippy/pkg/db/models"
 )
 
@@ -112,7 +114,14 @@ func (c *Changelog) PullRequests() []models.ReleasePullRequest {
 		return nil
 	}
 
-	rows := make([]models.ReleasePullRequest, 0)
+	// Ensure PR uniqueness, there have been examples of the release controller
+	// listing the same PR twice (from upstream and the fork). See OCPCRT-152.
+	type prlocator struct {
+		name string
+		url  string
+	}
+	rows := make(map[prlocator]models.ReleasePullRequest, 0)
+
 	for _, section := range sections {
 		_, imageName, err := extractAnchor(section.Find("a"))
 		if err != nil {
@@ -148,11 +157,24 @@ func (c *Changelog) PullRequests() []models.ReleasePullRequest {
 					row.BugURL = url
 				}
 			}
-			rows = append(rows, row)
+
+			prl := prlocator{
+				url:  row.URL,
+				name: row.Name,
+			}
+			if _, ok := rows[prl]; ok {
+				log.Warningf("duplicate PR in %q: %q, %q", c.releaseTag, row.URL, row.Name)
+			} else {
+				rows[prl] = row
+			}
 		}
 	}
 
-	return rows
+	result := make([]models.ReleasePullRequest, 0)
+	for _, v := range rows {
+		result = append(result, v)
+	}
+	return result
 }
 
 func extractAnchor(anchor soup.Root) (href, text string, err error) {

--- a/pkg/releasesync/changelog_parser.go
+++ b/pkg/releasesync/changelog_parser.go
@@ -120,7 +120,7 @@ func (c *Changelog) PullRequests() []models.ReleasePullRequest {
 		name string
 		url  string
 	}
-	rows := make(map[prlocator]models.ReleasePullRequest, 0)
+	rows := make(map[prlocator]models.ReleasePullRequest)
 
 	for _, section := range sections {
 		_, imageName, err := extractAnchor(section.Find("a"))


### PR DESCRIPTION
[TRT-414](https://issues.redhat.com//browse/TRT-414)

Sippy prow isn't currently syncing due to this error:

```
panic: ERROR: insert or update on table "release_tag_pull_requests" violates foreign key constraint "fk_release_tag_pull_requests_release_pull_request" (SQLSTATE 23503)
```

The release controller has a bug when merging from upstream repos: it
assumes a mentioned PR belongs to the openshift fork, and makes a link
to it, despite the PR actually belonging to upstream.

If you look at
https://arm64.ocp.releases.ci.openshift.org/releasestream/4.12.0-0.nightly-arm64/release/4.12.0-0.nightly-arm64-2022-07-24-180825,
gcp-pd-csi-driver lists PR 1 multiple times, but only 1 refers to the
actual first PR to openshift, the other is from upstream.

This change will just unbreak fetching data, but doesn't resolve the actual problem.

I filed a bug against the CRT team for the release-controller.

For Sippy, a proper fix is really moving away from the release pull
requests table and using the prow data -- we would then be able to
only adding PR to the release payload that we've seen in Prow.