### PR TITLE
new payload category

### DIFF
--- a/pkg/db/models/releases.go
+++ b/pkg/db/models/releases.go
@@ -59,8 +59,12 @@ type ReleaseTag struct {
 
 	JobRuns []ReleaseJobRun `json:"-" gorm:"foreignKey:release_tag_id"`
 
-	// RejectReason is used to indicate why a payload is rejected.
+	// RejectReason is category of failure for why the payload was rejected. Today this is manually assigned
+	// by TRT, and there is no guarantee it will always be set.
 	RejectReason string `json:"reject_reason" gorm:"column:reject_reason"`
+
+	// RejectReasonNote is a description from TRT as to why the payload was categorized as it was.
+	RejectReasonNote string `json:"reject_reason_note" gorm:"column:reject_reason_note"`
 }
 
 // ReleasePullRequest represents a pull request that was included for the first time

--- a/scripts/rejected-payloads.md
+++ b/scripts/rejected-payloads.md
@@ -27,7 +27,54 @@ Or if you are on Fedora:
 
 ## Key Functions
 
+### Categorize
+
+Categorize is used to update the reject-reason in the DB.
+It can be used to update a single release tag when -t or --release_tag is specified.
+If no release_tag is specified, it will find all uncategorized release tags and provide an interactive prompt to update each release tag.
+
+```
+  -t RELEASE_TAG, --release_tag RELEASE_TAG     Specifies a release payload tag, like 4.11.0-0.nightly-2022-06-25-081133
+  -r RELEASE, --release RELEASE                 Specifies a release, like 4.11
+  -s STREAM, --stream STREAM                    Specifies a stream, like nightly or ci
+  -a, --all                                     List all rejected payloads. If not specified , list only uncategorized ones.
+```
+
+To list most recent failed payloads in a stream, and select one to categorize interactively:
+
+```
+% python ./rejected-payloads.py -d "your-dsn" categorize -s ci -r 4.12
+index     release tag                                       phase               reject reason
+1         4.11.0-0.ci-2022-06-29-121424                     Rejected            None
+2         4.11.0-0.ci-2022-06-28-211909                     Rejected            None
+Select tag between 1 and 2 to categorize, enter q to exit: 1
+Please choose the reject reason for tag 4.11.0-0.ci-2022-06-29-121424 from the following list:
+         1:           TEST_FLAKE
+         2:          CLOUD_INFRA
+         3:             RH_INFRA
+         4:   PRODUCT_REGRESSION
+         5:      TEST_REGRESSION
+Enter your selection between 1 and 5: 3
+index     release tag                                       phase               reject reason
+1         4.11.0-0.ci-2022-06-28-211909                     Rejected            None
+Select tag between 1 and 1 to categorize, enter q to exit: q
+```
+
+If you already know the payload tag you'd like to categorize:
+
+```
+% python ./rejected-payloads.py -d "your-dsn" categorize -t 4.11.0-0.nightly-2022-06-28-111405
+Please choose the reject reason for tag 4.11.0-0.nightly-2022-06-28-111405 from the following list:
+         1:           TEST_FLAKE
+         2:          CLOUD_INFRA
+         3:             RH_INFRA
+         4:   PRODUCT_REGRESSION
+         5:      TEST_REGRESSION
+Enter your selection between 1 and 5: 2
+```
+
 ### List
+
 List command can be used to list uncategorized release tags.
 Additional options can be provided to limit the scope of the query.
 
@@ -44,49 +91,4 @@ The following example lists all uncategorized release tags for 4.11 ci payloads:
 index     release tag                                       phase               reject reason
 1         4.11.0-0.ci-2022-06-29-121424                     Rejected            None
 2         4.11.0-0.ci-2022-06-28-211909                     Rejected            None
