### PR TITLE
Sync release tag associations in batches

### DIFF
--- a/pkg/releasesync/releasesync.go
+++ b/pkg/releasesync/releasesync.go
@@ -72,7 +72,7 @@ func (r *releaseSyncOptions) Run() error {
 					continue
 				}
 
-				if err := r.db.DB.Clauses(clause.OnConflict{UpdateAll: true}).Create(&releaseTag).Error; err != nil {
+				if err := r.db.DB.Clauses(clause.OnConflict{UpdateAll: true}).CreateInBatches(&releaseTag, 100).Error; err != nil {
 					return err
 				}
 			}

--- a/scripts/fetchdata.sh
+++ b/scripts/fetchdata.sh
@@ -19,6 +19,11 @@ while [ true ]; do
     --release 4.11 \
     --release 4.12 \
     --release Presubmits \
+    --arch amd64 \
+    --arch arm64 \
+    --arch multi \
+    --arch s390x \
+    --arch ppc64le \
     --config /config/openshift.yaml \
     --mode=ocp
   echo "Done fetching data, refreshing server"


### PR DESCRIPTION
[TRT-585](https://issues.redhat.com//browse/TRT-585)

When creating release tags that include multiple revendors of libraries
with large numbers of commits (say, kube), we're trying to create it
all in one single INSERT which doesn't work well. We need to tell gorm
to create things in batches.

`CreateBatchSize` works for releations (in this case PR's).