### PR TITLE
Show CI infra failures as overall status 'n'

### DIFF
--- a/pkg/api/job_analysis.go
+++ b/pkg/api/job_analysis.go
@@ -133,7 +133,7 @@ func PrintJobAnalysisJSONFromDB(w http.ResponseWriter, req *http.Request, dbc *d
 				v1sippyprocessing.JobInfrastructureFailure: sum.Infrastructure,
 				v1sippyprocessing.JobUpgradeFailure:        sum.Upgrade,
 				v1sippyprocessing.JobInstallFailure:        sum.Install,
-				v1sippyprocessing.JobNoResults:             sum.NoResult,
+				v1sippyprocessing.JobFailureBeforeSetup:    sum.NoResult,
 				v1sippyprocessing.JobUnknown:               sum.FailureOther,
 				v1sippyprocessing.JobAborted:               sum.Aborted,
 			},

--- a/pkg/apis/sippyprocessing/v1/types.go
+++ b/pkg/apis/sippyprocessing/v1/types.go
@@ -76,7 +76,7 @@ const (
 	JobInstallFailure        JobOverallResult = "I"
 	JobUpgradeFailure        JobOverallResult = "U"
 	JobTestFailure           JobOverallResult = "F"
-	JobNoResults             JobOverallResult = "n"
+	JobFailureBeforeSetup    JobOverallResult = "n"
 	JobAborted               JobOverallResult = "A"
 	JobUnknown               JobOverallResult = "f"
 )
@@ -146,6 +146,7 @@ type RawJobRunResult struct {
 	FailedTestNames []string // TODO: drop this and favor TestResults going forward, it has caused bugs.
 	TestResults     []RawJobRunTestResult
 	Failed          bool
+	Errored         bool
 	Succeeded       bool
 	Aborted         bool
 

--- a/pkg/prowloader/testconversion/testconversion.go
+++ b/pkg/prowloader/testconversion/testconversion.go
@@ -13,7 +13,8 @@ import (
 func ConvertProwJobRunToSyntheticTests(pj prow.ProwJob, tests map[string]*models.ProwJobRunTest, manager synthetictests.SyntheticTestManager) (*junit.TestSuite, v1.JobOverallResult) {
 	jrr := v1.RawJobRunResult{
 		Job:       pj.Spec.Job,
-		Failed:    pj.Status.State == prow.ErrorState || pj.Status.State == prow.FailureState,
+		Errored:   pj.Status.State == prow.ErrorState,
+		Failed:    pj.Status.State == prow.FailureState,
 		Succeeded: pj.Status.State == prow.SuccessState,
 		Aborted:   pj.Status.State == prow.AbortedState,
 	}

--- a/pkg/synthetictests/ocp_synthetic_tests.go
+++ b/pkg/synthetictests/ocp_synthetic_tests.go
@@ -206,13 +206,14 @@ func jobRunStatus(result *sippyprocessingv1.RawJobRunResult) sippyprocessingv1.J
 	if result.Succeeded {
 		return sippyprocessingv1.JobSucceeded
 	}
-
 	if result.Aborted {
 		return sippyprocessingv1.JobAborted
 	}
-
 	if !result.Failed {
 		return sippyprocessingv1.JobRunning
+	}
+	if result.Errored {
+		return sippyprocessingv1.JobFailureBeforeSetup
 	}
 
 	if result.InstallStatus == failure {
@@ -228,7 +229,7 @@ func jobRunStatus(result *sippyprocessingv1.RawJobRunResult) sippyprocessingv1.J
 		return sippyprocessingv1.JobTestFailure
 	}
 	if result.InstallStatus == "" {
-		return sippyprocessingv1.JobNoResults
+		return sippyprocessingv1.JobFailureBeforeSetup
 	}
 	return sippyprocessingv1.JobUnknown
 }


### PR DESCRIPTION
[TRT-526](https://issues.redhat.com//browse/TRT-526)

Currently in prow-based Sippy, CI infrastructure failures are showing up
as a general non-e2e failure ('f'). This is because failed and errored
are considered the same. Instead, an errored prow job should be
considered a failure before setup (a.k.a. likely CI infra).

TestGrid sippy had no way to know this as it had no distinct error state, it
just say a failed job without install results, which it called JobNoResults. This
change also renames it to more correctly be failure before setup (which is
how the UI shows it). 