### PR TITLE
Allow use of environment variables for sippy e2e test

### DIFF
--- a/test/e2e/util/e2erequest.go
+++ b/test/e2e/util/e2erequest.go
@@ -4,7 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
+	"os"
+	"strconv"
 )
 
 const (
@@ -17,7 +20,20 @@ const (
 )
 
 func buildURL(apiPath string) string {
-	return fmt.Sprintf("http://localhost:%d%s", APIPort, apiPath)
+	envSippyAPIPort := os.Getenv("SIPPY_API_PORT")
+	envSippyEndpoint := os.Getenv("SIPPY_ENDPOINT")
+
+	var port = APIPort
+	if len(envSippyAPIPort) > 0 {
+		val, err := strconv.Atoi(envSippyAPIPort)
+		if err == nil {
+			port = val
+		}
+	}
+	if len(envSippyEndpoint) == 0 {
+		envSippyEndpoint = "localhost"
+	}
+	return fmt.Sprintf("http://%s%s", net.JoinHostPort(envSippyEndpoint, strconv.Itoa(port)), apiPath)
 }
 
 func SippyRequest(path string, data interface{}) error {


### PR DESCRIPTION
This helps out [TRT-246](https://issues.redhat.com//browse/TRT-246) and let's us remove the sed in the sippy-e2e-commands.sh script in [this PR](https://github.com/openshift/release/pull/32818/files).

If no environment variables are set, you get the existing behavior.

If you do this, you will get to use those values:

```
export SIPPY_ENDPOINT=sippy-server-postgres.apps-crc.testing
export SIPPY_API_PORT=80
```