### PR TITLE
Only render testgrid link when present

### DIFF
--- a/sippy-ng/src/jobs/JobTable.js
+++ b/sippy-ng/src/jobs/JobTable.js
@@ -97,6 +97,10 @@ export const getColumns = (config, openBugzillaDialog) => {
       headerName: ' ',
       flex: 0.4,
       renderCell: (params) => {
+        if (params.value === undefined || params.value === '') {
+          return
+        }
+
         return (
           <Tooltip title="TestGrid">
             <Button


### PR DESCRIPTION
Currently we always render the TestGrid button regardless of whether Sippy knows the testgrid link for that job.  This change makes it only render when we know the URL. This will make it easier to identify jobs where we don't know the TG dashboard, as well as not showing on jobs that will never have one (e.g. presubmits).