### PR TITLE
Skip ignored tests during risk analysis

### DIFF
--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -218,8 +218,7 @@ func runJobRunAnalysis(jobRun *models.ProwJobRun, compareRelease string,
 	// see how often we've passed in the last week.
 	for _, ft := range jobRun.Tests {
 
-		if ft.Test.Name == testidentification.OpenShiftTestsName {
-			// This can be quite misleading
+		if ft.Test.Name == testidentification.OpenShiftTestsName || testidentification.IsIgnoredTest(ft.Test.Name) {
 			continue
 		}
 


### PR DESCRIPTION
This was causing Cluster should remain functional during upgrade to show up in the risk analysis with unknown state, because we don't import this in sippy.

[TRT-703](https://issues.redhat.com//browse/TRT-703)
