### PR TITLE
Second attempt at fixing the test nurps by suite

### DIFF
--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -190,7 +190,7 @@ func TestsByNURPAndStandardDeviation(dbc *db.DB, release, table string) *gorm.DB
 	stats := dbc.DB.Table(table).
 		Select(`
                  id                                                                             AS test_id,
-                 suite_name                                                                     AS stats_suite_name,
+                 COALESCE(suite_name, '')                                                       AS stats_suite_name,
                  avg((current_successes + current_flakes) * 100.0 / NULLIF(current_runs, 0))    AS working_average,
                  stddev((current_successes + current_flakes) * 100.0 / NULLIF(current_runs, 0)) AS working_standard_deviation,
                  avg(current_successes * 100.0 / NULLIF(current_runs, 0))                       AS passing_average,
@@ -202,15 +202,15 @@ func TestsByNURPAndStandardDeviation(dbc *db.DB, release, table string) *gorm.DB
 
 	// 2. Collect standard stats for all tests. Each row applies to one variant of a test.
 	passRates := dbc.DB.Table(table).
-		Select(`id as test_id, suite_name as pass_rate_suite_name, variants as pass_rate_variants, `+QueryTestPercentages).
+		Select(`id as test_id, COALESCE(suite_name, '') as pass_rate_suite_name, variants as pass_rate_variants, `+QueryTestPercentages).
 		Where(`release = ?`, release)
 
 	// 3. Join the tables to produce test report. Each row represent one variant of a test and contains all stats, both unique to the specific variant and average across all variants.
 	return dbc.DB.
 		Table(table).
 		Select("*, (current_working_percentage - working_average) as delta_from_working_average, (current_pass_percentage - passing_average) as delta_from_passing_average, (current_flake_percentage - flake_average) as delta_from_flake_average").
-		Joins(fmt.Sprintf(`INNER JOIN (?) as pass_rates on pass_rates.test_id = %s.id AND pass_rates.pass_rate_suite_name IS NOT DISTINCT FROM %s.suite_name AND pass_rates.pass_rate_variants = %s.variants`, table, table, table), passRates).
-		Joins(fmt.Sprintf(`JOIN (?) as stats ON stats.test_id = %s.id AND stats.stats_suite_name IS NOT DISTINCT FROM %s.suite_name`, table, table), stats).
+		Joins(fmt.Sprintf(`INNER JOIN (?) as pass_rates on pass_rates.test_id = %s.id AND pass_rates.pass_rate_suite_name = %s.suite_name AND pass_rates.pass_rate_variants = %s.variants`, table, table, table), passRates).
+		Joins(fmt.Sprintf(`JOIN (?) as stats ON stats.test_id = %s.id AND stats.stats_suite_name = %s.suite_name`, table, table), stats).
 		Where(`release = ?`, release).
 		Where(fmt.Sprintf("NOT ('never-stable'=any(%s.variants))", table))
 }


### PR DESCRIPTION
[TRT-538](https://issues.redhat.com//browse/TRT-538)

`IS DISTINCT FROM` which I introduced in https://github.com/openshift/sippy/pull/570 is very slow -- a join on anything other than an `=` produces complicated nested loops.  I had only tested on a single test, but for the full list of all nurps for all tests the query was taking nearly 5m.

Using `COALESCE(suite_name, '')` (make suite name an empty string and joining on that) is faster.

This version:

```
 Subquery Scan on final_results  (cost=48431.31..89012.72 rows=1 width=856) (actual time=738.060..5490.006 rows=26617 loops=1)
   Filter: ((final_results.current_runs >= '7'::bigint) AND (final_results.delta_from_working_average <= '20'::numeric) AND (final_results.working_standard_deviation > '1'::numeric))
   Rows Removed by Filter: 100979
   ->  WindowAgg  (cost=48431.31..89012.70 rows=1 width=856) (actual time=738.030..5467.364 rows=127596 loops=1)
         ->  Nested Loop  (cost=48431.31..89012.42 rows=1 width=384) (actual time=738.007..3787.267 rows=127596 loops=1)
               ->  Nested Loop  (cost=48430.76..86618.78 rows=291 width=408) (actual time=737.991..2352.379 rows=127596 loops=1)
                     ->  Finalize GroupAggregate  (cost=48430.21..49387.24 rows=4476 width=264) (actual time=737.673..1531.589 rows=5469 loops=1)
                           Group Key: prow_test_report_7d_matview_2.id, prow_test_report_7d_matview_2.suite_name
                           ->  Gather Merge  (cost=48430.21..49137.23 rows=3946 width=232) (actual time=737.398..1469.694 rows=5469 loops=1)
                                 Workers Planned: 2
                                 Workers Launched: 0
                                 ->  Partial GroupAggregate  (cost=47430.19..47681.74 rows=1973 width=232) (actual time=737.066..1468.402 rows=5469 loops=1)
                                       Group Key: prow_test_report_7d_matview_2.id, prow_test_report_7d_matview_2.suite_name
                                       ->  Sort  (cost=47430.19..47435.12 rows=1973 width=64) (actual time=736.950..799.132 rows=213892 loops=1)
                                             Sort Key: prow_test_report_7d_matview_2.id, prow_test_report_7d_matview_2.suite_name
                                             Sort Method: external merge  Disk: 11976kB
                                             ->  Parallel Seq Scan on prow_test_report_7d_matview prow_test_report_7d_matview_2  (cost=0.00..47322.20 rows=1973 width=64) (actual time=0.863..526.660 rows=213892 loops=1)
                                                   Filter: (release = '4.12'::text)
                                                   Rows Removed by Filter: 567221
                     ->  Index Scan using idx_prow_test_report_7d_matview on prow_test_report_7d_matview  (cost=0.55..8.30 rows=1 width=176) (actual time=0.016..0.143 rows=23 loops=5469)
                           Index Cond: ((id = prow_test_report_7d_matview_2.id) AND (release = '4.12'::text) AND (suite_name = (COALESCE(prow_test_report_7d_matview_2.suite_name, ''::text))))
                           Filter: ((name !~~ '%.Overall%'::text) AND (name !~~ '%step graph.%'::text) AND ((current_runs > 0) OR (previous_runs > 0)) AND ('never-stable'::text <> ALL (variants)) AND ('never-stable'::text <> ALL (variants)))
                           Rows Removed by Filter: 13
               ->  Index Scan using idx_prow_test_report_7d_matview on prow_test_report_7d_matview prow_test_report_7d_matview_1  (cost=0.55..8.22 rows=1 width=96) (actual time=0.010..0.010 rows=1 loops=127596)
                     Index Cond: ((id = prow_test_report_7d_matview.id) AND (release = '4.12'::text) AND (variants = prow_test_report_7d_matview.variants))
                     Filter: (prow_test_report_7d_matview.suite_name = COALESCE(suite_name, ''::text))
                     Rows Removed by Filter: 0
 Planning Time: 0.875 ms
 Execution Time: 5495.315 ms
```

`IS DISTINCT FROM` version:

```
 Subquery Scan on final_results  (cost=49430.76..113676.91 rows=1 width=856) (actual time=3610.921..314706.105 rows=29001 loops=1)
   Filter: ((final_results.current_runs >= '7'::bigint) AND (final_results.delta_from_working_average <= '20'::numeric) AND (final_results.working_standard_deviation > '1'::numeric))
   Rows Removed by Filter: 105150
   ->  WindowAgg  (cost=49430.76..113676.89 rows=1 width=856) (actual time=3535.734..314668.353 rows=134151 loops=1)
         ->  Nested Loop  (cost=49430.76..113676.61 rows=1 width=384) (actual time=3535.709..313544.609 rows=134151 loops=1)
               Join Filter: ((NOT (prow_test_report_7d_matview_2.suite_name IS DISTINCT FROM prow_test_report_7d_matview.suite_name)) AND (prow_test_report_7d_matview_1.id = prow_test_report_7d_matview_2.id))
               Rows Removed by Join Filter: 733537668
               ->  Finalize GroupAggregate  (cost=48430.21..49387.24 rows=4476 width=232) (actual time=695.574..1358.384 rows=5469 loops=1)
                     Group Key: prow_test_report_7d_matview_2.id, prow_test_report_7d_matview_2.suite_name
                     ->  Gather Merge  (cost=48430.21..49137.23 rows=3946 width=232) (actual time=695.298..1281.495 rows=5469 loops=1)
                           Workers Planned: 2
                           Workers Launched: 0
                           ->  Partial GroupAggregate  (cost=47430.19..47681.74 rows=1973 width=232) (actual time=694.988..1277.758 rows=5469 loops=1)
                                 Group Key: prow_test_report_7d_matview_2.id, prow_test_report_7d_matview_2.suite_name
                                 ->  Sort  (cost=47430.19..47435.12 rows=1973 width=64) (actual time=694.874..742.636 rows=213892 loops=1)
                                       Sort Key: prow_test_report_7d_matview_2.id, prow_test_report_7d_matview_2.suite_name
                                       Sort Method: external merge  Disk: 11976kB
                                       ->  Parallel Seq Scan on prow_test_report_7d_matview prow_test_report_7d_matview_2  (cost=0.00..47322.20 rows=1973 width=64) (actual time=0.846..577.394 rows=213892 loops=1)
                                             Filter: (release = '4.12'::text)
                                             Rows Removed by Filter: 567221
               ->  Materialize  (cost=1000.55..64087.95 rows=2 width=208) (actual time=0.003..29.224 rows=134151 loops=5469)
                     ->  Gather  (cost=1000.55..64087.94 rows=2 width=208) (actual time=1.204..3349.795 rows=134151 loops=1)
                           Workers Planned: 2
                           Workers Launched: 0
                           ->  Nested Loop  (cost=0.55..63087.74 rows=1 width=208) (actual time=0.871..3336.002 rows=134151 loops=1)
                                 ->  Parallel Seq Scan on prow_test_report_7d_matview prow_test_report_7d_matview_1  (cost=0.00..47322.20 rows=1973 width=96) (actual time=0.837..570.598 rows=213892 loops=1)
                                       Filter: (release = '4.12'::text)
                                       Rows Removed by Filter: 567221
                                 ->  Index Scan using idx_prow_test_report_7d_matview on prow_test_report_7d_matview  (cost=0.55..7.98 rows=1 width=176) (actual time=0.012..0.012 rows=1 loops=213892)
                                       Index Cond: ((id = prow_test_report_7d_matview_1.id) AND (release = '4.12'::text) AND (variants = prow_test_report_7d_matview_1.variants))
                                       Filter: ((name !~~ '%.Overall%'::text) AND (name !~~ '%step graph.%'::text) AND (NOT (prow_test_report_7d_matview_1.suite_name IS DISTINCT FROM suite_name)) AND ((current_runs > 0) OR (previous_runs > 0)) AND ('never-stable'::text <> ALL (variants)) AND ('never-stable'::text <> ALL (variants)))
                                       Rows Removed by Filter: 0
 Planning Time: 0.769 ms
 Execution Time: 314719.835 ms
```