### PR TITLE
Retrieve html url so that we can link to the actual PR in sippy UI

### DIFF
--- a/pkg/prowloader/github/github.go
+++ b/pkg/prowloader/github/github.go
@@ -285,7 +285,7 @@ func (c *Client) PRFetch(org, repo string, number int) (prEntry *PREntry, err er
 		prEntry = &PREntry{
 			MergedAt: pr.MergedAt,
 			Title:    pr.Title,
-			URL:      pr.URL,
+			URL:      pr.HTMLURL,
 			State:    pr.State,
 		}
 

--- a/pkg/prowloader/github/github_test.go
+++ b/pkg/prowloader/github/github_test.go
@@ -37,8 +37,8 @@ func TestClient_GetPRSHAMerged(t *testing.T) {
 				Head: &gh.PullRequestBranch{
 					SHA: &mergedSha,
 				},
-				Title: &pr1Title,
-				URL:   &pr1URL,
+				Title:   &pr1Title,
+				HTMLURL: &pr1URL,
 			}, nil
 		} else if org == openshift && repo == kubernetes && number == 2 {
 			return &gh.PullRequest{}, nil


### PR DESCRIPTION
[TRT-859](https://issues.redhat.com//browse/TRT-859)

I believe we want the html url for the pull request info:

```
$ curl https://api.github.com/repos/openshift/cluster-resource-override-admission-operator/pulls/101 > x.json
$ cat x.json |jq .url
"https://api.github.com/repos/openshift/cluster-resource-override-admission-operator/pulls/101"
$ cat x.json |jq .html_url
"https://github.com/openshift/cluster-resource-override-admission-operator/pull/101"
```

The .html_url is the html link to the pull request which is what a user would want to click on vs. the other link in .url which is the raw api endpoint.