### PR TITLE
Hide low frequency jobs by default

### DIFF
--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -189,8 +189,8 @@ func calculateJobResultStatistics(results []apitype.Job) (currStats, prevStats s
 	prevStats.Histogram = make([]int, 10)
 
 	for _, result := range results {
-		// Skip jobs that have no runs
-		if result.CurrentRuns == 0 {
+		// Skip jobs that have few runs
+		if result.CurrentRuns < 7 {
 			continue
 		}
 

--- a/sippy-ng/src/components/Sidebar.js
+++ b/sippy-ng/src/components/Sidebar.js
@@ -173,7 +173,7 @@ export default function Sidebar(props) {
                   component={Link}
                   to={withSort(
                     pathForJobsWithFilter(release, {
-                      items: withoutUnstable(),
+                      items: [BOOKMARKS.RUN_7, ...withoutUnstable()],
                     }),
                     'net_improvement',
                     'asc'

--- a/sippy-ng/src/constants.js
+++ b/sippy-ng/src/constants.js
@@ -77,6 +77,11 @@ export const BOOKMARKS = {
     operatorValue: '=',
     value: '0',
   },
+  RUN_FEW: {
+    columnField: 'current_runs',
+    operatorValue: '<',
+    value: '7',
+  },
   RUN_1: {
     columnField: 'current_runs',
     operatorValue: '>=',
@@ -137,7 +142,7 @@ export const BOOKMARKS = {
     value: '.Overall',
   },
   UPGRADE: {
-    columnField: 'tags',
+    columnField: 'name',
     operatorValue: 'contains',
     value: 'upgrade',
   },

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -218,6 +218,7 @@ export function pathForJobsInPercentile(release, start, end) {
   return `/jobs/${release}?${multiple(
     filterFor('current_pass_percentage', '>=', `${start}`),
     filterFor('current_pass_percentage', '<', `${end}`),
+    filterFor('current_runs', '>=', '7'),
     ...withoutUnstable()
   )}`
 }

--- a/sippy-ng/src/jobs/JobTable.js
+++ b/sippy-ng/src/jobs/JobTable.js
@@ -25,7 +25,8 @@ import React, { Fragment, useEffect } from 'react'
 
 const bookmarks = [
   { name: 'New jobs (no previous runs)', model: [BOOKMARKS.NEW_JOBS] },
-  { name: 'Runs > 10', model: [BOOKMARKS.RUN_10] },
+  { name: 'Low frequency jobs', model: [BOOKMARKS.RUN_FEW] },
+  { name: 'High frequency jobs', model: [BOOKMARKS.RUN_7] },
   { name: 'Upgrade related', model: [BOOKMARKS.UPGRADE] },
 ]
 
@@ -363,7 +364,15 @@ function JobTable(props) {
   }
 
   const addFilters = (filter) => {
-    const currentFilters = filterModel.items.filter((item) => item.value !== '')
+    const currentFilters = filterModel.items.filter((item) => {
+      for (let i = 0; i < filter.length; i++) {
+        if (filter[i].columnField === item.columnField) {
+          return false
+        }
+      }
+
+      return item.value !== ''
+    })
 
     filter.forEach((item) => {
       if (item.value && item.value !== '') {

--- a/sippy-ng/src/releases/ReleaseOverview.js
+++ b/sippy-ng/src/releases/ReleaseOverview.js
@@ -149,7 +149,7 @@ export default function ReleaseOverview(props) {
                   </Link>
                   <Tooltip
                     title={
-                      'Histogram of job pass rates. Bucketed by current period pass percentage. ' +
+                      'Histogram of job pass rates for frequently running jobs. Bucketed by current period pass percentage. ' +
                       'Tech preview and never-stable jobs are excluded. The solid line indicates the current ' +
                       "period's mean, and the dashed line is the previous period."
                     }


### PR DESCRIPTION
TRT-824

This adjusts the Sippy UI to stop showing low frequency jobs by default. For jobs that run less than daily, especially once a week jobs, when one run fails it ends up showing up in various reporting showing the job significantly regressed.