### PR TITLE
Improve performance of test 7d and 2d matviews by 10x

### DIFF
--- a/pkg/db/matviews.go
+++ b/pkg/db/matviews.go
@@ -228,7 +228,7 @@ FROM prow_job_run_tests
    LEFT JOIN suites on suites.id = prow_job_run_tests.suite_id
    JOIN prow_job_runs ON prow_job_runs.id = prow_job_run_tests.prow_job_run_id
    JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id
-WHERE NOT ('aggregated'::text = ANY (prow_jobs.variants))
+WHERE prow_job_runs.timestamp >= |||START||| AND NOT ('aggregated'::text = ANY (prow_jobs.variants))
 GROUP BY tests.id, tests.name, suites.name, prow_jobs.variants, prow_jobs.release
 `
 


### PR DESCRIPTION
Refreshing the matviews for tests are now taking about 40 minutes each. Looking at the query, I noticed we are not including a WHERE clause to filter out older runs. The timestamp filtering only happens in the COALESCE, meaning postgres has to loop over all of the rows for all tests from all runs from all time.

The difference here is substantial. Matview refresh time goes from 40 minutes to about 4.

Old costs:
```
 GroupAggregate  (cost=26144776.29..119329657.85 rows=254166812 width=331)
```

This version:

```
 GroupAggregate  (cost=6592283.66..17031032.88 rows=30129839 width=331)
```