### PR TITLE
Correctly handle suite names for prow

### DIFF
--- a/pkg/synthetictests/ocp_synthetic_tests.go
+++ b/pkg/synthetictests/ocp_synthetic_tests.go
@@ -2,6 +2,7 @@ package synthetictests
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/openshift/sippy/pkg/apis/junit"
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
@@ -156,6 +157,8 @@ func (openshiftSyntheticManager) CreateSyntheticTests(jrr *sippyprocessingv1.Raw
 	}
 
 	for testName, result := range syntheticTests {
+		testNameWithoutSuite := strings.TrimPrefix(testName, testidentification.SippySuiteName+".")
+
 		// convert the result.pass or .fail to the status value we use for test results:
 		if result.fail > 0 {
 			jrr.TestFailures += result.fail
@@ -163,7 +166,7 @@ func (openshiftSyntheticManager) CreateSyntheticTests(jrr *sippyprocessingv1.Raw
 		} else if result.pass > 0 {
 			// Add successful test results as well.
 			jrr.TestResults = append(jrr.TestResults, sippyprocessingv1.RawJobRunTestResult{
-				Name:   testName,
+				Name:   testNameWithoutSuite,
 				Status: v1.TestStatusSuccess,
 			})
 		}
@@ -171,11 +174,11 @@ func (openshiftSyntheticManager) CreateSyntheticTests(jrr *sippyprocessingv1.Raw
 		// Create junits
 		if result.pass > 0 {
 			results = append(results, &junit.TestCase{
-				Name: testName,
+				Name: testNameWithoutSuite,
 			})
 		} else if result.fail > 0 {
 			results = append(results, &junit.TestCase{
-				Name: testName,
+				Name: testNameWithoutSuite,
 				FailureOutput: &junit.FailureOutput{
 					Output: fmt.Sprintf("Synthetic test %q failed", testName),
 				},

--- a/pkg/synthetictests/ocp_synthetic_tests_test.go
+++ b/pkg/synthetictests/ocp_synthetic_tests_test.go
@@ -36,9 +36,9 @@ func TestSyntheticSippyTestGeneration(t *testing.T) {
 				TestResults: map[string]v1.RawTestResult{},
 			},
 			expectedTestResults: []v1.RawJobRunTestResult{
-				{Name: testidentification.SippySuiteName + "." + testidentification.InstallTestName, Status: tgv1.TestStatusSuccess},
-				{Name: testidentification.SippySuiteName + "." + testidentification.FinalOperatorHealthTestName, Status: tgv1.TestStatusSuccess},
-				{Name: "sippy.operator install openshift-apiserver", Status: tgv1.TestStatusSuccess},
+				{Name: testidentification.InstallTestName, Status: tgv1.TestStatusSuccess},
+				{Name: testidentification.FinalOperatorHealthTestName, Status: tgv1.TestStatusSuccess},
+				{Name: "operator install openshift-apiserver", Status: tgv1.TestStatusSuccess},
 			},
 		},
 		{
@@ -55,8 +55,8 @@ func TestSyntheticSippyTestGeneration(t *testing.T) {
 				TestResults: map[string]v1.RawTestResult{},
 			},
 			expectedTestResults: []v1.RawJobRunTestResult{
-				{Name: testidentification.SippySuiteName + "." + testidentification.FinalOperatorHealthTestName, Status: tgv1.TestStatusSuccess},
-				{Name: "sippy.operator install openshift-apiserver", Status: tgv1.TestStatusSuccess},
+				{Name: testidentification.FinalOperatorHealthTestName, Status: tgv1.TestStatusSuccess},
+				{Name: "operator install openshift-apiserver", Status: tgv1.TestStatusSuccess},
 			},
 			expectedFailedTestNames: []string{
 				testidentification.SippySuiteName + "." + testidentification.InstallTestName,

--- a/pkg/testgridanalysis/testgridconversion/to_raw_data.go
+++ b/pkg/testgridanalysis/testgridconversion/to_raw_data.go
@@ -35,7 +35,7 @@ func (o ProcessingOptions) ProcessJobDetailsIntoRawJobResult(jobDetails testgrid
 				failed = 1
 				passed = 0
 			}
-			addTestResult(jobResult.TestResults, &jobDetails, test.Name, passed, failed, 0)
+			addTestResult(jobResult.TestResults, &jobDetails, fmt.Sprintf("%s.%s", syntheticTests.Name, test.Name), passed, failed, 0)
 		}
 	}
 	return jobResult, []string{}


### PR DESCRIPTION
Sippy prow is missing some synthetic test data because the suite isn't
removed like it is on TestGrid. I attempted to fix this in
https://github.com/openshift/sippy/pull/488, but I didn't realize
the synthetic test generation code was adding the sippy suite name to
the test name directly *as well as* the junit testsuite.

This ensures junits are correct: suite name only in the testsuite, and
where required for testgrid, joins them.