### PR TITLE
Fix broken columns on release_job_runs.

### DIFF
--- a/pkg/db/models/releases.go
+++ b/pkg/db/models/releases.go
@@ -112,7 +112,7 @@ type ReleaseJobRun struct {
 
 	ReleaseTag     ReleaseTag `json:"release_tag" gorm:"foreignKey:release_tag_id"`
 	ReleaseTagID   string     `gorm:"column:release_tag_id"`
-	Name           uint       `json:"name" gorm:"column:prow_job_run_id,index:unique"` // TODO: this could use a rename to ProwJobRunID
+	Name           uint       `json:"name" gorm:"column:prow_job_run_id;index:,unique"` // TODO: this could use a rename to ProwJobRunID
 	JobName        string     `json:"job_name" gorm:"column:job_name"`
 	Kind           string     `json:"kind" gorm:"column:kind"`
 	State          string     `json:"state" gorm:"column:state"`


### PR DESCRIPTION
This syntax resulted in a column named: prow_job_run_id,index:unique
We needed the semi-colon to tell gorm to separate the two, index and
unique are related thus the use of a comma, but if you're moving to a
different directive you  need to use semi-colon.

This error is completely silent because the old prow_job_run_id column
still exists, won't show up in prow or any dev setup that uses a prod
db. If you make a fresh db it will though.

We've got some bad data to cleanup since this change merged.
