### PR TITLE
Remove use of unique index on prow_job_run_id

### DIFF
--- a/pkg/db/models/releases.go
+++ b/pkg/db/models/releases.go
@@ -112,7 +112,7 @@ type ReleaseJobRun struct {
 
 	ReleaseTag     ReleaseTag `json:"release_tag" gorm:"foreignKey:release_tag_id"`
 	ReleaseTagID   string     `gorm:"column:release_tag_id"`
-	Name           uint       `json:"name" gorm:"column:prow_job_run_id;index:,unique"` // TODO: this could use a rename to ProwJobRunID
+	Name           uint       `json:"name" gorm:"column:prow_job_run_id"` // TODO: this could use a rename to ProwJobRunID
 	JobName        string     `json:"job_name" gorm:"column:job_name"`
 	Kind           string     `json:"kind" gorm:"column:kind"`
 	State          string     `json:"state" gorm:"column:state"`


### PR DESCRIPTION
This is causing sippy problems:

```
2022/08/25 19:17:33 /go/src/sippy/vendor/gorm.io/driver/postgres/migrator.go:140 ERROR: could not create unique index "idx_release_job_runs_name" (SQLSTATE 23505)
[20.931ms] [rows:0] CREATE UNIQUE INDEX "idx_release_job_runs_name" ON "release_job_runs" ("prow_job_run_id")
time="2022-08-25T19:17:33.263Z" level=fatal msg="error running command" error="ERROR: could not create unique index \"idx_release_job_runs_name\" (SQLSTATE 23505)"
```