### PR TITLE
Be able to run sippy-e2e locally from sippy repo

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -163,3 +163,30 @@ This runs as a presubmit on the repo, but developers can also run locally if the
 ```bash
 GCS_SA_JSON_PATH=~/creds/openshift-ci-data-analysis.json make e2e
 ```
+
+## Running the sippy e2e tests
+
+The sippy e2e tests run in
+[prow](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-openshift-sippy-master-e2e)
+as part of CI using the [scripts](e2e-scripts) in this repo.
+
+You can also run them locally using your own Kubernetes cluster.  These Kubernetes types have been tested:
+
+* [Minikube](https://minikube.sigs.k8s.io/docs/) on MacOS and Linux
+* [K3s](https://k3s.io/) on Linux
+* [Redhat Openshift Local](https://developers.redhat.com/products/openshift-local/overview)
+
+Setup you Kubernetes cluster, login, set context to your Kubernetes cluster, and run the
+[run-e2e.sh](e2e-scripts/run-e2e.sh) script like this:
+
+```
+  SIPPY_IMAGE=quay.io/username/sippy BIG_QUERY_CRED=/path/to/cred.json e2e-scripts/run-e2e.sh
+```
+
+Include and set the `DOCKERCONFIGJSON` variable appropriately if using a private container registry.
+
+To skip the `docker build` and `docker push` steps, set `SKIP_BUILD=1' like this:
+
+```
+  SIPPY_IMAGE=quay.io/username/sippy BIG_QUERY_CRED=/path/to/cred.json SKIP_BUILD=1 e2e-scripts/run-e2e.sh
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ COPY --from=builder /go/src/sippy/scripts/fetchdata.sh /bin/fetchdata.sh
 COPY --from=builder /go/src/sippy/scripts/fetchdata-testgrid.sh /bin/fetchdata-testgrid.sh
 COPY --from=builder /go/src/sippy/scripts/fetchdata-kube.sh /bin/fetchdata-kube.sh
 COPY --from=builder /go/src/sippy/historical-data /historical-data/
-COPY --from=builder /go/src/sippy/config/*.yaml /config
+COPY --from=builder /go/src/sippy/config/*.yaml /config/
 ENTRYPOINT ["/bin/sippy"]
 EXPOSE 8080

--- a/e2e-scripts/run-e2e.sh
+++ b/e2e-scripts/run-e2e.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Use this script for running the sippy-e2e tests locally.
+# Examples:
+#
+#   When using a private registry (where auth.json is one of ~/.docker/config.json for Docker or
+#   ${XDG_RUNTIME_DIR}/containers/auth.json for Podman):
+#     SIPPY_IMAGE=quay.io/username/sippy BIG_QUERY_CRED=/path/to/cred.json DOCKERCONFIGJSON=auth.json e2e-scripts/run-e2e.sh
+#
+#   When using a public registry (where authentication is not needed):
+#     SIPPY_IMAGE=quay.io/username/sippy BIG_QUERY_CRED=/path/to/cred.json e2e-scripts/run-e2e.sh
+
+# Print out the current kube context
+echo "The cluster context is: $(kubectl config current-context)"
+
+# The sippy executable needs to be in a container image; set SIPPY_IMAGE that the image spec.
+if [ -z ${SIPPY_IMAGE} ]; then
+  echo "Aborting: Set SIPPY_IMAGE to a valid image pull spec."
+  echo "  Example: SIPPY_IMAGE=quay.io/username/sippy:1.0"
+  exit 1
+fi
+
+# Big query credentials should be read-only for safety.
+if [ -z ${BIG_QUERY_CRED} ]; then
+  echo "Aborting: Set BIG_QUERY_CRED to a valid filespec where your big query read-only credentials are located."
+  echo "  Example: BIG_QUERY_CRED=/path/to/bigquery-readonly.json"
+  exit 1
+fi
+
+if [ ! -f ${BIG_QUERY_CRED} ]; then
+  echo "Aborting: Missing Big Query credentials file; file not found: ${BIG_QUERY_CRED}"
+fi
+
+# The artifacts directory is for logs and can be any directory you have access to.
+export ARTIFACT_DIR="${ARTIFACT_DIR:=/tmp/sippy_artifacts}"
+mkdir -p $ARTIFACT_DIR
+
+if [ -z ${DOCKERCONFIGJSON} ]; then
+  # Create an empty registry auth file in case we're using public container images that
+  # don't need authentication.
+  echo "DOCKERCONFIGJSON is not set; assuming public container image registry"
+  echo '{ "auths": {} }' > /tmp/empty_auth.json
+  export DOCKERCONFIGJSON=/tmp/empty_auth.json
+fi
+echo "DOCKERCONFIGJSON: ${DOCKERCONFIGJSON}"
+if [ ! -f ${DOCKERCONFIGJSON} ]; then
+  echo "Aborting: File does not exist: ${DOCKERCONFIGJSON}"
+  exit 1
+fi
+
+if [ -z ${SKIP_BUILD} ]; then
+  SKIP_BUILD=0
+fi
+
+# Ensure you have kubectl and that it's installed and on your path
+export KUBECTL_CMD=kubectl
+
+set -euo pipefail
+
+if [ $(${KUBECTL_CMD} get ns|grep postgres|wc -l) -gt 0 ]; then
+  ${KUBECTL_CMD} delete ns postgres
+fi
+
+if [[ ${SKIP_BUILD} == "1" ]]; then
+  echo "Skipping build"
+else
+  echo "Building docker image for ${SIPPY_IMAGE} .."
+  docker build -t ${SIPPY_IMAGE} .
+  echo "Pushing docker image for ${SIPPY_IMAGE} .."
+  docker push ${SIPPY_IMAGE}
+fi
+
+e2e-scripts/sippy-e2e-sippy-e2e-setup-commands.sh
+e2e-scripts/sippy-e2e-sippy-e2e-test-commands.sh
+
+# Cleanup as needed
+${KUBECTL_CMD} delete ns postgres

--- a/e2e-scripts/sippy-e2e-sippy-e2e-setup-commands.sh
+++ b/e2e-scripts/sippy-e2e-sippy-e2e-setup-commands.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+
+# In Prow CI, SIPPY_IMAGE variable is defined in the sippy-e2e-ref.yaml file as a
+# dependency so that the pipeline:sippy image (containing the sippy binary)
+# will be available to start the sippy-load and sippy-server pods.
+# When running locally, the user has to define SIPPY_IMAGE.
+echo "The sippy CI image: ${SIPPY_IMAGE}"
+
+# The BIG_QUERY_CRED is so you login to Big Query.
+# Redefine BIG_QUERY_CRED to use your own.
+BIG_QUERY_CRED="${BIG_QUERY_CRED:=/var/run/sippy-ci-gcs-sa/gcs-sa}"
+echo "The Big Query cred is: ${BIG_QUERY_CRED}"
+
+# If you're using Openshift, we use oc, if you're using plain Kubernetes,
+# we use kubectl.
+#
+KUBECTL_CMD="${KUBECTL_CMD:=oc}"
+echo "The kubectl command is: ${KUBECTL_CMD}"
+
+echo "The Docker config.json is: ${DOCKERCONFIGJSON}"
+
+is_ready=0
+echo "Waiting for cluster-pool cluster to be usable ..."
+
+e2e_pause() {
+  if [ -z $OPENSHIFT_CI ]; then
+    return
+  fi
+
+  # In prow, we need these sleeps to keep things consistent -- TODO: we need to figure out why.
+  echo "Sleeping 30 seconds ..."
+  sleep 30
+}
+
+# We need this for Linux version of base64 to suppress the line breaks.
+BASE64_OPTION="-w0"
+if [[ "${OSTYPE}" == "darwin"* ]]; then
+  # On MacOS, the -w0 option is an error.
+  BASE64_OPTION=""
+fi
+
+set +e
+# We don't want to exit on timeouts if the cluster we got was not quite ready yet.
+for i in `seq 1 20`; do
+  echo -n "${i})"
+  e2e_pause
+  echo "Checking cluster nodes"
+  ${KUBECTL_CMD} get node
+  if [ $? -eq 0 ]; then
+    echo "Cluster looks ready"
+    is_ready=1
+    break
+  fi
+  echo "Cluster-pool cluster not ready yet ..."
+done
+set -e
+
+# This should be set to the KUBECONFIG for the cluster claimed from the cluster-pool.
+echo "KUBECONFIG=${KUBECONFIG}"
+
+echo "Showing kube context"
+${KUBECTL_CMD} config current-context
+
+if [ $is_ready -eq 0 ]; then
+  echo "Cluster never became ready aborting"
+  exit 1
+fi
+
+e2e_pause
+
+echo "Checking for presense of GCS credentials ..."
+if [ -f ${BIG_QUERY_CRED} ]; then
+  ls -l ${BIG_QUERY_CRED}
+else
+  echo "Aborting: Big Query credential file ${BIG_QUERY_CRED} not found"
+  exit 1
+fi
+
+echo "Starting postgres on cluster-pool cluster..."
+
+# Make the "postgres" namespace and pod.
+cat << END | ${KUBECTL_CMD} apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: postgres
+  labels:
+    openshift.io/run-level: "0"
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+END
+
+e2e_pause
+
+cat << END | ${KUBECTL_CMD} apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: postg1
+  namespace: postgres
+  labels:
+    app: postgres
+spec:
+  volumes:
+    - name: postgredb
+      emptyDir: {}
+  containers:
+  - name: postgres
+    image: quay.io/enterprisedb/postgresql
+    ports:
+    - containerPort: 5432
+    env:
+    - name: POSTGRES_PASSWORD
+      value: password
+    - name: POSTGRESQL_DATABASE
+      value: postgres
+    volumeMounts:
+      - mountPath: /var/lib/postgresql/data
+        name: postgredb
+    securityContext:
+      privileged: false
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+      runAsUser: 3
+      seccompProfile:
+        type: RuntimeDefault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: postgres
+  name: postgres
+  namespace: postgres
+spec:
+  ports:
+  - name: postgres
+    port: 5432
+    protocol: TCP
+  selector:
+    app: postgres
+END
+
+echo "Waiting for postgres pod to be Ready ..."
+
+# We set +e to avoid the script aborting before we can retrieve logs.
+set +e
+TIMEOUT=120s
+echo "Waiting up to ${TIMEOUT} for the postgres to come up..."
+${KUBECTL_CMD} -n postgres wait --for=condition=Ready pod/postg1 --timeout=${TIMEOUT}
+retVal=$?
+set -e
+echo
+echo "Saving postgres logs ..."
+${KUBECTL_CMD} -n postgres logs postg1 > ${ARTIFACT_DIR}/postgres.log
+if [ ${retVal} -ne 0 ]; then
+  echo "Postgres pod never came up"
+  exit 1
+fi
+
+${KUBECTL_CMD} -n postgres get po -o wide
+${KUBECTL_CMD} -n postgres get svc,ep
+
+# Get the gcs credentials out to the cluster-pool cluster.
+# These credentials are in vault and maintained by the TRT team (e.g. for updates and rotations).
+# See https://vault.ci.openshift.org/ui/vault/secrets/kv/show/selfservice/technical-release-team/sippy-ci-gcs-read-sa
+cat << END | sed s/CONTENT/"$(cat ${BIG_QUERY_CRED} |base64 ${BASE64_OPTION})"/| ${KUBECTL_CMD} apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gcs-cred
+  namespace: postgres
+data:
+  openshift-ci-data-analysis-ro: CONTENT
+END
+
+# Get the registry credentials for all build farm clusters out to the cluster-pool cluster.
+${KUBECTL_CMD} -n postgres create secret generic regcred --from-file=.dockerconfigjson=${DOCKERCONFIGJSON} --type=kubernetes.io/dockerconfigjson
+
+# Make the "sippy loader" pod.
+cat << END | ${KUBECTL_CMD} apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sippy-load-job
+  namespace: postgres
+spec:
+  template:
+    spec:
+      containers:
+      - name: sippy
+        image: ${SIPPY_IMAGE}
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 2G
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        command:  ["/bin/sh", "-c"]
+        args:
+          - /bin/sippy --load-database --log-level=debug --load-prow=true --load-testgrid=false --release 4.7 --database-dsn=postgresql://postgres:password@postgres.postgres.svc.cluster.local:5432/postgres --mode=ocp --config ./config/openshift.yaml --google-service-account-credential-file /tmp/secrets/openshift-ci-data-analysis-ro
+        env:
+        - name: GCS_SA_JSON_PATH
+          value: /tmp/secrets/openshift-ci-data-analysis-ro
+        volumeMounts:
+        - mountPath: /tmp/secrets
+          name: gcs-cred
+          readOnly: true
+      imagePullSecrets:
+      - name: regcred
+      volumes:
+        - name: gcs-cred
+          secret:
+            secretName: gcs-cred
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  backoffLimit: 1
+END
+
+date
+echo "Waiting for sippy loader job to finish ..."
+${KUBECTL_CMD} -n postgres get job sippy-load-job
+${KUBECTL_CMD} -n postgres describe job sippy-load-job
+
+# We set +e to avoid the script aborting before we can retrieve logs.
+set +e
+# This takes under 3 minutes so 5 minutes (300 seconds) should be plenty.
+TIMEOUT=300s
+echo "Waiting up to ${TIMEOUT} for the sippy-load-job to complete..."
+${KUBECTL_CMD} -n postgres wait --for=condition=complete job/sippy-load-job --timeout ${TIMEOUT}
+retVal=$?
+set -e
+
+job_pod=$(${KUBECTL_CMD} -n postgres get pod --selector=job-name=sippy-load-job --output=jsonpath='{.items[0].metadata.name}')
+${KUBECTL_CMD} -n postgres logs ${job_pod} > ${ARTIFACT_DIR}/sippy-load.log
+
+if [ ${retVal} -ne 0 ]; then
+  echo "sippy loading never finished on time."
+  exit 1
+fi
+
+date

--- a/e2e-scripts/sippy-e2e-sippy-e2e-test-commands.sh
+++ b/e2e-scripts/sippy-e2e-sippy-e2e-test-commands.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# In Prow CI, SIPPY_IMAGE variable is defined in the sippy-e2e-ref.yaml file as a
+# dependency so that the pipeline:sippy image (containing the sippy binary)
+# will be available to start the sippy-load and sippy-server pods.
+# When running locally, the user has to define SIPPY_IMAGE.
+echo "The sippy CI image: ${SIPPY_IMAGE}"
+
+# If you're using Openshift, we use oc, if you're using plain Kubernetes,
+# we use kubectl.
+#
+KUBECTL_CMD="${KUBECTL_CMD:=oc}"
+echo "The kubectl command is: ${KUBECTL_CMD}"
+
+# Launch the sippy api server pod.
+cat << END | ${KUBECTL_CMD} apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sippy-server
+  namespace: postgres
+  labels:
+    app: sippy-server
+spec:
+  containers:
+  - name: sippy-server
+    image: ${SIPPY_IMAGE}
+    imagePullPolicy: Always
+    ports:
+    - name: www
+      containerPort: 8080
+      protocol: TCP
+    - name: metrics
+      containerPort: 12112
+      protocol: TCP
+    readinessProbe:
+      exec:
+        command:
+        - echo
+        - "Wait for a short time"
+      initialDelaySeconds: 10
+    resources:
+      limits:
+        memory: 2G
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    command:
+    - /bin/sippy
+    args:
+    - --server
+    - --listen
+    - ":8080"
+    - --listen-metrics
+    -  ":12112"
+    - --local-data
+    -  /opt/sippy-testdata
+    - --database-dsn=postgresql://postgres:password@postgres.postgres.svc.cluster.local:5432/postgres
+    - --log-level
+    - debug
+    - --mode
+    - ocp
+  imagePullSecrets:
+  - name: regcred
+  dnsPolicy: ClusterFirst
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  terminationGracePeriodSeconds: 30
+END
+
+# The basic readiness probe will give us at least 10 seconds before declaring the pod as ready.
+echo "Waiting for sippy api server pod to be Ready ..."
+${KUBECTL_CMD} -n postgres wait --for=condition=Ready pod/sippy-server --timeout=30s
+
+is_ready=0
+for i in `seq 1 20`; do
+  c=$(${KUBECTL_CMD} -n postgres logs sippy-server|grep "Refresh complete"|wc -l)
+  if [ $c -eq 1 ]; then
+    echo "sippy server is ready."
+    is_ready=1
+    break
+  fi
+  echo "sippy server pod not ready yet ..."
+  echo "${i} Sleeping 30s ..."
+  sleep 30
+done
+if [ $is_ready -eq 0 ]; then
+  echo "sippy server didn't become ready in time."
+  exit 1
+fi
+
+${KUBECTL_CMD} -n postgres get pod -o wide
+${KUBECTL_CMD} -n postgres logs sippy-server > ${ARTIFACT_DIR}/sippy-server.log
+
+echo "Setup services and port forwarding for the sippy api server ..."
+set -x
+
+function cleanup() {
+  echo "Cleaning up port forward"
+  pf_job=$(jobs -p)
+  kill ${pf_job} && wait
+  echo "Port forward is cleaned up"
+}
+trap cleanup EXIT
+
+# Create the Kubernetes service for the sippy-server pod
+# Setup port forward for port 18080 to get to the sippy-server pod
+${KUBECTL_CMD} -n postgres expose pod sippy-server
+${KUBECTL_CMD} -n postgres port-forward pod/sippy-server 8080:8080 &
+SIPPY_API_PORT=8080
+export SIPPY_API_PORT
+
+${KUBECTL_CMD} -n postgres get svc,ep
+
+${KUBECTL_CMD} -n postgres delete secret regcred
+
+go test ./test/e2e/ -v


### PR DESCRIPTION
Re: [TRT-638](https://issues.redhat.com//browse/TRT-638)

* The trailing `/` on Dockerfile was needed because `minikube image build` fails on it missing.
* The `sippy-e2e-*-command.sh` scripts are pulled from the version in [this PR](https://github.com/openshift/release/pull/33653) where they have been tested in prow.
* `run-e2e.sh` is introduced to make is easier to run the scripts locally.

This will do nothing with CI unless this [release PR](https://github.com/openshift/release/pull/33694) merges. 