### PR TITLE
Move release indicators to  "working" percentage and include flakes

### DIFF
--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -717,7 +717,7 @@ type Variants struct {
 }
 
 type Health struct {
-	Indicators  map[string]Indicator `json:"indicators"`
+	Indicators  map[string]Test      `json:"indicators"`
 	Variants    Variants             `json:"variants"`
 	LastUpdated time.Time            `json:"last_updated"`
 	Promotions  map[string]time.Time `json:"promotions"`

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -129,8 +129,7 @@ func TestReportExcludeVariants(
 
 	// Query and group by variant:
 	var testReport api.Test
-	q := `
-WITH results AS (
+	q := `WITH results AS (
     SELECT name,
            release,
            sum(current_runs)       AS current_runs,
@@ -144,15 +143,8 @@ WITH results AS (
     FROM prow_test_report_7d_matview
     WHERE release = @release AND name = @testname %s
     GROUP BY name, release
-)
-SELECT *,
-       current_successes * 100.0 / NULLIF(current_runs, 0) AS current_pass_percentage,
-       current_failures * 100.0 / NULLIF(current_runs, 0) AS current_failure_percentage,
-       previous_successes * 100.0 / NULLIF(previous_runs, 0) AS previous_pass_percentage,
-       previous_failures * 100.0 / NULLIF(previous_runs, 0) AS previous_failure_percentage,
-       (current_successes * 100.0 / NULLIF(current_runs, 0)) - (previous_successes * 100.0 / NULLIF(previous_runs, 0)) AS net_improvement
-FROM results;
-`
+) SELECT *, ` + QueryTestPercentages + ` FROM results;`
+
 	q = fmt.Sprintf(q, excludeVariantsQuery)
 	r := dbc.DB.Raw(q,
 		sql.Named("release", release),

--- a/sippy-ng/src/components/SummaryCard.js
+++ b/sippy-ng/src/components/SummaryCard.js
@@ -27,7 +27,9 @@ export default function SummaryCard(props) {
   const theme = useTheme()
 
   const percent =
-    (props.success / ((props.flakes || 0) + props.fail + props.success)) * 100
+    ((props.success + props.flakes) /
+      ((props.flakes || 0) + props.fail + props.success)) *
+    100
 
   const colors = scale([
     theme.palette.error.light,
@@ -41,15 +43,13 @@ export default function SummaryCard(props) {
 
   const bgColor = colors(percent).hex()
 
-  const labels = ['Pass', 'Fail']
-  const data = [props.success, props.fail]
-  const color = [theme.palette.success.dark, theme.palette.error.dark]
-
-  if (props.flakes) {
-    labels.push('Flakes')
-    data.push(props.flakes)
-    color.push(theme.palette.warning.dark)
-  }
+  const labels = ['Pass', 'Flake', 'Fail']
+  const data = [props.success, props.flakes, props.fail]
+  const color = [
+    theme.palette.success.dark,
+    theme.palette.warning.dark,
+    theme.palette.error.dark,
+  ]
 
   let card = (
     <Card
@@ -116,6 +116,7 @@ export default function SummaryCard(props) {
 SummaryCard.defaultProps = {
   success: 0,
   fail: 0,
+  flakes: 0,
   caption: '',
   tooltip: '',
   units: 'percent',

--- a/sippy-ng/src/releases/InstallTopLevelIndicators.js
+++ b/sippy-ng/src/releases/InstallTopLevelIndicators.js
@@ -20,17 +20,13 @@ export default function TopLevelIndicators(props) {
   const indicatorCaption = (indicator) => {
     return (
       <Box component="h3">
-        {indicator.current.percentage.toFixed(0)}% ({indicator.current.runs}{' '}
-        runs)
+        {indicator.current_working_percentage.toFixed(0)}% (
+        {indicator.current_runs} runs)
         <br />
-        <PassRateIcon
-          improvement={
-            indicator.current.percentage - indicator.previous.percentage
-          }
-        />
+        <PassRateIcon improvement={indicator.net_working_improvement} />
         <br />
-        {indicator.previous.percentage.toFixed(0)}% ({indicator.previous.runs}{' '}
-        runs)
+        {indicator.previous_working_percentage.toFixed(0)}% (
+        {indicator.previous_runs} runs)
       </Box>
     )
   }
@@ -45,8 +41,8 @@ export default function TopLevelIndicators(props) {
     'install',
   ].forEach((indicator) => {
     if (
-      props.indicators[indicator].current.runs !== 0 ||
-      props.indicators[indicator].previous.runs !== 0
+      props.indicators[indicator].current_runs !== 0 ||
+      props.indicators[indicator].previous_runs !== 0
     ) {
       noData = false
     }
@@ -77,8 +73,9 @@ export default function TopLevelIndicators(props) {
             props.release,
             'cluster install.install should succeed: infrastructure'
           )}
-          success={props.indicators.infrastructure.current.percentage}
-          fail={100 - props.indicators.infrastructure.current.percentage}
+          success={props.indicators.infrastructure.current_pass_percentage}
+          flakes={props.indicators.infrastructure.current_flake_percentage}
+          fail={props.indicators.infrastructure.current_failure_percentage}
           caption={indicatorCaption(props.indicators.infrastructure)}
           tooltip="How often install fails due to infrastructure failures."
         />
@@ -93,8 +90,9 @@ export default function TopLevelIndicators(props) {
             props.release,
             'cluster install.install should succeed: configuration'
           )}
-          success={props.indicators.installConfig.current.percentage}
-          fail={100 - props.indicators.installConfig.current.percentage}
+          success={props.indicators.installConfig.current_pass_percentage}
+          flakes={props.indicators.installConfig.current_flake_percentage}
+          fail={props.indicators.installConfig.current_failure_percentage}
           caption={indicatorCaption(props.indicators.installConfig)}
           tooltip="How often the install configuration check completes successfully."
         />
@@ -109,8 +107,9 @@ export default function TopLevelIndicators(props) {
             props.release,
             'cluster install.install should succeed: cluster bootstrap'
           )}
-          success={props.indicators.bootstrap.current.percentage}
-          fail={100 - props.indicators.bootstrap.current.percentage}
+          success={props.indicators.bootstrap.current_pass_percentage}
+          flakes={props.indicators.bootstrap.current_flake_percentage}
+          fail={props.indicators.bootstrap.current_failure_percentage}
           caption={indicatorCaption(props.indicators.bootstrap)}
           tooltip="How often bootstrap completes successfully."
         />
@@ -125,8 +124,9 @@ export default function TopLevelIndicators(props) {
             props.release,
             'cluster install.install should succeed: other'
           )}
-          success={props.indicators.installOther.current.percentage}
-          fail={100 - props.indicators.installOther.current.percentage}
+          success={props.indicators.installOther.current_pass_percentage}
+          flakes={props.indicators.installOther.current_flake_percentage}
+          fail={props.indicators.installOther.current_failure_percentage}
           caption={indicatorCaption(props.indicators.installOther)}
           tooltip="How often install fails because other reasons."
         />
@@ -138,8 +138,9 @@ export default function TopLevelIndicators(props) {
           threshold={INSTALL_THRESHOLDS}
           name="Install"
           link={'/install/' + props.release}
-          success={props.indicators.install.current.percentage}
-          fail={100 - props.indicators.install.current.percentage}
+          success={props.indicators.install.current_pass_percentage}
+          flakes={props.indicators.install.current_flake_percentage}
+          fail={props.indicators.install.current_failure_percentage}
           caption={indicatorCaption(props.indicators.install)}
           tooltip="How often the install completes successfully."
         />

--- a/sippy-ng/src/releases/TopLevelIndicators.js
+++ b/sippy-ng/src/releases/TopLevelIndicators.js
@@ -19,17 +19,13 @@ export default function TopLevelIndicators(props) {
   const indicatorCaption = (indicator) => {
     return (
       <Box component="h3">
-        {indicator.current.percentage.toFixed(0)}% ({indicator.current.runs}{' '}
-        runs)
+        {indicator.current_working_percentage.toFixed(0)}% (
+        {indicator.current_runs} runs)
         <br />
-        <PassRateIcon
-          improvement={
-            indicator.current.percentage - indicator.previous.percentage
-          }
-        />
+        <PassRateIcon improvement={indicator.net_working_improvement} />
         <br />
-        {indicator.previous.percentage.toFixed(0)}% ({indicator.previous.runs}{' '}
-        runs)
+        {indicator.previous_working_percentage.toFixed(0)}% (
+        {indicator.previous_runs} runs)
       </Box>
     )
   }
@@ -38,8 +34,8 @@ export default function TopLevelIndicators(props) {
   let noData = true
   ;['infrastructure', 'install', 'tests', 'upgrade'].forEach((indicator) => {
     if (
-      props.indicators[indicator].current.runs !== 0 ||
-      props.indicators[indicator].previous.runs !== 0
+      props.indicators[indicator].current_runs !== 0 ||
+      props.indicators[indicator].previous_runs !== 0
     ) {
       noData = false
     }
@@ -70,8 +66,9 @@ export default function TopLevelIndicators(props) {
               props.release,
               'cluster install.install should succeed: infrastructure'
             )}
-            success={props.indicators.infrastructure.current.percentage}
-            fail={100 - props.indicators.infrastructure.current.percentage}
+            success={props.indicators.infrastructure.current_pass_percentage}
+            flakes={props.indicators.infrastructure.current_flake_percentage}
+            fail={props.indicators.infrastructure.current_failure_percentage}
             caption={indicatorCaption(props.indicators.infrastructure)}
             tooltip="How often install fails due to infrastructure failures."
           />
@@ -86,8 +83,9 @@ export default function TopLevelIndicators(props) {
               props.release,
               '[sig-sippy] infrastructure should work'
             )}
-            success={props.indicators.infrastructure.current.percentage}
-            fail={100 - props.indicators.infrastructure.current.percentage}
+            success={props.indicators.infrastructure.current_pass_percentage}
+            flakes={props.indicators.infrastructure.current_flake_percentage}
+            fail={props.indicators.infrastructure.current_failure_percentage}
             caption={indicatorCaption(props.indicators.infrastructure)}
             tooltip="How often we get to the point of running the installer. This is judged by whether a kube-apiserver is available, it's not perfect, but it's very close."
           />
@@ -100,8 +98,9 @@ export default function TopLevelIndicators(props) {
           threshold={INSTALL_THRESHOLDS}
           name="Install"
           link={'/install/' + props.release}
-          success={props.indicators.install.current.percentage}
-          fail={100 - props.indicators.install.current.percentage}
+          success={props.indicators.install.current_pass_percentage}
+          flakes={props.indicators.install.current_flake_percentage}
+          fail={props.indicators.install.current_failure_percentage}
           caption={indicatorCaption(props.indicators.install)}
           tooltip="How often the install completes successfully."
         />
@@ -113,8 +112,9 @@ export default function TopLevelIndicators(props) {
           threshold={UPGRADE_THRESHOLDS}
           name="Upgrade"
           link={'/upgrade/' + props.release}
-          success={props.indicators.upgrade.current.percentage}
-          fail={100 - props.indicators.upgrade.current.percentage}
+          success={props.indicators.upgrade.current_pass_percentage}
+          flakes={props.indicators.upgrade.current_flake_percentage}
+          fail={props.indicators.upgrade.current_failure_percentage}
           caption={indicatorCaption(props.indicators.upgrade)}
           tooltip="How often an upgrade that is started completes successfully."
         />
@@ -129,8 +129,9 @@ export default function TopLevelIndicators(props) {
             '[sig-sippy] openshift-tests should work'
           )}
           name="Tests"
-          success={props.indicators.tests.current.percentage}
-          fail={100 - props.indicators.tests.current.percentage}
+          success={props.indicators.tests.current_pass_percentage}
+          flakes={props.indicators.tests.current_flake_percentage}
+          fail={props.indicators.tests.current_failure_percentage}
           caption={indicatorCaption(props.indicators.tests)}
           tooltip={
             'How often e2e tests complete successfully. Sippy tries to figure out which runs ran an e2e test ' +

--- a/test/e2e/releases_test.go
+++ b/test/e2e/releases_test.go
@@ -3,10 +3,11 @@ package e2e
 import (
 	"testing"
 
-	"github.com/openshift/sippy/pkg/apis/api"
-	"github.com/openshift/sippy/test/e2e/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openshift/sippy/pkg/apis/api"
+	"github.com/openshift/sippy/test/e2e/util"
 )
 
 func TestReleasesAPI(t *testing.T) {
@@ -23,13 +24,13 @@ func TestReleaseHealth(t *testing.T) {
 	err := util.SippyRequest("/api/health?release="+util.Release, &health)
 	require.NoError(t, err)
 
-	assert.Greater(t, health.Indicators["bootstrap"].Current.Runs, 0, "no bootstrap runs")
-	assert.Greater(t, health.Indicators["infrastructure"].Current.Runs, 0, "no infrastructure runs")
-	assert.Greater(t, health.Indicators["install"].Current.Runs, 0, "no install runs")
-	assert.Greater(t, health.Indicators["installConfig"].Current.Runs, 0, "no installConfig runs")
-	assert.Greater(t, health.Indicators["installOther"].Current.Runs, 0, "no installOther runs")
-	assert.Greater(t, health.Indicators["tests"].Current.Runs, 0, "no tests runs")
-	assert.Greater(t, health.Indicators["upgrade"].Current.Runs, 0, "no upgrade runs")
+	assert.Greater(t, health.Indicators["bootstrap"].CurrentRuns, 0, "no bootstrap runs")
+	assert.Greater(t, health.Indicators["infrastructure"].CurrentRuns, 0, "no infrastructure runs")
+	assert.Greater(t, health.Indicators["install"].CurrentRuns, 0, "no install runs")
+	assert.Greater(t, health.Indicators["installConfig"].CurrentRuns, 0, "no installConfig runs")
+	assert.Greater(t, health.Indicators["installOther"].CurrentRuns, 0, "no installOther runs")
+	assert.Greater(t, health.Indicators["tests"].CurrentRuns, 0, "no tests runs")
+	assert.Greater(t, health.Indicators["upgrade"].CurrentRuns, 0, "no upgrade runs")
 
 	assert.False(t, health.LastUpdated.IsZero())
 }


### PR DESCRIPTION
Infrastructure is the only one that flakes at the moment, but this changes the view to show working (success + flakes) as well as showing flakes in the chart. The current view shows success % only, and shows failure percentage incorrectly

New view:

![image](https://user-images.githubusercontent.com/429763/220666104-53d4e3ef-9627-451d-bfb1-9ab65edf8526.png)
