### PR TITLE
Fix test queries to show nurp when suites are null, and misc ui clean-ups

### DIFF
--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -194,8 +194,8 @@ func TestsByNURPAndStandardDeviation(dbc *db.DB, release, table string) *gorm.DB
 	return dbc.DB.
 		Table(table).
 		Select("*, (current_working_percentage - working_average) as delta_from_working_average, (current_pass_percentage - passing_average) as delta_from_passing_average, (current_flake_percentage - flake_average) as delta_from_flake_average").
-		Joins(fmt.Sprintf(`INNER JOIN (?) as pass_rates on pass_rates.test_id = %s.id AND pass_rates.pass_rate_suite_name = %s.suite_name AND pass_rates.pass_rate_variants = %s.variants`, table, table, table), passRates).
-		Joins(fmt.Sprintf(`JOIN (?) as stats ON stats.test_id = %s.id AND stats.stats_suite_name = %s.suite_name`, table, table), stats).
+		Joins(fmt.Sprintf(`INNER JOIN (?) as pass_rates on pass_rates.test_id = %s.id AND pass_rates.pass_rate_suite_name IS NOT DISTINCT FROM %s.suite_name AND pass_rates.pass_rate_variants = %s.variants`, table, table, table), passRates).
+		Joins(fmt.Sprintf(`JOIN (?) as stats ON stats.test_id = %s.id AND stats.stats_suite_name IS NOT DISTINCT FROM %s.suite_name`, table, table), stats).
 		Where(`release = ?`, release).
 		Where(fmt.Sprintf("NOT ('never-stable'=any(%s.variants))", table))
 }

--- a/sippy-ng/src/tests/TestAnalysis.js
+++ b/sippy-ng/src/tests/TestAnalysis.js
@@ -48,6 +48,7 @@ export function TestAnalysis(props) {
       items: [
         filterFor('name', 'equals', testName),
         not(filterFor('variants', 'contains', 'never-stable')),
+        filterFor('current_runs', '>', '0'),
       ],
     },
     setFilterModel,
@@ -509,6 +510,8 @@ export function TestAnalysis(props) {
                 hideControls={true}
                 collapse={false}
                 release={props.release}
+                sortField="delta_from_working_average"
+                sort="asc"
                 filterModel={filterModel}
               />
             </Card>

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -124,6 +124,7 @@ function TestTable(props) {
         {
           field: 'suite_name',
           flex: 1.0,
+          hide: props.collapse,
         },
         {
           field: 'variants',
@@ -145,7 +146,7 @@ function TestTable(props) {
         {
           field: 'working_standard_deviation',
           flex: 0.75,
-          hide: props.collapse || props.briefTable,
+          hide: true,
           headerClassName: props.briefTable ? '' : 'wrapHeader',
         },
         {
@@ -404,7 +405,7 @@ function TestTable(props) {
     },
     delta_from_working_average: {
       field: 'delta_from_working_average',
-      headerName: 'Delta',
+      headerName: 'Delta (working)',
       type: 'number',
       renderCell: (params) => {
         return (
@@ -418,7 +419,7 @@ function TestTable(props) {
     },
     working_average: {
       field: 'working_average',
-      headerName: 'Average',
+      headerName: 'Average (working)',
       type: 'number',
       renderCell: (params) => (
         <div className="percentage-cell">
@@ -430,12 +431,13 @@ function TestTable(props) {
     },
     working_standard_deviation: {
       field: 'working_standard_deviation',
-      headerName: 'StdDev',
+      headerName: 'Standard Deviation (working)',
       type: 'number',
     },
     delta_from_passing_average: {
       field: 'delta_from_passing_average',
-      headerName: 'Delta',
+      headerName: 'Delta (pass)',
+      filterable: false,
       type: 'number',
       renderCell: (params) => {
         return (
@@ -449,7 +451,8 @@ function TestTable(props) {
     },
     passing_average: {
       field: 'passing_average',
-      headerName: 'Average',
+      headerName: 'Average (pass)',
+      filterable: false,
       type: 'number',
       renderCell: (params) => (
         <div className="percentage-cell">
@@ -461,12 +464,14 @@ function TestTable(props) {
     },
     passing_standard_deviation: {
       field: 'passing_standard_deviation',
-      headerName: 'StdDev',
+      headerName: 'Standard Deviation (pass)',
+      filterable: false,
       type: 'number',
     },
     delta_from_flake_average: {
       field: 'delta_from_flake_average',
-      headerName: 'Delta',
+      headerName: 'Delta (flake)',
+      filterable: false,
       type: 'number',
       renderCell: (params) => {
         return (
@@ -480,7 +485,8 @@ function TestTable(props) {
     },
     flake_average: {
       field: 'flake_average',
-      headerName: 'Average',
+      headerName: 'Average (flake)',
+      filterable: false,
       type: 'number',
       renderCell: (params) => (
         <div className="percentage-cell">
@@ -492,7 +498,8 @@ function TestTable(props) {
     },
     flake_standard_deviation: {
       field: 'flake_standard_deviation',
-      headerName: 'StdDev',
+      headerName: 'Standard Deviation (flake)',
+      filterable: false,
       type: 'number',
     },
     current_working_percentage: {
@@ -504,6 +511,7 @@ function TestTable(props) {
     net_improvement: {
       field: 'net_improvement',
       headerName: 'Improvement (pass)',
+      filterable: false,
       type: 'number',
       renderCell: (params) => {
         return <PassRateIcon tooltip={true} improvement={params.value} />
@@ -520,6 +528,7 @@ function TestTable(props) {
     net_flake_improvement: {
       field: 'net_flake_improvement',
       headerName: 'Improvement (flake)',
+      filterable: false,
       type: 'number',
       renderCell: (params) => {
         return (
@@ -534,6 +543,7 @@ function TestTable(props) {
     net_failure_improvement: {
       field: 'net_failure_improvement',
       headerName: 'Improvement (failure)',
+      filterable: false,
       type: 'number',
       renderCell: (params) => {
         return <PassRateIcon tooltip={true} improvement={params.value} />


### PR DESCRIPTION
Fixes [TRT-536](https://issues.redhat.com//browse/TRT-536) and [TRT-486](https://issues.redhat.com//browse/TRT-486)

- Joins using `=` will not work when the fields are null, which is the case for tests without a suite.  A workaround for this is joining on `x.a IS NOT DISTINCT FROM y.a`.
- UI clean up test filter list, only show nurps with runs, etc.