### PR TITLE
Sippy should not panic if path is not found

### DIFF
--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -744,7 +744,12 @@ func (s *Server) Serve() {
 			fullPath := strings.TrimPrefix(r.URL.Path, "/sippy-ng/")
 			if _, err := fs.Open(fullPath); err != nil {
 				if !os.IsNotExist(err) {
-					panic(err)
+					w.WriteHeader(http.StatusNotFound)
+					w.Header().Set("Content-Type", "text/plain")
+					if _, err := w.Write([]byte(fmt.Sprintf("404 Not Found: %s", fullPath))); err != nil {
+						log.WithError(err).Warningf("could not write response")
+					}
+					return
 				}
 				r.URL.Path = "/sippy-ng/"
 			}


### PR DESCRIPTION
If a user tries to access a UI page that's non-existent, Sippy panics. It should just return a gentler 404 instead.

```
2022/09/13 18:37:21 http: panic serving 10.129.2.9:42468: open repositories/Presubmits/: invalid name
goroutine 5758 [running]:
net/http.(*conn).serve.func1()
/usr/lib/golang/src/net/http/server.go:1802 +0xb9
panic({0x11df800, 0xc000ced9e0})
/usr/lib/golang/src/runtime/panic.go:1047 +0x266
github.com/openshift/sippy/pkg/sippyserver.(*Server).Serve.func1({0x1c15668, 0xc0006d6540}, 0xc004452b00)
/go/src/sippy/pkg/sippyserver/server.go:747 +0x268
net/http.HandlerFunc.ServeHTTP(0x0, {0x1c15668, 0xc0006d6540}, 0x6320cde1)
/usr/lib/golang/src/net/http/server.go:2047 +0x2f
net/http.(*ServeMux).ServeHTTP(0xc0006d6540, {0x1c15668, 0xc0006d6540}, 0xc004452b00)
/usr/lib/golang/src/net/http/server.go:2425 +0x149
github.com/openshift/sippy/pkg/sippyserver.logRequestHandler.func1({0x1c15668, 0xc0006d6540}, 0xc004452b00)
/go/src/sippy/pkg/sippyserver/server.go:822 +0x8f
net/http.HandlerFunc.ServeHTTP(0x0, {0x1c15668, 0xc0006d6540}, 0x468a8e)
/usr/lib/golang/src/net/http/server.go:2047 +0x2f
net/http.serverHandler.ServeHTTP({0xc000ced8f0}, {0x1c15668, 0xc0006d6540}, 0xc004452b00)
/usr/lib/golang/src/net/http/server.go:2879 +0x43b
net/http.(*conn).serve(0xc0002ae0a0, {0x1c1b238, 0xc0003b39e0})
/usr/lib/golang/src/net/http/server.go:1930 +0xb08
created by net/http.(*Server).Serve
/usr/lib/golang/src/net/http/server.go:3034 +0x4e8
2022/09/13 18:37:21 http: panic serving 10.129.2.9:42482: open repositories/Presubmits/: invalid name
goroutine 5704 [running]:
net/http.(*conn).serve.func1()
/usr/lib/golang/src/net/http/server.go:1802 +0xb9
panic({0x11df800, 0xc000b923f0})
```