### PR TITLE
Add support for GA snapshots.

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -88,6 +88,10 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 		return err
 	}
 
+	if err := d.DB.AutoMigrate(&models.APISnapshot{}); err != nil {
+		return err
+	}
+
 	if err := d.DB.AutoMigrate(&models.Bug{}); err != nil {
 		return err
 	}

--- a/pkg/db/models/models.go
+++ b/pkg/db/models/models.go
@@ -3,6 +3,7 @@ package models
 import (
 	"time"
 
+	"github.com/jackc/pgtype"
 	"gorm.io/gorm"
 )
 
@@ -27,4 +28,32 @@ type SchemaHash struct {
 	// Hash is the SHA256 hash of the string we generate programatically to see if anything
 	// has changed since last applied.
 	Hash string `json:"hash"`
+}
+
+// APISnapshot is a minimal implementation of historical data tracking. On GA or other dates of interest, we use the snapshot CLI command
+// to query some of the main API endpoints, and store the resulting json with an type (indicating the API) into our database.
+type APISnapshot struct {
+	gorm.Model
+	// Name is a user friendly name for this snapshot, i.e. "4.12 GA"
+	Name    string `json:"name" gorm:"unique"`
+	Release string `json:"release"`
+
+	// OverallHealth is json from the /api/health?release=X API.
+	OverallHealth pgtype.JSONB `json:"overall_health" gorm:"type:jsonb"`
+
+	// PayloadHealth is json from the /api/releases/health?release=4.12 API and contains stats on payload health for
+	// each stream in the release.
+	PayloadHealth pgtype.JSONB `json:"payload_health" gorm:"type:jsonb"`
+
+	// VariantHealth is json from the /api/variants?release=4.12 API and contains stats on job pass rates
+	// for each variant.
+	VariantHealth pgtype.JSONB `json:"variant_health" gorm:"type:jsonb"`
+
+	// InstallHealth is json from the /api/install?release=4.12 API and contains stats on install success rates
+	// by variant.
+	InstallHealth pgtype.JSONB `json:"install_health" gorm:"type:jsonb"`
+
+	// UpgradeHealth is json from the /api/upgrade?release=4.12 API and contains stats on upgrade success rates
+	// by variant.
+	UpgradeHealth pgtype.JSONB `json:"upgrade_health" gorm:"type:jsonb"`
 }

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -1,0 +1,128 @@
+package snapshot
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/jackc/pgtype"
+	apitype "github.com/openshift/sippy/pkg/apis/api"
+	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type Snapshotter struct {
+	DBC      *db.DB
+	Name     string
+	SippyURL string
+	Release  string
+}
+
+func (s *Snapshotter) Create() error {
+	log.Info("creating snapshot")
+
+	snapshot := models.APISnapshot{
+		Name:    s.Name,
+		Release: s.Release,
+	}
+
+	health, err := s.getHealth()
+	if err != nil {
+		return err
+	}
+	snapshot.OverallHealth = health
+
+	payloadHealth, err := s.getPayloadHealth()
+	if err != nil {
+		return err
+	}
+	snapshot.PayloadHealth = payloadHealth
+
+	variantHealth, err := s.getVariantHealth()
+	if err != nil {
+		return err
+	}
+	snapshot.VariantHealth = variantHealth
+
+	installHealth, err := s.getInstallHealth()
+	if err != nil {
+		return err
+	}
+	snapshot.InstallHealth = installHealth
+
+	upgradeHealth, err := s.getUpgradeHealth()
+	if err != nil {
+		return err
+	}
+	snapshot.UpgradeHealth = upgradeHealth
+
+	log.Info("storing snapshot in database")
+	err = s.DBC.DB.Create(&snapshot).Error
+	if err != nil {
+		log.WithError(err).Error("error creating snapshot")
+		return errors.Wrapf(err, "error creating snapshot")
+	}
+	log.Info("snapshot created successfully")
+
+	return nil
+
+}
+
+func (s *Snapshotter) getHealth() (pgtype.JSONB, error) {
+	relativeAPI := fmt.Sprintf("/api/health?release=%s", s.Release)
+	apiURL := s.SippyURL + relativeAPI
+	return get(apiURL, &apitype.Health{})
+}
+
+func (s *Snapshotter) getPayloadHealth() (pgtype.JSONB, error) {
+	relativeAPI := fmt.Sprintf("/api/releases/health?release=%s", s.Release)
+	apiURL := s.SippyURL + relativeAPI
+	return get(apiURL, &[]apitype.ReleaseHealthReport{})
+}
+
+func (s *Snapshotter) getVariantHealth() (pgtype.JSONB, error) {
+	relativeAPI := fmt.Sprintf("/api/variants?release=%s", s.Release)
+	apiURL := s.SippyURL + relativeAPI
+	return get(apiURL, &[]apitype.Variant{})
+}
+
+func (s *Snapshotter) getInstallHealth() (pgtype.JSONB, error) {
+	relativeAPI := fmt.Sprintf("/api/install?release=%s", s.Release)
+	apiURL := s.SippyURL + relativeAPI
+	return get(apiURL, &map[string]interface{}{})
+}
+
+func (s *Snapshotter) getUpgradeHealth() (pgtype.JSONB, error) {
+	relativeAPI := fmt.Sprintf("/api/upgrade?release=%s", s.Release)
+	apiURL := s.SippyURL + relativeAPI
+	return get(apiURL, &map[string]interface{}{})
+}
+
+func get(url string, data interface{}) (pgtype.JSONB, error) {
+	logger := log.WithField("api", url)
+	logger.Info("GET")
+	res, err := http.Get(url)
+	if err != nil {
+		return pgtype.JSONB{}, err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return pgtype.JSONB{}, err
+	}
+	err = json.Unmarshal(body, data)
+	if err != nil {
+		return pgtype.JSONB{}, err
+	}
+
+	jsonb := pgtype.JSONB{}
+	if err := jsonb.Set(data); err != nil {
+		logger.WithError(err).Error("error setting jsonb value with api output")
+		return pgtype.JSONB{}, err
+	}
+
+	return jsonb, nil
+}

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -101,6 +101,7 @@ func (s *Snapshotter) getUpgradeHealth() (pgtype.JSONB, error) {
 	return get(apiURL, &map[string]interface{}{})
 }
 
+// nolint:gosec
 func get(url string, data interface{}) (pgtype.JSONB, error) {
 	logger := log.WithField("api", url)
 	logger.Info("GET")


### PR DESCRIPTION
Query various overview health APIs, store the resulting JSON in the db.
We can later use this data via scripts or the UI to compare current
release vs past releases on their GA date.

Implemented in a fashion such that we could take snapshots at other
arbitrary times if desired.

[TRT-727](https://issues.redhat.com//browse/TRT-727)