### PR TITLE
Test analysis page should URI encode test names for bugs API

### DIFF
--- a/sippy-ng/src/tests/TestAnalysis.js
+++ b/sippy-ng/src/tests/TestAnalysis.js
@@ -76,7 +76,11 @@ export function TestAnalysis(props) {
         `${process.env.REACT_APP_API_URL}/api/tests?release=${props.release}&filter=${filter}`
       ),
       fetch(
-        `${process.env.REACT_APP_API_URL}/api/tests/bugs?test=${testName}&filter=${filter}`
+        `${
+          process.env.REACT_APP_API_URL
+        }/api/tests/bugs?test=${safeEncodeURIComponent(
+          testName
+        )}&filter=${filter}`
       ),
     ])
       .then(([test, bugs]) => {


### PR DESCRIPTION
TRT-843

Currently test names aren't being URI encoded for the bugs API, causing errors when there's characters like `#` in a test name.

Example: https://sippy.dptools.openshift.org/sippy-ng/tests/4.13/analysis?test=Create%20the%20different%20workloads%20from%20Add%20page.Create%20the%20different%20workloads%20from%20Add%20page%20Create%20Sample%20Application%20from%20Add%20page%3A%20GS-03-TC05%20(example%20%231)