### PR TITLE
Compare prow job variants as same type

### DIFF
--- a/pkg/prowloader/prow.go
+++ b/pkg/prowloader/prow.go
@@ -216,7 +216,7 @@ func (pl *ProwLoader) prowJobToJobRun(pj prow.ProwJob, release string) error {
 		pl.prowJobCache[pj.Spec.Job] = dbProwJob
 	} else {
 		newVariants := pl.variantManager.IdentifyVariants(pj.Spec.Job, release)
-		if !reflect.DeepEqual(newVariants, dbProwJob.Variants) || dbProwJob.Kind != models.ProwKind(pj.Spec.Type) {
+		if !reflect.DeepEqual(newVariants, []string(dbProwJob.Variants)) || dbProwJob.Kind != models.ProwKind(pj.Spec.Type) {
 			dbProwJob.Kind = models.ProwKind(pj.Spec.Type)
 			dbProwJob.Variants = newVariants
 			pl.dbc.DB.Save(&dbProwJob)


### PR DESCRIPTION
I noticed while watching fetchdata this morning, we update the prow job every single time we insert a prow job run:

```
[3.735ms] [rows:1] UPDATE "prow_jobs" SET "created_at"='2022-04-25 16:47:04.149',"updated_at"='2022-09-08 11:34:21.623',"deleted_at"=NULL,"kind"='periodic',"name"='periodic-ci-openshift-multiarch-master-nightly-4.6-ocp-jenkins-e2e-remote-libvirt-s390x',"release"='4.6',"variants"='{"s390x","sdn","ha"}',"test_grid_url"='https://testgrid.k8s.io/redhat-openshift-ocp-release-4.6-informing#periodic-ci-openshift-multiarch-master-nightly-4.6-ocp-jenkins-e2e-remote-libvirt-s390x' WHERE "id" = 60
```

reflect.DeepEqual requires the two variables to be the same time, but before the prow job variants were `[]string`, and the db variants were `pq.StringArray`. This adds an explicit cast of `pq.StringArray` to `[]string`, which seems to prevent the prow job from being updated every time.