### PR TITLE
Update the 'Forced' flag when release tag's phase change is detected

### DIFF
--- a/pkg/releasesync/releasesync.go
+++ b/pkg/releasesync/releasesync.go
@@ -60,6 +60,7 @@ func (r *releaseSyncOptions) run() []error {
 					if mReleaseTag.Phase != tag.Phase {
 						log.Warningf("Phase change detected (%q to %q) -- updating tag %s...", mReleaseTag.Phase, tag.Phase, tag.Name)
 						mReleaseTag.Phase = tag.Phase
+						mReleaseTag.Forced = true
 						if err := r.db.DB.Clauses(clause.OnConflict{UpdateAll: true}).Table(releaseTagsTable).Save(mReleaseTag).Error; err != nil {
 							log.WithError(err).Errorf("error updating release tag")
 							errs = append(errs, errors.Wrapf(err, "error updating release tag %s for new phase: %s -> %s", tag.Name, mReleaseTag.Phase, tag.Phase))


### PR DESCRIPTION
[TRT-903](https://issues.redhat.com//browse/TRT-903)

A phase change is detected when the phase, as indicated by the release-controller, is different from that which was recorded in the sippyDB; this happens when a payload is force accepted or rejected.

Existing code updates the phase in the sippyDB to match what is in the release-controller.
This PR sets the "Forced" flag to true so that the sippy UI will show the payload as forced accepted or force rejected.