### PR TITLE
Handle change in OS component name

### DIFF
--- a/pkg/api/releases_test.go
+++ b/pkg/api/releases_test.go
@@ -3,9 +3,10 @@ package api
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/db/models"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestScanReleaseHealthForRHCOSVersionMisMatches(t *testing.T) {

--- a/pkg/releasesync/releasesync.go
+++ b/pkg/releasesync/releasesync.go
@@ -244,7 +244,7 @@ func parseChangeLogJSON(releaseTag string, changeLogJSON ChangeLog) models.Relea
 	for _, c := range changeLogJSON.Components {
 		if c.Name == "Kubernetes" {
 			releaseChangeLogJSON.KubernetesVersion = c.Version
-		} else if c.Name == "Red Hat Enterprise Linux CoreOS" {
+		} else if strings.Contains(c.Name, "CoreOS") {
 			releaseChangeLogJSON.CurrentOSVersion = c.Version
 			releaseChangeLogJSON.CurrentOSURL = c.VersionURL
 			releaseChangeLogJSON.PreviousOSURL = c.FromURL


### PR DESCRIPTION
[TRT-904](https://issues.redhat.com//browse/TRT-904)

The OS changed from "Red Hat Enterprise Linux CoreOS" to "CentOS Stream CoreOS". Sippy is now reporting `unable to parse OpenShift version from OS version` because the OS version isn't populated.