### PR TITLE
Temporarily disable release syncing

### DIFF
--- a/scripts/fetchdata.sh
+++ b/scripts/fetchdata.sh
@@ -19,11 +19,6 @@ while [ true ]; do
     --release 4.11 \
     --release 4.12 \
     --release Presubmits \
-    --arch amd64 \
-    --arch arm64 \
-    --arch multi \
-    --arch s390x \
-    --arch ppc64le \
     --config /config/openshift.yaml \
     --mode=ocp
   echo "Done fetching data, refreshing server"


### PR DESCRIPTION
There's some weird payload that's preventing sippy from syncing, it's list of pull requests is really huge, and then things end up getting killed on the INSERT due to OOM.

It's Saturday so I'm just going to disable it so prow syncing continues to work, and then we can sort it out on Monday.

```
2022/10/01 12:16:46 /go/src/sippy/pkg/releasesync/releasesync.go:97 record not found
[1.140ms] [rows:0] SELECT * FROM "release_pull_requests" WHERE url = 'https://github.com/openshift/kubernetes/pull/97965' AND name = 'ibm-vpc-block-csi-driver-operator' AND "release_pull_requests"."deleted_at" IS NULL ORDER BY "release_pull_requests"."id" LIMIT 1
2022/10/01 12:16:46 /go/src/sippy/pkg/releasesync/releasesync.go:75
[6.725ms] [rows:36] INSERT INTO "release_repositories" ("created_at","updated_at","deleted_at","name","release_tag_id","repository_head","diff_url") VALUES ('2022-10-01 12:16:46.947','2022-10-01 12:16:46.947',NULL,'agent-installer-api-server','10878','https://github.com/openshift/assisted-service/tree/e69c126e90b94eff81a193a2b8fd132451971bd2','https://github.com/openshift/assisted-service/compare/4329264e8913dcb0147579f0592d991ffd283c34...e69c126e90b94eff81a193a2b8fd132451971bd2'),('2022-10-01 12:16:46.947','2022-10-01 12:16:46.947',NULL,'baremetal-installer, installer, installer-artifacts','10878','https://github.com/openshift/installer/tree/bfddf9024f671ad3e81cf72857a1db7f42199682','https://github.com/openshift/installer/compare/ac9f1c19c96ebab17e67490cf8ccf6504166a566...bfddf9024f671ad3e81cf72857a1db7f42199682'),('2022-10-01 12:16:46.947','2022-10-01 12:16:46.947',NULL,'baremetal-machine-controllers','10878','https://github.com/openshift/cluster-api-provider-baremetal/tree/fa56fb5a64...
2022/10/01 12:16:46 /go/src/sippy/pkg/releasesync/releasesync.go:75
[3.164ms] [rows:1] INSERT INTO "release_job_runs" ("created_at","updated_at","deleted_at","release_tag_id","prow_job_run_id","job_name","kind","state","transition_time","retries","url","upgrades_from","upgrades_to","upgrade") VALUES ('2022-10-01 12:16:46.955','2022-10-01 12:16:46.955',NULL,'10878',1575939076354215936,'e2e-ppc64le','Informing','Failed','0000-00-00 00:00:00',0,'https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-multiarch-master-nightly-4.12-ocp-e2e-sdn-remote-libvirt-ppc64le/1575939076354215936','','',false) ON CONFLICT ("id") DO UPDATE SET "release_tag_id"="excluded"."release_tag_id" RETURNING "id"
Done fetching data, refreshing server
/bin/fetchdata.sh: line 33: 8 Killed /bin/sippy --load-database --load-prow=true --load-github=true --load-testgrid=false --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10 --release 4.11 --release 4.12 --release Presubmits --arch amd64 --arch arm64 --arch multi --arch s390x --arch ppc64le --config /config/openshift.yaml --mode=ocp
% Total % Received % Xferd Average Speed Time Time Time Current
```