### PR TITLE
Fix CI infra failure logic

### DIFF
--- a/pkg/synthetictests/ocp_synthetic_tests.go
+++ b/pkg/synthetictests/ocp_synthetic_tests.go
@@ -209,11 +209,11 @@ func jobRunStatus(result *sippyprocessingv1.RawJobRunResult) sippyprocessingv1.J
 	if result.Aborted {
 		return sippyprocessingv1.JobAborted
 	}
-	if !result.Failed {
-		return sippyprocessingv1.JobRunning
-	}
 	if result.Errored {
 		return sippyprocessingv1.JobFailureBeforeSetup
+	}
+	if !result.Failed {
+		return sippyprocessingv1.JobRunning
 	}
 
 	if result.InstallStatus == failure {


### PR DESCRIPTION
`if result.Errored` needed to go before the Running case to be detected.  We never hit this case currently.