### PR TITLE
Improve the DateTimePicker local vs. UTC display

### DIFF
--- a/sippy-ng/src/datagrid/GridToolbarFilterDateUtils.js
+++ b/sippy-ng/src/datagrid/GridToolbarFilterDateUtils.js
@@ -5,18 +5,16 @@ export class GridToolbarFilterDateUtils extends DateFnsUtils {
     super()
   }
 
-  getHours(date) {
-    return date.getUTCHours()
-  }
-
-  getMinutes(date) {
-    return date.getUTCMinutes()
-  }
-
   format(date, formatString) {
     return `${format(utcToZonedTime(date, 'UTC'), formatString, {
       timeZone: 'Etc/UTC',
       locale: this.locale,
     })}`
+  }
+
+  // This changes the text header in the DateTimePicker.
+  // The captial HH will make it 24 hour format.
+  getHourText(date, ampm) {
+    return format(utcToZonedTime(date, 'UTC'), 'HH')
   }
 }

--- a/sippy-ng/src/datagrid/GridToolbarFilterItem.js
+++ b/sippy-ng/src/datagrid/GridToolbarFilterItem.js
@@ -93,7 +93,7 @@ export default function GridToolbarFilterItem(props) {
                 disabled={disabled}
                 showTodayButton
                 disableFuture
-                label="Value"
+                label="Date"
                 format="yyyy-MM-dd HH:mm 'UTC'"
                 ampm={false}
                 value={

--- a/sippy-ng/src/jobs/JobRunsTable.js
+++ b/sippy-ng/src/jobs/JobRunsTable.js
@@ -82,7 +82,7 @@ export default function JobRunsTable(props) {
       renderCell: (params) => {
         return (
           <Tooltip title={relativeTime(new Date(params.value), startDate)}>
-            <p>{new Date(params.value).toLocaleString()}</p>
+            <p>{new Date(params.value).toISOString()}</p>
           </Tooltip>
         )
       },

--- a/sippy-ng/src/pull_requests/PullRequestsTable.js
+++ b/sippy-ng/src/pull_requests/PullRequestsTable.js
@@ -255,7 +255,7 @@ export default function PullRequestsTable(props) {
 
         return (
           <Tooltip title={relativeTime(new Date(params.value), startDate)}>
-            <p>{new Date(params.value).toLocaleString()}</p>
+            <p>{new Date(params.value).toISOString()}</p>
           </Tooltip>
         )
       },


### PR DESCRIPTION
This change makes the DateTimePicker stay in UTC time for header text (i.e., the hour displayed at the top).

<img width="412" alt="PR-pic1" src="https://user-images.githubusercontent.com/93946516/230235805-e85eec83-14ec-4e07-a49a-929e6ad02c0a.png">

The DateTimePicker interactive arrows remain in local time (header text remains UTC).

Since `getHours(date)` method was adding more time to the time represented in the interactive arrow on the clock it was removed.  The `getMinutes(date)` date didn't look like it was doing anything.

`getHourText(date)` sets the header text to UTC; I ignore `ampm` to keep it in 24 hour format.

`format(date, formatString)` affects the time in the Date slot for the date that was chosen.

Set a few other dates to UTC format. 

TODO:

- [ ] Try a few more tests before review.