### PR TITLE
transient risk analysis

### DIFF
--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -15,6 +15,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	// maxFailuresToFullyAnalyze is a limit to the number of failures we'll attempt to
+	// individually analyze, if you exceed this the job failure is classified as high risk.
+	maxFailuresToFullyAnalyze = 20
+)
+
 func (runs apiRunResults) sort(req *http.Request) apiRunResults {
 	sortField := req.URL.Query().Get("sortField")
 	sort := apitype.Sort(req.URL.Query().Get("sort"))
@@ -90,14 +96,6 @@ func JobsRunsReportFromDB(dbc *db.DB, filterOpts *filter.FilterOptions, release 
 // risk level for each failed test, and the job run overall.
 func JobRunRiskAnalysis(dbc *db.DB, jobRun *models.ProwJobRun) (apitype.ProwJobRunRiskAnalysis, error) {
 
-	// TODO: load bugs for the job and it's failed tests
-	/*
-		jobBugs := []models.Bug{}
-		testBugs := []models.Bug{}
-		res := dbc.DB.Joins("Jobs", db.Where(&))
-
-	*/
-
 	// If this job is a Presubmit, compare to test results from master, not presubmits, which may perform
 	// worse due to dev code that hasn't merged. We do not presently track presubmits on branches other than
 	// master, so it should be safe to assume the latest compareRelease in the db.
@@ -115,13 +113,29 @@ func JobRunRiskAnalysis(dbc *db.DB, jobRun *models.ProwJobRun) (apitype.ProwJobR
 		compareRelease = ar[0].Release
 	}
 
+	// NOTE: we are including bugs for all releases, may want to filter here in future to just those
+	// with an AffectsVersions that seems to match our compareRelease?
+	jobBugs, err := query.LoadBugsForJobs(dbc, []int{int(jobRun.ProwJob.ID)}, true)
+	if err != nil {
+		return apitype.ProwJobRunRiskAnalysis{}, err
+	}
+	jobRun.ProwJob.Bugs = jobBugs
+
+	// Pre-load test bugs as well:
+	if len(jobRun.Tests) <= maxFailuresToFullyAnalyze {
+		for i, tr := range jobRun.Tests {
+			bugs, err := query.LoadBugsForTest(dbc, tr.Test.Name, true)
+			if err != nil {
+				return apitype.ProwJobRunRiskAnalysis{}, err
+			}
+			log.Infof("Found %d bugs for test %s", len(bugs), tr.Test.Name)
+			tr.Test.Bugs = bugs
+			jobRun.Tests[i] = tr
+		}
+	}
+
 	return runJobRunAnalysis(jobRun, compareRelease,
 		func(testName, release, suite string, variants []string) (*apitype.Test, error) {
-
-			logger := log.WithFields(log.Fields{
-				"func":     "testResultsFunc",
-				"jobRunID": jobRun.ID,
-			})
 
 			fil := &filter.Filter{
 				Items: []filter.FilterItem{
@@ -134,27 +148,20 @@ func JobRunRiskAnalysis(dbc *db.DB, jobRun *models.ProwJobRun) (apitype.ProwJobR
 				},
 				LinkOperator: "and",
 			}
-			logger.Infof("searching for results for release: %s and variants: %v", release, variants)
 			trs, _, err := BuildTestsResults(dbc, release, "default", false, false,
 				fil)
 			if err != nil {
 				return nil, err
 			}
-			logger.Infof("Got test results: %d", len(trs))
 			gosort.Strings(variants)
-			logger.Infof("sorted variants: %v", variants)
-			logger.Infof("suite: %s", suite)
 			for _, tr := range trs {
-				// TODO: this is a weird way to get the variant we want, but it allows re-use
+				// this is a weird way to get the variant we want, but it allows re-use
 				// of the existing code.
 				gosort.Strings(tr.Variants)
-				logger.Infof("sorted row variants: %v, suiteName: %s", tr.Variants, tr.SuiteName)
 				if stringSlicesEqual(variants, tr.Variants) && tr.SuiteName == suite {
-					logger.Infof("found our row!")
 					return &tr, nil
 				}
 			}
-			logger.Infof("unable to find a test results")
 
 			return nil, nil
 		})
@@ -171,15 +178,12 @@ func runJobRunAnalysis(jobRun *models.ProwJobRun, compareRelease string,
 		"jobRunID": jobRun.ID,
 	})
 
-	logger.WithField("url", jobRun.URL).Info("loaded prow job run for analysis")
+	logger.Info("loaded prow job run for analysis")
 	logger.Infof("this job run has %d failed tests", len(jobRun.Tests))
-	logger.WithField("variants", jobRun.ProwJob.Variants).Debug("job variants")
 
 	response := apitype.ProwJobRunRiskAnalysis{
 		ProwJobRunID: jobRun.ID,
 		ProwJobName:  jobRun.ProwJob.Name,
-		ProwJobURL:   jobRun.URL,
-		Timestamp:    jobRun.Timestamp,
 		Tests:        []apitype.ProwJobRunTestRiskAnalysis{},
 		OverallRisk: apitype.FailureRisk{
 			Level:   apitype.FailureRiskLevelNone,
@@ -198,7 +202,7 @@ func runJobRunAnalysis(jobRun *models.ProwJobRun, compareRelease string,
 		return response, nil
 
 	// Return early if we see mass test failures:
-	case len(jobRun.Tests) > 20:
+	case len(jobRun.Tests) > maxFailuresToFullyAnalyze:
 		response.OverallRisk.Level = apitype.FailureRiskLevelHigh
 		response.OverallRisk.Reasons = append(response.OverallRisk.Reasons,
 			fmt.Sprintf("%d tests failed in this run: High", len(jobRun.Tests)))
@@ -251,6 +255,7 @@ func runJobRunAnalysis(jobRun *models.ProwJobRun, compareRelease string,
 							jobRun.ProwJob.Variants),
 					},
 				},
+				OpenBugs: ft.Test.Bugs,
 			})
 		}
 	}

