### PR TITLE
Make Jobs table match query for build clusters

### DIFF
--- a/sippy-ng/src/build_clusters/BuildClusterDetails.js
+++ b/sippy-ng/src/build_clusters/BuildClusterDetails.js
@@ -1,5 +1,5 @@
 import { Card, Container, Grid, Typography } from '@material-ui/core'
-import { filterFor, getReportStartDate } from '../helpers'
+import { filterFor, getReportStartDate, not } from '../helpers'
 import { JobStackedChart } from '../jobs/JobStackedChart'
 import { ReportEndContext } from '../App'
 import JobRunsTable from '../jobs/JobRunsTable'
@@ -13,13 +13,16 @@ export default function BuildClusterDetails(props) {
       <Grid container spacing={3} alignItems="stretch">
         <Grid item md={12} sm={12}>
           <Card elevation={5} style={{ padding: 20, height: '100%' }}>
-            <Typography variant="h6">Job Runs On {props.cluster}</Typography>
+            <Typography variant="h6">
+              Periodic Job Runs On {props.cluster}
+            </Typography>
             <JobRunsTable
               pageSize={10}
               hideControls={true}
               filterModel={{
                 items: [
                   filterFor('cluster', 'equals', props.cluster),
+                  not(filterFor('name', 'starts with', 'pull-ci')),
                   filterFor(
                     'timestamp',
                     '>',


### PR DESCRIPTION
[TRT-955](https://issues.redhat.com//browse/TRT-955)

For the build cluster, the query is for [periodic jobs](https://github.com/openshift/sippy/blob/d6f82be99bbb7c170bf580a80febf6cedbc36644/pkg/db/query/build_clusters.go#L66) only.  This makes the query for the JobsTable match.