### PR TITLE
Fix counts on test materialized views

### DIFF
--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -26,7 +26,7 @@ const (
            sum(previous_successes) AS previous_successes,
            sum(previous_failures)  AS previous_failures,
            sum(previous_flakes)    AS previous_flakes,
-           sum(open_bugs)          AS open_bugs`
+           (array_agg(open_bugs))[1] AS open_bugs`
 
 	QueryTestFields = `
 		current_runs,


### PR DESCRIPTION
[TRT-784](https://issues.redhat.com//browse/TRT-784)

The number of runs, successes, failures, etc are scaled by the number of open bugs. Each bug causes new rows to be created with the LEFT JOIN.

We only really noticed because of how many bugs pathological events has, making ovirt appear to have way too many runs. The good thing is the percentages are accurate (all values are scaled by the # of open bugs).

The bug count was also summed and showed aggregated, causing pathological events to show up with 1200+ open bugs (we're not *quite* there yet).