### PR TITLE
Adjust presubmit regex to pull in additional jobs

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -9,4 +9,4 @@ releases:
       periodic-ci-openshift-origin-release-3.11-e2e-gcp: true
   "Presubmits":
     regexp:
-      - "^pull-ci-openshift-.*-(master|main)-e2e-.*"
+      - "^pull-ci-openshift-.*-(master|main).*-e2e-.*"


### PR DESCRIPTION
[TRT-503](https://issues.redhat.com//browse/TRT-503)

The openshift/windows* repos all use presubmits in the format of
`<branch>-<platform>-e2e` instead of `<branch>-e2e-<platform>`. This
adjusts the regex for presubmits to capture those.