### PR TITLE
Add sql queries for aggregating most common backstop issues

### DIFF
--- a/scripts/sql/find-job-runs-with-alert.sql
+++ b/scripts/sql/find-job-runs-with-alert.sql
@@ -1,0 +1,32 @@
+SELECT
+    r.timestamp,
+    md.metadata->>'alert' AS "alert",
+    md.metadata->>'namespace' AS "namespace",
+    md.metadata->>'result' AS "result",
+    r.test_failures,
+    r.url
+FROM
+    prow_job_run_test_output_metadata md,
+    prow_job_run_test_outputs o,
+    prow_job_run_tests rt,
+    prow_job_runs r,
+    prow_jobs j,
+    tests t
+WHERE
+    md.created_at > NOW() - INTERVAL '14 days' AND
+    md.metadata->>'result' != 'allow' AND
+    md.prow_job_run_test_output_id = o.id AND
+    o.prow_job_run_test_id = rt.id AND
+    (rt.status = 12 OR rt.status = 13) AND
+    rt.prow_job_run_id = r.id AND
+    r.prow_job_id = j.id AND
+    (j.release = '4.13' OR j.release = 'Presubmits') AND
+    rt.test_id = t.id AND (
+        t.name LIKE '%unexpected alerts in firing or pending%' OR
+        t.name LIKE '%during or after upgrade%') AND
+    /* replace with the alert you're interested in */
+    md.metadata->>'alert' = 'TargetDown' AND
+    md.metadata->>'namespace' = 'openshift-dns'
+ORDER BY r.timestamp DESC
+LIMIT 30;
+

--- a/scripts/sql/find-job-runs-with-pathological-event.sql
+++ b/scripts/sql/find-job-runs-with-pathological-event.sql
@@ -1,0 +1,28 @@
+SELECT
+    r.timestamp,
+    md.metadata->>'reason' as "reason",
+    md.metadata->>'ns' as "ns",
+    r.test_failures,
+    r.url
+FROM
+    prow_job_run_test_output_metadata md,
+    prow_job_run_test_outputs o,
+    prow_job_run_tests rt,
+    prow_job_runs r,
+    prow_jobs j,
+    tests t
+WHERE
+    md.created_at > NOW() - INTERVAL '14 days' AND
+    md.prow_job_run_test_output_id = o.id AND
+    o.prow_job_run_test_id = rt.id AND
+    rt.status = 12 AND
+    rt.prow_job_run_id = r.id AND
+    r.prow_job_id = j.id AND
+    rt.test_id = t.id AND
+    (j.release = '4.13' OR j.release = 'Presubmits') AND
+    t.name LIKE '%pathological%' AND
+    /* replace with the alert you're interested in */
+    md.metadata->>'reason' = 'Unable' AND
+    md.metadata->>'ns' = 'default'
+ORDER BY r.timestamp DESC
+LIMIT 30;

--- a/scripts/sql/most-common-alerts.sql
+++ b/scripts/sql/most-common-alerts.sql
@@ -1,0 +1,33 @@
+SELECT
+    j.release,
+    t.id AS "test_id",
+    md.metadata->>'alert' AS "alert",
+    md.metadata->>'namespace' AS "namespace",
+    md.metadata->>'result' AS "result",
+    count(md.metadata->>'alert') AS "alert_count"
+FROM
+    prow_job_run_test_output_metadata md,
+	prow_job_run_test_outputs o,
+	prow_job_run_tests rt,
+	prow_job_runs r,
+	prow_jobs j,
+	tests t
+WHERE
+    md.created_at > NOW() - INTERVAL '14 days' AND
+    md.metadata->>'result' != 'allow' AND
+	md.prow_job_run_test_output_id = o.id AND
+	o.prow_job_run_test_id = rt.id AND
+	(rt.status = 12 OR rt.status = 13) AND
+	rt.prow_job_run_id = r.id AND
+	r.prow_job_id = j.id AND
+	(j.release = '4.13' OR j.release = 'Presubmits') AND
+	rt.test_id = t.id AND (
+		t.name LIKE '%unexpected alerts in firing or pending%' OR
+		t.name LIKE '%during or after upgrade%'
+	)
+GROUP BY
+    t.id, md.metadata->>'alert', md.metadata->>'namespace', md.metadata->>'result', j.release
+ORDER BY
+    alert_count DESC
+LIMIT 30;
+

--- a/scripts/sql/most-common-pathological-events.sql
+++ b/scripts/sql/most-common-pathological-events.sql
@@ -1,0 +1,27 @@
+SELECT
+    j.release,
+    t.id AS "test_id",
+    md.metadata->>'reason' as "reason",
+    md.metadata->>'ns' as "ns",
+    count(md.metadata)
+FROM
+    prow_job_run_test_output_metadata md,
+	prow_job_run_test_outputs o,
+	prow_job_run_tests rt,
+	prow_job_runs r,
+	prow_jobs j,
+	tests t
+WHERE
+    md.created_at > NOW() - INTERVAL '14 days' AND
+	md.prow_job_run_test_output_id = o.id AND
+	o.prow_job_run_test_id = rt.id AND
+	rt.status = 12 AND
+	rt.prow_job_run_id = r.id AND
+	r.prow_job_id = j.id AND
+	rt.test_id = t.id AND
+	(j.release = '4.13' OR j.release = 'Presubmits') AND
+	t.name LIKE '%pathological%'
+GROUP BY
+    t.id, md.metadata->>'ns', md.metadata->>'reason', j.release
+ORDER BY count DESC
+LIMIT 30;


### PR DESCRIPTION
Adds an sql query for both firing alerts, and pathologically repeating events.

[TRT-723](https://issues.redhat.com//browse/TRT-723)