### PR TITLE
risk analysis fixes

### DIFF
--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -182,10 +182,11 @@ func runJobRunAnalysis(jobRun *models.ProwJobRun, compareRelease string,
 	logger.Infof("this job run has %d failed tests", len(jobRun.Tests))
 
 	response := apitype.ProwJobRunRiskAnalysis{
-		ProwJobRunID: jobRun.ID,
-		ProwJobName:  jobRun.ProwJob.Name,
-		Release:      jobRun.ProwJob.Release,
-		Tests:        []apitype.ProwJobRunTestRiskAnalysis{},
+		ProwJobRunID:   jobRun.ID,
+		ProwJobName:    jobRun.ProwJob.Name,
+		Release:        jobRun.ProwJob.Release,
+		CompareRelease: compareRelease,
+		Tests:          []apitype.ProwJobRunTestRiskAnalysis{},
 		OverallRisk: apitype.FailureRisk{
 			Level:   apitype.FailureRiskLevelNone,
 			Reasons: []string{},

--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -225,7 +225,8 @@ func runJobRunAnalysis(jobRun *models.ProwJobRun, compareRelease string,
 		if err != nil {
 			return response, err
 		}
-		if testResult != nil {
+		// Watch out for tests that ran in previous period, but not current, no sense comparing to 0 runs:
+		if testResult != nil && testResult.CurrentRuns > 0 {
 			testRiskLvl := getSeverityLevelForPassRate(testResult.CurrentPassPercentage)
 			if testRiskLvl.Level >= response.OverallRisk.Level.Level {
 				response.OverallRisk.Level = testRiskLvl

--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/filter"
+	"github.com/openshift/sippy/pkg/testidentification"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -216,6 +217,12 @@ func runJobRunAnalysis(jobRun *models.ProwJobRun, compareRelease string,
 	// Iterate each failed test, query it's pass rates by NURPs, find a matching variant combo, and
 	// see how often we've passed in the last week.
 	for _, ft := range jobRun.Tests {
+
+		if ft.Test.Name == testidentification.OpenShiftTestsName {
+			// This can be quite misleading
+			continue
+		}
+
 		logger.WithFields(log.Fields{
 			"name": ft.Test.Name,
 		}).Debug("failed test")

--- a/pkg/api/job_runs_test.go
+++ b/pkg/api/job_runs_test.go
@@ -127,6 +127,7 @@ func TestRunJobAnalysis(t *testing.T) {
 			testResultsLookupFunc := func(testName, release, suite string, variants []string) (*apitype.Test, error) {
 				for _, tpr := range tc.testPassRates {
 					if tpr.Name == testName && tpr.CurrentPassPercentage > 0 {
+						tpr.CurrentRuns = 100
 						return &tpr, nil
 					}
 				}

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -700,12 +700,13 @@ type TestOutput struct {
 }
 
 type ProwJobRunRiskAnalysis struct {
-	ProwJobName  string
-	ProwJobRunID uint
-	Release      string
-	Tests        []ProwJobRunTestRiskAnalysis
-	OverallRisk  FailureRisk
-	OpenBugs     []models.Bug
+	ProwJobName    string
+	ProwJobRunID   uint
+	Release        string
+	CompareRelease string
+	Tests          []ProwJobRunTestRiskAnalysis
+	OverallRisk    FailureRisk
+	OpenBugs       []models.Bug
 }
 
 type ProwJobRunTestRiskAnalysis struct {


### PR DESCRIPTION
[TRT-679](https://issues.redhat.com//browse/TRT-679)

- Add CompareRelease field to risk analysis API
- risk analysis: Treat 0 runs the same as no results
- risk analysis: skip openshift-tests should work
