### PR TITLE
[wip] support pinnedDateTime for historical sippy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 report.sh
 /sippy
 /data
+.vscode/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,8 +30,7 @@ Sippy obtains data from multiple sources:
 
 ### From a Prod Sippy Backup
 
-The simplest way to fetch data for Sippy, is to just get a copy of the production database. See the TRT team drive in
-Google, periodically there is a gzip'd backup stored there. Restore it locally with:
+The simplest way to fetch data for Sippy, is to just get a copy of the production database. TRT stores gzip'd backups in S3 periodically, see the staff slack channel for links or reach out to a team member for more information. Restore it locally with:
 
 ```bash
 psql -h localhost -U postgres -p 5432 postgres < sippy-backup-2022-05-02.sql

--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -67,7 +67,7 @@ func useNewInstallTest(release string) bool {
 
 // PrintOverallReleaseHealthFromDB gives a summarized status of the overall health, including
 // infrastructure, install, upgrade, and variant success rates.
-func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release string, timeNow time.Time) {
+func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release string, reportEnd time.Time) {
 	excludedVariants := []string{"never-stable"}
 	// Minor upgrades install a previous version and should not be counted against the current version's install stat.
 	excludedInstallVariants := append(excludedVariants, "upgrade-minor")
@@ -153,9 +153,9 @@ func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release 
 		Sort:      apitype.SortDescending,
 		Limit:     0,
 	}
-	start := timeNow.Add(-14 * 24 * time.Hour)
-	boundary := timeNow.Add(-7 * 24 * time.Hour)
-	end := timeNow
+	start := reportEnd.Add(-14 * 24 * time.Hour)
+	boundary := reportEnd.Add(-7 * 24 * time.Hour)
+	end := reportEnd
 	jobReports, err := query.JobReports(dbc, filterOpts, release, start, boundary, end)
 	if err != nil {
 		log.WithError(err).Error("error querying job reports")
@@ -163,7 +163,7 @@ func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release 
 	}
 	currStats, prevStats := calculateJobResultStatistics(jobReports)
 
-	warnings := ScanForReleaseWarnings(dbc, release, timeNow)
+	warnings := ScanForReleaseWarnings(dbc, release, reportEnd)
 
 	RespondWithJSON(http.StatusOK, w, health{
 		Indicators:  indicators,

--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -67,7 +67,7 @@ func useNewInstallTest(release string) bool {
 
 // PrintOverallReleaseHealthFromDB gives a summarized status of the overall health, including
 // infrastructure, install, upgrade, and variant success rates.
-func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release string) {
+func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release string, timeNow time.Time) {
 	excludedVariants := []string{"never-stable"}
 	// Minor upgrades install a previous version and should not be counted against the current version's install stat.
 	excludedInstallVariants := append(excludedVariants, "upgrade-minor")
@@ -153,9 +153,9 @@ func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release 
 		Sort:      apitype.SortDescending,
 		Limit:     0,
 	}
-	start := time.Now().Add(-14 * 24 * time.Hour)
-	boundary := time.Now().Add(-7 * 24 * time.Hour)
-	end := time.Now()
+	start := timeNow.Add(-14 * 24 * time.Hour)
+	boundary := timeNow.Add(-7 * 24 * time.Hour)
+	end := timeNow
 	jobReports, err := query.JobReports(dbc, filterOpts, release, start, boundary, end)
 	if err != nil {
 		log.WithError(err).Error("error querying job reports")
@@ -163,7 +163,7 @@ func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release 
 	}
 	currStats, prevStats := calculateJobResultStatistics(jobReports)
 
-	warnings := ScanForReleaseWarnings(dbc, release)
+	warnings := ScanForReleaseWarnings(dbc, release, timeNow)
 
 	RespondWithJSON(http.StatusOK, w, health{
 		Indicators:  indicators,

--- a/pkg/api/job_analysis.go
+++ b/pkg/api/job_analysis.go
@@ -25,7 +25,7 @@ type apiJobAnalysisResult struct {
 	ByPeriod map[string]analysisResult `json:"by_period"`
 }
 
-func PrintJobAnalysisJSONFromDB(w http.ResponseWriter, req *http.Request, dbc *db.DB, release string) {
+func PrintJobAnalysisJSONFromDB(w http.ResponseWriter, req *http.Request, dbc *db.DB, release string, timeNow time.Time) {
 	fil, err := filter.ExtractFilters(req)
 	if err != nil {
 		RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": "Could not marshal query:" + err.Error()})
@@ -63,7 +63,7 @@ func PrintJobAnalysisJSONFromDB(w http.ResponseWriter, req *http.Request, dbc *d
 		period = PeriodDay
 	}
 
-	table, err := jobResultsFromDB(req, dbc.DB, release)
+	table, err := jobResultsFromDB(req, dbc.DB, release, timeNow)
 	if err != nil {
 		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": "Error building job analysis report:" + table.Error.Error()})
 		return

--- a/pkg/api/job_analysis.go
+++ b/pkg/api/job_analysis.go
@@ -25,7 +25,7 @@ type apiJobAnalysisResult struct {
 	ByPeriod map[string]analysisResult `json:"by_period"`
 }
 
-func PrintJobAnalysisJSONFromDB(w http.ResponseWriter, req *http.Request, dbc *db.DB, release string, timeNow time.Time) {
+func PrintJobAnalysisJSONFromDB(w http.ResponseWriter, req *http.Request, dbc *db.DB, release string, reportEnd time.Time) {
 	fil, err := filter.ExtractFilters(req)
 	if err != nil {
 		RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": "Could not marshal query:" + err.Error()})
@@ -63,7 +63,7 @@ func PrintJobAnalysisJSONFromDB(w http.ResponseWriter, req *http.Request, dbc *d
 		period = PeriodDay
 	}
 
-	table, err := jobResultsFromDB(req, dbc.DB, release, timeNow)
+	table, err := jobResultsFromDB(req, dbc.DB, release, reportEnd)
 	if err != nil {
 		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": "Error building job analysis report:" + table.Error.Error()})
 		return

--- a/pkg/api/jobs.go
+++ b/pkg/api/jobs.go
@@ -66,7 +66,7 @@ func briefName(job string) string {
 
 // PrintVariantReportFromDB
 func PrintVariantReportFromDB(w http.ResponseWriter, req *http.Request,
-	dbc *db.DB, release string) {
+	dbc *db.DB, release string, timeNow time.Time) {
 	// Preferred method of slicing is with start->boundary->end query params in the format ?start=2021-12-02&boundary=2021-12-07.
 	// 'end' can be specified if you wish to view historical reports rather than now, which is assumed if end param is absent.
 	var start time.Time
@@ -83,10 +83,10 @@ func PrintVariantReportFromDB(w http.ResponseWriter, req *http.Request,
 		}
 	} else if req.URL.Query().Get("period") == periodTwoDay {
 		// twoDay report period starts 9 days ago, (comparing last 2 days vs previous 7)
-		start = time.Now().Add(-9 * 24 * time.Hour)
+		start = timeNow.Add(-9 * 24 * time.Hour)
 	} else {
 		// Default start to 14 days ago
-		start = time.Now().Add(-14 * 24 * time.Hour)
+		start = timeNow.Add(-14 * 24 * time.Hour)
 	}
 
 	// TODO: currently we're assuming dates use the 00:00:00, is it more logical to add 23:23 for boundary and end? or
@@ -99,10 +99,10 @@ func PrintVariantReportFromDB(w http.ResponseWriter, req *http.Request,
 			return
 		}
 	} else if req.URL.Query().Get("period") == periodTwoDay {
-		boundary = time.Now().Add(-2 * 24 * time.Hour)
+		boundary = timeNow.Add(-2 * 24 * time.Hour)
 	} else {
 		// Default boundary to 7 days ago
-		boundary = time.Now().Add(-7 * 24 * time.Hour)
+		boundary = timeNow.Add(-7 * 24 * time.Hour)
 
 	}
 
@@ -115,7 +115,7 @@ func PrintVariantReportFromDB(w http.ResponseWriter, req *http.Request,
 		}
 	} else {
 		// Default end to now
-		end = time.Now()
+		end = timeNow
 	}
 
 	log.Debugf("Querying between %s -> %s -> %s", start.Format(time.RFC3339), boundary.Format(time.RFC3339), end.Format(time.RFC3339))
@@ -131,7 +131,7 @@ func PrintVariantReportFromDB(w http.ResponseWriter, req *http.Request,
 
 // PrintJobsReportFromDB renders a filtered summary of matching jobs.
 func PrintJobsReportFromDB(w http.ResponseWriter, req *http.Request,
-	dbc *db.DB, release string) {
+	dbc *db.DB, release string, timeNow time.Time) {
 
 	var fil *filter.Filter
 
@@ -188,7 +188,7 @@ func PrintJobsReportFromDB(w http.ResponseWriter, req *http.Request,
 		return
 	}
 
-	jobsResult, err := JobReportsFromDB(dbc, release, req.URL.Query().Get("period"), filterOpts, start, boundary, end)
+	jobsResult, err := JobReportsFromDB(dbc, release, req.URL.Query().Get("period"), filterOpts, start, boundary, end, timeNow)
 	if err != nil {
 		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": "Error building job report:" + err.Error()})
 		return
@@ -197,7 +197,7 @@ func PrintJobsReportFromDB(w http.ResponseWriter, req *http.Request,
 	RespondWithJSON(http.StatusOK, w, jobsResult)
 }
 
-func JobReportsFromDB(dbc *db.DB, release, period string, filterOpts *filter.FilterOptions, start, boundary, end time.Time) ([]apitype.Job, error) {
+func JobReportsFromDB(dbc *db.DB, release, period string, filterOpts *filter.FilterOptions, start, boundary, end, timeNow time.Time) ([]apitype.Job, error) {
 
 	// set a default filter if none provided
 	if filterOpts == nil {
@@ -209,24 +209,24 @@ func JobReportsFromDB(dbc *db.DB, release, period string, filterOpts *filter.Fil
 	if period == periodTwoDay {
 		// twoDay report period starts 9 days ago, (comparing last 2 days vs previous 7)
 		if start.IsZero() {
-			start = time.Now().Add(-9 * 24 * time.Hour)
+			start = timeNow.Add(-9 * 24 * time.Hour)
 		}
 		if boundary.IsZero() {
-			boundary = time.Now().Add(-2 * 24 * time.Hour)
+			boundary = timeNow.Add(-2 * 24 * time.Hour)
 		}
 	} else {
 		if start.IsZero() {
-			start = time.Now().Add(-14 * 24 * time.Hour)
+			start = timeNow.Add(-14 * 24 * time.Hour)
 		}
 		if boundary.IsZero() {
 			// Default boundary to 7 days ago
-			boundary = time.Now().Add(-7 * 24 * time.Hour)
+			boundary = timeNow.Add(-7 * 24 * time.Hour)
 		}
 
 	}
 
 	if end.IsZero() {
-		end = time.Now()
+		end = timeNow
 	}
 
 	jobsResult, err := query.JobReports(dbc, filterOpts, release, start, boundary, end)
@@ -259,12 +259,12 @@ func (jobs jobDetailAPIResult) limit(req *http.Request) jobDetailAPIResult {
 }
 
 // PrintJobDetailsReportFromDB renders the detailed list of runs for matching jobs.
-func PrintJobDetailsReportFromDB(w http.ResponseWriter, req *http.Request, dbc *db.DB, release, jobSearchStr string) error {
+func PrintJobDetailsReportFromDB(w http.ResponseWriter, req *http.Request, dbc *db.DB, release, jobSearchStr string, timeNow time.Time) error {
 	var min, max int
 
 	// List all ProwJobRuns for the given release in the last two weeks.
 	// TODO: 14 days matches orig API behavior, may want to add query params in future to control.
-	since := time.Now().Add(-14 * 24 * time.Hour)
+	since := timeNow.Add(-14 * 24 * time.Hour)
 
 	prowJobRuns := make([]*models.ProwJobRun, 0)
 	res := dbc.DB.Joins("ProwJob").
@@ -361,7 +361,7 @@ func PrintPerfscaleWorkloadMetricsReport(w http.ResponseWriter, req *http.Reques
 
 }
 
-func jobResultsFromDB(req *http.Request, dbc *gorm.DB, release string) (*gorm.DB, error) {
+func jobResultsFromDB(req *http.Request, dbc *gorm.DB, release string, timeNow time.Time) (*gorm.DB, error) {
 	// Preferred method of slicing is with start->boundary->end query params in the format ?start=2021-12-02&boundary=2021-12-07.
 	// 'end' can be specified if you wish to view historical reports rather than now, which is assumed if end param is absent.
 	var start time.Time
@@ -377,10 +377,10 @@ func jobResultsFromDB(req *http.Request, dbc *gorm.DB, release string) (*gorm.DB
 		}
 	} else if req.URL.Query().Get("period") == periodTwoDay {
 		// twoDay report period starts 9 days ago, (comparing last 2 days vs previous 7)
-		start = time.Now().UTC().Add(-9 * 24 * time.Hour)
+		start = timeNow.UTC().Add(-9 * 24 * time.Hour)
 	} else {
 		// Default start to 14 days ago
-		start = time.Now().UTC().Add(-14 * 24 * time.Hour)
+		start = timeNow.Add(-14 * 24 * time.Hour)
 	}
 
 	// TODO: currently we're assuming dates use the 00:00:00, is it more logical to add 23:23 for boundary and end? or
@@ -392,10 +392,10 @@ func jobResultsFromDB(req *http.Request, dbc *gorm.DB, release string) (*gorm.DB
 			return nil, fmt.Errorf("error decoding boundary param: %s", err.Error())
 		}
 	} else if req.URL.Query().Get("period") == periodTwoDay {
-		boundary = time.Now().UTC().Add(-2 * 24 * time.Hour)
+		boundary = timeNow.UTC().Add(-2 * 24 * time.Hour)
 	} else {
 		// Default boundary to 7 days ago
-		boundary = time.Now().UTC().Add(-7 * 24 * time.Hour)
+		boundary = timeNow.UTC().Add(-7 * 24 * time.Hour)
 
 	}
 
@@ -407,7 +407,7 @@ func jobResultsFromDB(req *http.Request, dbc *gorm.DB, release string) (*gorm.DB
 		}
 	} else {
 		// Default end to now
-		end = time.Now().UTC()
+		end = timeNow.UTC()
 	}
 
 	log.Infof("Querying between %s -> %s -> %s", start.Format(time.RFC3339), boundary.Format(time.RFC3339), end.Format(time.RFC3339))

--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -81,7 +81,7 @@ type PayloadFailedTest struct {
 
 // GetPayloadStreamTestFailures loads the most recent payloads for a stream and attempts to search for most commonly
 // failing tests, possible perma-failing blockers, etc.
-func GetPayloadStreamTestFailures(dbc *db.DB, release, stream, arch string, filterOpts *filter.FilterOptions) ([]*apitype.TestFailureAnalysis, error) {
+func GetPayloadStreamTestFailures(dbc *db.DB, release, stream, arch string, filterOpts *filter.FilterOptions, timeNow time.Time) ([]*apitype.TestFailureAnalysis, error) {
 
 	logger := log.WithFields(log.Fields{
 		"release": release,
@@ -95,7 +95,7 @@ func GetPayloadStreamTestFailures(dbc *db.DB, release, stream, arch string, filt
 
 	// Get latest payload tags for analysis:
 	lastPayloads, err := query.GetLastPayloadTags(dbc.DB, release,
-		stream, arch)
+		stream, arch, timeNow)
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +315,7 @@ func PrintReleasesReport(w http.ResponseWriter, req *http.Request, dbClient *db.
 
 // ReleaseHealthReports returns a report on the most recent payload status for each arch/stream in
 // the given release.
-func ReleaseHealthReports(dbClient *db.DB, release string) ([]apitype.ReleaseHealthReport, error) {
+func ReleaseHealthReports(dbClient *db.DB, release string, timeNow time.Time) ([]apitype.ReleaseHealthReport, error) {
 	apiResults := make([]apitype.ReleaseHealthReport, 0)
 	if dbClient == nil || dbClient.DB == nil {
 		return apiResults, fmt.Errorf("no db client configured")
@@ -344,7 +344,7 @@ func ReleaseHealthReports(dbClient *db.DB, release string) ([]apitype.ReleaseHea
 				release, archStream.Architecture, archStream.Stream)
 		}
 
-		weekAgo := time.Now().Add(-7 * 24 * time.Hour)
+		weekAgo := timeNow.Add(-7 * 24 * time.Hour)
 		currentWeekPhaseCountsDB, err := query.GetPayloadStreamPhaseCounts(dbClient.DB, release, archStream.Architecture, archStream.Stream, &weekAgo)
 		if err != nil {
 			return apiResults, errors.Wrapf(err, "error finding %s payload status counts for %s %s",
@@ -393,8 +393,8 @@ func dbPayloadPhaseCountToAPI(dbpc []models.PayloadPhaseCount) apitype.PayloadPh
 }
 
 // ScanForReleaseWarnings looks for problems in current release health and returns them to the user.
-func ScanForReleaseWarnings(dbClient *db.DB, release string) []string {
-	payloadHealth, err := ReleaseHealthReports(dbClient, release)
+func ScanForReleaseWarnings(dbClient *db.DB, release string, timeNow time.Time) []string {
+	payloadHealth, err := ReleaseHealthReports(dbClient, release, timeNow)
 	if err != nil {
 		// treat the error as a warning itself
 		return []string{fmt.Sprintf("error checking release health, see logs: %v", err)}

--- a/pkg/api/repositories.go
+++ b/pkg/api/repositories.go
@@ -9,6 +9,6 @@ import (
 	"github.com/openshift/sippy/pkg/filter"
 )
 
-func GetRepositoriesReportFromDB(dbc *db.DB, release string, filterOpts *filter.FilterOptions, timeNow time.Time) ([]apitype.Repository, error) {
-	return query.RepositoryReport(dbc, filterOpts, release, timeNow)
+func GetRepositoriesReportFromDB(dbc *db.DB, release string, filterOpts *filter.FilterOptions, reportEnd time.Time) ([]apitype.Repository, error) {
+	return query.RepositoryReport(dbc, filterOpts, release, reportEnd)
 }

--- a/pkg/api/repositories.go
+++ b/pkg/api/repositories.go
@@ -1,12 +1,14 @@
 package api
 
 import (
+	"time"
+
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/filter"
 )
 
-func GetRepositoriesReportFromDB(dbc *db.DB, release string, filterOpts *filter.FilterOptions) ([]apitype.Repository, error) {
-	return query.RepositoryReport(dbc, filterOpts, release)
+func GetRepositoriesReportFromDB(dbc *db.DB, release string, filterOpts *filter.FilterOptions, timeNow time.Time) ([]apitype.Repository, error) {
+	return query.RepositoryReport(dbc, filterOpts, release, timeNow)
 }

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -3,6 +3,7 @@ package db
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"gorm.io/driver/postgres"
@@ -28,7 +29,7 @@ type DB struct {
 	BatchSize int
 }
 
-func New(dsn string) (*DB, error) {
+func New(dsn string, timeNow time.Time) (*DB, error) {
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Info),
 	})
@@ -96,7 +97,7 @@ func New(dsn string) (*DB, error) {
 		return nil, err
 	}
 
-	if err := syncPostgresMaterializedViews(db); err != nil {
+	if err := syncPostgresMaterializedViews(db, timeNow); err != nil {
 		return nil, err
 	}
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -29,7 +29,7 @@ type DB struct {
 	BatchSize int
 }
 
-func New(dsn string, timeNow time.Time) (*DB, error) {
+func New(dsn string, reportEnd time.Time) (*DB, error) {
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Info),
 	})
@@ -97,7 +97,7 @@ func New(dsn string, timeNow time.Time) (*DB, error) {
 		return nil, err
 	}
 
-	if err := syncPostgresMaterializedViews(db, timeNow); err != nil {
+	if err := syncPostgresMaterializedViews(db, reportEnd); err != nil {
 		return nil, err
 	}
 

--- a/pkg/db/matviews.go
+++ b/pkg/db/matviews.go
@@ -85,10 +85,10 @@ type PostgresMaterializedView struct {
 	IndexColumns []string
 }
 
-func syncPostgresMaterializedViews(db *gorm.DB, timeNow time.Time) error {
+func syncPostgresMaterializedViews(db *gorm.DB, reportEnd time.Time) error {
 
 	// initialize outside our loop
-	timeNowFmt := "TO_TIMESTAMP('" + timeNow.UTC().Format(TimestampFormat) + "', 'YYYY-MM-DD HH24:MI:SS')"
+	reportEndFmt := "TO_TIMESTAMP('" + reportEnd.UTC().Format(TimestampFormat) + "', 'YYYY-MM-DD HH24:MI:SS')"
 
 	for _, pmv := range PostgresMatViews {
 		// Sync materialized view:
@@ -98,7 +98,7 @@ func syncPostgresMaterializedViews(db *gorm.DB, timeNow time.Time) error {
 		}
 
 		// This has to occur after the replaceAll above as they might contain the REPLACE_TIME_NOW constant as well
-		viewDef = strings.ReplaceAll(viewDef, ReplaceTimeNow, timeNowFmt)
+		viewDef = strings.ReplaceAll(viewDef, ReplaceTimeNow, reportEndFmt)
 
 		dropSQL := fmt.Sprintf("DROP MATERIALIZED VIEW IF EXISTS %s", pmv.Name)
 		schema := fmt.Sprintf("CREATE MATERIALIZED VIEW %s AS %s WITH NO DATA", pmv.Name, viewDef)

--- a/pkg/db/matviews.go
+++ b/pkg/db/matviews.go
@@ -3,19 +3,24 @@ package db
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"gorm.io/gorm"
 )
 
+const ReplaceTimeNow = "|||TIMENOW|||"
+const TimestampFormat = "2006-01-02 15:04:05"
+
+// TODO: for historical sippy we need to specify the pinnedDate and not use NOW
 var PostgresMatViews = []PostgresMaterializedView{
 	{
 		Name:         "prow_test_report_7d_matview",
 		Definition:   testReportMatView,
 		IndexColumns: []string{"id", "release", "variants", "suite_name"},
 		ReplaceStrings: map[string]string{
-			"|||START|||":    "NOW() - INTERVAL '14 DAY'",
-			"|||BOUNDARY|||": "NOW() - INTERVAL '7 DAY'",
-			"|||END|||":      "NOW()",
+			"|||START|||":    "|||TIMENOW||| - INTERVAL '14 DAY'",
+			"|||BOUNDARY|||": "|||TIMENOW||| - INTERVAL '7 DAY'",
+			"|||END|||":      "|||TIMENOW|||",
 		},
 	},
 	{
@@ -23,9 +28,9 @@ var PostgresMatViews = []PostgresMaterializedView{
 		Definition:   testReportMatView,
 		IndexColumns: []string{"id", "release", "variants", "suite_name"},
 		ReplaceStrings: map[string]string{
-			"|||START|||":    "NOW() - INTERVAL '9 DAY'",
-			"|||BOUNDARY|||": "NOW() - INTERVAL '2 DAY'",
-			"|||END|||":      "NOW()",
+			"|||START|||":    "|||TIMENOW||| - INTERVAL '9 DAY'",
+			"|||BOUNDARY|||": "|||TIMENOW||| - INTERVAL '2 DAY'",
+			"|||END|||":      "|||TIMENOW|||",
 		},
 	},
 	{
@@ -80,13 +85,21 @@ type PostgresMaterializedView struct {
 	IndexColumns []string
 }
 
-func syncPostgresMaterializedViews(db *gorm.DB) error {
+func syncPostgresMaterializedViews(db *gorm.DB, timeNow time.Time) error {
+
+	// initialize outside our loop
+	timeNowFmt := "TO_TIMESTAMP('" + timeNow.UTC().Format(TimestampFormat) + "', 'YYYY-MM-DD HH24:MI:SS')"
+
 	for _, pmv := range PostgresMatViews {
 		// Sync materialized view:
 		viewDef := pmv.Definition
 		for k, v := range pmv.ReplaceStrings {
 			viewDef = strings.ReplaceAll(viewDef, k, v)
 		}
+
+		// This has to occur after the replaceAll above as they might contain the REPLACE_TIME_NOW constant as well
+		viewDef = strings.ReplaceAll(viewDef, ReplaceTimeNow, timeNowFmt)
+
 		dropSQL := fmt.Sprintf("DROP MATERIALIZED VIEW IF EXISTS %s", pmv.Name)
 		schema := fmt.Sprintf("CREATE MATERIALIZED VIEW %s AS %s WITH NO DATA", pmv.Name, viewDef)
 		matViewUpdated, err := syncSchema(db, hashTypeMatView, pmv.Name, schema, dropSQL, false)
@@ -237,29 +250,29 @@ SELECT tests.id AS test_id,
    prow_jobs.release,
    COALESCE(count(
        CASE
-           WHEN prow_job_runs."timestamp" >= (now() - '14 days'::interval) AND prow_job_runs."timestamp" <= now() THEN 1
+           WHEN prow_job_runs."timestamp" >= (|||TIMENOW||| - '14 days'::interval) AND prow_job_runs."timestamp" <= |||TIMENOW||| THEN 1
            ELSE NULL::integer
        END), 0::bigint) AS runs,
    COALESCE(count(
        CASE
-           WHEN prow_job_run_tests.status = 1 AND prow_job_runs."timestamp" >= (now() - '14 days'::interval) AND prow_job_runs."timestamp" <= now() THEN 1
+           WHEN prow_job_run_tests.status = 1 AND prow_job_runs."timestamp" >= (|||TIMENOW||| - '14 days'::interval) AND prow_job_runs."timestamp" <= |||TIMENOW||| THEN 1
            ELSE NULL::integer
        END), 0::bigint) AS passes,
    COALESCE(count(
        CASE
-           WHEN prow_job_run_tests.status = 13 AND prow_job_runs."timestamp" >= (now() - '14 days'::interval) AND prow_job_runs."timestamp" <= now() THEN 1
+           WHEN prow_job_run_tests.status = 13 AND prow_job_runs."timestamp" >= (|||TIMENOW||| - '14 days'::interval) AND prow_job_runs."timestamp" <= |||TIMENOW||| THEN 1
            ELSE NULL::integer
        END), 0::bigint) AS flakes,
    COALESCE(count(
        CASE
-           WHEN prow_job_run_tests.status = 12 AND prow_job_runs."timestamp" >= (now() - '14 days'::interval) AND prow_job_runs."timestamp" <= now() THEN 1
+           WHEN prow_job_run_tests.status = 12 AND prow_job_runs."timestamp" >= (|||TIMENOW||| - '14 days'::interval) AND prow_job_runs."timestamp" <= |||TIMENOW||| THEN 1
            ELSE NULL::integer
        END), 0::bigint) AS failures
 FROM prow_job_run_tests
     JOIN tests ON tests.id = prow_job_run_tests.test_id
 	JOIN prow_job_runs ON prow_job_runs.id = prow_job_run_tests.prow_job_run_id
 	JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id
-WHERE prow_job_runs."timestamp" > (now() - '14 days'::interval)
+WHERE prow_job_runs."timestamp" > (|||TIMENOW||| - '14 days'::interval)
 GROUP BY tests.name, tests.id, (date(prow_job_runs."timestamp")), (unnest(prow_jobs.variants)), prow_jobs.release
 `
 
