### PR TITLE
Move lint to container for consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test: builddir npm
 	LANG=en_US.utf-8 LC_ALL=en_US.utf-8 cd sippy-ng; CI=true npm test -- --coverage
 
 lint: builddir npm
-	golangci-lint run ./...
+	./hack/go-lint.sh run ./...
 	cd sippy-ng; npx eslint .
 
 npm:

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# If CI is true, run golangci-lint directly. If we're on a developer's
+# local machine, run golangci-lint from a container so we're ensuring
+# a consistent environment.
+
+set -ex
+
+if [ "$CI" = "true" ];
+then
+  golangci-lint "${@}"
+else
+  DOCKER=${DOCKER:-podman}
+
+  if ! which "$DOCKER" > /dev/null 2>&1;
+  then
+    echo "$DOCKER not found, please install."
+    exit 1
+  fi
+
+  $DOCKER run --rm \
+    --volume "${PWD}:/go/src/github.com/openshift/sippy:z" \
+    --workdir /go/src/github.com/openshift/sippy \
+    docker.io/golangci/golangci-lint:v1.45 \
+    golangci-lint "${@}"
+fi


### PR DESCRIPTION
Local developers may have various different versions of go and golangci-lint installed. For consistency, we should run it from a container that matches the versions used in CI.

This does require a user to have working rootless containers on their machine.