-```
-
-### Categorize
-Categorize is used to update the reject-reason in the DB.
-It can be used to update a single release tag when -t or --release_tag is specified.
-If no release_tag is specified, it will find all uncategorized release tags and provide an interactive prompt to update each release tag.
-
-```
-  -t RELEASE_TAG, --release_tag RELEASE_TAG     Specifies a release payload tag, like 4.11.0-0.nightly-2022-06-25-081133
-  -r RELEASE, --release RELEASE                 Specifies a release, like 4.11
-  -s STREAM, --stream STREAM                    Specifies a stream, like nightly or ci
-  -a, --all                                     List all rejected payloads. If not specified , list only uncategorized ones.
-```
-
-Here is a single update example:
-
-```
-% python ./rejected-payloads.py -d "your-dsn" categorize -t 4.11.0-0.nightly-2022-06-28-111405
-Please choose the reject reason for tag 4.11.0-0.nightly-2022-06-28-111405 from the following list:
-         1:           TEST_FLAKE
-         2:          CLOUD_INFRA
-         3:             RH_INFRA
-         4:   PRODUCT_REGRESSION
-         5:      TEST_REGRESSION
-Enter your selection between 1 and 5: 2
-```
-
-Here is a group update example:
-
-```
-% python ./rejected-payloads.py -d "your-dsn" categorize -s ci
-index     release tag                                       phase               reject reason
-1         4.11.0-0.ci-2022-06-29-121424                     Rejected            None
-2         4.11.0-0.ci-2022-06-28-211909                     Rejected            None
-Select tag between 1 and 2 to categorize, enter q to exit: 1
-Please choose the reject reason for tag 4.11.0-0.ci-2022-06-29-121424 from the following list:
-         1:           TEST_FLAKE
-         2:          CLOUD_INFRA
-         3:             RH_INFRA
-         4:   PRODUCT_REGRESSION
-         5:      TEST_REGRESSION
-Enter your selection between 1 and 5: 3
-index     release tag                                       phase               reject reason
-1         4.11.0-0.ci-2022-06-28-211909                     Rejected            None
-Select tag between 1 and 1 to categorize, enter q to exit: q
 ```

--- a/scripts/rejected-payloads.py
+++ b/scripts/rejected-payloads.py
@@ -19,6 +19,7 @@ class ReleaseTags(base):
     stream = Column(String)
     phase = Column(String)
     reject_reason = Column(String)
+    reject_reason_note = Column(String)
 
 class PayloadTestFailures(base):
     __tablename__ = 'payload_test_failures_14d_matview'
@@ -44,9 +45,9 @@ def selectReleases(session, release, stream, showAll, days):
     return selectedTags
 
 def printReleases(selectedTags):
-    print("%-10s%-50s%-20s%-20s" % ("index", "release tag", "phase", "reject reason"))
+    print("%-10s%-50s%-20s%-20s%s" % ("index", "release tag", "phase", "reject reason", "note"))
     for idx, releaseTag in enumerate(selectedTags):
-        print("%-10d%-50s%-20s%-20s" % (idx+1, releaseTag.release_tag, releaseTag.phase, releaseTag.reject_reason))
+        print("%-10d%-50s%-20s%-20s%s" % (idx+1, releaseTag.release_tag, releaseTag.phase, releaseTag.reject_reason, releaseTag.reject_reason_note))
 
 def list_releases(session, release, stream, showAll, days):
     selectedTags = selectReleases(session, release, stream, showAll, days)
@@ -100,6 +101,10 @@ def categorizeSingle(session, tag):
             except ValueError:
                 continue
         releaseTag.reject_reason = reject_reasons_keys[index-1]
+
+        note = input("Enter a brief note on why this payload was categorized as such (optional): ")
+        releaseTag.reject_reason_note = note
+
     session.commit()
 
 def categorize(session, release, stream, showAll, days):

--- a/scripts/rejected-payloads.py
+++ b/scripts/rejected-payloads.py
@@ -45,7 +45,7 @@ def list(session, release, stream, showAll, days):
     printReleases(selectedTags)
 
 def categorizeSingle(session, releaseTag):
-    reject_reasons = ["TEST_FLAKE", "CLOUD_INFRA", "RH_INFRA", "PRODUCT_REGRESSION", "TEST_REGRESSION"]
+    reject_reasons = ["TEST_FLAKE", "CLOUD_INFRA", "CLOUD_QUOTA", "RH_INFRA", "PRODUCT_REGRESSION", "TEST_REGRESSION"]
     releaseTags = session.query(ReleaseTags).filter(ReleaseTags.release_tag == releaseTag).all()
     for releaseTag in releaseTags:
         print("Please choose the reject reason for tag %s from the following list:" % releaseTag.release_tag)

--- a/scripts/rejected-payloads.py
+++ b/scripts/rejected-payloads.py
@@ -23,7 +23,7 @@ class ReleaseTags(base):
 def selectReleases(session, release, stream, showAll, days):
     selectedTags = []
     start = datetime.datetime.utcnow() - datetime.timedelta(days=days)
-    releaseTags = session.query(ReleaseTags).filter(ReleaseTags.phase == "Rejected", ReleaseTags.release_time >= start).all()
+    releaseTags = session.query(ReleaseTags).filter(ReleaseTags.phase == "Rejected", ReleaseTags.release_time >= start).order_by(ReleaseTags.release_time.desc()).all()
     for releaseTag in releaseTags:
         if release and releaseTag.release != release:
             continue

--- a/sippy-ng/src/releases/ReleasePayloadTable.js
+++ b/sippy-ng/src/releases/ReleasePayloadTable.js
@@ -121,6 +121,13 @@ function ReleasePayloadTable(props) {
       headerName: 'Reject reason',
       flex: 1.5,
       hide: props.briefTable,
+      renderCell: (params) => {
+        return (
+          <Tooltip title={`${params.row.reject_reason_note}`}>
+            <Typography>{params.value}</Typography>
+          </Tooltip>
+        )
+      },
     },
     {
       field: 'release_tag',


### PR DESCRIPTION
[TRT-416](https://issues.redhat.com//browse/TRT-416)

- Add a new failed payload categorization for cloud quota issues.
- Sort payloads by tag descending.
- List descriptions for payload reject reasons and fix dangerous list() override.
- Display the list of failed jobs and the tests that failed within them (max 5) once a payload is selected to categorize.
- Allow adding a note for why payload was categorized as it was (optional).
- Display notes from TRT for reject reason as a tooltip in UI table.
- Reorder payload categorize script slightly to put most relevant info at the top.