@@ -271,29 +284,29 @@ SELECT tests.id AS test_id,
    prow_jobs.name AS job_name,
    COALESCE(count(
        CASE
-           WHEN prow_job_runs."timestamp" >= (now() - '14 days'::interval) AND prow_job_runs."timestamp" <= now() THEN 1
+           WHEN prow_job_runs."timestamp" >= (|||TIMENOW||| - '14 days'::interval) AND prow_job_runs."timestamp" <= |||TIMENOW||| THEN 1
            ELSE NULL::integer
        END), 0::bigint) AS runs,
    COALESCE(count(
        CASE
-           WHEN prow_job_run_tests.status = 1 AND prow_job_runs."timestamp" >= (now() - '14 days'::interval) AND prow_job_runs."timestamp" <= now() THEN 1
+           WHEN prow_job_run_tests.status = 1 AND prow_job_runs."timestamp" >= (|||TIMENOW||| - '14 days'::interval) AND prow_job_runs."timestamp" <= |||TIMENOW||| THEN 1
            ELSE NULL::integer
        END), 0::bigint) AS passes,
    COALESCE(count(
        CASE
-           WHEN prow_job_run_tests.status = 13 AND prow_job_runs."timestamp" >= (now() - '14 days'::interval) AND prow_job_runs."timestamp" <= now() THEN 1
+           WHEN prow_job_run_tests.status = 13 AND prow_job_runs."timestamp" >= (|||TIMENOW||| - '14 days'::interval) AND prow_job_runs."timestamp" <= |||TIMENOW||| THEN 1
            ELSE NULL::integer
        END), 0::bigint) AS flakes,
    COALESCE(count(
        CASE
-           WHEN prow_job_run_tests.status = 12 AND prow_job_runs."timestamp" >= (now() - '14 days'::interval) AND prow_job_runs."timestamp" <= now() THEN 1
+           WHEN prow_job_run_tests.status = 12 AND prow_job_runs."timestamp" >= (|||TIMENOW||| - '14 days'::interval) AND prow_job_runs."timestamp" <= |||TIMENOW||| THEN 1
            ELSE NULL::integer
        END), 0::bigint) AS failures
 FROM prow_job_run_tests
     JOIN tests ON tests.id = prow_job_run_tests.test_id
     JOIN prow_job_runs ON prow_job_runs.id = prow_job_run_tests.prow_job_run_id
     JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id
