### PR TITLE
TRT-845: Risk analysis pr commenting - Validate record, cap error att…

### DIFF
--- a/pkg/db/models/pr_commenting.go
+++ b/pkg/db/models/pr_commenting.go
@@ -11,12 +11,14 @@ const (
 )
 
 type PullRequestComment struct {
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-	PullNumber  int    `json:"pullNumber" gorm:"primaryKey"`
-	CommentType int8   `json:"commentType" gorm:"primaryKey"`
-	SHA         string `json:"sha" gorm:"primaryKey"`
-	Org         string `json:"org" gorm:"primaryKey"`
-	Repo        string `json:"repo" gorm:"primaryKey"`
-	ProwJobRoot string `json:"prowJobRoot"`
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+	PullNumber            int       `json:"pullNumber" gorm:"primaryKey"`
+	CommentType           int8      `json:"commentType" gorm:"primaryKey"`
+	SHA                   string    `json:"sha" gorm:"primaryKey"`
+	Org                   string    `json:"org" gorm:"primaryKey"`
+	Repo                  string    `json:"repo" gorm:"primaryKey"`
+	ProwJobRoot           string    `json:"prowJobRoot"`
+	LastCommentAttempt    time.Time `json:"lastCommentAttempt"`
+	FailedCommentAttempts int       `json:"failedCommentAttempts"`
 }

--- a/pkg/prowloader/github/github.go
+++ b/pkg/prowloader/github/github.go
@@ -311,20 +311,20 @@ func (c *Client) DeletePRComment(org, repo string, updateID int64) error {
 	return err
 }
 
-func (c *Client) FindCommentID(org, repo string, number int, commentKey, commentID string) (*int64, error) {
+func (c *Client) FindCommentID(org, repo string, number int, commentKey, commentID string) (*int64, *string, error) {
 	comments, err := c.prCommentsFetch(org, repo, number)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for _, cmt := range comments {
 
 		if c.isCommentIDMatch(*cmt.Body, commentKey, commentID) {
-			return cmt.ID, nil
+			return cmt.ID, cmt.Body, nil
 		}
 	}
-	return nil, nil
+	return nil, nil, nil
 }
 
 func (c *Client) isCommentIDMatch(comment, commentKey, commentID string) bool {

--- a/pkg/prowloader/prow.go
+++ b/pkg/prowloader/prow.go
@@ -243,7 +243,7 @@ func (pl *ProwLoader) syncPRStatus() error {
 
 				for _, pc := range pendingComments {
 					pcp := pc
-					pl.ghCommenter.ClearPendingRecord(pcp.Org, pcp.Repo, pcp.PullNumber, pcp.SHA, &pcp)
+					pl.ghCommenter.ClearPendingRecord(pcp.Org, pcp.Repo, pcp.PullNumber, pcp.SHA, models.CommentTypeRiskAnalysis, &pcp)
 				}
 			}
 		}


### PR DESCRIPTION

Check the pending record before writing the comment

- Check when we last attempted to write a comment
- Skip if we are within wait period
- Track number of errors, increase wait based on that number
- Delete the record if too many errors
- Update the last attempted time when we are ready to try adding the comment
- Check the contents of existing comment if there is one and if it matches the pending update leave it and skip commenting
- Sort by job name when risk level matches so we have deterministic comment content