### PR TITLE
Add index on prow_job_run_tests.status

### DIFF
--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -82,7 +82,7 @@ type ProwJobRunTest struct {
 	// SuiteID may be nil if no suite name could be parsed from the testgrid test name.
 	SuiteID   *uint `gorm:"index"`
 	Suite     Suite
-	Status    int // would like to use smallint here, but gorm auto-migrate breaks trying to change the type every start
+	Status    int `gorm:"index"`
 	Duration  float64
 	CreatedAt time.Time
 	DeletedAt gorm.DeletedAt


### PR DESCRIPTION
TRT-731

This should improve the performance of the test anaylsis mat view, as it does look-ups on statuses which is an unindexed field.