### PR TITLE
TRT-800: Missing variant data during Risk analysis

### DIFF
--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -182,35 +182,39 @@ func calculateJobResultStatistics(results []apitype.Job) (currStats, prevStats s
 		prevPercentages = append(prevPercentages, result.PreviousPassPercentage)
 	}
 
-	data := stats.LoadRawData(currPercentages)
-	mean, _ := stats.Mean(data)
-	sd, _ := stats.StandardDeviation(data)
-	quartiles, _ := stats.Quartile(data)
-	p95, _ := stats.Percentile(data, 95)
+	if len(currPercentages) > 0 {
+		data := stats.LoadRawData(currPercentages)
+		mean, _ := stats.Mean(data)
+		sd, _ := stats.StandardDeviation(data)
+		quartiles, _ := stats.Quartile(data)
+		p95, _ := stats.Percentile(data, 95)
 
-	currStats.Mean = mean
-	currStats.StandardDeviation = sd
-	currStats.Quartiles = []float64{
-		testreportconversion.ConvertNaNToZero(quartiles.Q1),
-		testreportconversion.ConvertNaNToZero(quartiles.Q2),
-		testreportconversion.ConvertNaNToZero(quartiles.Q3),
+		currStats.Mean = mean
+		currStats.StandardDeviation = sd
+		currStats.Quartiles = []float64{
+			testreportconversion.ConvertNaNToZero(quartiles.Q1),
+			testreportconversion.ConvertNaNToZero(quartiles.Q2),
+			testreportconversion.ConvertNaNToZero(quartiles.Q3),
+		}
+		currStats.P95 = p95
 	}
-	currStats.P95 = p95
 
-	data = stats.LoadRawData(prevPercentages)
-	mean, _ = stats.Mean(data)
-	sd, _ = stats.StandardDeviation(data)
-	quartiles, _ = stats.Quartile(data)
-	p95, _ = stats.Percentile(data, 95)
+	if len(prevPercentages) > 0 {
+		data := stats.LoadRawData(prevPercentages)
+		mean, _ := stats.Mean(data)
+		sd, _ := stats.StandardDeviation(data)
+		quartiles, _ := stats.Quartile(data)
+		p95, _ := stats.Percentile(data, 95)
 
-	prevStats.Mean = mean
-	prevStats.StandardDeviation = sd
-	prevStats.Quartiles = []float64{
-		testreportconversion.ConvertNaNToZero(quartiles.Q1),
-		testreportconversion.ConvertNaNToZero(quartiles.Q2),
-		testreportconversion.ConvertNaNToZero(quartiles.Q3),
+		prevStats.Mean = mean
+		prevStats.StandardDeviation = sd
+		prevStats.Quartiles = []float64{
+			testreportconversion.ConvertNaNToZero(quartiles.Q1),
+			testreportconversion.ConvertNaNToZero(quartiles.Q2),
+			testreportconversion.ConvertNaNToZero(quartiles.Q3),
+		}
+		prevStats.P95 = p95
 	}
-	prevStats.P95 = p95
 
 	return currStats, prevStats
 }

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -756,6 +756,8 @@ type RiskLevel struct {
 
 var FailureRiskLevelNone = RiskLevel{Name: "None", Level: 0}
 var FailureRiskLevelLow = RiskLevel{Name: "Low", Level: 1}
-var FailureRiskLevelMedium = RiskLevel{Name: "Medium", Level: 5}
-var FailureRiskLevelUnknown = RiskLevel{Name: "Unknown", Level: 7}
-var FailureRiskLevelHigh = RiskLevel{Name: "High", Level: 10}
+var FailureRiskLevelUnknown = RiskLevel{Name: "Unknown", Level: 25}
+var FailureRiskLevelMedium = RiskLevel{Name: "Medium", Level: 50}
+var FailureRiskLevelIncompleteTests = RiskLevel{Name: "IncompleteTests", Level: 75}
+var FailureRiskLevelMissingData = RiskLevel{Name: "MissingData", Level: 76}
+var FailureRiskLevelHigh = RiskLevel{Name: "High", Level: 100}

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -60,7 +60,8 @@ type ProwJobRun struct {
 	Duration      time.Duration
 	OverallResult v1.JobOverallResult `gorm:"index"`
 	// used to pass the TestCount in via the api, we have the actual tests in the db and can calculate it here so don't persist
-	TestCount int `gorm:"-"`
+	TestCount   int         `gorm:"-"`
+	ClusterData ClusterData `gorm:"-"`
 }
 
 type Test struct {
@@ -174,4 +175,17 @@ type ProwPullRequest struct {
 
 	// MergedAt contains the time retrieved from GitHub that this PR was merged.
 	MergedAt *time.Time `json:"merged_at,omitempty" gorm:"merged_at"`
+}
+
+type ClusterData struct {
+	Release               string
+	FromRelease           string
+	Platform              string
+	Architecture          string
+	Network               string
+	Topology              string
+	NetworkStack          string
+	CloudRegion           string
+	CloudZone             string
+	ClusterVersionHistory []string
 }

--- a/pkg/prowloader/gcs/gcs_jobrun.go
+++ b/pkg/prowloader/gcs/gcs_jobrun.go
@@ -16,9 +16,14 @@ import (
 )
 
 const TestFailureSummaryFilePrefix = "risk-analysis"
+const ClusterDataFilePrefix = "cluster-data_"
 
 func GetDefaultRiskAnalysisSummaryFile() *regexp.Regexp {
 	return regexp.MustCompile(fmt.Sprintf("%s.json", TestFailureSummaryFilePrefix))
+}
+
+func GetDefaultClusterDataFile() *regexp.Regexp {
+	return regexp.MustCompile(fmt.Sprintf("%s.*json", ClusterDataFilePrefix))
 }
 
 type GCSJobRun struct {
@@ -153,4 +158,24 @@ func (j *GCSJobRun) FindFirstFile(root string, filename *regexp.Regexp) []byte {
 	}
 
 	return nil
+}
+
+func (j *GCSJobRun) FindAllMatches(root string, filename *regexp.Regexp) []string {
+	matches := make([]string, 0)
+
+	it := j.bkt.Objects(context.Background(), &storage.Query{
+		Prefix: root,
+	})
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+
+		if filename.MatchString(attrs.Name) {
+			matches = append(matches, attrs.Name)
+		}
+	}
+
+	return matches
 }

--- a/pkg/prowloader/gcs/gcs_jobrun.go
+++ b/pkg/prowloader/gcs/gcs_jobrun.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"regexp"
-	"strings"
 
 	"cloud.google.com/go/storage"
 	log "github.com/sirupsen/logrus"
@@ -17,13 +16,33 @@ import (
 
 const TestFailureSummaryFilePrefix = "risk-analysis"
 const ClusterDataFilePrefix = "cluster-data_"
+const JunitRegExStr = "\\/junit.*xml"
+
+var (
+	defaultRiskAnalysisSummaryFileRegEx *regexp.Regexp
+	defaultClusterDataFileRegEx         *regexp.Regexp
+	defaultJunitFileRegEx               *regexp.Regexp
+)
 
 func GetDefaultRiskAnalysisSummaryFile() *regexp.Regexp {
-	return regexp.MustCompile(fmt.Sprintf("%s.json", TestFailureSummaryFilePrefix))
+	if defaultRiskAnalysisSummaryFileRegEx == nil {
+		defaultRiskAnalysisSummaryFileRegEx = regexp.MustCompile(fmt.Sprintf("%s.json", TestFailureSummaryFilePrefix))
+	}
+	return defaultRiskAnalysisSummaryFileRegEx
 }
 
 func GetDefaultClusterDataFile() *regexp.Regexp {
-	return regexp.MustCompile(fmt.Sprintf("%s.*json", ClusterDataFilePrefix))
+	if defaultClusterDataFileRegEx == nil {
+		defaultClusterDataFileRegEx = regexp.MustCompile(fmt.Sprintf("%s.*json", ClusterDataFilePrefix))
+	}
+	return defaultClusterDataFileRegEx
+}
+
+func GetDefaultJunitFile() *regexp.Regexp {
+	if defaultJunitFileRegEx == nil {
+		defaultJunitFileRegEx = regexp.MustCompile(JunitRegExStr)
+	}
+	return defaultJunitFileRegEx
 }
 
 type GCSJobRun struct {
@@ -43,20 +62,16 @@ func NewGCSJobRun(bkt *storage.BucketHandle, path string) *GCSJobRun {
 	}
 }
 
+func (j *GCSJobRun) SetGCSJunitPaths(paths []string) {
+	j.gcsJunitPaths = paths
+}
+
 func (j *GCSJobRun) GetGCSJunitPaths() []string {
 	if len(j.gcsJunitPaths) == 0 {
-		it := j.bkt.Objects(context.Background(), &storage.Query{
-			Prefix: j.gcsProwJobPath,
-		})
-		for {
-			attrs, err := it.Next()
-			if err == iterator.Done {
-				break
-			}
+		matches := j.FindAllMatches([]*regexp.Regexp{GetDefaultJunitFile()})
 
-			if strings.HasSuffix(attrs.Name, "xml") && strings.Contains(attrs.Name, "/junit") {
-				j.gcsJunitPaths = append(j.gcsJunitPaths, attrs.Name)
-			}
+		if len(matches) > 0 {
+			j.gcsJunitPaths = matches[0]
 		}
 	}
 
@@ -160,11 +175,19 @@ func (j *GCSJobRun) FindFirstFile(root string, filename *regexp.Regexp) []byte {
 	return nil
 }
 
-func (j *GCSJobRun) FindAllMatches(root string, filename *regexp.Regexp) []string {
-	matches := make([]string, 0)
+// FindAllMatches takes an array of regexes
+// and compares the name of the object in gcs
+// with each regex for a match
+// each regex that matches will get the attribute name
+// in the returned matches with the index matching the regex
+func (j *GCSJobRun) FindAllMatches(filenames []*regexp.Regexp) [][]string {
+	if len(filenames) < 1 {
+		return nil
+	}
+	matches := make([][]string, len(filenames))
 
 	it := j.bkt.Objects(context.Background(), &storage.Query{
-		Prefix: root,
+		Prefix: j.gcsProwJobPath,
 	})
 	for {
 		attrs, err := it.Next()
@@ -172,8 +195,13 @@ func (j *GCSJobRun) FindAllMatches(root string, filename *regexp.Regexp) []strin
 			break
 		}
 
-		if filename.MatchString(attrs.Name) {
-			matches = append(matches, attrs.Name)
+		for i, filename := range filenames {
+			if matches[i] == nil {
+				matches[i] = make([]string, 0)
+			}
+			if filename.MatchString(attrs.Name) {
+				matches[i] = append(matches[i], attrs.Name)
+			}
 		}
 	}
 

--- a/pkg/prowloader/prow_test.go
+++ b/pkg/prowloader/prow_test.go
@@ -1,0 +1,61 @@
+package prowloader
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDateTimeNameComparisons(t *testing.T) {
+	tests := []struct {
+		name           string
+		names          []string
+		expectedResult string
+	}{
+		{
+			name: "standard",
+			names: []string{`https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27731/pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade/1626951434970861568/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/test-failures-summary_20230218-180228.json`,
+				`https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27731/pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade/1626951434970861568/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/test-failures-summary_20230218-153052.json`},
+			expectedResult: `https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27731/pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade/1626951434970861568/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/test-failures-summary_20230218-180228.json`,
+		},
+		{
+			name: "reversed",
+			names: []string{`https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27731/pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade/1626951434970861568/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/test-failures-summary_20230218-153052.json`,
+				`https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27731/pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade/1626951434970861568/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/test-failures-summary_20230218-180228.json`},
+			expectedResult: `https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27731/pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade/1626951434970861568/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/test-failures-summary_20230218-180228.json`,
+		},
+		{
+			name: "older date",
+			names: []string{`https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27731/pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade/1626951434970861568/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/test-failures-summary_20230219-153052.json`,
+				`https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27731/pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade/1626951434970861568/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/test-failures-summary_20230218-180228.json`},
+			expectedResult: `https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27731/pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade/1626951434970861568/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/test-failures-summary_20230219-153052.json`,
+		},
+		{
+			name: "invalid date",
+			names: []string{`https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27731/pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade/1626951434970861568/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/test-failures-summary_20230219153052.json`,
+				`https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27731/pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade/1626951434970861568/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/test-failures-summary_20230218-180228.json`},
+			expectedResult: `https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27731/pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade/1626951434970861568/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/test-failures-summary_20230218-180228.json`,
+		},
+		{
+			name: "invalid dates",
+			names: []string{`https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27731/pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade/1626951434970861568/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/test-failures-summary_20230219153052.json`,
+				`https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27731/pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade/1626951434970861568/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/test-failures-summary.json`},
+			expectedResult: ``,
+		},
+		{
+			name:           "empty names",
+			names:          []string{},
+			expectedResult: ``,
+		},
+		{
+			name:           "no names",
+			expectedResult: ``,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedResult, findMostRecentDateTimeMatch(tt.names), "Test: %s failed mostRecentDateTimeMatch", tt.name)
+		})
+	}
+}

--- a/pkg/sippyserver/dbloader.go
+++ b/pkg/sippyserver/dbloader.go
@@ -109,7 +109,7 @@ func createOrUpdateJob(dbc *db.DB, reportName string,
 		dbProwJob := &models.ProwJob{
 			Name:        jr.JobName,
 			Release:     reportName,
-			Variants:    variantManager.IdentifyVariants(jr.JobName, reportName),
+			Variants:    variantManager.IdentifyVariants(jr.JobName, reportName, models.ClusterData{}),
 			TestGridURL: jr.TestGridJobURL,
 		}
 		err := dbc.DB.Clauses(clause.OnConflict{UpdateAll: true}).Create(dbProwJob).Error
@@ -118,9 +118,9 @@ func createOrUpdateJob(dbc *db.DB, reportName string,
 		}
 		prowJobCache[jr.JobName] = dbProwJob
 	} else {
-		// Ensure the job is up to date, especially for variants.
+		// Ensure the job is up-to-date, especially for variants.
 		dbProwJob := prowJobCache[jr.JobName]
-		dbProwJob.Variants = variantManager.IdentifyVariants(jr.JobName, reportName)
+		dbProwJob.Variants = variantManager.IdentifyVariants(jr.JobName, reportName, models.ClusterData{})
 		dbProwJob.TestGridURL = jr.TestGridJobURL
 		dbc.DB.Save(&dbProwJob)
 	}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -828,7 +828,7 @@ func (s *Server) jsonJobRunRiskAnalysis(w http.ResponseWriter, req *http.Request
 			log.Warn("Invalid ProwJob provided for analysis, returning elevated risk")
 			result := apitype.ProwJobRunRiskAnalysis{
 				OverallRisk: apitype.FailureRisk{
-					Level:   apitype.FailureRiskLevelHigh,
+					Level:   apitype.FailureRiskLevelMissingData,
 					Reasons: []string{fmt.Sprintf("Invalid ProwJob provided for analysis: %s", detailReason)},
 				},
 			}
@@ -851,6 +851,11 @@ func (s *Server) jsonJobRunRiskAnalysis(w http.ResponseWriter, req *http.Request
 			return
 		}
 		jobRun.ProwJob = *job
+
+		// if the ClusterData is being passed in then use it to override the variants (agnostic case, etc)
+		if jobRun.ClusterData.Release != "" {
+			jobRun.ProwJob.Variants = s.variantManager.IdentifyVariants(jobRun.ProwJob.Name, jobRun.ClusterData.Release, jobRun.ClusterData)
+		}
 		logger = logger.WithField("jobRunID", jobRun.ID)
 	}
 

--- a/pkg/testidentification/kube_variants.go
+++ b/pkg/testidentification/kube_variants.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/util/sets"
 )
 
@@ -54,7 +55,7 @@ func (kubeVariants) AllPlatforms() sets.String {
 	return sets.String{}
 }
 
-func (v kubeVariants) IdentifyVariants(jobName, release string) []string {
+func (v kubeVariants) IdentifyVariants(jobName, release string, jobVariants models.ClusterData) []string {
 	variants := []string{}
 
 	defer func() {

--- a/pkg/testidentification/no_variants.go
+++ b/pkg/testidentification/no_variants.go
@@ -1,6 +1,7 @@
 package testidentification
 
 import (
+	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/util/sets"
 )
 
@@ -18,7 +19,7 @@ func (noVariants) AllPlatforms() sets.String {
 	return sets.String{}
 }
 
-func (v noVariants) IdentifyVariants(jobName, release string) []string {
+func (v noVariants) IdentifyVariants(jobName, release string, jobVariants models.ClusterData) []string {
 	return []string{}
 }
 func (noVariants) IsJobNeverStable(jobName string) bool {

--- a/pkg/testidentification/ocp_variants_test.go
+++ b/pkg/testidentification/ocp_variants_test.go
@@ -3,13 +3,16 @@ package testidentification
 import (
 	"reflect"
 	"testing"
+
+	"github.com/openshift/sippy/pkg/db/models"
 )
 
 func Test_openshiftVariants_IdentifyVariants(t *testing.T) {
 	tests := []struct {
-		name    string
-		release string
-		want    []string
+		name        string
+		release     string
+		clusterData models.ClusterData
+		want        []string
 	}{
 		{
 			name:    "periodic-ci-openshift-hypershift-main-periodics-conformance-aws-ovn-4-12",
@@ -46,11 +49,41 @@ func Test_openshiftVariants_IdentifyVariants(t *testing.T) {
 			release: "invalid",
 			want:    []string{"aws", "amd64", "ha"},
 		},
+		{
+			name:        "periodic-ci-openshift-release-master-ci-e2e-aws-clusterrelease",
+			release:     "4.13",
+			clusterData: models.ClusterData{Release: "4.13"},
+			want:        []string{"aws", "amd64", "ovn", "ha"},
+		},
+		{
+			name:        "periodic-ci-openshift-release-master-ci-e2e-aws-clusterrelease-with-network",
+			release:     "4.13",
+			clusterData: models.ClusterData{Release: "4.13", Network: "sdn"},
+			want:        []string{"aws", "amd64", "sdn", "ha"},
+		},
+		{
+			name:        "periodic-ci-openshift-release-master-ci-e2e-aws-clusterrelease-with-network-platform-override",
+			release:     "4.13",
+			clusterData: models.ClusterData{Release: "4.13", Network: "sdn", Platform: "azure"},
+			want:        []string{"azure", "amd64", "sdn", "ha"},
+		},
+		{
+			name:        "periodic-ci-openshift-release-master-ci-e2e-aws-clusterrelease-with-network-platform-override-architecture",
+			release:     "4.13",
+			clusterData: models.ClusterData{Release: "4.13", Network: "sdn", Platform: "azure", Architecture: "arm64"},
+			want:        []string{"azure", "arm64", "sdn", "ha"},
+		},
+		{
+			name:        "periodic-ci-openshift-release-master-ci-e2e-aws-clusterrelease-with-network-platform-override-architecture-topology",
+			release:     "4.13",
+			clusterData: models.ClusterData{Release: "4.13", Network: "sdn", Platform: "azure", Architecture: "arm64", Topology: "single-node"},
+			want:        []string{"azure", "arm64", "sdn", "single-node"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			v := openshiftVariants{}
-			if got := v.IdentifyVariants(tt.name, tt.release); !reflect.DeepEqual(got, tt.want) {
+			if got := v.IdentifyVariants(tt.name, tt.release, tt.clusterData); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("IdentifyVariants() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/testidentification/variants.go
+++ b/pkg/testidentification/variants.go
@@ -1,6 +1,9 @@
 package testidentification
 
-import "github.com/openshift/sippy/pkg/util/sets"
+import (
+	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/openshift/sippy/pkg/util/sets"
+)
 
 // VariantManager identifies and describes different variants
 type VariantManager interface {
@@ -11,7 +14,7 @@ type VariantManager interface {
 	AllPlatforms() sets.String
 
 	// IdentifyVariants takes a job name and returns the list of variants that job belongs to.
-	IdentifyVariants(jobName string, release string) []string
+	IdentifyVariants(jobName string, release string, jobVariants models.ClusterData) []string
 
 	// IsJobNeverStable returns true if the job has been curated as never having passed more than 50ish% of the time.
 	// This is used sparingly for jobs that are persistently failing and never taken stable.


### PR DESCRIPTION
Addresses [TRT-838](https://issues.redhat.com/browse/TRT-838) as well as [TRT-800](https://issues.redhat.com/browse/TRT-800)

- Missing variant data like presubmit / agnostic tests
- Missing data all together - Sets Risk Level MissingData
- Missing tests - Sets Risk Level IncompleteTests
- Missing variant match on TestRuns, secondary pass looking for the first super set of variants
- Accepts job variant data on incoming test-failures-summary data for risk analysis
- Performs secondary pass to match test run when we don't have complete variant data for a match
- Looks for new job-variants.json on import to fill in variant data from cluster info when available