### PR TITLE
Add metrics for build cluster health

### DIFF
--- a/pkg/sippyserver/parameters.go
+++ b/pkg/sippyserver/parameters.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/openshift/sippy/pkg/util"
 )
 
 func getISO8601Date(paramName string, req *http.Request) (*time.Time, error) {
@@ -24,6 +26,7 @@ func getISO8601Date(paramName string, req *http.Request) (*time.Time, error) {
 func getPeriodDates(defaultPeriod string, req *http.Request) (start, boundary, end time.Time) {
 	period := getPeriod(req, defaultPeriod)
 
+	// If start, boundary, and end params are all specified, use those
 	startp := getDateParam("start", req)
 	boundaryp := getDateParam("boundary", req)
 	endp := getDateParam("end", req)
@@ -31,17 +34,8 @@ func getPeriodDates(defaultPeriod string, req *http.Request) (start, boundary, e
 		return *startp, *boundaryp, *endp
 	}
 
-	if period == "twoDay" {
-		start = time.Now().Add(-9 * 24 * time.Hour)
-		boundary = time.Now().Add(-2 * 24 * time.Hour)
-
-	} else {
-		start = time.Now().Add(-14 * 24 * time.Hour)
-		boundary = time.Now().Add(-7 * 24 * time.Hour)
-	}
-	end = time.Now()
-
-	return start, boundary, end
+	// Otherwise generate from the period name
+	return util.PeriodToDates(period)
 }
 
 func getDateParam(paramName string, req *http.Request) *time.Time {

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"regexp"
+	"time"
 
 	bugsv1 "github.com/openshift/sippy/pkg/apis/bugs/v1"
 )
@@ -41,4 +42,19 @@ func StrSliceContains(strSlice []string, elem string) bool {
 		}
 	}
 	return false
+}
+
+// PeriodToDates takes a period name such as twoDay or default, and
+// converts to start, boundary, and end times.
+func PeriodToDates(period string) (start, boundary, end time.Time) {
+	if period == "twoDay" {
+		start = time.Now().Add(-9 * 24 * time.Hour)
+		boundary = time.Now().Add(-2 * 24 * time.Hour)
+	} else {
+		start = time.Now().Add(-14 * 24 * time.Hour)
+		boundary = time.Now().Add(-7 * 24 * time.Hour)
+	}
+	end = time.Now()
+
+	return start, boundary, end
 }


### PR DESCRIPTION
[TRT-328](https://issues.redhat.com//browse/TRT-328)

This adds a new pass ratio metric for build cluster health, e.g.:

```
sippy_build_cluster_pass_ratio{cluster="build01",period="default"} 0.7524868344060854
sippy_build_cluster_pass_ratio{cluster="build01",period="twoDay"} 0.7578231292517007
sippy_build_cluster_pass_ratio{cluster="build02",period="default"} 0.8801810385898047
sippy_build_cluster_pass_ratio{cluster="build02",period="twoDay"} 0.8487348734873487
sippy_build_cluster_pass_ratio{cluster="build03",period="default"} 0.8037963761863675
sippy_build_cluster_pass_ratio{cluster="build03",period="twoDay"} 0.7949526813880127
sippy_build_cluster_pass_ratio{cluster="build04",period="default"} 0.8026266416510319
sippy_build_cluster_pass_ratio{cluster="build04",period="twoDay"} 0.7825
sippy_build_cluster_pass_ratio{cluster="build05",period="default"} 0.8577981651376148
sippy_build_cluster_pass_ratio{cluster="build05",period="twoDay"} 0.8383838383838383
sippy_build_cluster_pass_ratio{cluster="vsphere",period="default"} 0.537521815008726
sippy_build_cluster_pass_ratio{cluster="vsphere",period="twoDay"} 0.5451127819548872
```