### PR TITLE
Don't add '.' to test name if there is no suite

### DIFF
--- a/pkg/prowloader/prow.go
+++ b/pkg/prowloader/prow.go
@@ -407,7 +407,7 @@ func (pl *ProwLoader) extractTestCases(suite *junit.TestSuite, testCases map[str
 
 		testNameWithKnownSuite := tc.Name
 		suiteID := pl.findSuite(suite.Name)
-		if suiteID == nil {
+		if suiteID == nil && suite.Name != "" {
 			testNameWithKnownSuite = fmt.Sprintf("%s.%s", suite.Name, tc.Name)
 		}
 


### PR DESCRIPTION
We're creating some tests that start with a period currently.