-WHERE prow_job_runs."timestamp" > (now() - '14 days'::interval) AND NOT ('aggregated'::text = ANY (prow_jobs.variants))
+WHERE prow_job_runs."timestamp" > (|||TIMENOW||| - '14 days'::interval) AND NOT ('aggregated'::text = ANY (prow_jobs.variants))
 GROUP BY tests.name, tests.id, (date(prow_job_runs."timestamp")), prow_jobs.release, prow_jobs.name
 `
 
@@ -332,7 +345,7 @@ FROM
      prow_jobs pj,
      prow_job_runs pjr
 WHERE
-    rt.release_time > (NOW() - '14 days'::interval)
+    rt.release_time > (|||TIMENOW||| - '14 days'::interval)
     AND rjr.release_tag_id = rt.id
     AND rjr.kind = 'Blocking'
     AND rjr.State = 'Failed'

--- a/pkg/db/query/payload_queries.go
+++ b/pkg/db/query/payload_queries.go
@@ -57,13 +57,13 @@ func GetLastOSUpgradeByArchitectureAndStream(db *gorm.DB, release string) ([]mod
 }
 
 // GetLastPayloadTags returns payloads tags for last two weeks, sorted by date in descending order.
-func GetLastPayloadTags(db *gorm.DB, release, stream, arch string) ([]models.ReleaseTag, error) {
+func GetLastPayloadTags(db *gorm.DB, release, stream, arch string, timeNow time.Time) ([]models.ReleaseTag, error) {
 	results := []models.ReleaseTag{}
 
 	result := db.Where("release = ?", release).
 		Where("stream = ?", stream).
 		Where("architecture = ?", arch).
-		Where("release_time >= ?", time.Now().Add(-14*24*time.Hour)).
+		Where("release_time >= ?", timeNow.Add(-14*24*time.Hour)).
 		Order("release_time DESC").Find(&results)
 	if result.Error != nil {
 		return nil, result.Error

--- a/pkg/db/query/payload_queries.go
+++ b/pkg/db/query/payload_queries.go
@@ -57,13 +57,13 @@ func GetLastOSUpgradeByArchitectureAndStream(db *gorm.DB, release string) ([]mod
 }
 
 // GetLastPayloadTags returns payloads tags for last two weeks, sorted by date in descending order.
-func GetLastPayloadTags(db *gorm.DB, release, stream, arch string, timeNow time.Time) ([]models.ReleaseTag, error) {
+func GetLastPayloadTags(db *gorm.DB, release, stream, arch string, reportEnd time.Time) ([]models.ReleaseTag, error) {
 	results := []models.ReleaseTag{}
 
 	result := db.Where("release = ?", release).
 		Where("stream = ?", stream).
 		Where("architecture = ?", arch).
-		Where("release_time >= ?", timeNow.Add(-14*24*time.Hour)).
+		Where("release_time >= ?", reportEnd.Add(-14*24*time.Hour)).
 		Order("release_time DESC").Find(&results)
 	if result.Error != nil {
 		return nil, result.Error

--- a/pkg/db/query/repository_queries.go
+++ b/pkg/db/query/repository_queries.go
@@ -8,9 +8,9 @@ import (
 	"github.com/openshift/sippy/pkg/filter"
 )
 
-func RepositoryReport(dbc *db.DB, filterOpts *filter.FilterOptions, release string) ([]api.Repository, error) {
-	start := time.Now().Add(-14 * 24 * time.Hour)
-	end := time.Now()
+func RepositoryReport(dbc *db.DB, filterOpts *filter.FilterOptions, release string, timeNow time.Time) ([]api.Repository, error) {
+	start := timeNow.Add(-14 * 24 * time.Hour)
+	end := timeNow
 	averageByJob := PullRequestAveragePremergeFailures(dbc, &start, &end)
 
 	repos := dbc.DB.Table("prow_pull_requests").

--- a/pkg/db/query/repository_queries.go
+++ b/pkg/db/query/repository_queries.go
@@ -8,9 +8,9 @@ import (
 	"github.com/openshift/sippy/pkg/filter"
 )
 
-func RepositoryReport(dbc *db.DB, filterOpts *filter.FilterOptions, release string, timeNow time.Time) ([]api.Repository, error) {
-	start := timeNow.Add(-14 * 24 * time.Hour)
-	end := timeNow
+func RepositoryReport(dbc *db.DB, filterOpts *filter.FilterOptions, release string, reportEnd time.Time) ([]api.Repository, error) {
+	start := reportEnd.Add(-14 * 24 * time.Hour)
+	end := reportEnd
 	averageByJob := PullRequestAveragePremergeFailures(dbc, &start, &end)
 
 	repos := dbc.DB.Table("prow_pull_requests").

--- a/pkg/perfscaleanalysis/perfscalehelpers.go
+++ b/pkg/perfscaleanalysis/perfscalehelpers.go
@@ -26,7 +26,7 @@ const (
 	ScaleJobsFilename = "perfscale-metrics.json"
 )
 
-func DownloadPerfScaleData(storagePath string) error {
+func DownloadPerfScaleData(storagePath string, timeNow time.Time) error {
 	log.Debugf("Downloading perfscale data from %s index %s", esURL, esIndex)
 	cfg := es7.Config{
 		Addresses: []string{esURL},
@@ -37,8 +37,9 @@ func DownloadPerfScaleData(storagePath string) error {
 		return err
 	}
 
+	//TODO: Review with Devan how this is (or isn't) impacted by historical sippy / pinned timeNow
 	// Calculate dates for our buckets:
-	now := time.Now()
+	now := timeNow
 	// Hardcoded for now:
 	currPeriod := 7 * 24 * time.Hour  // last week
 	prevPeriod := 30 * 24 * time.Hour // last month
@@ -102,7 +103,7 @@ func DownloadPerfScaleData(storagePath string) error {
 		gjson.Get(j, "took").Int(),
 	)
 
-	// We are not presently preapred for pagination. At time of writing we expect roughly 600 results, and we're requesting 2000 at a time.
+	// We are not presently prepared for pagination. At time of writing we expect roughly 600 results, and we're requesting 2000 at a time.
 	// This will start erroring once if we surpass those limits and we'll need to bump our request, or paginate.
 	if totalHits > esQuerySize {
 		return fmt.Errorf("%d results returned which is greater than our query size of %d, code needs to be updated", totalHits, esQuerySize)

--- a/pkg/perfscaleanalysis/perfscalehelpers.go
+++ b/pkg/perfscaleanalysis/perfscalehelpers.go
@@ -26,7 +26,7 @@ const (
 	ScaleJobsFilename = "perfscale-metrics.json"
 )
 
-func DownloadPerfScaleData(storagePath string, timeNow time.Time) error {
+func DownloadPerfScaleData(storagePath string, reportEnd time.Time) error {
 	log.Debugf("Downloading perfscale data from %s index %s", esURL, esIndex)
 	cfg := es7.Config{
 		Addresses: []string{esURL},
@@ -37,9 +37,9 @@ func DownloadPerfScaleData(storagePath string, timeNow time.Time) error {
 		return err
 	}
 
-	//TODO: Review with Devan how this is (or isn't) impacted by historical sippy / pinned timeNow
+	//TODO: Review with Devan how this is (or isn't) impacted by historical sippy / pinned reportEnd
 	// Calculate dates for our buckets:
-	now := timeNow
+	now := reportEnd
 	// Hardcoded for now:
 	currPeriod := 7 * 24 * time.Hour  // last week
 	prevPeriod := 30 * 24 * time.Hour // last month

--- a/pkg/sippyserver/dbloader.go
+++ b/pkg/sippyserver/dbloader.go
@@ -29,7 +29,7 @@ func (a TestReportGeneratorConfig) LoadDatabase(
 	dashboard TestGridDashboardCoordinates,
 	variantManager testidentification.VariantManager,
 	syntheticTestManager synthetictests.SyntheticTestManager,
-	startDay, numDays int, timeNow time.Time) error {
+	startDay, numDays int, reportEnd time.Time) error {
 
 	testGridJobDetails, _ := a.TestGridLoadingConfig.load(dashboard.TestGridDashboardNames)
 	rawJobResultOptions := testgridconversion.ProcessingOptions{
@@ -70,7 +70,7 @@ func (a TestReportGeneratorConfig) LoadDatabase(
 	log.Infof("test cache created with %d entries from database", len(testCache))
 
 	for i, jobDetails := range testGridJobDetails {
-		jobResult, warnings := rawJobResultOptions.ProcessJobDetailsIntoRawJobResult(jobDetails, timeNow)
+		jobResult, warnings := rawJobResultOptions.ProcessJobDetailsIntoRawJobResult(jobDetails, reportEnd)
 		for _, warning := range warnings {
 			log.Warningf("warning from testgrid processing: " + warning)
 		}

--- a/pkg/sippyserver/dbloader.go
+++ b/pkg/sippyserver/dbloader.go
@@ -29,7 +29,7 @@ func (a TestReportGeneratorConfig) LoadDatabase(
 	dashboard TestGridDashboardCoordinates,
 	variantManager testidentification.VariantManager,
 	syntheticTestManager synthetictests.SyntheticTestManager,
-	startDay, numDays int) error {
+	startDay, numDays int, timeNow time.Time) error {
 
 	testGridJobDetails, _ := a.TestGridLoadingConfig.load(dashboard.TestGridDashboardNames)
 	rawJobResultOptions := testgridconversion.ProcessingOptions{
@@ -70,7 +70,7 @@ func (a TestReportGeneratorConfig) LoadDatabase(
 	log.Infof("test cache created with %d entries from database", len(testCache))
 
 	for i, jobDetails := range testGridJobDetails {
-		jobResult, warnings := rawJobResultOptions.ProcessJobDetailsIntoRawJobResult(jobDetails)
+		jobResult, warnings := rawJobResultOptions.ProcessJobDetailsIntoRawJobResult(jobDetails, timeNow)
 		for _, warning := range warnings {
 			log.Warningf("warning from testgrid processing: " + warning)
 		}

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -53,7 +53,9 @@ var (
 	}, []string{"release", "stream", "architecture"})
 )
 
-func RefreshMetricsDB(dbc *db.DB) error {
+// presume in a historical context there won't be scraping of these metrics
+// pinning the time just to be consistent
+func RefreshMetricsDB(dbc *db.DB, timeNow time.Time) error {
 	releases, err := query.ReleasesFromDB(dbc)
 	if err != nil {
 		return err
@@ -68,7 +70,7 @@ func RefreshMetricsDB(dbc *db.DB) error {
 		// start, boundary and end will just be defaults
 		// the api will decide based on the period
 		// and current day / time
-		jobsResult, err := api.JobReportsFromDB(dbc, pType.release, pType.period, nil, time.Time{}, time.Time{}, time.Time{})
+		jobsResult, err := api.JobReportsFromDB(dbc, pType.release, pType.period, nil, time.Time{}, time.Time{}, time.Time{}, timeNow)
 
 		if err != nil {
 			return errors.Wrapf(err, "error refreshing prom report type %s - %s", pType.period, pType.release)
@@ -81,22 +83,22 @@ func RefreshMetricsDB(dbc *db.DB) error {
 	// Add a metric for any warnings for each release. We can't convey exact details with prom, but we can
 	// tell you x warnings are present and link you to the overview in the alert.
 	for _, release := range releases {
-		releaseWarnings := api.ScanForReleaseWarnings(dbc, release.Release)
+		releaseWarnings := api.ScanForReleaseWarnings(dbc, release.Release, timeNow)
 		releaseWarningsMetric.WithLabelValues(release.Release).Set(float64(len(releaseWarnings)))
 	}
 
-	if err := refreshBuildClusterMetrics(dbc); err != nil {
+	if err := refreshBuildClusterMetrics(dbc, timeNow); err != nil {
 		return errors.Wrapf(err, "error refreshing build cluster metrics")
 	}
 
-	refreshPayloadMetrics(dbc)
+	refreshPayloadMetrics(dbc, timeNow)
 
 	return nil
 }
 
-func refreshBuildClusterMetrics(dbc *db.DB) error {
+func refreshBuildClusterMetrics(dbc *db.DB, timeNow time.Time) error {
 	for _, period := range []string{"default", "twoDay"} {
-		start, boundary, end := util.PeriodToDates(period)
+		start, boundary, end := util.PeriodToDates(period, timeNow)
 		result, err := query.BuildClusterHealth(dbc, start, boundary, end)
 		if err != nil {
 			return err
@@ -110,14 +112,14 @@ func refreshBuildClusterMetrics(dbc *db.DB) error {
 	return nil
 }
 
-func refreshPayloadMetrics(dbc *db.DB) {
+func refreshPayloadMetrics(dbc *db.DB, timeNow time.Time) {
 	releases, err := query.ReleasesFromDB(dbc)
 	if err != nil {
 		log.WithError(err).Error("error querying releases from db")
 		return
 	}
 	for _, r := range releases {
-		results, err := api.ReleaseHealthReports(dbc, r.Release)
+		results, err := api.ReleaseHealthReports(dbc, r.Release, timeNow)
 		if err != nil {
 			log.WithError(err).Error("error calling ReleaseHealthReports")
 			return
@@ -133,7 +135,7 @@ func refreshPayloadMetrics(dbc *db.DB) {
 			// Piggy back the results here to use the list of arch+streams:
 			if rhr.LastPhase == apitype.PayloadRejected {
 				possibleTestBlockers, err := api.GetPayloadStreamTestFailures(dbc, r.Release, rhr.Stream,
-					rhr.Architecture, &filter.FilterOptions{Filter: &filter.Filter{}})
+					rhr.Architecture, &filter.FilterOptions{Filter: &filter.Filter{}}, timeNow)
 				if err != nil {
 					log.WithError(err).Error("error getting payload stream test failures")
 					return

--- a/pkg/sippyserver/parameters.go
+++ b/pkg/sippyserver/parameters.go
@@ -23,7 +23,7 @@ func getISO8601Date(paramName string, req *http.Request) (*time.Time, error) {
 	return &date, nil
 }
 
-func getPeriodDates(defaultPeriod string, req *http.Request) (start, boundary, end time.Time) {
+func getPeriodDates(defaultPeriod string, req *http.Request, timeNow time.Time) (start, boundary, end time.Time) {
 	period := getPeriod(req, defaultPeriod)
 
 	// If start, boundary, and end params are all specified, use those
@@ -35,7 +35,7 @@ func getPeriodDates(defaultPeriod string, req *http.Request) (start, boundary, e
 	}
 
 	// Otherwise generate from the period name
-	return util.PeriodToDates(period)
+	return util.PeriodToDates(period, timeNow)
 }
 
 func getDateParam(paramName string, req *http.Request) *time.Time {

--- a/pkg/sippyserver/parameters.go
+++ b/pkg/sippyserver/parameters.go
@@ -23,7 +23,7 @@ func getISO8601Date(paramName string, req *http.Request) (*time.Time, error) {
 	return &date, nil
 }
 
-func getPeriodDates(defaultPeriod string, req *http.Request, timeNow time.Time) (start, boundary, end time.Time) {
+func getPeriodDates(defaultPeriod string, req *http.Request, reportEnd time.Time) (start, boundary, end time.Time) {
 	period := getPeriod(req, defaultPeriod)
 
 	// If start, boundary, and end params are all specified, use those
@@ -35,7 +35,7 @@ func getPeriodDates(defaultPeriod string, req *http.Request, timeNow time.Time) 
 	}
 
 	// Otherwise generate from the period name
-	return util.PeriodToDates(period, timeNow)
+	return util.PeriodToDates(period, reportEnd)
 }
 
 func getDateParam(paramName string, req *http.Request) *time.Time {

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -116,8 +116,8 @@ type TestGridDashboardCoordinates struct {
 	BugzillaRelease string
 }
 
-func (s *Server) GetTimeNow() time.Time {
-	return util.GetTimeNow(s.pinnedDateTime)
+func (s *Server) GetReportEnd() time.Time {
+	return util.GetReportEnd(s.pinnedDateTime)
 }
 
 func (s *Server) refresh(w http.ResponseWriter, req *http.Request) {
@@ -128,7 +128,7 @@ func (s *Server) refresh(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *Server) refreshMetrics() {
-	err := metrics.RefreshMetricsDB(s.db, s.GetTimeNow())
+	err := metrics.RefreshMetricsDB(s.db, s.GetReportEnd())
 	if err != nil {
 		log.WithError(err).Error("error refreshing metrics")
 	}
@@ -391,7 +391,7 @@ func (s *Server) jsonGetPayloadAnalysis(w http.ResponseWriter, req *http.Request
 		"arch":    arch,
 	}).Info("analyzing payload stream")
 
-	result, err := api.GetPayloadStreamTestFailures(s.db, release, stream, arch, filterOpts, s.GetTimeNow())
+	result, err := api.GetPayloadStreamTestFailures(s.db, release, stream, arch, filterOpts, s.GetReportEnd())
 	if err != nil {
 		log.WithError(err).Error("error")
 		api.RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError,
@@ -412,7 +412,7 @@ func (s *Server) jsonReleaseHealthReport(w http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	results, err := api.ReleaseHealthReports(s.db, release, s.GetTimeNow())
+	results, err := api.ReleaseHealthReports(s.db, release, s.GetReportEnd())
 	if err != nil {
 		log.WithError(err).Error("error generating release health report")
 		api.RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{
@@ -502,12 +502,12 @@ func (s *Server) jsonReleasesReportFromDB(w http.ResponseWriter, _ *http.Request
 func (s *Server) jsonHealthReportFromDB(w http.ResponseWriter, req *http.Request) {
 	release := s.getReleaseOrFail(w, req)
 	if release != "" {
-		api.PrintOverallReleaseHealthFromDB(w, s.db, release, s.GetTimeNow())
+		api.PrintOverallReleaseHealthFromDB(w, s.db, release, s.GetReportEnd())
 	}
 }
 
 func (s *Server) jsonBuildClusterHealth(w http.ResponseWriter, req *http.Request) {
-	start, boundary, end := getPeriodDates("default", req, s.GetTimeNow())
+	start, boundary, end := getPeriodDates("default", req, s.GetReportEnd())
 
 	results, err := api.GetBuildClusterHealthReport(s.db, start, boundary, end)
 	if err != nil {
@@ -563,7 +563,7 @@ func (s *Server) jsonJobsDetailsReportFromDB(w http.ResponseWriter, req *http.Re
 	release := s.getReleaseOrFail(w, req)
 	jobName := req.URL.Query().Get("job")
 	if release != "" && jobName != "" {
-		err := api.PrintJobDetailsReportFromDB(w, req, s.db, release, jobName, s.GetTimeNow())
+		err := api.PrintJobDetailsReportFromDB(w, req, s.db, release, jobName, s.GetReportEnd())
 		if err != nil {
 			log.Errorf("Error from PrintJobDetailsReportFromDB: %v", err)
 		}
@@ -580,14 +580,14 @@ func (s *Server) printCanaryReportFromDB(w http.ResponseWriter, req *http.Reques
 func (s *Server) jsonVariantsReportFromDB(w http.ResponseWriter, req *http.Request) {
 	release := s.getReleaseOrFail(w, req)
 	if release != "" {
-		api.PrintVariantReportFromDB(w, req, s.db, release, s.GetTimeNow())
+		api.PrintVariantReportFromDB(w, req, s.db, release, s.GetReportEnd())
 	}
 }
 
 func (s *Server) jsonJobsReportFromDB(w http.ResponseWriter, req *http.Request) {
 	release := s.getReleaseOrFail(w, req)
 	if release != "" {
-		api.PrintJobsReportFromDB(w, req, s.db, release, s.GetTimeNow())
+		api.PrintJobsReportFromDB(w, req, s.db, release, s.GetReportEnd())
 	}
 }
 
@@ -601,7 +601,7 @@ func (s *Server) jsonRepositoriesReportFromDB(w http.ResponseWriter, req *http.R
 			return
 		}
 
-		results, err := api.GetRepositoriesReportFromDB(s.db, release, filterOpts, s.GetTimeNow())
+		results, err := api.GetRepositoriesReportFromDB(s.db, release, filterOpts, s.GetReportEnd())
 		if err != nil {
 			log.WithError(err).Error("error")
 			api.RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError,
@@ -641,7 +641,7 @@ func (s *Server) jsonJobRunsReportFromDB(w http.ResponseWriter, req *http.Reques
 
 func (s *Server) jsonJobsAnalysisFromDB(w http.ResponseWriter, req *http.Request) {
 	release := s.getRelease(req)
-	api.PrintJobAnalysisJSONFromDB(w, req, s.db, release, s.GetTimeNow())
+	api.PrintJobAnalysisJSONFromDB(w, req, s.db, release, s.GetReportEnd())
 }
 
 func (s *Server) jsonPerfScaleMetricsReport(w http.ResponseWriter, req *http.Request) {

--- a/pkg/testgridanalysis/testgridconversion/to_raw_data.go
+++ b/pkg/testgridanalysis/testgridconversion/to_raw_data.go
@@ -22,9 +22,9 @@ type ProcessingOptions struct {
 
 // ProcessJobDetailsIntoRawJobResult returns the raw data and a list of warnings encountered processing the data
 // for a specific job.
-func (o ProcessingOptions) ProcessJobDetailsIntoRawJobResult(jobDetails testgridv1.JobDetails, timeNow time.Time) (*v1.RawJobResult, []string) {
+func (o ProcessingOptions) ProcessJobDetailsIntoRawJobResult(jobDetails testgridv1.JobDetails, reportEnd time.Time) (*v1.RawJobResult, []string) {
 	log.Infof("processing test details for job %s\n", jobDetails.Name)
-	startCol, endCol := computeLookback(o.StartDay, o.NumDays, jobDetails.Timestamps, timeNow)
+	startCol, endCol := computeLookback(o.StartDay, o.NumDays, jobDetails.Timestamps, reportEnd)
 	jobResult := processJobDetails(jobDetails, startCol, endCol)
 	for _, jrr := range jobResult.JobRunResults {
 		syntheticTests := o.SyntheticTestManager.CreateSyntheticTests(jrr)
@@ -56,11 +56,11 @@ func processJobDetails(job testgridv1.JobDetails, startCol, endCol int) *v1.RawJ
 	return jobResult
 }
 
-func computeLookback(startDay, numDays int, timestamps []int, timeNow time.Time) (int, int) {
+func computeLookback(startDay, numDays int, timestamps []int, reportEnd time.Time) (int, int) {
 	// WARNING: this is modelled as it is in testgrid where we read newest results to oldest left to right.
 	// Thus startTs is the newest timestamp, stopTs is the oldest.
-	stopTs := timeNow.Add(time.Duration(-1*(startDay+numDays)*24)*time.Hour).Unix() * 1000
-	startTs := timeNow.Add(time.Duration(-1*startDay*24)*time.Hour).Unix() * 1000
+	stopTs := reportEnd.Add(time.Duration(-1*(startDay+numDays)*24)*time.Hour).Unix() * 1000
+	startTs := reportEnd.Add(time.Duration(-1*startDay*24)*time.Hour).Unix() * 1000
 	if startDay <= -1 { // find the most recent startTime
 		mostRecentTimestamp := 0
 		for _, t := range timestamps {

--- a/pkg/testgridanalysis/testgridconversion/to_raw_data.go
+++ b/pkg/testgridanalysis/testgridconversion/to_raw_data.go
@@ -22,9 +22,9 @@ type ProcessingOptions struct {
 
 // ProcessJobDetailsIntoRawJobResult returns the raw data and a list of warnings encountered processing the data
 // for a specific job.
-func (o ProcessingOptions) ProcessJobDetailsIntoRawJobResult(jobDetails testgridv1.JobDetails) (*v1.RawJobResult, []string) {
+func (o ProcessingOptions) ProcessJobDetailsIntoRawJobResult(jobDetails testgridv1.JobDetails, timeNow time.Time) (*v1.RawJobResult, []string) {
 	log.Infof("processing test details for job %s\n", jobDetails.Name)
-	startCol, endCol := computeLookback(o.StartDay, o.NumDays, jobDetails.Timestamps)
+	startCol, endCol := computeLookback(o.StartDay, o.NumDays, jobDetails.Timestamps, timeNow)
 	jobResult := processJobDetails(jobDetails, startCol, endCol)
 	for _, jrr := range jobResult.JobRunResults {
 		syntheticTests := o.SyntheticTestManager.CreateSyntheticTests(jrr)
@@ -56,11 +56,11 @@ func processJobDetails(job testgridv1.JobDetails, startCol, endCol int) *v1.RawJ
 	return jobResult
 }
 
-func computeLookback(startDay, numDays int, timestamps []int) (int, int) {
+func computeLookback(startDay, numDays int, timestamps []int, timeNow time.Time) (int, int) {
 	// WARNING: this is modelled as it is in testgrid where we read newest results to oldest left to right.
 	// Thus startTs is the newest timestamp, stopTs is the oldest.
-	stopTs := time.Now().Add(time.Duration(-1*(startDay+numDays)*24)*time.Hour).Unix() * 1000
-	startTs := time.Now().Add(time.Duration(-1*startDay*24)*time.Hour).Unix() * 1000
+	stopTs := timeNow.Add(time.Duration(-1*(startDay+numDays)*24)*time.Hour).Unix() * 1000
+	startTs := timeNow.Add(time.Duration(-1*startDay*24)*time.Hour).Unix() * 1000
 	if startDay <= -1 { // find the most recent startTime
 		mostRecentTimestamp := 0
 		for _, t := range timestamps {

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -46,15 +46,23 @@ func StrSliceContains(strSlice []string, elem string) bool {
 
 // PeriodToDates takes a period name such as twoDay or default, and
 // converts to start, boundary, and end times.
-func PeriodToDates(period string) (start, boundary, end time.Time) {
+func PeriodToDates(period string, timeNow time.Time) (start, boundary, end time.Time) {
 	if period == "twoDay" {
-		start = time.Now().Add(-9 * 24 * time.Hour)
-		boundary = time.Now().Add(-2 * 24 * time.Hour)
+		start = timeNow.Add(-9 * 24 * time.Hour)
+		boundary = timeNow.Add(-2 * 24 * time.Hour)
 	} else {
-		start = time.Now().Add(-14 * 24 * time.Hour)
-		boundary = time.Now().Add(-7 * 24 * time.Hour)
+		start = timeNow.Add(-14 * 24 * time.Hour)
+		boundary = timeNow.Add(-7 * 24 * time.Hour)
 	}
-	end = time.Now()
+	end = timeNow
 
 	return start, boundary, end
+}
+
+func GetTimeNow(pinnedTime *time.Time) time.Time {
+	if pinnedTime == nil {
+		return time.Now()
+	}
+
+	return *pinnedTime
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -46,20 +46,20 @@ func StrSliceContains(strSlice []string, elem string) bool {
 
 // PeriodToDates takes a period name such as twoDay or default, and
 // converts to start, boundary, and end times.
-func PeriodToDates(period string, timeNow time.Time) (start, boundary, end time.Time) {
+func PeriodToDates(period string, reportEnd time.Time) (start, boundary, end time.Time) {
 	if period == "twoDay" {
-		start = timeNow.Add(-9 * 24 * time.Hour)
-		boundary = timeNow.Add(-2 * 24 * time.Hour)
+		start = reportEnd.Add(-9 * 24 * time.Hour)
+		boundary = reportEnd.Add(-2 * 24 * time.Hour)
 	} else {
-		start = timeNow.Add(-14 * 24 * time.Hour)
-		boundary = timeNow.Add(-7 * 24 * time.Hour)
+		start = reportEnd.Add(-14 * 24 * time.Hour)
+		boundary = reportEnd.Add(-7 * 24 * time.Hour)
 	}
-	end = timeNow
+	end = reportEnd
 
 	return start, boundary, end
 }
 
-func GetTimeNow(pinnedTime *time.Time) time.Time {
+func GetReportEnd(pinnedTime *time.Time) time.Time {
 	if pinnedTime == nil {
 		return time.Now()
 	}


### PR DESCRIPTION
Main, Server and matviews contain the majority of the logic / changes.  The rest just allow a specific time instance to be used instead of time.Now() calls.