### PR TITLE
Test analysis refactor

### DIFF
--- a/main.go
+++ b/main.go
@@ -673,10 +673,10 @@ func (o *Options) runServerMode(pinnedDateTime *time.Time, gormLogLevel gormlogg
 	)
 
 	// Do an immediate metrics update
-	err = metrics.RefreshMetricsDB(dbc, o.getVariantManager(), util.GetReportEnd(pinnedDateTime))
+	/*err = metrics.RefreshMetricsDB(dbc, o.getVariantManager(), util.GetReportEnd(pinnedDateTime))
 	if err != nil {
 		log.WithError(err).Error("error refreshing metrics")
-	}
+	}*/
 
 	// Refresh our metrics every 5 minutes:
 	ticker := time.NewTicker(5 * time.Minute)

--- a/main.go
+++ b/main.go
@@ -673,10 +673,10 @@ func (o *Options) runServerMode(pinnedDateTime *time.Time, gormLogLevel gormlogg
 	)
 
 	// Do an immediate metrics update
-	/*err = metrics.RefreshMetricsDB(dbc, o.getVariantManager(), util.GetReportEnd(pinnedDateTime))
+	err = metrics.RefreshMetricsDB(dbc, o.getVariantManager(), util.GetReportEnd(pinnedDateTime))
 	if err != nil {
 		log.WithError(err).Error("error refreshing metrics")
-	}*/
+	}
 
 	// Refresh our metrics every 5 minutes:
 	ticker := time.NewTicker(5 * time.Minute)

--- a/pkg/api/jobs.go
+++ b/pkg/api/jobs.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"regexp"
 	gosort "sort"
 	"strconv"
 	"time"
@@ -55,11 +54,6 @@ func (jobs jobsAPIResult) limit(req *http.Request) jobsAPIResult {
 	}
 
 	return jobs
-}
-
-func briefName(job string) string {
-	briefName := regexp.MustCompile("periodic-ci-openshift-(multiarch|release)-master-(ci|nightly)-[0-9]+.[0-9]+-")
-	return briefName.ReplaceAllString(job, "")
 }
 
 // PrintVariantReportFromDB

--- a/pkg/api/test_analysis.go
+++ b/pkg/api/test_analysis.go
@@ -1,14 +1,11 @@
 package api
 
 import (
-	"fmt"
-	"net/http"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 
 	"github.com/openshift/sippy/pkg/db"
-	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/filter"
 )
 
@@ -22,24 +19,6 @@ type CountByDate struct {
 	Passes          int     `json:"passes"`
 	Flakes          int     `json:"flakes"`
 	Failures        int     `json:"failures"`
-}
-
-type counts struct {
-	Runs     int `json:"runs"`
-	Failures int `json:"failures"`
-
-	Passes int `json:"passes"`
-	Flakes int `json:"flakes"`
-}
-
-type testResultDay struct {
-	Overall   counts             `json:"overall"`
-	ByVariant map[string]*counts `json:"by_variant"`
-	ByJob     map[string]*counts `json:"by_job"`
-}
-
-type apiTestByDayresults struct {
-	ByDay map[string]testResultDay `json:"by_day"`
 }
 
 func GetTestAnalysisOverallFromDB(dbc *db.DB, filters *filter.Filter, release, testName string, reportEnd time.Time) ([]CountByDate, error) {
@@ -216,158 +195,4 @@ func GetTestAnalysisByVariantFromDB(dbc *db.DB, filters *filter.Filter, release,
 	}
 
 	return results, nil
-}
-
-func PrintTestAnalysisJSONFromDB(dbc *db.DB, w http.ResponseWriter, req *http.Request, release, testName string, reportEnd time.Time) error {
-	results := apiTestByDayresults{
-		ByDay: make(map[string]testResultDay),
-	}
-
-	filters, err := filter.ExtractFilters(req)
-	if err != nil {
-		return err
-	}
-
-	// We're using two views, one for by variant and one for by job, thus we will do
-	// two queries and combine the results into the struct we need.
-	var byVariantAnalysisRows []models.TestAnalysisRow
-	vq := dbc.DB.Table("prow_test_analysis_by_variant_14d_matview").
-		Where("release = ?", release).
-		Where("test_name = ?", testName).
-		Select(`test_id,
-	       test_name,
-    	   date,
-	       release,
-	       variant,
-	       runs,
-	       passes,
-	       flakes,
-    	   failures`).
-		Group("test_id, test_name, date, release, variant, runs, passes, flakes, failures")
-
-	var allowedVariants, blockedVariants []string
-	if filters != nil {
-		for _, f := range filters.Items {
-			if f.Field == "variants" {
-				if f.Not {
-					blockedVariants = append(blockedVariants, f.Value)
-				} else {
-					allowedVariants = append(allowedVariants, f.Value)
-				}
-			}
-		}
-
-		if len(blockedVariants) > 0 {
-			vq = vq.Where("variant NOT IN ?", blockedVariants)
-		}
-
-		if len(allowedVariants) > 0 {
-			vq = vq.Where("variant IN ?", allowedVariants)
-		}
-	}
-
-	r := vq.Scan(&byVariantAnalysisRows)
-	if r.Error != nil {
-		log.WithError(r.Error).Error("error querying test analysis by variant")
-		return r.Error
-	}
-
-	// Reset analysis rows and now we query from the by job view
-	byJobAnalysisRows := []models.TestAnalysisRow{}
-	jq := dbc.DB.Table("prow_test_analysis_by_job_14d_matview").
-		Select(`test_id,
-			test_name,
-			date,
-			prow_jobs.release,
-			job_name,
-			runs,
-			passes,
-			flakes,
-			failures,
-			ARRAY_AGG(variants) as variants`).
-		Joins("INNER JOIN prow_jobs on prow_jobs.name = job_name").
-		Where("prow_jobs.release = ?", release).
-		Where("test_name = ?", testName).
-		Group("test_id, test_name, date, prow_jobs.release, job_name, runs, passes, flakes, failures")
-
-	for _, bv := range blockedVariants {
-		jq = jq.Where("? != ANY(variants)", bv)
-	}
-
-	for _, av := range allowedVariants {
-		jq = jq.Where("? = ANY(variants)", av)
-	}
-
-	r = jq.Scan(&byJobAnalysisRows)
-	if r.Error != nil {
-		log.WithError(r.Error).Error("error querying test analysis by job")
-		return r.Error
-	}
-
-	allRows := append(byVariantAnalysisRows, byJobAnalysisRows...)
-
-	for _, row := range allRows {
-
-		// need to know the report end, if the date is greater than that skip the row
-		// tried modifying the query but still get extra rows / days
-		// Where("date < ? ", reportEnd.UTC()).
-		if row.Date.After(reportEnd) {
-			continue
-		}
-
-		date := row.Date.Format("2006-01-02")
-
-		var dayResult testResultDay
-		if _, ok := results.ByDay[date]; !ok {
-			dayResult = testResultDay{
-				ByVariant: make(map[string]*counts),
-				ByJob:     make(map[string]*counts),
-			}
-		} else {
-			dayResult = results.ByDay[date]
-		}
-
-		// We're reusing the same model object when we query by variant or job, so we fork based on what field is set
-		if row.Variant != "" {
-			if _, ok := dayResult.ByVariant[row.Variant]; ok {
-				// Should not happen if our query is correct.
-				return fmt.Errorf("test '%s' showed duplicate variant '%s' row on date '%s'", testName, row.Variant, date)
-			}
-			dayResult.ByVariant[row.Variant] = &counts{
-				Runs:     row.Runs,
-				Passes:   row.Passes,
-				Flakes:   row.Flakes,
-				Failures: row.Failures,
-			}
-		} else {
-			// Assuming that if row.Variant is not set, row.JobName must be.
-			if _, ok := dayResult.ByJob[briefName(row.JobName)]; !ok {
-				dayResult.ByJob[briefName(row.JobName)] = &counts{
-					Runs:     row.Runs,
-					Passes:   row.Passes,
-					Flakes:   row.Flakes,
-					Failures: row.Failures,
-				}
-			} else {
-				// the briefName() function will map to the same value for some jobs, this appears to be intentional.
-				// As such if we see a brief job name that we already have, we need to increment it's counters.
-				dayResult.ByJob[briefName(row.JobName)].Runs += row.Runs
-				dayResult.ByJob[briefName(row.JobName)].Passes += row.Passes
-				dayResult.ByJob[briefName(row.JobName)].Flakes += row.Flakes
-				dayResult.ByJob[briefName(row.JobName)].Failures += row.Failures
-			}
-
-			// Increment our overall counter using the rows with job names, as these are distinct.
-			// (unlike variants which can overlap and would cause double counted test runs)
-			dayResult.Overall.Runs += row.Runs
-			dayResult.Overall.Passes += row.Passes
-			dayResult.Overall.Flakes += row.Flakes
-			dayResult.Overall.Failures += row.Failures
-		}
-
-		results.ByDay[date] = dayResult
-	}
-
-	RespondWithJSON(http.StatusOK, w, results)
-	return nil
 }

