### PR TITLE
Include hypershift jobs in customization file

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -7,6 +7,12 @@ releases:
       periodic-ci-openshift-openshift-ansible-release-3.11-e2e-aws-nightly: true
       periodic-ci-openshift-openshift-ansible-release-3.11-e2e-gcp-nightly: true
       periodic-ci-openshift-origin-release-3.11-e2e-gcp: true
+  "4.13":
+    regexp:
+      - "^periodic-ci-openshift-hypershift.*-4.13-.*"
+  "4.12":
+    regexp:
+      - "^periodic-ci-openshift-hypershift.*-4.12-.*"
   "Presubmits":
     regexp:
       - "^pull-ci-openshift-.*-(master|main).*-e2e-.*"


### PR DESCRIPTION
Currently there is a problem for ci-operator to identify release for hypershift jobs. Until that is resolved, we can use sippy customization file to add hypershift jobs to sippy. 

[TRT-716](https://issues.redhat.com/browse/TRT-716)