### PR TITLE
Add infrastructure success metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -673,7 +673,7 @@ func (o *Options) runServerMode(pinnedDateTime *time.Time, gormLogLevel gormlogg
 	)
 
 	// Do an immediate metrics update
-	err = metrics.RefreshMetricsDB(dbc, util.GetReportEnd(pinnedDateTime))
+	err = metrics.RefreshMetricsDB(dbc, o.getVariantManager(), util.GetReportEnd(pinnedDateTime))
 	if err != nil {
 		log.WithError(err).Error("error refreshing metrics")
 	}
@@ -686,7 +686,7 @@ func (o *Options) runServerMode(pinnedDateTime *time.Time, gormLogLevel gormlogg
 			select {
 			case <-ticker.C:
 				log.Info("tick")
-				err := metrics.RefreshMetricsDB(dbc, util.GetReportEnd(pinnedDateTime))
+				err := metrics.RefreshMetricsDB(dbc, o.getVariantManager(), util.GetReportEnd(pinnedDateTime))
 				if err != nil {
 					log.WithError(err).Error("error refreshing metrics")
 				}

--- a/pkg/db/query/misc_queries.go
+++ b/pkg/db/query/misc_queries.go
@@ -1,0 +1,47 @@
+package query
+
+import (
+	"fmt"
+
+	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/testidentification"
+	"github.com/openshift/sippy/pkg/util/sets"
+)
+
+// PlatformInfraSuccess takes a list of platforms and a period (default
+// or twoDay), and returns a map containing keys for platform, and infra
+// success percentage for that period.
+func PlatformInfraSuccess(dbc *db.DB, platforms sets.String, period string) (map[string]float64, error) {
+	results := make(map[string]float64)
+
+	table := ""
+	switch period {
+	case "default":
+		table = "prow_test_report_7d_matview"
+	case "twoDay":
+		table = "prow_test_report_2d_matview"
+	default:
+		return nil, fmt.Errorf("unknown period %s", period)
+	}
+
+	raw := dbc.DB.Table(table).
+		Select("*, unnest(variants) as variant").
+		Where("name = ?", testidentification.NewInfrastructureTestName)
+
+	var sqlResults []struct {
+		Variant        string
+		PassPercentage float64
+	}
+	q := dbc.DB.Table("(?) as results", raw).
+		Select(`
+			variant,
+			SUM(current_successes) * 100.0 / NULLIF(SUM(current_runs), 0) AS pass_percentage`).
+		Where("variant in ?", platforms.List()).
+		Group("variant").Scan(&sqlResults)
+
+	for _, r := range sqlResults {
+		results[r.Variant] = r.PassPercentage
+	}
+
+	return results, q.Error
+}

--- a/pkg/testidentification/kube_variants.go
+++ b/pkg/testidentification/kube_variants.go
@@ -50,6 +50,10 @@ func (kubeVariants) AllVariants() sets.String {
 	return allKubeVariants
 }
 
+func (kubeVariants) AllPlatforms() sets.String {
+	return sets.String{}
+}
+
 func (v kubeVariants) IdentifyVariants(jobName, release string) []string {
 	variants := []string{}
 

--- a/pkg/testidentification/no_variants.go
+++ b/pkg/testidentification/no_variants.go
@@ -14,6 +14,10 @@ func (noVariants) AllVariants() sets.String {
 	return sets.String{}
 }
 
+func (noVariants) AllPlatforms() sets.String {
+	return sets.String{}
+}
+
 func (v noVariants) IdentifyVariants(jobName, release string) []string {
 	return []string{}
 }

--- a/pkg/testidentification/ocp_variants.go
+++ b/pkg/testidentification/ocp_variants.go
@@ -21,7 +21,8 @@ var openshiftJobsNeverStableRaw string
 var openshiftJobsNeverStable = strings.Split(openshiftJobsNeverStableRaw, "\n")
 
 var (
-	// variant regexes
+	// variant regexes - when adding a new one, please update both allOpenshiftVariants,
+	// and allPlatforms as appropriate.
 	aggregatedRegex = regexp.MustCompile(`(?i)aggregated-`)
 	alibabaRegex    = regexp.MustCompile(`(?i)-alibaba`)
 	arm64Regex      = regexp.MustCompile(`(?i)-arm64`)
@@ -98,6 +99,20 @@ var (
 		"vsphere-ipi",
 		"vsphere-upi",
 	)
+
+	allPlatforms = sets.NewString(
+		"alibaba",
+		"aws",
+		"azure",
+		"gcp",
+		"metal-assisted",
+		"metal-ipi",
+		"metal-upi",
+		"openstack",
+		"ovirt",
+		"vsphere-ipi",
+		"vsphere-upi",
+	)
 )
 
 type openshiftVariants struct{}
@@ -108,6 +123,9 @@ func NewOpenshiftVariantManager() VariantManager {
 
 func (openshiftVariants) AllVariants() sets.String {
 	return allOpenshiftVariants
+}
+func (openshiftVariants) AllPlatforms() sets.String {
+	return allPlatforms
 }
 
 func (v openshiftVariants) IdentifyVariants(jobName, release string) []string {

--- a/pkg/testidentification/ocp_variants.go
+++ b/pkg/testidentification/ocp_variants.go
@@ -32,6 +32,7 @@ var (
 	compactRegex    = regexp.MustCompile(`(?i)-compact`)
 	fipsRegex       = regexp.MustCompile(`(?i)-fips`)
 	hypershiftRegex = regexp.MustCompile(`(?i)-hypershift`)
+	libvirtRegex    = regexp.MustCompile(`(?i)-libvirt`)
 	metalRegex      = regexp.MustCompile(`(?i)-metal`)
 	// metal-assisted jobs do not have a trailing -version segment
 	metalAssistedRegex = regexp.MustCompile(`(?i)-metal-assisted`)
@@ -75,6 +76,7 @@ var (
 		"ha",
 		"hypershift",
 		"heterogeneous",
+		"libvirt",
 		"metal-assisted",
 		"metal-ipi",
 		"metal-upi",
@@ -105,6 +107,7 @@ var (
 		"aws",
 		"azure",
 		"gcp",
+		"libvirt",
 		"metal-assisted",
 		"metal-ipi",
 		"metal-upi",
@@ -241,8 +244,8 @@ func determinePlatform(jobName, _ string) string {
 		return "azure"
 	} else if gcpRegex.MatchString(jobName) {
 		return "gcp"
-	} else if openstackRegex.MatchString(jobName) {
-		return "openstack"
+	} else if libvirtRegex.MatchString(jobName) {
+		return "libvirt"
 	} else if metalAssistedRegex.MatchString(jobName) || (metalRegex.MatchString(jobName) && singleNodeRegex.MatchString(jobName)) {
 		// Without support for negative lookbacks in the native
 		// regexp library, it's easiest to differentiate these
@@ -253,6 +256,8 @@ func determinePlatform(jobName, _ string) string {
 		return "metal-ipi"
 	} else if metalRegex.MatchString(jobName) {
 		return "metal-upi"
+	} else if openstackRegex.MatchString(jobName) {
+		return "openstack"
 	} else if ovirtRegex.MatchString(jobName) {
 		return "ovirt"
 	} else if vsphereUPIRegex.MatchString(jobName) {

--- a/pkg/testidentification/variants.go
+++ b/pkg/testidentification/variants.go
@@ -4,8 +4,11 @@ import "github.com/openshift/sippy/pkg/util/sets"
 
 // VariantManager identifies and describes different variants
 type VariantManager interface {
-	// allOpenshiftVariants returns a set of all known variants
+	// AllVariants returns a set of all known variants
 	AllVariants() sets.String
+
+	// AllPlatforms returns a set of all known platform variants
+	AllPlatforms() sets.String
 
 	// IdentifyVariants takes a job name and returns the list of variants that job belongs to.
 	IdentifyVariants(jobName string, release string) []string


### PR DESCRIPTION
[TRT-858](https://issues.redhat.com//browse/TRT-858)

This adds new metrics for per-platform infrastructure success rates. This is a global value not constrained by releases, but we could scope it by release if we thought it was useful.

This metric is the true success rate, so alerts based on this value will be taking into account both failures and flakes (i.e. retrying infra worked). This will let us make sure that we don't excessively start flaking on infra and not detect the problem.