### PR TITLE
Set an upper bound on PR's for a release tag

### DIFF
--- a/pkg/releasesync/changelog_parser.go
+++ b/pkg/releasesync/changelog_parser.go
@@ -171,8 +171,17 @@ func (c *Changelog) PullRequests() []models.ReleasePullRequest {
 	}
 
 	result := make([]models.ReleasePullRequest, 0)
+	items := 0
 	for _, v := range rows {
+		// We had a case of a release payload changelog that contained 235,000 pull requests. Sippy got stuck on it
+		// so this check is here to prevent something like that from ever happening again.  2,500 seems like a very
+		// reasonable upper bound.
+		if items > 2500 {
+			log.Warningf("%q had more than 2,500 PR's! Ignoring the rest to protect ourself.", c.releaseTag)
+			break
+		}
 		result = append(result, v)
+		items++
 	}
 	return result
 }


### PR DESCRIPTION
[TRT-585](https://issues.redhat.com//browse/TRT-585)

https://ppc64le.ocp.releases.ci.openshift.org/releasestream/4.12.0-0.nightly-ppc64le/release/4.12.0-0.nightly-ppc64le-2022-09-30-200103 had 235,000 pull requests in it's diff, and it made sippy quite unhappy.

We could probably improve the release syncing code to handle this better, but for now just set an upper bound of what's reasonable.