### PR TITLE
TRT-718: Risk analysis pr commenting -Log error, delete record before…

### DIFF
--- a/pkg/util/rate_limiter.go
+++ b/pkg/util/rate_limiter.go
@@ -46,6 +46,10 @@ func (rl *RateLimiter) UpdateRate(error bool) {
 	}
 
 	if update {
-		rl.ticker.Reset(rl.baseRate * time.Duration(rl.errorCount))
+		tickerRate := rl.baseRate
+		if rl.errorCount > 0 {
+			tickerRate = rl.baseRate * time.Duration(rl.errorCount)
+		}
+		rl.ticker.Reset(tickerRate)
 	}
 }


### PR DESCRIPTION
A couple of issues here, the code was attempting to update the rate limiter before deleting the just commented record so when we hit our failure the record was not deleted and we reprocessed.  The failure indicates we saw an error from github prior but I don't think it was being logged.  And lastly the ticker rate has to be above 0 which is what caused to overall failure.
