### PR TITLE
Enable job runs pagination to be server-side

### DIFF
--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -46,11 +46,12 @@ type apiRunResults []apitype.JobRun
 // JobsRunsReportFromDB renders a filtered summary of matching jobs.
 func JobsRunsReportFromDB(dbc *db.DB, filterOpts *filter.FilterOptions, release string, pagination *apitype.Pagination) (*apitype.PaginationResult, error) {
 	jobsResult := make([]apitype.JobRun, 0)
-	q, err := filter.FilterableDBResult(dbc.DB, filterOpts, apitype.JobRun{})
+	table := "prow_job_runs_report_matview"
+	q, err := filter.FilterableDBResult(dbc.DB.Table(table), filterOpts, apitype.JobRun{})
 	if err != nil {
 		return nil, err
 	}
-	q = q.Table("prow_job_runs_report_matview").Where("release = ?", release)
+	q = q.Where("release = ?", release)
 
 	// Get the row count before pagination
 	var rowCount int64

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -27,6 +27,9 @@ const (
 	SortDescending Sort = "desc"
 )
 
+// PaginationResult is a type used by API endpoints that enable server-side
+// pagination. It wraps the returned rows  with page information such as page
+// size, which page, and the total rows.
 type PaginationResult struct {
 	Rows      interface{} `json:"rows"`
 	PageSize  int         `json:"page_size"`
@@ -34,8 +37,10 @@ type PaginationResult struct {
 	TotalRows int64       `json:"total_rows"`
 }
 
+// Pagination is a type used to request specific per-page and offset values
+// in an API request.
 type Pagination struct {
-	PerPage int `json:"perPage"`
+	PerPage int `json:"per_page"`
 	Page    int `json:"page"`
 }
 

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -27,6 +27,11 @@ const (
 	SortDescending Sort = "desc"
 )
 
+type Pagination struct {
+	PerPage int `json:"perPage"`
+	Offset  int `json:"offset"`
+}
+
 type Repository struct {
 	ID       int    `json:"id"`
 	Org      string `json:"org"`

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -27,9 +27,16 @@ const (
 	SortDescending Sort = "desc"
 )
 
+type PaginationResult struct {
+	Rows      interface{} `json:"rows"`
+	PageSize  int         `json:"page_size"`
+	Page      int         `json:"page"`
+	TotalRows int64       `json:"total_rows"`
+}
+
 type Pagination struct {
 	PerPage int `json:"perPage"`
-	Offset  int `json:"offset"`
+	Page    int `json:"page"`
 }
 
 type Repository struct {

--- a/pkg/sippyserver/parameters.go
+++ b/pkg/sippyserver/parameters.go
@@ -76,16 +76,16 @@ func getLimitParam(req *http.Request) int {
 
 func getPaginationParams(req *http.Request) (*apitype.Pagination, error) {
 	perPage := req.URL.Query().Get("perPage")
-	offset := req.URL.Query().Get("offset")
+	page := req.URL.Query().Get("page")
 	if perPage != "" {
 		perPageInt, err := strconv.Atoi(perPage)
 		if err != nil {
 			return nil, err
 		}
 
-		offsetInt := 0
-		if offset != "" {
-			offsetInt, err = strconv.Atoi(offset)
+		pageNo := 0
+		if page != "" {
+			pageNo, err = strconv.Atoi(page)
 			if err != nil {
 				return nil, err
 			}
@@ -93,7 +93,7 @@ func getPaginationParams(req *http.Request) (*apitype.Pagination, error) {
 
 		return &apitype.Pagination{
 			PerPage: perPageInt,
-			Offset:  offsetInt,
+			Page:    pageNo,
 		}, nil
 	}
 

--- a/pkg/sippyserver/parameters.go
+++ b/pkg/sippyserver/parameters.go
@@ -5,9 +5,10 @@ import (
 	"strconv"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/filter"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/openshift/sippy/pkg/util"
 )
@@ -71,6 +72,32 @@ func getPeriod(req *http.Request, defaultValue string) string {
 func getLimitParam(req *http.Request) int {
 	limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
 	return limit
+}
+
+func getPaginationParams(req *http.Request) (*apitype.Pagination, error) {
+	perPage := req.URL.Query().Get("perPage")
+	offset := req.URL.Query().Get("offset")
+	if perPage != "" {
+		perPageInt, err := strconv.Atoi(perPage)
+		if err != nil {
+			return nil, err
+		}
+
+		offsetInt := 0
+		if offset != "" {
+			offsetInt, err = strconv.Atoi(offset)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return &apitype.Pagination{
+			PerPage: perPageInt,
+			Offset:  offsetInt,
+		}, nil
+	}
+
+	return nil, nil
 }
 
 func getSortParams(req *http.Request) (string, apitype.Sort) {

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -700,7 +700,13 @@ func (s *Server) jsonJobRunsReportFromDB(w http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	api.JobsRunsReportFromDB(s.db, filterOpts, release, pagination)
+	result, err := api.JobsRunsReportFromDB(s.db, filterOpts, release, pagination)
+	if err != nil {
+		api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": err.Error()})
+		return
+	}
+
+	api.RespondWithJSON(http.StatusOK, w, result)
 }
 
 func (s *Server) jsonJobsAnalysisFromDB(w http.ResponseWriter, req *http.Request) {

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -686,7 +686,21 @@ func (s *Server) jsonPullRequestsReportFromDB(w http.ResponseWriter, req *http.R
 }
 
 func (s *Server) jsonJobRunsReportFromDB(w http.ResponseWriter, req *http.Request) {
-	api.PrintJobsRunsReportFromDB(w, req, s.db)
+	release := s.getRelease(req)
+
+	filterOpts, err := filter.FilterOptionsFromRequest(req, "timestamp", "asc")
+	if err != nil {
+		api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": "Could not marshal query:" + err.Error()})
+		return
+	}
+
+	pagination, err := getPaginationParams(req)
+	if err != nil {
+		api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": "Could not parse pagination options: " + err.Error()})
+		return
+	}
+
+	api.JobsRunsReportFromDB(s.db, filterOpts, release, pagination)
 }
 
 func (s *Server) jsonJobsAnalysisFromDB(w http.ResponseWriter, req *http.Request) {

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -688,7 +688,7 @@ func (s *Server) jsonPullRequestsReportFromDB(w http.ResponseWriter, req *http.R
 func (s *Server) jsonJobRunsReportFromDB(w http.ResponseWriter, req *http.Request) {
 	release := s.getRelease(req)
 
-	filterOpts, err := filter.FilterOptionsFromRequest(req, "timestamp", "asc")
+	filterOpts, err := filter.FilterOptionsFromRequest(req, "timestamp", "desc")
 	if err != nil {
 		api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": "Could not marshal query:" + err.Error()})
 		return


### PR DESCRIPTION
Part of [TRT-314](https://issues.redhat.com//browse/TRT-314)

Loading the job runs page takes a lot of memory, since we have 80K rows
and we're sending them all to the client. It causes a big spike in Sippy
memory usage.

This enables server-side pagination for job runs. I only did one page since
it's the worst offender, but we should convert most API's I think.  Perhaps
a good issue for someone not familiar with sippy to tackle, since the blueprint
is in this PR for how to do the rest of the pages.
