### PR TITLE
Fix loss of indicies when matviews change.

### DIFF
--- a/pkg/db/functions.go
+++ b/pkg/db/functions.go
@@ -25,7 +25,7 @@ var PostgresFunctions = []PostgresFunction{
 func syncPostgresFunctions(db *gorm.DB) error {
 	for _, pgFunc := range PostgresFunctions {
 		dropSQL := fmt.Sprintf("DROP FUNCTION IF EXISTS %s", pgFunc.Name)
-		if err := syncSchema(db, hashTypeFunction, pgFunc.Name, pgFunc.Definition, dropSQL); err != nil {
+		if _, err := syncSchema(db, hashTypeFunction, pgFunc.Name, pgFunc.Definition, dropSQL, false); err != nil {
 			return err
 		}
 	}

--- a/pkg/db/matviews.go
+++ b/pkg/db/matviews.go
@@ -89,7 +89,8 @@ func syncPostgresMaterializedViews(db *gorm.DB) error {
 		}
 		dropSQL := fmt.Sprintf("DROP MATERIALIZED VIEW IF EXISTS %s", pmv.Name)
 		schema := fmt.Sprintf("CREATE MATERIALIZED VIEW %s AS %s WITH NO DATA", pmv.Name, viewDef)
-		if err := syncSchema(db, hashTypeMatView, pmv.Name, schema, dropSQL); err != nil {
+		matViewUpdated, err := syncSchema(db, hashTypeMatView, pmv.Name, schema, dropSQL, false)
+		if err != nil {
 			return err
 		}
 
@@ -97,7 +98,7 @@ func syncPostgresMaterializedViews(db *gorm.DB) error {
 		indexName := fmt.Sprintf("idx_%s", pmv.Name)
 		index := fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s(%s)", indexName, pmv.Name, strings.Join(pmv.IndexColumns, ","))
 		dropSQL = fmt.Sprintf("DROP INDEX IF EXISTS %s", indexName)
-		if err := syncSchema(db, hashTypeMatViewIndex, indexName, index, dropSQL); err != nil {
+		if _, err := syncSchema(db, hashTypeMatViewIndex, indexName, index, dropSQL, matViewUpdated); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Possible alternative to #532 which would preserve ability to update indicies without requiring a matview update.

This change returns a bool when we update schema that will be true if we detected a schema change and did an update. This can be passed to as a force to the index schema update telling it to sync regardless if we see a hash change or not.