### PR TITLE
Ignore skipped test cases

### DIFF
--- a/pkg/prowloader/prow.go
+++ b/pkg/prowloader/prow.go
@@ -340,7 +340,9 @@ func (pl *ProwLoader) extractTestCases(suite *junit.TestSuite, testCases map[str
 	for _, tc := range suite.TestCases {
 		status := v1.TestStatusFailure
 		var failureOutput *models.ProwJobRunTestOutput
-		if tc.FailureOutput == nil {
+		if tc.SkipMessage != nil {
+			continue
+		} else if tc.FailureOutput == nil {
 			status = v1.TestStatusSuccess
 		} else {
 			failureOutput = &models.ProwJobRunTestOutput{


### PR DESCRIPTION
[TRT-439](https://issues.redhat.com//browse/TRT-439)

Prow-based sippy doesn't ignore skipped test cases, but instead
considers them a success. This is throwing off success percentages
for tests that have criteria that gets them skipped. This was hard to
spot since *most* conformance tests run on *most* jobs, so the numbers
between the two sippys are very close except on certain tests.

For example sippy-prow says `Cluster topology single node tests Verify
that OpenShift components deploy one replica in SingleReplica topology
mode` has thousands of runs in the last 7 days, but testgrid sippy only
shows 160. It's been counted on all the platforms it was skipped (i.e.
all HA job runs).