### PR TITLE
Create indexes with materialized views

### DIFF
--- a/pkg/db/functions.go
+++ b/pkg/db/functions.go
@@ -25,7 +25,7 @@ var PostgresFunctions = []PostgresFunction{
 func syncPostgresFunctions(db *gorm.DB) error {
 	for _, pgFunc := range PostgresFunctions {
 		dropSQL := fmt.Sprintf("DROP FUNCTION IF EXISTS %s", pgFunc.Name)
-		if err := syncSchema(db, hashTypeFunction, pgFunc.Name, pgFunc.Definition, dropSQL); err != nil {
+		if err := syncSchema(db, hashTypeFunction, pgFunc.Name, pgFunc.Definition, dropSQL, nil, nil); err != nil {
 			return err
 		}
 	}

--- a/pkg/db/matviews.go
+++ b/pkg/db/matviews.go
@@ -89,15 +89,10 @@ func syncPostgresMaterializedViews(db *gorm.DB) error {
 		}
 		dropSQL := fmt.Sprintf("DROP MATERIALIZED VIEW IF EXISTS %s", pmv.Name)
 		schema := fmt.Sprintf("CREATE MATERIALIZED VIEW %s AS %s WITH NO DATA", pmv.Name, viewDef)
-		if err := syncSchema(db, hashTypeMatView, pmv.Name, schema, dropSQL); err != nil {
-			return err
-		}
-
-		// Sync index for the materialized view:
 		indexName := fmt.Sprintf("idx_%s", pmv.Name)
 		index := fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s(%s)", indexName, pmv.Name, strings.Join(pmv.IndexColumns, ","))
-		dropSQL = fmt.Sprintf("DROP INDEX IF EXISTS %s", indexName)
-		if err := syncSchema(db, hashTypeMatViewIndex, indexName, index, dropSQL); err != nil {
+		indexDropSQL := fmt.Sprintf("DROP INDEX IF EXISTS %s", indexName)
+		if err := syncSchema(db, hashTypeMatView, pmv.Name, schema, dropSQL, &index, &indexDropSQL); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
[TRT-480](https://issues.redhat.com//browse/TRT-480)

Dropping a materialized view, drops its indexes -- but the schema hash table for the indexes remains unchanged, making us think the indexes are still in place.

The tests matviews are currently missing their indexes since we've updated them.  This change makes indexes created together with the matviews.