--- a/pkg/api/job_runs_test.go
+++ b/pkg/api/job_runs_test.go
@@ -179,7 +179,7 @@ func buildFakeProwJobRun() *models.ProwJobRun {
 	return fakeProwJobRun
 }
 
-func getTestRisk(result apitype.ProwJobRunFailureAnalysis, testName string) *apitype.ProwJobRunTestFailureAnalysis {
+func getTestRisk(result apitype.ProwJobRunRiskAnalysis, testName string) *apitype.ProwJobRunTestRiskAnalysis {
 	for _, ta := range result.Tests {
 		if ta.Name == testName {
 			return &ta

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -691,8 +691,6 @@ type JobAnalysisResult struct {
 type ProwJobRunRiskAnalysis struct {
 	ProwJobName  string
 	ProwJobRunID uint
-	ProwJobURL   string
-	Timestamp    time.Time
 	Tests        []ProwJobRunTestRiskAnalysis
 	OverallRisk  FailureRisk
 	OpenBugs     []models.Bug

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -688,17 +688,17 @@ type JobAnalysisResult struct {
 	ByPeriod map[string]AnalysisResult `json:"by_period"`
 }
 
-type ProwJobRunFailureAnalysis struct {
+type ProwJobRunRiskAnalysis struct {
 	ProwJobName  string
 	ProwJobRunID uint
 	ProwJobURL   string
 	Timestamp    time.Time
-	Tests        []ProwJobRunTestFailureAnalysis
+	Tests        []ProwJobRunTestRiskAnalysis
 	OverallRisk  FailureRisk
 	OpenBugs     []models.Bug
 }
 
-type ProwJobRunTestFailureAnalysis struct {
+type ProwJobRunTestRiskAnalysis struct {
 	Name     string
 	Risk     FailureRisk
 	OpenBugs []models.Bug

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -726,9 +726,9 @@ func (s *Server) jsonJobRunsReportFromDB(w http.ResponseWriter, req *http.Reques
 	api.RespondWithJSON(http.StatusOK, w, result)
 }
 
-// jsonJobRunAnalysis is an API to make a guess at the severity of failures in a prow job run, based on historical
+// jsonJobRunRiskAnalysis is an API to make a guess at the severity of failures in a prow job run, based on historical
 // pass rates for each failed test, on-going incidents, and other factors.
-func (s *Server) jsonJobRunAnalysis(w http.ResponseWriter, req *http.Request) {
+func (s *Server) jsonJobRunRiskAnalysis(w http.ResponseWriter, req *http.Request) {
 
 	jobRunIDStr := req.URL.Query().Get("prow_job_run_id")
 	if jobRunIDStr == "" {
@@ -742,7 +742,7 @@ func (s *Server) jsonJobRunAnalysis(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	result, err := api.JobRunAnalysis(s.db, jobRunID)
+	result, err := api.JobRunRiskAnalysis(s.db, jobRunID)
 	if err != nil {
 		api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": err.Error()})
 		return
@@ -833,7 +833,7 @@ func (s *Server) Serve() {
 	serveMux.HandleFunc("/api/autocomplete/", s.jsonAutocompleteFromDB)
 	serveMux.HandleFunc("/api/jobs", s.jsonJobsReportFromDB)
 	serveMux.HandleFunc("/api/jobs/runs", s.jsonJobRunsReportFromDB)
-	serveMux.HandleFunc("/api/jobs/runs/analysis", s.jsonJobRunAnalysis)
+	serveMux.HandleFunc("/api/jobs/runs/risk_analysis", s.jsonJobRunRiskAnalysis)
 	serveMux.HandleFunc("/api/jobs/analysis", s.jsonJobsAnalysisFromDB)
 	serveMux.HandleFunc("/api/jobs/details", s.jsonJobsDetailsReportFromDB)
 	serveMux.HandleFunc("/api/jobs/bugs", s.jsonJobBugsFromDB)

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -451,7 +451,7 @@ func (s *Server) jsonTestBugsFromDB(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	bugs, err := query.LoadBugsForTest(s.db, testName)
+	bugs, err := query.LoadBugsForTest(s.db, testName, false)
 	if err != nil {
 		log.WithError(err).Error("error querying test bugs from db")
 		api.RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{
@@ -491,7 +491,7 @@ func (s *Server) jsonJobBugsFromDB(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	bugs, err := query.LoadBugsForJobs(s.db, jobIDs)
+	bugs, err := query.LoadBugsForJobs(s.db, jobIDs, false)
 	if err != nil {
 		log.WithError(err).Error("error querying job bugs from db")
 		api.RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -728,21 +729,65 @@ func (s *Server) jsonJobRunsReportFromDB(w http.ResponseWriter, req *http.Reques
 
 // jsonJobRunRiskAnalysis is an API to make a guess at the severity of failures in a prow job run, based on historical
 // pass rates for each failed test, on-going incidents, and other factors.
+//
+// This API can be called in two ways, a GET with a prow_job_run_id query param, or a POST with a
+// partial ProwJobRun struct serialized as json in the request body. The GET version will return the
+// stored analysis for the job when it was imported into sippy. The POST version is a transient
+// request to be used when sippy has not yet imported the job, but we wish to analyze the failure risk.
+// Soon, we expecct the POST version is called from CI to get a risk analysis json result, which will
+// be stored in the job run artifacts, then imported with the job run, and will ultimately be the
+// data that is returned by the GET version.
 func (s *Server) jsonJobRunRiskAnalysis(w http.ResponseWriter, req *http.Request) {
 
-	jobRunIDStr := req.URL.Query().Get("prow_job_run_id")
-	if jobRunIDStr == "" {
-		api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": "prow_job_run_id parameter required"})
+	jobRun := &models.ProwJobRun{}
+
+	switch req.Method {
+	case "GET":
+		jobRunIDStr := req.URL.Query().Get("prow_job_run_id")
+		if jobRunIDStr == "" {
+			api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": "prow_job_run_id parameter required"})
+			return
+		}
+
+		jobRunID, err := strconv.ParseInt(jobRunIDStr, 10, 64)
+		if err != nil {
+			api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": "unable to parse prow_job_run_id: " + err.Error()})
+			return
+		}
+
+		// Load the ProwJobRun, ProwJob, and failed tests:
+		// TODO: we may want to expand to analyzing flakes here in the future
+		res := s.db.DB.Joins("ProwJob").
+			Preload("Tests", "status = 12").
+			Preload("Tests.Test").
+			Preload("Tests.Suite").First(jobRun, jobRunID)
+		if res.Error != nil {
+			api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": res.Error.Error()})
+			return
+		}
+		// TODO: post implies a create, maybe we should just use GET with body or not
+	case "POST":
+		err := json.NewDecoder(req.Body).Decode(&jobRun)
+		if err != nil {
+			api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": fmt.Sprintf("error decoding prow job run json in request body: %s", err)})
+			return
+		}
+		// We don't expect the caller to fully populate the ProwJob, just it's name, so
+		// override the input by looking up the actual ProwJob by name so we have access to release and variants.
+		job := &models.ProwJob{}
+		res := s.db.DB.Where("name = ?", jobRun.ProwJob.Name).First(&job)
+		if res.Error != nil {
+			api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": fmt.Sprintf("unable to find ProwJob: %s", jobRun.ProwJob.Name)})
+			return
+		}
+		jobRun.ProwJob = *job
+	default:
+		api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": fmt.Sprintf("unsupported http request for this api: %s", req.Method)})
 		return
 	}
 
-	jobRunID, err := strconv.ParseInt(jobRunIDStr, 10, 64)
-	if err != nil {
-		api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": "unable to parse prow_job_run_id: " + err.Error()})
-		return
-	}
-
-	result, err := api.JobRunRiskAnalysis(s.db, jobRunID)
+	log.Infof("job run = %+v", *jobRun)
+	result, err := api.JobRunRiskAnalysis(s.db, jobRun)
 	if err != nil {
 		api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": err.Error()})
 		return


### PR DESCRIPTION
- Rename API to risk_analysis for clarity.
- Working POST requests for transient risk analysis of jobs we don't have.
- Hookup bug data for transient risk analysis requests.
- Stick to GET instead of POST.
