### PR TITLE
Revert "Differentiate on test suite in NURPs test tables."

### DIFF
--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -165,7 +165,7 @@ func BuildTestsResults(dbc *db.DB, release, period string, collapse, includeOver
 		rawQuery = rawQuery.Select(`name,` + query.QueryTestSummer).Group("name")
 	} else {
 		rawQuery = query.TestsByNURPAndStandardDeviation(dbc, release, table)
-		variantSelect = "suite_name, variants, " +
+		variantSelect = "variants, " +
 			"delta_from_working_average, working_average, working_standard_deviation, " +
 			"delta_from_passing_average, passing_average, passing_standard_deviation, " +
 			"delta_from_flake_average, flake_average, flake_standard_deviation, "
@@ -178,8 +178,7 @@ func BuildTestsResults(dbc *db.DB, release, period string, collapse, includeOver
 	testReports := make([]apitype.Test, 0)
 	// FIXME: Add test id to matview, for now generate with ROW_NUMBER OVER
 	processedResults := dbc.DB.Table("(?) as results", rawQuery).
-		Select(`ROW_NUMBER() OVER() as id, name,` + variantSelect + query.QueryTestSummarizer).
-		Where("current_runs > 0 or previous_runs > 0")
+		Select(`ROW_NUMBER() OVER() as id, name,` + variantSelect + query.QueryTestSummarizer)
 
 	finalResults := dbc.DB.Table("(?) as final_results", processedResults)
 	if processedFilter != nil {

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -240,11 +240,10 @@ func (run JobRun) GetArrayValue(param string) ([]string, error) {
 // Test contains the full accounting of a test's history, with a synthetic ID. The format
 // of this struct is suitable for use in a data table.
 type Test struct {
-	ID        int            `json:"id,omitempty"`
-	Name      string         `json:"name"`
-	SuiteName string         `json:"suite_name"`
-	Variant   string         `json:"variant,omitempty"`
-	Variants  pq.StringArray `json:"variants" gorm:"type:text[]"`
+	ID       int            `json:"id,omitempty"`
+	Name     string         `json:"name"`
+	Variant  string         `json:"variant,omitempty"`
+	Variants pq.StringArray `json:"variants" gorm:"type:text[]"`
 
 	CurrentSuccesses         int     `json:"current_successes"`
 	CurrentFailures          int     `json:"current_failures"`

--- a/pkg/db/matviews.go
+++ b/pkg/db/matviews.go
@@ -153,7 +153,6 @@ FROM prow_job_runs
 const testReportMatView = `
 SELECT tests.id,
    tests.name,
-   suites.name as suite_name,
    COALESCE(count(
        CASE
            WHEN prow_job_run_tests.status = 1 AND prow_job_runs."timestamp" BETWEEN |||START||| AND |||BOUNDARY||| THEN 1
@@ -198,11 +197,10 @@ SELECT tests.id,
    prow_jobs.release
 FROM prow_job_run_tests
    JOIN tests ON tests.id = prow_job_run_tests.test_id
-   JOIN suites on suites.id = prow_job_run_tests.suite_id
    JOIN prow_job_runs ON prow_job_runs.id = prow_job_run_tests.prow_job_run_id
    JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id
 WHERE NOT ('aggregated'::text = ANY (prow_jobs.variants))
-GROUP BY tests.id, tests.name, suites.name, prow_jobs.variants, prow_jobs.release
+GROUP BY tests.id, tests.name, prow_jobs.variants, prow_jobs.release
 `
 
 const testAnalysisByVariantMatView = `

--- a/sippy-ng/package-lock.json
+++ b/sippy-ng/package-lock.json
@@ -6164,20 +6164,14 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001374",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
-      "integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==",
+      "version": "1.0.30001312",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
+      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
       "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        }
-      ]
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -28964,9 +28958,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001374",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
-      "integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==",
+      "version": "1.0.30001312",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
+      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
       "dev": true
     },
     "capture-exit": {

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -117,10 +117,6 @@ function TestTable(props) {
           flex: 3.5,
         },
         {
-          field: 'suite_name',
-          flex: 1.0,
-        },
-        {
           field: 'variants',
           flex: 1.5,
           hide: props.collapse,
@@ -178,10 +174,6 @@ function TestTable(props) {
           flex: 3.5,
         },
         {
-          field: 'suite_name',
-          flex: 1.0,
-        },
-        {
           field: 'variants',
           flex: 1.5,
           hide: props.collapse,
@@ -236,10 +228,6 @@ function TestTable(props) {
         {
           field: 'name',
           flex: 3.5,
-        },
-        {
-          field: 'suite_name',
-          flex: 1.0,
         },
         {
           field: 'variants',
@@ -378,13 +366,6 @@ function TestTable(props) {
           </div>
         )
       },
-    },
-    suite_name: {
-      field: 'suite_name',
-      headerName: 'Suite',
-      autocomplete: 'suite_name',
-      type: 'array',
-      renderCell: (params) => <div className="test-name">{params.value}</div>,
     },
     variants: {
       field: 'variants',


### PR DESCRIPTION
Reverts openshift/sippy#518

Any test that doesn't have a suite name ends up excluded from the matview, resulting in a bunch of missing data:

```
sippy_openshift=> SELECT * FROM prow_test_report_7d_matview WHERE release = '4.12' AND name LIKE '%cluster install%';
 id | name | suite_name | previous_successes | previous_flakes | previous_failures | previous_runs | current_successes | current_flakes | current_failures | current_runs | variants | release 
----+------+------------+--------------------+-----------------+-------------------+---------------+-------------------+----------------+------------------+--------------+----------+---------
(0 rows)
```


I think it needs to be a LEFT JOIN [here](https://github.com/openshift/sippy/pull/518/files#diff-7fa1b9fbef139e2c0d9eadf51d97fa898c9360bcfcbdcc407207629fcdca60cfR201).

All the top-level indicators on sippy are blank right now: https://sippy.dptools.openshift.org/sippy-ng/.  I think this PR is safe to revert, so gives us time to find a proper fix.

