### PR TITLE
Cascade delete for all relevant DB models

### DIFF
--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -23,7 +23,8 @@ type ProwJob struct {
 	Release     string         `gorm:"varchar(10)"`
 	Variants    pq.StringArray `gorm:"type:text[]"`
 	TestGridURL string
-	Bugs        []Bug `gorm:"many2many:bug_jobs;"`
+	Bugs        []Bug        `gorm:"many2many:bug_jobs;"`
+	JobRuns     []ProwJobRun `gorm:"constraint:OnDelete:CASCADE;"`
 }
 
 // IDName is a partial struct to query limited fields we need for caching. Can be used
@@ -46,8 +47,8 @@ type ProwJobRun struct {
 
 	URL          string
 	TestFailures int
-	Tests        []ProwJobRunTest
-	PullRequests []ProwPullRequest `gorm:"many2many:prow_job_run_prow_pull_requests;"`
+	Tests        []ProwJobRunTest  `gorm:"constraint:OnDelete:CASCADE;"`
+	PullRequests []ProwPullRequest `gorm:"many2many:prow_job_run_prow_pull_requests;constraint:OnDelete:CASCADE;"`
 	Failed       bool
 	// InfrastructureFailure is true if the job run failed, for reasons which appear to be related to test/CI infra.
 	InfrastructureFailure bool
@@ -82,12 +83,12 @@ type ProwJobRunTest struct {
 
 	// ProwJobRunTestOutput collect the output of a failed test run. This is stored as a separate object in the DB, so
 	// we can keep the test result for a longer period of time than we keep the full failure output.
-	ProwJobRunTestOutput *ProwJobRunTestOutput
+	ProwJobRunTestOutput *ProwJobRunTestOutput `gorm:"constraint:OnDelete:CASCADE;"`
 }
 
 type ProwJobRunTestOutput struct {
 	gorm.Model
-	ProwJobRunTestID uint `gorm:"constraint:OnDelete:SET NULL;"`
+	ProwJobRunTestID uint `gorm:"index"`
 	// Output stores the output of a ProwJobRunTest.
 	Output string
 }
@@ -132,8 +133,8 @@ type Bug struct {
 	FixVersions     pq.StringArray `json:"fix_versions" gorm:"type:text[]"`
 	Components      pq.StringArray `json:"components" gorm:"type:text[]"`
 	URL             string         `json:"url"`
-	Tests           []Test         `json:"-" gorm:"many2many:bug_tests;"`
-	Jobs            []ProwJob      `json:"-" gorm:"many2many:bug_jobs;"`
+	Tests           []Test         `json:"-" gorm:"many2many:bug_tests;constraint:OnDelete:CASCADE;"`
+	Jobs            []ProwJob      `json:"-" gorm:"many2many:bug_jobs;constraint:OnDelete:CASCADE;"`
 }
 
 // ProwPullRequest represents a GitHub pull request, there can be multiple entries

--- a/pkg/db/models/releases.go
+++ b/pkg/db/models/releases.go
@@ -53,11 +53,11 @@ type ReleaseTag struct {
 	OSDiffURL string `json:"os_diff_url" gorm:"os_diff_url"`
 
 	// ReleasePullRequest contains a list of all the PR's in a release.
-	PullRequests []ReleasePullRequest `json:"-" gorm:"many2many:release_tag_pull_requests;"`
+	PullRequests []ReleasePullRequest `json:"-" gorm:"many2many:release_tag_pull_requests;constraint:OnDelete:CASCADE;"`
 
-	Repositories []ReleaseRepository `json:"-" gorm:"foreignKey:release_tag_id"`
+	Repositories []ReleaseRepository `json:"-" gorm:"foreignKey:release_tag_id;constraint:OnDelete:CASCADE;"`
 
-	JobRuns []ReleaseJobRun `json:"-" gorm:"foreignKey:release_tag_id"`
+	JobRuns []ReleaseJobRun `json:"-" gorm:"foreignKey:release_tag_id;constraint:OnDelete:CASCADE;"`
 
 	// RejectReason is category of failure for why the payload was rejected. Today this is manually assigned
 	// by TRT, and there is no guarantee it will always be set.

--- a/scripts/clear-constraints-for-cascading.sql
+++ b/scripts/clear-constraints-for-cascading.sql
@@ -14,5 +14,7 @@ ALTER TABLE "release_job_runs" DROP CONSTRAINT "fk_release_tags_job_runs";
 ALTER TABLE "release_repositories" DROP CONSTRAINT "fk_release_tags_repositories";
 
 ALTER TABLE "bug_jobs" DROP CONSTRAINT "fk_bug_jobs_bug";
+ALTER TABLE "bug_jobs" DROP CONSTRAINT "fk_bug_jobs_prow_job";
+ALTER TABLE "bug_tests" DROP CONSTRAINT "fk_bug_tests_test";
 ALTER TABLE "bug_tests" DROP CONSTRAINT "fk_bug_tests_bug";
 

--- a/scripts/clear-constraints-for-cascading.sql
+++ b/scripts/clear-constraints-for-cascading.sql
@@ -4,7 +4,6 @@
  * October 17, 2022. */
 ALTER TABLE "prow_job_runs" DROP CONSTRAINT "fk_prow_job_runs_prow_job";
 ALTER TABLE "prow_job_run_tests" DROP CONSTRAINT "fk_prow_job_runs_tests";
-ALTER TABLE "prow_job_run_tests" DROP CONSTRAINT "fk_prow_job_runs_tests";
 ALTER TABLE "prow_job_run_test_outputs" DROP CONSTRAINT "fk_prow_job_run_tests_prow_job_run_test_output";
 ALTER TABLE "prow_job_run_prow_pull_requests" DROP CONSTRAINT "fk_prow_job_run_prow_pull_requests_prow_job_run";
 ALTER TABLE "prow_job_run_prow_pull_requests" DROP CONSTRAINT "fk_prow_job_run_prow_pull_requests_prow_pull_request";

--- a/scripts/clear-constraints-for-cascading.sql
+++ b/scripts/clear-constraints-for-cascading.sql
@@ -1,0 +1,18 @@
+/* This drops the fk constraints on tables where
+ * we need to re-add them with OnDelete CASCADES. This is a one time
+ * operation that should be done manually on a database created prior to
+ * October 17, 2022. */
+ALTER TABLE "prow_job_runs" DROP CONSTRAINT "fk_prow_job_runs_prow_job";
+ALTER TABLE "prow_job_run_tests" DROP CONSTRAINT "fk_prow_job_runs_tests";
+ALTER TABLE "prow_job_run_tests" DROP CONSTRAINT "fk_prow_job_runs_tests";
+ALTER TABLE "prow_job_run_test_outputs" DROP CONSTRAINT "fk_prow_job_run_tests_prow_job_run_test_output";
+ALTER TABLE "prow_job_run_prow_pull_requests" DROP CONSTRAINT "fk_prow_job_run_prow_pull_requests_prow_job_run";
+ALTER TABLE "prow_job_run_prow_pull_requests" DROP CONSTRAINT "fk_prow_job_run_prow_pull_requests_prow_pull_request";
+
+ALTER TABLE "release_tag_pull_requests" DROP CONSTRAINT "fk_release_tag_pull_requests_release_tag";
+ALTER TABLE "release_job_runs" DROP CONSTRAINT "fk_release_tags_job_runs";
+ALTER TABLE "release_repositories" DROP CONSTRAINT "fk_release_tags_repositories";
+
+ALTER TABLE "bug_jobs" DROP CONSTRAINT "fk_bug_jobs_bug";
+ALTER TABLE "bug_tests" DROP CONSTRAINT "fk_bug_tests_bug";
+


### PR DESCRIPTION
[TRT-599](https://issues.redhat.com//browse/TRT-599)

Note: proposed process after merging is 1) scale openshift and kube sippys down, 2) run scripts/clear-constraints-for-cascading.sql, 3) wait for image to be rebuilt, 4) scale back up

When deleting a DB row that has relations, these are not automatically deleted and the foreign key constraints prevent you from actually deleting the row. We need to cascade the deletes, however gorm does not support patching constraints[1], therefore we have to delete them.

There's a one-time SQL script in scripts/ that we can run to clear the constraints, which gorm wil re-add back. I've tested this on a production database restore and it seems to do what I expect. We could write our own migrator, but it looks somewhat challenging, and this is probably a one-ish time thing.

[1] https://github.com/go-gorm/gorm/issues/5559#issuecomment-1200718658