### PR TITLE
Change how aggregated variants are filtered out

### DIFF
--- a/pkg/db/matviews.go
+++ b/pkg/db/matviews.go
@@ -258,7 +258,7 @@ FROM prow_job_run_tests
    LEFT JOIN suites on suites.id = prow_job_run_tests.suite_id
    JOIN prow_job_runs ON prow_job_runs.id = prow_job_run_tests.prow_job_run_id
    JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id
-WHERE prow_job_runs.timestamp >= |||START||| AND NOT ('aggregated'::text = ANY (prow_jobs.variants))
+WHERE prow_job_runs.timestamp >= |||START|||
 GROUP BY tests.id, tests.name, suites.name, open_bugs.open_bugs, prow_jobs.variants, prow_jobs.release
 `
 
@@ -328,7 +328,7 @@ FROM prow_job_run_tests
     JOIN tests ON tests.id = prow_job_run_tests.test_id
     JOIN prow_job_runs ON prow_job_runs.id = prow_job_run_tests.prow_job_run_id
     JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id
-WHERE prow_job_runs."timestamp" > (|||TIMENOW||| - '14 days'::interval) AND NOT ('aggregated'::text = ANY (prow_jobs.variants))
+WHERE prow_job_runs."timestamp" > (|||TIMENOW||| - '14 days'::interval)
 GROUP BY tests.name, tests.id, (date(prow_job_runs."timestamp")), prow_jobs.release, prow_jobs.name
 `
 

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -230,7 +230,6 @@ func TestOutputs(dbc *db.DB, release, test string, includedVariants, excludedVar
 		Joins("JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id").
 		Where("prow_job_runs.timestamp > current_date - interval '14' day").
 		Where("prow_job_run_tests.test_id = (?)", testQuery).
-		Where("NOT 'aggregated' = any(prow_jobs.variants)").
 		Where("prow_jobs.release = ?", release)
 
 	for _, variant := range includedVariants {

--- a/sippy-ng/src/components/Sidebar.js
+++ b/sippy-ng/src/components/Sidebar.js
@@ -215,6 +215,7 @@ export default function Sidebar(props) {
                       items: [
                         BOOKMARKS.RUN_7,
                         BOOKMARKS.NO_NEVER_STABLE,
+                        BOOKMARKS.NO_AGGREGATED,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                         BOOKMARKS.NO_STEP_GRAPH,
                         BOOKMARKS.NO_OPENSHIFT_TESTS_SHOULD_WORK,

--- a/sippy-ng/src/constants.js
+++ b/sippy-ng/src/constants.js
@@ -108,6 +108,12 @@ export const BOOKMARKS = {
     operatorValue: 'contains',
     value: 'never-stable',
   },
+  NO_AGGREGATED: {
+    columnField: 'variants',
+    not: true,
+    operatorValue: 'contains',
+    value: 'aggregated',
+  },
   NO_STEP_GRAPH: {
     columnField: 'name',
     not: true,

--- a/sippy-ng/src/releases/PayloadMiniCalendar.js
+++ b/sippy-ng/src/releases/PayloadMiniCalendar.js
@@ -76,12 +76,10 @@ export default function PayloadMiniCalendar(props) {
         // Rejected payloads will make the square red, and no payload at all will be an empty square.
         let eventsOnePerDay = {}
         json.forEach((event) => {
-          console.log(event)
           if (
             event.phase === 'Accepted' ||
             eventsOnePerDay[event.start] === undefined
           ) {
-            console.log('Updating')
             event.display = 'background'
             event.title = event.phase.charAt(0) // Show 'A' for accepted for 'R' for rejected
             eventsOnePerDay[event.start] = event

--- a/sippy-ng/src/releases/PayloadStreamOverview.js
+++ b/sippy-ng/src/releases/PayloadStreamOverview.js
@@ -61,8 +61,6 @@ function PayloadStreamOverview(props) {
             stream.architecture === props.arch &&
             stream.stream === props.stream
           ) {
-            console.log('Found our stream')
-            console.log(stream)
             setStreamHealth(stream)
           }
         }

--- a/sippy-ng/src/releases/ReleaseOverview.js
+++ b/sippy-ng/src/releases/ReleaseOverview.js
@@ -346,6 +346,7 @@ export default function ReleaseOverview(props) {
                   to={`/tests/${props.release}?${queryForBookmark(
                     BOOKMARKS.RUN_7,
                     BOOKMARKS.NO_NEVER_STABLE,
+                    BOOKMARKS.NO_AGGREGATED,
                     BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                     BOOKMARKS.NO_STEP_GRAPH
                   )}&sortField=net_working_improvement&sort=asc`}
@@ -369,6 +370,7 @@ export default function ReleaseOverview(props) {
                       items: [
                         BOOKMARKS.RUN_7,
                         BOOKMARKS.NO_NEVER_STABLE,
+                        BOOKMARKS.NO_AGGREGATED,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                         BOOKMARKS.NO_STEP_GRAPH,
                       ],
@@ -390,6 +392,7 @@ export default function ReleaseOverview(props) {
                   }?period=twoDay&sortField=net_working_improvement&sort=asc&${queryForBookmark(
                     BOOKMARKS.RUN_2,
                     BOOKMARKS.NO_NEVER_STABLE,
+                    BOOKMARKS.NO_AGGREGATED,
                     BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                     BOOKMARKS.NO_STEP_GRAPH
                   )}`}
@@ -412,6 +415,7 @@ export default function ReleaseOverview(props) {
                       items: [
                         BOOKMARKS.RUN_2,
                         BOOKMARKS.NO_NEVER_STABLE,
+                        BOOKMARKS.NO_AGGREGATED,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                         BOOKMARKS.NO_STEP_GRAPH,
                       ],
@@ -432,6 +436,7 @@ export default function ReleaseOverview(props) {
                   to={`/tests/${props.release}/details?${queryForBookmark(
                     BOOKMARKS.RUN_7,
                     BOOKMARKS.NO_NEVER_STABLE,
+                    BOOKMARKS.NO_AGGREGATED,
                     BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                     BOOKMARKS.NO_STEP_GRAPH,
                     BOOKMARKS.HIGH_DELTA_FROM_WORKING_AVERAGE,
@@ -463,6 +468,7 @@ export default function ReleaseOverview(props) {
                       items: [
                         BOOKMARKS.RUN_7,
                         BOOKMARKS.NO_NEVER_STABLE,
+                        BOOKMARKS.NO_AGGREGATED,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                         BOOKMARKS.NO_STEP_GRAPH,
                         BOOKMARKS.HIGH_DELTA_FROM_WORKING_AVERAGE,
@@ -484,6 +490,7 @@ export default function ReleaseOverview(props) {
                   to={`/tests/${props.release}?${queryForBookmark(
                     BOOKMARKS.RUN_7,
                     BOOKMARKS.NO_NEVER_STABLE,
+                    BOOKMARKS.NO_AGGREGATED,
                     BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                     BOOKMARKS.NO_STEP_GRAPH
                   )}&sortField=current_working_percentage&sort=asc`}
@@ -507,6 +514,7 @@ export default function ReleaseOverview(props) {
                       items: [
                         BOOKMARKS.RUN_7,
                         BOOKMARKS.NO_NEVER_STABLE,
+                        BOOKMARKS.NO_AGGREGATED,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                         BOOKMARKS.NO_STEP_GRAPH,
                       ],

--- a/sippy-ng/src/tests/TestAnalysis.js
+++ b/sippy-ng/src/tests/TestAnalysis.js
@@ -51,6 +51,7 @@ export function TestAnalysis(props) {
     filterModel = {
       items: [
         filterFor('name', 'equals', testName),
+        not(filterFor('variants', 'contains', 'aggregated')),
         not(filterFor('variants', 'contains', 'never-stable')),
         filterFor('current_runs', '>', '0'),
       ],

--- a/sippy-ng/src/tests/TestStackedChart.js
+++ b/sippy-ng/src/tests/TestStackedChart.js
@@ -75,7 +75,6 @@ export function TestStackedChart(props) {
   analysis.forEach((dt) => {
     daySet.add(dt.date)
   })
-  console.log(daySet)
   const resultChart = {
     labels: Array.from(daySet),
     datasets: [],

--- a/sippy-ng/src/tests/Tests.js
+++ b/sippy-ng/src/tests/Tests.js
@@ -82,6 +82,7 @@ export default function Tests(props) {
                           items: [
                             BOOKMARKS.RUN_7,
                             BOOKMARKS.NO_NEVER_STABLE,
+                            BOOKMARKS.NO_AGGREGATED,
                             BOOKMARKS.WATCHLIST,
                           ],
                           linkOperator: 'and',


### PR DESCRIPTION
[TRT-837](https://issues.redhat.com//browse/TRT-837)

This moves the filtering of aggregation from test results from being hardcoded to being done in the UI.  By moving it to the UI, the filter can be removed and you can view tests for only aggregation. We need to do this because there are tests that *only* appear in aggregation (e.g. the new disruption tests).

Aggregated will be filtered out by default, but users wanting to see the aggregated results can add a filter for `variants contains aggregated`.

The reason for needing a default exclusion is because the jobs that make up an aggregated run are already tracked in Sippy. We are injecting unwanted hysteresis that will cause changes to pass rates to lag behind if you do not filter it out. The effect is probably small. 

Here's an example:

The follow test runs 10x and passes 7.

```
[sig-pizza] Pizza should be delivered within 30 minutes
```

It has a pass rate of 70%, in line with historical results.

If it is aggregated, we have an 11th entry in Sippy of a pass. Sippy actually thinks the test passed 8 times out of 11 -- a pass rate of 72.7%.