### PR TITLE
TRT-800: Defer to jobNameVariant if there is a conflict

### DIFF
--- a/pkg/testidentification/ocp_variants.go
+++ b/pkg/testidentification/ocp_variants.go
@@ -138,8 +138,10 @@ func compareAndSelectVariant(jobNameVariant, clusterVariant, variantKey string) 
 	if clusterVariant != "" {
 		if val != "" && clusterVariant != val {
 			log.Errorf("ClusterData %s: %s, does not match jobName %s: %s", variantKey, clusterVariant, variantKey, jobNameVariant)
+		} else {
+			// defer to the jobNameVariant for now if they don't match as we have found conflicts
+			val = clusterVariant
 		}
-		val = clusterVariant
 	}
 
 	return val

--- a/pkg/testidentification/ocp_variants_test.go
+++ b/pkg/testidentification/ocp_variants_test.go
@@ -59,25 +59,25 @@ func Test_openshiftVariants_IdentifyVariants(t *testing.T) {
 			name:        "periodic-ci-openshift-release-master-ci-e2e-aws-clusterrelease-with-network",
 			release:     "4.13",
 			clusterData: models.ClusterData{Release: "4.13", Network: "sdn"},
-			want:        []string{"aws", "amd64", "sdn", "ha"},
+			want:        []string{"aws", "amd64", "ovn", "ha"},
 		},
 		{
 			name:        "periodic-ci-openshift-release-master-ci-e2e-aws-clusterrelease-with-network-platform-override",
 			release:     "4.13",
 			clusterData: models.ClusterData{Release: "4.13", Network: "sdn", Platform: "azure"},
-			want:        []string{"azure", "amd64", "sdn", "ha"},
+			want:        []string{"aws", "amd64", "ovn", "ha"},
 		},
 		{
 			name:        "periodic-ci-openshift-release-master-ci-e2e-aws-clusterrelease-with-network-platform-override-architecture",
 			release:     "4.13",
 			clusterData: models.ClusterData{Release: "4.13", Network: "sdn", Platform: "azure", Architecture: "arm64"},
-			want:        []string{"azure", "arm64", "sdn", "ha"},
+			want:        []string{"aws", "amd64", "ovn", "ha"},
 		},
 		{
 			name:        "periodic-ci-openshift-release-master-ci-e2e-aws-clusterrelease-with-network-platform-override-architecture-topology",
 			release:     "4.13",
 			clusterData: models.ClusterData{Release: "4.13", Network: "sdn", Platform: "azure", Architecture: "arm64", Topology: "single-node"},
-			want:        []string{"azure", "arm64", "sdn", "single-node"},
+			want:        []string{"aws", "amd64", "ovn", "ha"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Only use the cluster variant value if the jobNameVariant is missing or there is no conflict.

Short term fix will need a longer term plan.