### PR TITLE
Only call GitHub once per PR

### DIFF
--- a/pkg/prowloader/github/github.go
+++ b/pkg/prowloader/github/github.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"time"
 
@@ -15,19 +16,25 @@ type prlocator struct {
 	org    string
 	repo   string
 	number int
-	sha    string
+}
+
+type prentry struct {
+	mergedAt *time.Time
+	sha      string
 }
 
 type Client struct {
-	ctx    context.Context
-	client *gh.Client
-	cache  map[prlocator]*time.Time
+	ctx   context.Context
+	cache map[prlocator]*prentry
 }
+
+// PRFetch as a global allows tests to override.
+var PRFetch func(org, repo string, number int) (*gh.PullRequest, error)
 
 func New(ctx context.Context) *Client {
 	client := &Client{
 		ctx:   ctx,
-		cache: make(map[prlocator]*time.Time),
+		cache: make(map[prlocator]*prentry),
 	}
 	token := os.Getenv("GITHUB_TOKEN")
 	if token == "" {
@@ -39,39 +46,73 @@ func New(ctx context.Context) *Client {
 		}
 	}
 
-	if token != "" {
-		ts := oauth2.StaticTokenSource(
-			&oauth2.Token{
-				AccessToken: token,
-			},
-		)
-		tc := oauth2.NewClient(client.ctx, ts)
-		client.client = gh.NewClient(tc)
-	} else {
-		logrus.Warningf("using unathenticated GitHub client, requests will be rate-limited")
-		client.client = gh.NewClient(nil)
+	if PRFetch != nil {
+		var ghc *gh.Client
+
+		if token != "" {
+			ts := oauth2.StaticTokenSource(
+				&oauth2.Token{
+					AccessToken: token,
+				},
+			)
+			tc := oauth2.NewClient(client.ctx, ts)
+			ghc = gh.NewClient(tc)
+		} else {
+			logrus.Warningf("using unathenticated GitHub client, requests will be rate-limited")
+			ghc = gh.NewClient(nil)
+		}
+
+		PRFetch = func(org, repo string, number int) (*gh.PullRequest, error) {
+			pr, _, err := ghc.PullRequests.Get(client.ctx, org, repo, number)
+			return pr, err
+		}
 	}
 
 	return client
 }
 
-func (c *Client) GetPRMerged(org, repo string, number int, sha string) (*time.Time, error) {
-	prl := prlocator{org: org, repo: repo, number: number, sha: sha}
-	if val, ok := c.cache[prl]; ok {
-		return val, nil
+// GetPRSHAMerged returns the merge time for a PR/SHA combination. The caching is designed
+// to minimize queries to GitHub. We basically have to handle these cases:
+//   - the PR doesn't exist (cache as nil)
+//   - the PR is unmerged (cache as nil)
+//   - the PR is merged with a different SHA (cache with the merged sha, return nil)
+//   - the PR is merged with the same SHA (cache with the merged sha, return merged time)
+func (c *Client) GetPRSHAMerged(org, repo string, number int, sha string) (*time.Time, error) {
+	prl := prlocator{org: org, repo: repo, number: number}
+	if val, ok := c.cache[prl]; ok && val != nil && val.sha == sha {
+		// If it's in the cache, and sha matches, this sha was merged.
+		return val.mergedAt, nil
+	} else if ok {
+		// If it's in the cache, but this isn't the sha, this sha wasn't merged.
+		return nil, nil
 	}
 
-	pr, _, err := c.client.PullRequests.Get(c.ctx, org, repo, number)
+	// Get PR from GitHub
+	pr, err := PRFetch(org, repo, number)
 	if err != nil {
+		if resp, ok := err.(*gh.ErrorResponse); ok && resp.Response != nil && resp.Response.StatusCode == http.StatusNotFound {
+			c.cache[prl] = nil
+			return nil, nil
+		}
 		return nil, err
 	}
 
-	// see if PR was merged yet
-	state := pr.MergedAt
-	if pr.Head != nil && pr.Head.SHA != nil && *pr.Head.SHA != sha {
-		state = nil
+	var state *prentry
+	if pr != nil && pr.Head != nil && pr.Head.SHA != nil && pr.MergedAt != nil {
+		// If PR was merged, store merged sha in cache
+		state = &prentry{
+			sha:      *pr.Head.SHA,
+			mergedAt: pr.MergedAt,
+		}
+		c.cache[prl] = state
+	} else if pr != nil && pr.MergedAt == nil {
+		// If PR was not merged yet, store that in cache
+		c.cache[prl] = nil
 	}
 
-	c.cache[prl] = state
-	return state, nil
+	if state != nil && state.sha == sha {
+		return state.mergedAt, nil
+	}
+
+	return nil, nil
 }

--- a/pkg/prowloader/github/github.go
+++ b/pkg/prowloader/github/github.go
@@ -79,7 +79,8 @@ func (c *Client) GetPRSHAMerged(org, repo string, number int, sha string) (*time
 		// If it's in the cache, and sha matches, this sha was merged.
 		return val.mergedAt, nil
 	} else if ok {
-		// If it's in the cache, but this isn't the sha, the PR merged but not with this sha.
+		// If it's in the cache, then either the PR merged with a different
+		// SHA, or has not merged at all.
 		return nil, nil
 	}
 

--- a/pkg/prowloader/github/github_test.go
+++ b/pkg/prowloader/github/github_test.go
@@ -9,6 +9,11 @@ import (
 	gh "github.com/google/go-github/v45/github"
 )
 
+const (
+	openshift  = "openshift"
+	kubernetes = "kubernetes"
+)
+
 func TestClient_GetPRSHAMerged(t *testing.T) {
 	now := time.Now()
 	mergedSha := "96dcf2b704502a0b05c4bbff5e8c9bb836449fa6"
@@ -22,16 +27,16 @@ func TestClient_GetPRSHAMerged(t *testing.T) {
 
 	PRFetch = func(org, repo string, number int) (*gh.PullRequest, error) {
 		prFetchCalls++
-		if org == "openshift" && repo == "kubernetes" && number == 1 {
+		if org == openshift && repo == kubernetes && number == 1 {
 			return &gh.PullRequest{
 				MergedAt: &now,
 				Head: &gh.PullRequestBranch{
 					SHA: &mergedSha,
 				},
 			}, nil
-		} else if org == "openshift" && repo == "kubernetes" && number == 2 {
+		} else if org == openshift && repo == kubernetes && number == 2 {
 			return &gh.PullRequest{}, nil
-		} else if org == "openshift" && repo == "not-exist" {
+		} else if org == openshift && repo == "not-exist" {
 			return nil, &gh.ErrorResponse{
 				Response: &http.Response{
 					StatusCode: 404,
@@ -58,39 +63,39 @@ func TestClient_GetPRSHAMerged(t *testing.T) {
 	}{
 		{
 			name:       "merged pr with matching sha",
-			org:        "openshift",
-			repo:       "kubernetes",
+			org:        openshift,
+			repo:       kubernetes,
 			sha:        mergedSha,
 			number:     1,
 			wantMerged: true,
 		},
 		{
 			name:       "merged pr with other sha",
-			org:        "openshift",
-			repo:       "kubernetes",
+			org:        openshift,
+			repo:       kubernetes,
 			sha:        unmergedSha1,
 			number:     1,
 			wantMerged: false,
 		},
 		{
 			name:       "unmerged pr",
-			org:        "openshift",
-			repo:       "kubernetes",
+			org:        openshift,
+			repo:       kubernetes,
 			sha:        unmergedSha1,
 			number:     2,
 			wantMerged: false,
 		},
 		{
 			name:       "unmerged pr other sha",
-			org:        "openshift",
-			repo:       "kubernetes",
+			org:        openshift,
+			repo:       kubernetes,
 			sha:        unmergedSha2,
 			number:     2,
 			wantMerged: false,
 		},
 		{
 			name:       "not found pr",
-			org:        "openshift",
+			org:        openshift,
 			repo:       "not-exist",
 			sha:        unmergedSha1,
 			number:     2,
@@ -98,7 +103,7 @@ func TestClient_GetPRSHAMerged(t *testing.T) {
 		},
 		{
 			name:       "not found pr other sha",
-			org:        "openshift",
+			org:        openshift,
 			repo:       "not-exist",
 			sha:        unmergedSha2,
 			number:     2,

--- a/pkg/prowloader/github/github_test.go
+++ b/pkg/prowloader/github/github_test.go
@@ -1,0 +1,129 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v45/github"
+)
+
+func TestClient_GetPRSHAMerged(t *testing.T) {
+	now := time.Now()
+	mergedSha := "96dcf2b704502a0b05c4bbff5e8c9bb836449fa6"
+	unmergedSha1 := "aff4434f177142ff6ae2e4df895be5173700cbbe"
+	unmergedSha2 := "aff4434f177142ff6ae2e4df895be5173700cbbf"
+
+	// We want to minimize the number of API calls to GitHub, this verifies
+	// we only called GitHub once for each PR, not each SHA.
+	prFetchCalls := 0
+	expectedCalls := 3
+
+	PRFetch = func(org, repo string, number int) (*gh.PullRequest, error) {
+		prFetchCalls++
+		if org == "openshift" && repo == "kubernetes" && number == 1 {
+			return &gh.PullRequest{
+				MergedAt: &now,
+				Head: &gh.PullRequestBranch{
+					SHA: &mergedSha,
+				},
+			}, nil
+		} else if org == "openshift" && repo == "kubernetes" && number == 2 {
+			return &gh.PullRequest{}, nil
+		} else if org == "openshift" && repo == "not-exist" {
+			return nil, &gh.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: 404,
+					Status:     "Not Found",
+				},
+			}
+		}
+		return nil, nil
+	}
+
+	client := &Client{
+		ctx:   context.TODO(),
+		cache: make(map[prlocator]*prentry),
+	}
+
+	tests := []struct {
+		name       string
+		org        string
+		repo       string
+		number     int
+		sha        string
+		wantMerged bool
+		wantErr    bool
+	}{
+		{
+			name:       "merged pr with matching sha",
+			org:        "openshift",
+			repo:       "kubernetes",
+			sha:        mergedSha,
+			number:     1,
+			wantMerged: true,
+		},
+		{
+			name:       "merged pr with other sha",
+			org:        "openshift",
+			repo:       "kubernetes",
+			sha:        unmergedSha1,
+			number:     1,
+			wantMerged: false,
+		},
+		{
+			name:       "unmerged pr",
+			org:        "openshift",
+			repo:       "kubernetes",
+			sha:        unmergedSha1,
+			number:     2,
+			wantMerged: false,
+		},
+		{
+			name:       "unmerged pr other sha",
+			org:        "openshift",
+			repo:       "kubernetes",
+			sha:        unmergedSha2,
+			number:     2,
+			wantMerged: false,
+		},
+		{
+			name:       "not found pr",
+			org:        "openshift",
+			repo:       "not-exist",
+			sha:        unmergedSha1,
+			number:     2,
+			wantMerged: false,
+		},
+		{
+			name:       "not found pr other sha",
+			org:        "openshift",
+			repo:       "not-exist",
+			sha:        unmergedSha2,
+			number:     2,
+			wantMerged: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetPRSHAMerged(tt.org, tt.repo, tt.number, tt.sha)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetPRSHAMerged() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantMerged && got == nil {
+				t.Errorf("GetPRSHAMerged() want merged, got unmerged")
+				return
+			}
+		})
+	}
+
+	t.Run("github API calls matched expected times", func(t *testing.T) {
+		if prFetchCalls != expectedCalls {
+			t.Errorf("GetPRSHAMerged() error, expected %d github api calls, got %d", expectedCalls, prFetchCalls)
+			return
+		}
+	})
+
+}

--- a/pkg/prowloader/github/github_test.go
+++ b/pkg/prowloader/github/github_test.go
@@ -25,7 +25,7 @@ func TestClient_GetPRSHAMerged(t *testing.T) {
 	prFetchCalls := 0
 	expectedCalls := 3
 
-	PRFetch = func(org, repo string, number int) (*gh.PullRequest, error) {
+	prFetch := func(org, repo string, number int) (*gh.PullRequest, error) {
 		prFetchCalls++
 		if org == openshift && repo == kubernetes && number == 1 {
 			return &gh.PullRequest{
@@ -48,8 +48,9 @@ func TestClient_GetPRSHAMerged(t *testing.T) {
 	}
 
 	client := &Client{
-		ctx:   context.TODO(),
-		cache: make(map[prlocator]*prentry),
+		ctx:     context.TODO(),
+		prFetch: prFetch,
+		cache:   make(map[prlocator]*prentry),
 	}
 
 	tests := []struct {


### PR DESCRIPTION
[TRT-585](https://issues.redhat.com//browse/TRT-585)

We track PR's based off the PR and the HEAD SHA.  We used to query GitHub for each SHA, instead of just once per PR. This adjusts the caching and syncing logic to ensure we only hit the API once for a PR.

GitHub limits us to 5,000 requests per hour. We know more SHA's than that now, so we're hitting the limits.  We have much fewer distinct PR's, so this should fix the rate limiting.