--- a/pkg/api/test_analysis.go
+++ b/pkg/api/test_analysis.go
@@ -21,7 +21,7 @@ type CountByDate struct {
 	Failures        int     `json:"failures"`
 }
 
-func GetTestAnalysisOverallFromDB(dbc *db.DB, filters *filter.Filter, release, testName string, reportEnd time.Time) ([]CountByDate, error) {
+func GetTestAnalysisOverallFromDB(dbc *db.DB, filters *filter.Filter, release, testName string, reportEnd time.Time) (map[string][]CountByDate, error) {
 	var rows []CountByDate
 	jq := dbc.DB.Table("prow_test_analysis_by_job_14d_matview").
 		Select(`test_id,
@@ -68,7 +68,9 @@ func GetTestAnalysisOverallFromDB(dbc *db.DB, filters *filter.Filter, release, t
 		return nil, r.Error
 	}
 
-	return rows, nil
+	result := make(map[string][]CountByDate)
+	result["overall"] = rows
+	return result, nil
 }
 
 func GetTestAnalysisByJobFromDB(dbc *db.DB, filters *filter.Filter, release, testName string, reportEnd time.Time) (map[string][]CountByDate, error) {
@@ -79,8 +81,8 @@ func GetTestAnalysisByJobFromDB(dbc *db.DB, filters *filter.Filter, release, tes
 	if err != nil {
 		return nil, err
 	}
-	if len(overallResult) > 0 {
-		results["overall"] = overallResult
+	if overall, ok := overallResult["overall"]; ok {
+		results["overall"] = overall
 	}
 
 	jq := dbc.DB.Table("prow_test_analysis_by_job_14d_matview").
@@ -145,8 +147,8 @@ func GetTestAnalysisByVariantFromDB(dbc *db.DB, filters *filter.Filter, release,
 	if err != nil {
 		return nil, err
 	}
-	if len(overallResult) > 0 {
-		results["overall"] = overallResult
+	if overall, ok := overallResult["overall"]; ok {
+		results["overall"] = overall
 	}
 
 	vq := dbc.DB.Table("prow_test_analysis_by_variant_14d_matview").

--- a/pkg/api/test_analysis.go
+++ b/pkg/api/test_analysis.go
@@ -100,7 +100,9 @@ func GetTestAnalysisByJobFromDB(dbc *db.DB, filters *filter.Filter, release, tes
 	if err != nil {
 		return nil, err
 	}
-	results["overall"] = overallResult
+	if len(overallResult) > 0 {
+		results["overall"] = overallResult
+	}
 
 	jq := dbc.DB.Table("prow_test_analysis_by_job_14d_matview").
 		Select(`test_id,
@@ -163,7 +165,9 @@ func GetTestAnalysisByVariantFromDB(dbc *db.DB, filters *filter.Filter, release,
 	if err != nil {
 		return nil, err
 	}
-	results["overall"] = overallResult
+	if len(overallResult) > 0 {
+		results["overall"] = overallResult
+	}
 
 	vq := dbc.DB.Table("prow_test_analysis_by_variant_14d_matview").
 		Where("release = ?", release).

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -435,6 +435,10 @@ func (s *Server) jsonTestAnalysisByVariantFromDB(w http.ResponseWriter, req *htt
 	s.jsonTestAnalysis(w, req, api.GetTestAnalysisByVariantFromDB)
 }
 
+func (s *Server) jsonTestAnalysisOverallFromDB(w http.ResponseWriter, req *http.Request) {
+	s.jsonTestAnalysis(w, req, api.GetTestAnalysisOverallFromDB)
+}
+
 func (s *Server) jsonTestBugsFromDB(w http.ResponseWriter, req *http.Request) {
 	testName := req.URL.Query().Get("test")
 	if testName == "" {
@@ -999,6 +1003,7 @@ func (s *Server) Serve() {
 	serveMux.HandleFunc("/api/repositories", s.jsonRepositoriesReportFromDB)
 	serveMux.HandleFunc("/api/tests", s.jsonTestsReportFromDB)
 	serveMux.HandleFunc("/api/tests/details", s.jsonTestDetailsReportFromDB)
+	serveMux.HandleFunc("/api/tests/analysis/overall", s.jsonTestAnalysisOverallFromDB)
 	serveMux.HandleFunc("/api/tests/analysis/variants", s.jsonTestAnalysisByVariantFromDB)
 	serveMux.HandleFunc("/api/tests/analysis/jobs", s.jsonTestAnalysisByJobFromDB)
 	serveMux.HandleFunc("/api/tests/bugs", s.jsonTestBugsFromDB)

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -400,6 +400,33 @@ func (s *Server) jsonReleaseHealthReport(w http.ResponseWriter, req *http.Reques
 	api.RespondWithJSON(http.StatusOK, w, results)
 }
 
+func (s *Server) jsonTestAnalysisByJobFromDB(w http.ResponseWriter, req *http.Request) {
+	testName := req.URL.Query().Get("test")
+	if testName == "" {
+		api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{
+			"code":    http.StatusBadRequest,
+			"message": "'test' is required.",
+		})
+		return
+	}
+	release := s.getReleaseOrFail(w, req)
+	if release != "" {
+		filters, err := filter.ExtractFilters(req)
+		if err != nil {
+			api.RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError,
+				"message": "couldn't parse filter opts " + err.Error()})
+			return
+		}
+		results, err := api.GetTestAnalysisByJobFromDB(s.db, filters, release, testName, s.GetReportEnd())
+		if err != nil {
+			api.RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError,
+				"message": err.Error()})
+			return
+		}
+		api.RespondWithJSON(200, w, results)
+	}
+}
+
 func (s *Server) jsonTestAnalysisByVariantFromDB(w http.ResponseWriter, req *http.Request) {
 	testName := req.URL.Query().Get("test")
 	if testName == "" {
@@ -1010,6 +1037,7 @@ func (s *Server) Serve() {
 	serveMux.HandleFunc("/api/tests", s.jsonTestsReportFromDB)
 	serveMux.HandleFunc("/api/tests/details", s.jsonTestDetailsReportFromDB)
 	serveMux.HandleFunc("/api/tests/analysis/variants", s.jsonTestAnalysisByVariantFromDB)
+	serveMux.HandleFunc("/api/tests/analysis/jobs", s.jsonTestAnalysisByJobFromDB)
 	serveMux.HandleFunc("/api/tests/analysis", s.jsonTestAnalysisReportFromDB)
 	serveMux.HandleFunc("/api/tests/bugs", s.jsonTestBugsFromDB)
 	serveMux.HandleFunc("/api/tests/outputs", s.jsonTestOutputsFromDB)

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -454,24 +454,6 @@ func (s *Server) jsonTestAnalysisByVariantFromDB(w http.ResponseWriter, req *htt
 	}
 }
 
-func (s *Server) jsonTestAnalysisReportFromDB(w http.ResponseWriter, req *http.Request) {
-	testName := req.URL.Query().Get("test")
-	if testName == "" {
-		api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{
-			"code":    http.StatusBadRequest,
-			"message": "'test' is required.",
-		})
-		return
-	}
-	release := s.getReleaseOrFail(w, req)
-	if release != "" {
-		err := api.PrintTestAnalysisJSONFromDB(s.db, w, req, release, testName, s.GetReportEnd())
-		if err != nil {
-			log.Errorf("error querying test analysis from db: %v", err)
-		}
-	}
-}
-
 func (s *Server) jsonTestBugsFromDB(w http.ResponseWriter, req *http.Request) {
 	testName := req.URL.Query().Get("test")
 	if testName == "" {
@@ -1038,7 +1020,6 @@ func (s *Server) Serve() {
 	serveMux.HandleFunc("/api/tests/details", s.jsonTestDetailsReportFromDB)
 	serveMux.HandleFunc("/api/tests/analysis/variants", s.jsonTestAnalysisByVariantFromDB)
 	serveMux.HandleFunc("/api/tests/analysis/jobs", s.jsonTestAnalysisByJobFromDB)
-	serveMux.HandleFunc("/api/tests/analysis", s.jsonTestAnalysisReportFromDB)
 	serveMux.HandleFunc("/api/tests/bugs", s.jsonTestBugsFromDB)
 	serveMux.HandleFunc("/api/tests/outputs", s.jsonTestOutputsFromDB)
 	serveMux.HandleFunc("/api/tests/durations", s.jsonTestDurationsFromDB)

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -400,6 +400,33 @@ func (s *Server) jsonReleaseHealthReport(w http.ResponseWriter, req *http.Reques
 	api.RespondWithJSON(http.StatusOK, w, results)
 }
 
+func (s *Server) jsonTestAnalysisByVariantFromDB(w http.ResponseWriter, req *http.Request) {
+	testName := req.URL.Query().Get("test")
+	if testName == "" {
+		api.RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{
+			"code":    http.StatusBadRequest,
+			"message": "'test' is required.",
+		})
+		return
+	}
+	release := s.getReleaseOrFail(w, req)
+	if release != "" {
+		filters, err := filter.ExtractFilters(req)
+		if err != nil {
+			api.RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError,
+				"message": "couldn't parse filter opts " + err.Error()})
+			return
+		}
+		results, err := api.GetTestAnalysisByVariantFromDB(s.db, filters, release, testName, s.GetReportEnd())
+		if err != nil {
+			api.RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError,
+				"message": err.Error()})
+			return
+		}
+		api.RespondWithJSON(200, w, results)
+	}
+}
+
 func (s *Server) jsonTestAnalysisReportFromDB(w http.ResponseWriter, req *http.Request) {
 	testName := req.URL.Query().Get("test")
 	if testName == "" {
@@ -982,6 +1009,7 @@ func (s *Server) Serve() {
 	serveMux.HandleFunc("/api/repositories", s.jsonRepositoriesReportFromDB)
 	serveMux.HandleFunc("/api/tests", s.jsonTestsReportFromDB)
 	serveMux.HandleFunc("/api/tests/details", s.jsonTestDetailsReportFromDB)
+	serveMux.HandleFunc("/api/tests/analysis/variants", s.jsonTestAnalysisByVariantFromDB)
 	serveMux.HandleFunc("/api/tests/analysis", s.jsonTestAnalysisReportFromDB)
 	serveMux.HandleFunc("/api/tests/bugs", s.jsonTestBugsFromDB)
 	serveMux.HandleFunc("/api/tests/outputs", s.jsonTestOutputsFromDB)

--- a/sippy-ng/src/tests/TestAnalysis.js
+++ b/sippy-ng/src/tests/TestAnalysis.js
@@ -279,6 +279,14 @@ export function TestAnalysis(props) {
             test={testName}
             release={props.release}
             filterModel={filterModel}
+            grouping="jobs"
+          />
+
+          <TestPassRateCharts
+            test={testName}
+            release={props.release}
+            filterModel={filterModel}
+            grouping="variants"
           />
 
           <Grid item md={12}>

--- a/sippy-ng/src/tests/TestAnalysis.js
+++ b/sippy-ng/src/tests/TestAnalysis.js
@@ -24,6 +24,7 @@ import { Link } from 'react-router-dom'
 import { TEST_THRESHOLDS } from '../constants'
 import { TestDurationChart } from './TestDurationChart'
 import { TestOutputs } from './TestOutputs'
+import { TestStackedChart } from './TestStackedChart'
 import { useQueryParam } from 'use-query-params'
 import Alert from '@material-ui/lab/Alert'
 import BugTable from '../bugzilla/BugTable'
@@ -274,6 +275,12 @@ export function TestAnalysis(props) {
               />
             </Card>
           </Grid>
+
+          <TestStackedChart
+            release={props.release}
+            test={testName}
+            filter={filterModel}
+          />
 
           <TestPassRateCharts
             test={testName}

--- a/sippy-ng/src/tests/TestPassRateCharts.js
+++ b/sippy-ng/src/tests/TestPassRateCharts.js
@@ -17,20 +17,11 @@ import GridToolbar from '../datagrid/GridToolbar'
 import InfoIcon from '@material-ui/icons/Info'
 import PropTypes from 'prop-types'
 import React, { Fragment, useEffect } from 'react'
-import { Link } from 'react-router-dom'
 
 export default function TestPassRateCharts(props) {
   const [isLoaded, setLoaded] = React.useState(false)
   const [groupedData, setGroupedData] = React.useState({})
   const [fetchError, setFetchError] = React.useState('')
-  const [groupSelectionDialog, setGroupSelectionDialog] = React.useState(false)
-  const [selectionModel, setSelectionModel] = React.useState([
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-  ])
-  const [selectedGroups = [], setSelectedGroups] = useQueryParam(
-    props.grouping,
-    ArrayParam
-  )
   const fetchData = () => {
     const filter = safeEncodeURIComponent(JSON.stringify(props.filterModel))
 
@@ -170,58 +161,6 @@ export default function TestPassRateCharts(props) {
               props.grouping.substr(1).toLowerCase()}
           </Typography>
           <Line data={chart} options={options} height={80} />
-          <Button
-            style={{ marginTop: 20 }}
-            variant="contained"
-            color="secondary"
-            onClick={() => setGroupSelectionDialog(true)}
-          >
-            Select {props.grouping} to chart
-          </Button>
-          <Dialog
-            fullWidth={true}
-            maxWidth="lg"
-            onClose={() => setGroupSelectionDialog(false)}
-            open={groupSelectionDialog}
-          >
-            <Grid className="test-dialog">
-              <Typography
-                variant="h6"
-                style={{ marginTop: 20, marginBottom: 20 }}
-              >
-                Select {props.grouping} to chart
-              </Typography>
-              <DataGrid
-                components={{ Toolbar: GridToolbar }}
-                columns={columns}
-                rows={allTests}
-                pageSize={10}
-                rowHeight={60}
-                autoHeight={true}
-                selectionModel={selectionModel}
-                onSelectionModelChange={(m) => updateSelectionModel(m)}
-                checkboxSelection
-                componentsProps={{
-                  toolbar: {
-                    columns: columns,
-                    filterModel: testFilter,
-                    setFilterModel: setTestFilter,
-                    clearSearch: () => requestSearch(''),
-                    doSearch: requestSearch,
-                  },
-                }}
-              />
-
-              <Button
-                style={{ marginTop: 20 }}
-                variant="contained"
-                color="primary"
-                onClick={() => setGroupSelectionDialog(false)}
-              >
-                OK
-              </Button>
-            </Grid>
-          </Dialog>
         </Card>
       </Grid>
     </Fragment>
@@ -230,6 +169,7 @@ export default function TestPassRateCharts(props) {
 
 TestPassRateCharts.defaultProps = {
   grouping: 'variants',
+  filterModel: { items: [] },
 }
 
 TestPassRateCharts.propTypes = {

--- a/sippy-ng/src/tests/TestPassRateCharts.js
+++ b/sippy-ng/src/tests/TestPassRateCharts.js
@@ -15,7 +15,7 @@ import React, { Fragment, useEffect } from 'react'
 
 export default function TestPassRateCharts(props) {
   const [isLoaded, setLoaded] = React.useState(false)
-  const [analysis, setAnalysis] = React.useState({ by_day: {} })
+  const [groupedData, setGroupedData] = React.useState({})
   const [fetchError, setFetchError] = React.useState('')
 
   const fetchData = () => {
@@ -23,22 +23,27 @@ export default function TestPassRateCharts(props) {
 
     Promise.all([
       fetch(
-        `${process.env.REACT_APP_API_URL}/api/tests/analysis?release=${props.release}&test=${props.test}&filter=${filter}`
+        `${process.env.REACT_APP_API_URL}/api/tests/analysis/${props.grouping}?release=${props.release}&test=${props.test}&filter=${filter}`
       ),
     ])
-      .then(([analysis]) => {
-        if (analysis.status !== 200) {
-          throw new Error('server returned ' + analysis.status)
+      .then(([apiResponse]) => {
+        if (apiResponse.status !== 200) {
+          throw new Error('server returned ' + apiResponse.status)
         }
-        return Promise.all([analysis.json()])
+        return Promise.all([apiResponse.json()])
       })
-      .then(([analysis]) => {
-        setAnalysis(analysis)
+      .then(([apiResponse]) => {
+        setGroupedData(apiResponse)
         setLoaded(true)
       })
       .catch((error) => {
         setFetchError(
-          'Could not retrieve test analysis ' + props.release + ', ' + error
+          'Could not retrieve test analysis for ' +
+            props.release +
+            +' ' +
+            props.grouping +
+            ' , ' +
+            error
         )
       })
   }
@@ -55,29 +60,8 @@ export default function TestPassRateCharts(props) {
     return (
       <Fragment>
         <Grid item md={12}>
-          <Card
-            className="test-failure-card"
-            elevation={5}
-            style={{ minHeight: 80 }}
-          >
-            <Typography variant="h5">
-              Pass Rate By Job
-              <Tooltip title="Only jobs with at least one failure over the reporting period are shown individually.">
-                <InfoIcon />
-              </Tooltip>
-            </Typography>
-            <CircularProgress color="inherit" />
-          </Card>
-        </Grid>
-
-        <Grid item md={12}>
           <Card className="test-failure-card" elevation={5}>
-            <Typography variant="h5">
-              Pass Rate By Variant
-              <Tooltip title="Test pass rate is approximated by number of job runs on the given day without a test failure. Only variants with at least one failure over the reporting period are shown individually.">
-                <InfoIcon />
-              </Tooltip>
-            </Typography>
+            <Typography variant="h5">Pass Rate By {props.grouping}</Typography>
             <CircularProgress color="inherit" />
           </Card>
         </Grid>
@@ -85,167 +69,15 @@ export default function TestPassRateCharts(props) {
     )
   }
 
-  const percentage = (passes, runs) => {
-    return (100 * (passes / runs)).toFixed(2)
-  }
+  const colors = scale('Set2')
+    .mode('lch')
+    .colors(Object.keys(groupedData).length)
 
-  const byJobChart = {
-    labels: Object.keys(analysis.by_day),
-    datasets: [
-      {
-        type: 'line',
-        label: 'overall',
-        tension: 0.25,
-        borderColor: 'black',
-        backgroundColor: 'black',
-        fill: false,
-        data: Object.keys(analysis.by_day).map((key) => {
-          const passes = analysis.by_day[key].overall.passes
-          const runs = analysis.by_day[key].overall.runs
-
-          return percentage(passes, runs)
-        }),
-      },
-    ],
-  }
-
-  const byVariantChart = {
-    labels: Object.keys(analysis.by_day),
-    datasets: [
-      {
-        type: 'line',
-        label: 'overall',
-        tension: 0.25,
-        borderColor: 'black',
-        backgroundColor: 'black',
-        fill: false,
-        data: Object.keys(analysis.by_day).map((key) => {
-          const passes = analysis.by_day[key].overall.passes
-          const runs = analysis.by_day[key].overall.runs
-
-          return percentage(passes, runs)
-        }),
-      },
-    ],
-  }
-
-  // Get list of jobs in this data set
-  const jobs = new Set()
-
-  // Get a list of variants in this data set
-  const variants = new Set()
-  const variantFailures = []
-
-  Object.keys(analysis.by_day).forEach((key) => {
-    Object.keys(analysis.by_day[key].by_variant || {}).forEach((variant) => {
-      variants.add(variant)
-    })
-
-    Object.keys(analysis.by_day[key].by_job || {}).forEach((job) => {
-      // Omit jobs that never failed
-      if (
-        analysis.by_day[key].by_job[job].failures > 0 ||
-        analysis.by_day[key].by_job[job].flakes > 0
-      ) {
-        jobs.add(job)
-      }
-    })
-  })
-
-  const colors = scale('Set2').mode('lch').colors(jobs.size)
-
-  const byJobChartOptions = {
-    plugins: {
-      tooltip: {
-        callbacks: {
-          label: function (context) {
-            let passes, failures, flakes, runs
-
-            if (context.dataset.label === 'overall') {
-              passes = analysis.by_day[context.label].overall.passes || 0
-              flakes = analysis.by_day[context.label].overall.flakes || 0
-              failures = analysis.by_day[context.label].overall.failures || 0
-            } else {
-              passes = analysis.by_day[context.label].by_job[
-                context.dataset.label
-              ]
-                ? analysis.by_day[context.label].by_job[context.dataset.label]
-                    .passes
-                : 0
-
-              failures = analysis.by_day[context.label].by_job[
-                context.dataset.label
-              ]
-                ? analysis.by_day[context.label].by_job[context.dataset.label]
-                    .failures
-                : 0
-
-              flakes = analysis.by_day[context.label].by_job[
-                context.dataset.label
-              ]
-                ? analysis.by_day[context.label].by_job[context.dataset.label]
-                    .flakes
-                : 0
-            }
-
-            return `${context.dataset.label} ${context.raw}% (${passes} passed, ${failures} failed, ${flakes} flaked)`
-          },
-        },
-      },
-    },
-    scales: {
-      y: {
-        max: 100,
-        ticks: {
-          callback: (value, index, values) => {
-            return `${value}%`
-          },
-        },
-      },
-    },
-  }
-
-  const byVariantChartOptions = {
-    plugins: {
-      tooltip: {
-        callbacks: {
-          label: function (context) {
-            let passes, failures, flakes
-
-            if (context.dataset.label === 'overall') {
-              passes = analysis.by_day[context.label].overall.passes || 0
-              flakes = analysis.by_day[context.label].overall.flakes || 0
-              failures = analysis.by_day[context.label].overall.failures || 0
-            } else {
-              passes = analysis.by_day[context.label].by_variant[
-                context.dataset.label
-              ]
-                ? analysis.by_day[context.label].by_variant[
-                    context.dataset.label
-                  ].passes
-                : 0
-
-              failures = analysis.by_day[context.label].by_variant[
-                context.dataset.label
-              ]
-                ? analysis.by_day[context.label].by_variant[
-                    context.dataset.label
-                  ].failures
-                : 0
-
-              flakes = analysis.by_day[context.label].by_variant[
-                context.dataset.label
-              ]
-                ? analysis.by_day[context.label].by_variant[
-                    context.dataset.label
-                  ].flakes
-                : 0
-            }
-
-            return `${context.dataset.label} ${context.raw}% (${passes} passed, ${failures} failed, ${flakes} flaked)`
-          },
-        },
-      },
+  const chart = { datasets: [] }
+  const options = {
+    parsing: {
+      xAxisKey: 'date',
+      yAxisKey: 'pass_percentage',
     },
     scales: {
       y: {
@@ -260,114 +92,41 @@ export default function TestPassRateCharts(props) {
   }
 
   let index = 0
-  variants.forEach((variant) => {
-    variantFailures.push(
-      Object.keys(analysis.by_day)
-        .map((key) => {
-          return analysis.by_day[key].by_variant[variant]
-            ? analysis.by_day[key].by_variant[variant].failures
-            : 0
-        })
-        .reduce((acc, val) => acc + val)
-    )
-
-    byVariantChart.datasets.push({
+  Object.keys(groupedData).forEach((variant) => {
+    chart.datasets.push({
       type: 'line',
       label: `${variant}`,
       tension: 0.25,
       yAxisID: 'y',
       borderColor: colors[index],
       backgroundColor: colors[index],
-      data: Object.keys(analysis.by_day).map((key) => {
-        const passes = analysis.by_day[key].by_variant[variant]
-          ? analysis.by_day[key].by_variant[variant].passes
-          : 0
-        const runs = analysis.by_day[key].by_variant[variant]
-          ? analysis.by_day[key].by_variant[variant].runs
-          : 0
-        // Percentage of variant runs not exhibiting failure, i.e.
-        // an approximation of the pass rate
-        return percentage(passes, runs)
-      }),
+      data: groupedData[variant],
     })
-
     index++
   })
-
-  index = 0
-  jobs.forEach((job) => {
-    byJobChart.datasets.push({
-      type: 'line',
-      label: `${job}`,
-      tension: 0.25,
-      yAxisID: 'y',
-      borderColor: colors[index],
-      backgroundColor: colors[index],
-      data: Object.keys(analysis.by_day).map((key) => {
-        const passes = analysis.by_day[key].by_job[job]
-          ? analysis.by_day[key].by_job[job].passes
-          : 0
-        const runs = analysis.by_day[key].by_job[job]
-          ? analysis.by_day[key].by_job[job].runs
-          : 0
-        // Percentage of job runs not exhibiting failure, i.e.
-        // an approximation of the pass rate
-        return percentage(passes, runs)
-      }),
-    })
-
-    index++
-  })
-
-  const variantPolar = {
-    labels: Array.from(variants),
-    datasets: [
-      {
-        label: '# of Failures',
-        data: variantFailures,
-        lineTension: 0.4,
-        backgroundColor: colors,
-        borderWidth: 1,
-      },
-    ],
-  }
 
   return (
     <Fragment>
       <Grid item md={12}>
         <Card className="test-failure-card" elevation={5}>
           <Typography variant="h5">
-            Pass Rate By Job
-            <Tooltip title="Only jobs with at least one failure over the reporting period are shown individually.">
-              <InfoIcon />
-            </Tooltip>
+            Pass Rate By{' '}
+            {props.grouping.charAt(0).toUpperCase() +
+              props.grouping.substr(1).toLowerCase()}
           </Typography>
-          <Line data={byJobChart} options={byJobChartOptions} height={80} />
-        </Card>
-      </Grid>
-
-      <Grid item md={12}>
-        <Card className="test-failure-card" elevation={5}>
-          <Typography variant="h5">
-            Pass Rate By Variant
-            <Tooltip title="Test pass rate is approximated by number of job runs on the given day without a test failure. Only variants with at least one failure over the reporting period are shown individually.">
-              <InfoIcon />
-            </Tooltip>
-          </Typography>
-          <Line
-            data={byVariantChart}
-            options={byVariantChartOptions}
-            height={80}
-          />
+          <Line data={chart} options={options} height={80} />
         </Card>
       </Grid>
     </Fragment>
   )
 }
 
-TestPassRateCharts.defaultProps = {}
+TestPassRateCharts.defaultProps = {
+  grouping: 'variants',
+}
 
 TestPassRateCharts.propTypes = {
+  grouping: PropTypes.string,
   release: PropTypes.string.isRequired,
   test: PropTypes.string.isRequired,
   filterModel: PropTypes.object.isRequired,

--- a/sippy-ng/src/tests/TestPassRateCharts.js
+++ b/sippy-ng/src/tests/TestPassRateCharts.js
@@ -73,11 +73,35 @@ export default function TestPassRateCharts(props) {
     .mode('lch')
     .colors(Object.keys(groupedData).length)
 
-  const chart = { datasets: [] }
+  let days = Array.from(
+    { length: 14 },
+    (_, x) => new Date(new Date() - 1000 * 60 * 60 * 24 * x)
+  )
+    .map((day) => day.toISOString().split('T')[0])
+    .reverse()
+
+  const chart = {
+    labels: days,
+    datasets: [],
+  }
+
   const options = {
     parsing: {
       xAxisKey: 'date',
       yAxisKey: 'pass_percentage',
+    },
+    plugins: {
+      tooltip: {
+        callbacks: {
+          label: function (context) {
+            let data = groupedData[context.dataset.label].find(
+              (element) => element.date === context.label
+            )
+
+            return `${context.dataset.label} ${data.pass_percentage}% (${data.passes} passed, ${data.failures} failed, ${data.flakes} flaked)`
+          },
+        },
+      },
     },
     scales: {
       y: {
@@ -92,15 +116,15 @@ export default function TestPassRateCharts(props) {
   }
 
   let index = 0
-  Object.keys(groupedData).forEach((variant) => {
+  Object.keys(groupedData).forEach((group) => {
     chart.datasets.push({
       type: 'line',
-      label: `${variant}`,
+      label: `${group}`,
       tension: 0.25,
       yAxisID: 'y',
       borderColor: colors[index],
       backgroundColor: colors[index],
-      data: groupedData[variant],
+      data: groupedData[group],
     })
     index++
   })

--- a/sippy-ng/src/tests/TestPassRateCharts.js
+++ b/sippy-ng/src/tests/TestPassRateCharts.js
@@ -65,7 +65,11 @@ export default function TestPassRateCharts(props) {
       <Fragment>
         <Grid item md={12}>
           <Card className="test-failure-card" elevation={5}>
-            <Typography variant="h5">Pass Rate By {props.grouping}</Typography>
+            <Typography variant="h5">
+              Pass Rate By{' '}
+              {props.grouping.charAt(0).toUpperCase() +
+                props.grouping.substr(1).toLowerCase()}
+            </Typography>
             <CircularProgress color="inherit" />
           </Card>
         </Grid>
@@ -169,7 +173,6 @@ export default function TestPassRateCharts(props) {
 
 TestPassRateCharts.defaultProps = {
   grouping: 'variants',
-  filterModel: { items: [] },
 }
 
 TestPassRateCharts.propTypes = {

--- a/sippy-ng/src/tests/TestPassRateCharts.js
+++ b/sippy-ng/src/tests/TestPassRateCharts.js
@@ -1,23 +1,36 @@
+import { ArrayParam, useQueryParam } from 'use-query-params'
 import {
+  Button,
   Card,
   CircularProgress,
+  Dialog,
   Grid,
   Tooltip,
   Typography,
 } from '@material-ui/core'
+import { DataGrid } from '@material-ui/data-grid'
 import { Line } from 'react-chartjs-2'
 import { safeEncodeURIComponent } from '../helpers'
 import { scale } from 'chroma-js'
 import Alert from '@material-ui/lab/Alert'
+import GridToolbar from '../datagrid/GridToolbar'
 import InfoIcon from '@material-ui/icons/Info'
 import PropTypes from 'prop-types'
 import React, { Fragment, useEffect } from 'react'
+import { Link } from 'react-router-dom'
 
 export default function TestPassRateCharts(props) {
   const [isLoaded, setLoaded] = React.useState(false)
   const [groupedData, setGroupedData] = React.useState({})
   const [fetchError, setFetchError] = React.useState('')
-
+  const [groupSelectionDialog, setGroupSelectionDialog] = React.useState(false)
+  const [selectionModel, setSelectionModel] = React.useState([
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+  ])
+  const [selectedGroups = [], setSelectedGroups] = useQueryParam(
+    props.grouping,
+    ArrayParam
+  )
   const fetchData = () => {
     const filter = safeEncodeURIComponent(JSON.stringify(props.filterModel))
 
@@ -89,6 +102,19 @@ export default function TestPassRateCharts(props) {
     datasets: [],
   }
 
+  const columns = [
+    {
+      field: 'id',
+      hide: true,
+      filterable: false,
+    },
+    {
+      field: 'name',
+      headerName: props.grouping,
+      flex: 4,
+    },
+  ]
+
   const options = {
     parsing: {
       xAxisKey: 'date',
@@ -144,6 +170,58 @@ export default function TestPassRateCharts(props) {
               props.grouping.substr(1).toLowerCase()}
           </Typography>
           <Line data={chart} options={options} height={80} />
+          <Button
+            style={{ marginTop: 20 }}
+            variant="contained"
+            color="secondary"
+            onClick={() => setGroupSelectionDialog(true)}
+          >
+            Select {props.grouping} to chart
+          </Button>
+          <Dialog
+            fullWidth={true}
+            maxWidth="lg"
+            onClose={() => setGroupSelectionDialog(false)}
+            open={groupSelectionDialog}
+          >
+            <Grid className="test-dialog">
+              <Typography
+                variant="h6"
+                style={{ marginTop: 20, marginBottom: 20 }}
+              >
+                Select {props.grouping} to chart
+              </Typography>
+              <DataGrid
+                components={{ Toolbar: GridToolbar }}
+                columns={columns}
+                rows={allTests}
+                pageSize={10}
+                rowHeight={60}
+                autoHeight={true}
+                selectionModel={selectionModel}
+                onSelectionModelChange={(m) => updateSelectionModel(m)}
+                checkboxSelection
+                componentsProps={{
+                  toolbar: {
+                    columns: columns,
+                    filterModel: testFilter,
+                    setFilterModel: setTestFilter,
+                    clearSearch: () => requestSearch(''),
+                    doSearch: requestSearch,
+                  },
+                }}
+              />
+
+              <Button
+                style={{ marginTop: 20 }}
+                variant="contained"
+                color="primary"
+                onClick={() => setGroupSelectionDialog(false)}
+              >
+                OK
+              </Button>
+            </Grid>
+          </Dialog>
         </Card>
       </Grid>
     </Fragment>

--- a/sippy-ng/src/tests/TestPassRateCharts.js
+++ b/sippy-ng/src/tests/TestPassRateCharts.js
@@ -73,12 +73,16 @@ export default function TestPassRateCharts(props) {
     .mode('lch')
     .colors(Object.keys(groupedData).length)
 
-  let days = Array.from(
-    { length: 14 },
-    (_, x) => new Date(new Date() - 1000 * 60 * 60 * 24 * x)
-  )
-    .map((day) => day.toISOString().split('T')[0])
-    .reverse()
+  // TODO: This is kind of awkward, but it's relatively fast. Need to create a list of all
+  // dates we'll chart, and have it sorted.
+  let daySet = new Set()
+  Object.keys(groupedData).forEach((key) => {
+    Object.keys(groupedData[key]).forEach((item) =>
+      daySet.add(groupedData[key][item].date)
+    )
+  })
+  let days = Array.from(daySet)
+  days.sort((a, b) => new Date(a) - new Date(b))
 
   const chart = {
     labels: days,
@@ -122,9 +126,10 @@ export default function TestPassRateCharts(props) {
       label: `${group}`,
       tension: 0.25,
       yAxisID: 'y',
-      borderColor: colors[index],
-      backgroundColor: colors[index],
+      borderColor: group === 'overall' ? 'black' : colors[index],
+      backgroundColor: group === 'overall' ? 'black' : colors[index],
       data: groupedData[group],
+      order: group === 'overall' ? 0 : 1,
     })
     index++
   })

--- a/sippy-ng/src/tests/TestStackedChart.js
+++ b/sippy-ng/src/tests/TestStackedChart.js
@@ -1,0 +1,209 @@
+import { Card, CircularProgress, Grid, Typography } from '@material-ui/core'
+import { Line } from 'react-chartjs-2'
+import { safeEncodeURIComponent } from '../helpers'
+import { useTheme } from '@material-ui/core/styles'
+import Alert from '@material-ui/lab/Alert'
+import PropTypes from 'prop-types'
+import React, { Fragment, useEffect } from 'react'
+
+export function TestStackedChart(props) {
+  const theme = useTheme()
+
+  const [isLoaded, setLoaded] = React.useState(false)
+  const [analysis, setAnalysis] = React.useState([])
+  const [fetchError, setFetchError] = React.useState('')
+
+  const fetchData = () => {
+    let queryParams = `release=${props.release}&test=${safeEncodeURIComponent(
+      props.test
+    )}`
+
+    if (props.filter) {
+      queryParams += `&filter=${safeEncodeURIComponent(
+        JSON.stringify(props.filter)
+      )}`
+    }
+
+    fetch(
+      `${process.env.REACT_APP_API_URL}/api/tests/analysis/overall?${queryParams}`
+    )
+      .then((analysis) => {
+        if (analysis.status !== 200) {
+          throw new Error('server returned ' + analysis.status)
+        }
+
+        return analysis.json()
+      })
+      .then((analysis) => {
+        setAnalysis(analysis['overall'])
+        setLoaded(true)
+      })
+      .catch((error) => {
+        setFetchError(
+          'Could not retrieve job analysis ' + props.release + ', ' + error
+        )
+      })
+  }
+
+  useEffect(() => {
+    if (props.analysis) {
+      setAnalysis(props.analysis)
+      setLoaded(true)
+    } else {
+      fetchData()
+    }
+  }, [props])
+
+  if (fetchError !== '') {
+    return <Alert severity="error">{fetchError}</Alert>
+  }
+
+  if (!isLoaded) {
+    return (
+      <Fragment>
+        <Grid item md={12}>
+          <Card className="test-failure-card" elevation={5}>
+            <Typography variant="h5">Overall Results</Typography>
+            <CircularProgress color="inherit" />
+          </Card>
+        </Grid>
+      </Fragment>
+    )
+  }
+
+  let daySet = new Set()
+  analysis.forEach((dt) => {
+    daySet.add(dt.date)
+  })
+  console.log(daySet)
+  const resultChart = {
+    labels: Array.from(daySet),
+    datasets: [],
+  }
+
+  const resultTypes = {
+    S: {
+      color: theme.palette.success.main,
+      key: 'pass_percentage',
+      name: 'Success',
+    },
+    F: {
+      color: theme.palette.warning.main,
+      key: 'flake_percentage',
+      name: 'Flake',
+    },
+    E: {
+      color: theme.palette.error.main,
+      key: 'fail_percentage',
+      name: 'Fail',
+    },
+  }
+
+  const colorByName = {}
+  Object.keys(resultTypes).forEach((key) => {
+    colorByName[resultTypes[key].name] = resultTypes[key].color
+  })
+
+  resultChart.datasets.push({
+    label: 'Run count',
+    tension: 0.5,
+    radius: 2,
+    yAxisID: 'y1',
+    xAxisID: 'x',
+    order: 1,
+    borderColor: '#000000',
+    backgroundColor: '#000000',
+    data: analysis.map((day) => day.runs),
+  })
+
+  Object.keys(resultTypes).forEach((result) => {
+    resultChart.datasets.push({
+      type: 'line',
+      fill: 'origin',
+      radius: 1,
+      label: `${resultTypes[result].name}`,
+      tension: 0.3,
+      yAxisID: 'y',
+      xAxisID: 'x',
+      order: 2,
+      borderColor: resultTypes[result].color,
+      backgroundColor: resultTypes[result].color,
+      data: analysis.map((day) => day[resultTypes[result].key]),
+    })
+  })
+
+  const handleHover = (e, item, legend) => {
+    legend.chart.data.datasets.forEach((dataset, index) => {
+      if (index !== item.datasetIndex) {
+        dataset.backgroundColor = '#ffffff'
+        dataset.borderColor = '#ffffff'
+      }
+    })
+    legend.chart.update()
+  }
+
+  const handleLeave = (e, item, legend) => {
+    legend.chart.data.datasets.forEach((dataset, index) => {
+      dataset.backgroundColor = colorByName[dataset.label]
+      dataset.borderColor = colorByName[dataset.label]
+    })
+    legend.chart.update()
+  }
+
+  const options = {
+    plugins: {
+      line: {
+        onHover: handleHover,
+        onLeave: handleLeave,
+      },
+    },
+    scales: {
+      x: {
+        grid: {
+          z: 1,
+        },
+      },
+      y: {
+        grid: {
+          z: 1,
+        },
+        stacked: true,
+        max: 100,
+        ticks: {
+          callback: (value, index, values) => {
+            return `${value}%`
+          },
+        },
+      },
+      y1: {
+        type: 'linear',
+        display: true,
+        position: 'right',
+      },
+    },
+  }
+
+  return (
+    <Fragment>
+      <Grid item md={12}>
+        <Card className="test-failure-card" elevation={5}>
+          <Typography variant="h5">Overall Results</Typography>
+          <Line
+            key="result-chart"
+            data={resultChart}
+            options={options}
+            height={80}
+          />
+        </Card>
+      </Grid>
+    </Fragment>
+  )
+}
+
+TestStackedChart.propTypes = {
+  release: PropTypes.string.isRequired,
+  test: PropTypes.string.isRequired,
+  filter: PropTypes.object,
+  period: PropTypes.string,
+  analysis: PropTypes.array,
+}


### PR DESCRIPTION
[TRT-808](https://issues.redhat.com//browse/TRT-808)

Currently the test analysis page generates the by-variant and by-job views by hitting one API that queries the DB in sequence (one after the other). 

This change:
- Splits the API so there's variant and job-based api endpoints meaning the UI can load them in parallel.  
- Optimizes some of the queries to be a little more efficient. This does seem to improve the responsiveness of the test analysis page a bit.
- Adds an overall stacked chart so we can visualize flakes better (this loads fast)