### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,105 +2,20 @@
 
 <img src=https://raw.github.com/openshift/sippy/master/sippy.svg height=100 width=100>
 
-CIPI (Continuous Integration Private Investigator) aka Sippy.
+CIPI (Continuous Integration Private Investigator) aka Sippy -- a tool
+to analyze prow job results.
 
-A tool to process the job results from https://testgrid.k8s.io/
-
-Analyzes any job with a status of `FLAKY` or `FAILING` as reported on the following dashboards:
-
-```
-https://testgrid.k8s.io/redhat-openshift-ocp-release-4.6-informing
-https://testgrid.k8s.io/redhat-openshift-ocp-release-4.5-informing
-https://testgrid.k8s.io/redhat-openshift-ocp-release-4.4-informing
-https://testgrid.k8s.io/redhat-openshift-ocp-release-4.3-informing
-https://testgrid.k8s.io/redhat-openshift-ocp-release-4.2-informing
-https://testgrid.k8s.io/redhat-openshift-ocp-release-4.6-blocking
-https://testgrid.k8s.io/redhat-openshift-ocp-release-4.5-blocking
-https://testgrid.k8s.io/redhat-openshift-ocp-release-4.4-blocking
-https://testgrid.k8s.io/redhat-openshift-ocp-release-4.3-blocking
-https://testgrid.k8s.io/redhat-openshift-ocp-release-4.2-blocking
-```
-
-Reports on which tests fail most frequently along different dimensions:
-
-* overall
-* by job
-* by platform (e.g. aws, gcp, etc)
-* by sig (sig ownership of the test)
-
-Also reports on:
-* Job runs that had large groups of test failures in a single run (generally indicative of a fundamental issue rather than a test problem)
-* Job pass rates (which jobs are failing frequently, which are not, in sorted order)
-
-Can filter based on time ranges, job names, and various thresholds.  See `./sippy -h`
+Reports on job and test statistics, sliced by various filters including
+name, suite, or NURP+ variants (network, upgrade, release, platform, etc).
 
 ## Typical usage
 
-```
-# Fetch the latest data.  Rerun this periodically to get new data.
-$ ./sippy --fetch-data /some/dir --release X.Y
-$ ./sippy --server --local-data /some/dir --release X.Y
-```
+See [DEVELOPMENT.md](DEVELOPMENT.md) for information about standing up a
+local environment.
 
-Browse to http://localhost:8080/?release=X.Y to see the report.
+See [resources](resources/) for example deployment manifests in
+Kubernetes.
 
-To force sippy to reload data from disk (Such as after rerunning fetch data): http://localhost:8080/refresh
-
-## Detailed usage
-Sippy can generate custom reports on a per request basis via:
-
-http://localhost:8080/detailed?release=4.5&parm1=foo&param2=bar
-
-Valid parameters include:
-
-* `startDay` - how many days back in history to start looking at job runs
-
-* `endDay` - how many days back in history to stop looking at job runs
-
-* `testSuccessThreshold` - ignore tests that have a passing percentage higher than this value
-
-* `jobFilter` - ignore jobs with names that match this value
-
-* `minTestRuns` - ignore tests that ran fewer than this many times either overall, or within each job or grouping
-
-* `failureClusterThreshold` - minimum number of test failures in a single job run to be considered a failure cluster/grouping
-
-* `jobTestCount` - number of failing tests to report on for each job definition
-
-## Historical usage
-
-At GA of an OpenShift release, take a snapshot of the current data by
-running the following:
-
-```
-$ ./sippy -v 1 --fetch-data ./historical-data/4.10GA --release 4.10
-$ cd historical-data
-$ ./rename.sh
-```
-
-Update the deployment config for the historical instance, and commit the
-results.
-
-## Local Historical usage with DB
-See the [Development documentation](DEVELOPMENT.md) `From a Prod Sippy Backup` section to restore a backup locally.
-
-Start the server locally, pointing to the restored db, and set the pinnedDateTime configuration reflecting the end of the reporting period for the historical queries.
-
-`--pinnedDateTime=2022-08-10T00:00:00+00:00` 
-
-## Non-OCP usage
-
-Sippy can be pointed at an arbitrary test-grid dashboard with a more limited featureset.
-Instead of using `--release`, you use `--dashboard`, and in order to specify a set of variants, you can use `--variant`.
-`--dashboard` usage is `--dashboard=<reportName>=<comma,delimited,list of dashboard names>=<optional ocp version if this is for ocp>`.
-`--variant` is limited to one of `{ocp,kube,none}` at the moment, but is expected to allow multiples eventually.
-
-Typical usage for this use-case is like
-```
-./sippy --fetch-data ../data-dir/  --dashboard=kube-master=sig-release-master-blocking,sig-release-master-informing=
-./sippy --server --local-data ../data-dir --dashboard=kube-master=sig-release-master-blocking,sig-release-master-informing= --variant=kube
-```
-
-### API
+## API
 
 See [the API documentation](pkg/api/README.md)

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -1,10 +1,11 @@
 # Sippy API
 
-Sippy has a simple REST API at `/api`. There is an older API available at `/json` as well, with a single endpoint that
-displays multiple reports.
+Sippy has a simple REST API at `/api`. The API is used by the front-end.
+The docs here may not be fully up-to-date, although we do try not to
+break backwards compatability where possible.
 
-Note that where the responses include a top-level ID, these are synthetic and may change across API calls. These are
-only used by the frontend data tables. Other ID's when provided such as Bugzilla, Prow ID's, etc are accurate.
+For exact API usage, you can use your browser's web developer tools to
+examine the requests we make.
 
 ## Filtering and sorting
 
@@ -262,7 +263,7 @@ Endpoint: `/api/jobs`
 |----------|----------------|--------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
 | release* | String         | The OpenShift release to return results from (e.g., 4.9)                                                                 | N/A                                                 |
 | filter   | Filter         | Filters the results by the specified value. Can be specified multiple times, e.g. filterBy=hasBug&filterBy=name&job=aws  | See filtering                                       |
-| sortField| Field name     | Sort by this field                                                                                                       |                                                     | 
+| sortField| Field name     | Sort by this field                                                                                                       |                                                     |
 | sort     | asc / desc     | Sort type, ascending or descending                                                                                       | "asc" or "desc"                                     |
 | limit    | Integer        | The maximum amount of results to return                                                                                  | N/A                                                 |
 
@@ -405,7 +406,7 @@ Endpoint: `/api/tests`
 |----------|----------------|-------------------------------------------------------------------------------------------|-----------------------------------------------------|
 | release* | String         | The OpenShift release to return results from (e.g., 4.9)                                  | N/A                                                 |
 | filter   | Filter         | Filters the results by the specified value.                                               | See filtering                                       |
-| sortField| Field name     | Sort by this field                                                                        |                                                     | 
+| sortField| Field name     | Sort by this field                                                                        |                                                     |
 | sort     | asc / desc     | Sort type, ascending or descending                                                        | "asc" or "desc"                                     |
 | limit    | Integer        | The maximum amount of results to return                                                   | N/A                                                 |
 


### PR DESCRIPTION
The main README is almost entirely out of date, with most of the relevant documentation moved to the DEVELOPMENT.md file. This removes the outdated info and links to where it is now.