### PR TITLE
Very basic e2e tests for presubmit job.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -148,3 +148,13 @@ See [Sippy front-end docs](sippy-ng/README.md]) for more details about developin
 ```bash
 cd sippy-ng && npm start
 ```
+
+## Run E2E Tests
+
+Sippy has a currently basic/minimal set of e2e tests which run a temporary postgres container, load the database with an
+older release with fewer runs, launch the API, and run a few tests against it to verify things are working.
+This runs as a presubmit on the repo, but developers can also run locally if they have a GCS service account JSON credential file.
+
+```bash
+GCS_SA_JSON_PATH=~/creds/openshift-ci-data-analysis.json make e2e
+```

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build: builddir clean npm
 	go build -mod=vendor .
 
 test: builddir npm
-	go test -v ./...
+	go test -v ./pkg/...
 	LANG=en_US.utf-8 LC_ALL=en_US.utf-8 cd sippy-ng; CI=true npm test -- --coverage
 
 lint: builddir npm
@@ -32,3 +32,6 @@ npm:
 clean:
 	rm -f sippy
 	rm -rf sippy-ng/build
+
+e2e:
+	./scripts/e2e.sh

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+DOCKER="docker"
+PSQL_CONTAINER="sippy-e2e-test-postgresql"
+PSQL_PORT="23433"
+
+if [[ -z "$GCS_SA_JSON_PATH" ]]; then
+    echo "Must provide path to GCS credential in GCS_SA_JSON_PATH env var" 1>&2
+    exit 1
+fi
+
+
+clean_up () {
+    ARG=$?
+    echo "Killing sippy API child process: $CHILD_PID"
+	kill $CHILD_PID
+	echo "Tearing down container $PSQL_CONTAINER"
+	$DOCKER stop -i $PSQL_CONTAINER
+	$DOCKER rm -i $PSQL_CONTAINER
+    exit $ARG
+}
+trap clean_up EXIT
+
+# make sure no old container running
+echo "Cleaning up old sippy postgresql container if present"
+$DOCKER stop -i $PSQL_CONTAINER
+$DOCKER rm -i $PSQL_CONTAINER
+
+# start postgresql in a container:
+echo "Starting new sippy postgresql container: $PSQL_CONTAINER"
+$DOCKER run --name $PSQL_CONTAINER -e POSTGRES_PASSWORD=password -p $PSQL_PORT:5432 -d quay.io/enterprisedb/postgresql
+
+echo "Wait 5s for postgresql to start..."
+sleep 5
+
+echo "Loading database..."
+# use an old release here as they have very few job runs and thus import quickly, ~5 minutes
+make build
+./sippy --load-database \
+  --log-level=debug \
+  --load-prow=true \
+  --load-testgrid=false \
+  --release 4.7 \
+  --database-dsn="postgresql://postgres:password@localhost:$PSQL_PORT/postgres" \
+  --mode=ocp \
+  --config ./config/openshift.yaml \
+  --google-service-account-credential-file $GCS_SA_JSON_PATH
+
+# Spawn sippy server off into a separate process:
+(
+./sippy --server \
+  --listen ":18080" \
+  --listen-metrics ":12112" \
+  --local-data /opt/sippy-testdata \
+  --database-dsn="postgresql://postgres:password@localhost:$PSQL_PORT/postgres" \
+  --log-level debug \
+  --mode ocp
+)&
+# store the child process for cleanup
+CHILD_PID=$!
+
+# Give it time to start up
+echo "Wait 30s for sippy API to start..."
+sleep 30
+
+# Run our tests that request against the API:
+go test ./test/e2e/ -v
+
+# WARNING: do not place more commands here without addressing return code from go test not being overridden by the cleanup func
+
+

--- a/test/e2e/jobs_test.go
+++ b/test/e2e/jobs_test.go
@@ -1,0 +1,19 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/openshift/sippy/pkg/apis/api"
+	"github.com/openshift/sippy/test/e2e/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJobsAPIs(t *testing.T) {
+	var jobs []api.Job
+	err := util.SippyRequest("/api/jobs?release="+util.Release, &jobs)
+	if !assert.NoError(t, err, "error making http request") {
+		return
+	}
+	t.Logf("found %d jobs", len(jobs))
+	assert.Greater(t, len(jobs), 0, "no jobs returned")
+}

--- a/test/e2e/util/e2erequest.go
+++ b/test/e2e/util/e2erequest.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+const (
+	// Release is the usually somewhat older release we're importing during e2e runs (as it has far less data)
+	// to then test sippy. Needs to match what we import in the e2e sh scripts.
+	Release = "4.7"
+
+	// APIPort is the port e2e.sh launches the sippy API on. These values must be kept in sync.
+	APIPort = 18080
+)
+
+func buildURL(apiPath string) string {
+	return fmt.Sprintf("http://localhost:%d%s", APIPort, apiPath)
+}
+
+func SippyRequest(path string, data interface{}) error {
+	res, err := http.Get(buildURL(path))
+	if err != nil {
+		return err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(body, data)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Very basic for now, make e2e will run the script which:

- builds sippy
- launches a postgresql container
- imports last 12 hours of job data from prow for an old release, 4.7 (roughly 5 minutes on my system)
- launches the sippy api in a subprocess and gives it a little time to start up and refresh views
- runs e2e tests defined as standard go tests, which hit the API.

Only one test now that lists job reports and checks it got something back. My plan is to get this in as it covers a lot of ground and we can expand to other tests as we go in future.


[TRT-246](https://issues.redhat.com//browse/TRT-246)