### PR TITLE
TRT-576 add check for release

### DIFF
--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -51,7 +51,10 @@ func JobsRunsReportFromDB(dbc *db.DB, filterOpts *filter.FilterOptions, release 
 	if err != nil {
 		return nil, err
 	}
-	q = q.Where("release = ?", release)
+
+	if len(release) > 0 {
+		q = q.Where("release = ?", release)
+	}
 
 	// Get the row count before pagination
 	var rowCount int64


### PR DESCRIPTION
[TRT-576](https://issues.redhat.com//browse/TRT-576) - fixes showing build cluster job runs when there is no release associated.