### PR TITLE
Get sippy ready for 4.13

### DIFF
--- a/resources/deploymentconfig.yaml
+++ b/resources/deploymentconfig.yaml
@@ -46,6 +46,10 @@ spec:
         - --local-data
         - /data
         - --release
+        - "4.13"
+        - --release
+        - "4.12"
+        - --release
         - "4.11"
         - --release
         - "4.10"

--- a/scripts/fetchdata-testgrid.sh
+++ b/scripts/fetchdata-testgrid.sh
@@ -7,10 +7,10 @@ sleep 600 # 10 minutes
 while [ true ]; do
   echo "Fetching new testgrid data"
   rm -rf /data/*
-  /bin/sippy --log-level debug --fetch-data /data --fetch-openshift-perfscale-data --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10 --release 4.11 --release 4.12
+  /bin/sippy --log-level debug --fetch-data /data --fetch-openshift-perfscale-data --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10 --release 4.11 --release 4.12 --release 4.13
   echo "Loading database"
   # Bug lookup skipped, we're struggling with the number of tests, and moving to Jira soon.
-  /bin/sippy --mode=ocp --log-level debug --load-database --local-data /data --skip-bug-lookup --arch amd64 --arch arm64 --arch multi --arch s390x --arch ppc64le --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10 --release 4.11 --release 4.12
+  /bin/sippy --mode=ocp --log-level debug --load-database --local-data /data --skip-bug-lookup --arch amd64 --arch arm64 --arch multi --arch s390x --arch ppc64le --release 3.11 --release 4.6 --release 4.7 --release 4.8 --release 4.9 --release 4.10 --release 4.11 --release 4.12 --release 4.13
   echo "Done fetching data, refreshing server"
   curl localhost:8080/refresh
   echo "Done refreshing data, sleeping"

--- a/scripts/fetchdata.sh
+++ b/scripts/fetchdata.sh
@@ -18,6 +18,7 @@ while [ true ]; do
     --release 4.10 \
     --release 4.11 \
     --release 4.12 \
+    --release 4.13 \
     --release Presubmits \
     --arch amd64 \
     --arch arm64 \


### PR DESCRIPTION
Regarding TRT-648.

I wonder if deploymentconfig.yaml is used because the one in [continuous-release-jobs repo](https://github.com/openshift/continuous-release-jobs/blob/ad0c0f453828ddbd5a96a55bcbd38a0b0e67b1ea/config/clusters/dpcr/services/sippy/deploymentconfig.yaml) seems the be the in use when we deploy on the DPCR cluster.  I include it in this PR and if it makes sense to delete it, I will.

this PR is related: https://github.com/openshift/continuous-release-jobs/pull/1237