### PR TITLE
Add index on timestamp by date

### DIFF
--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -21,7 +21,7 @@ type ProwJob struct {
 	Kind        ProwKind
 	Name        string         `gorm:"unique"`
 	Release     string         `gorm:"varchar(10)"`
-	Variants    pq.StringArray `gorm:"type:text[]"`
+	Variants    pq.StringArray `gorm:"index;type:text[]"`
 	TestGridURL string
 	Bugs        []Bug        `gorm:"many2many:bug_jobs;"`
 	JobRuns     []ProwJobRun `gorm:"constraint:OnDelete:CASCADE;"`
@@ -55,7 +55,7 @@ type ProwJobRun struct {
 	// KnownFailure is true if the job run failed, but we found a bug that is likely related already filed.
 	KnownFailure  bool
 	Succeeded     bool
-	Timestamp     time.Time `gorm:"index"`
+	Timestamp     time.Time `gorm:"index;index:idx_prow_job_runs_timestamp_date,expression:DATE(timestamp AT TIME ZONE 'UTC')"`
 	Duration      time.Duration
 	OverallResult v1.JobOverallResult `gorm:"index"`
 }

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -279,8 +279,13 @@ func TestDurations(dbc *db.DB, release, test string, includedVariants, excludedV
 		q = q.Where("NOT ? = any(prow_jobs.variants)", variant)
 	}
 
-	res := q.Select("prow_job_runs.timestamp::date as period, AVG(prow_job_run_tests.duration) as average_duration").
-		Group("prow_job_runs.timestamp::date").Order("prow_job_runs.timestamp::date").Scan(&rows)
+	res := q.
+		Select(`
+			date("timestamp" AT TIME ZONE 'UTC'::text) as period,
+			AVG(prow_job_run_tests.duration) as average_duration`).
+		Group(`date("timestamp" AT TIME ZONE 'UTC'::text)`).
+		Order(`date("timestamp" AT TIME ZONE 'UTC'::text)`).
+		Scan(&rows)
 
 	for _, row := range rows {
 		results[row.Period.Format("2006-01-02")] = row.AverageDuration


### PR DESCRIPTION
This speeds up the durations API by indexing prow job runs on the date contained in a time stamp.  See https://gist.github.com/cobusc/5875282

Without this index:
```
 Planning Time: 2.047 ms
 Execution Time: 14451.498 ms
```

With the index:
```
 Planning Time: 2.768 ms
 Execution Time: 12.823 ms
```