### PR TITLE
Add timing logging to prowloader

### DIFF
--- a/pkg/prowloader/github/github.go
+++ b/pkg/prowloader/github/github.go
@@ -56,6 +56,9 @@ func New(ctx context.Context) *Client {
 }
 
 func (c *Client) GetPRMerged(org, repo string, number int, sha string) (*time.Time, error) {
+	now := time.Now()
+	logrus.Infof("GetPRMerged(org=%s, repo=%s, number=%d, sha=%s) started at %s", org, repo, number, sha, now)
+
 	prl := prlocator{org: org, repo: repo, number: number, sha: sha}
 	if val, ok := c.cache[prl]; ok {
 		return val, nil
@@ -73,5 +76,6 @@ func (c *Client) GetPRMerged(org, repo string, number int, sha string) (*time.Ti
 	}
 
 	c.cache[prl] = state
+	logrus.Infof("GetPRMerged(org=%s, repo=%s, number=%d, sha=%s) completed at %s", org, repo, number, sha, time.Since(now))
 	return state, nil
 }


### PR DESCRIPTION
Devan added this in many places in Sippy, and the data is nice to help troubleshoot.  I spotted a case where fetchdata's last log entry was this:

```
2022/09/09 00:44:34 /go/src/sippy/pkg/prowloader/prow.go:155
[21.578ms] [rows:2416] SELECT * FROM "prow_pull_requests" WHERE merged_at IS NULL
```

That's a very quick query -- but without additional logging, I don't really know where Sippy got stuck.