### PR TITLE
Fix installation logic determination

### DIFF
--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -45,9 +45,9 @@ func useNewInstallTest(release string) bool {
 // PrintOverallReleaseHealthFromDB gives a summarized status of the overall health, including
 // infrastructure, install, upgrade, and variant success rates.
 func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release string, reportEnd time.Time) {
-	excludedVariants := []string{"never-stable"}
+	excludedVariants := testidentification.DefaultExcludedVariants
 	// Minor upgrades install a previous version and should not be counted against the current version's install stat.
-	excludedInstallVariants := append(excludedVariants, "upgrade-minor")
+	excludedInstallVariants := append(testidentification.DefaultExcludedVariants, "upgrade-minor")
 
 	indicators := make(map[string]apitype.Test)
 

--- a/pkg/api/install.go
+++ b/pkg/api/install.go
@@ -5,26 +5,29 @@ import (
 	"net/http"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	v1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/testidentification"
 	"github.com/openshift/sippy/pkg/util/sets"
-	log "github.com/sirupsen/logrus"
 )
 
 // PrintInstallJSONReportFromDB renders a report showing the success/fail rates of operator installation.
 func PrintInstallJSONReportFromDB(w http.ResponseWriter, dbc *db.DB, release string) {
-
-	exactTestNames := sets.NewString(testidentification.InstallTestName)
-	testPrefixes := sets.NewString(
-		testidentification.OperatorInstallPrefix,
-		testidentification.InstallTestNamePrefix,
-	)
+	excludedVariants := append(testidentification.DefaultExcludedVariants, "upgrade-minor")
+	exactTestNames := sets.NewString()
+	testPrefixes := sets.NewString(testidentification.OperatorInstallPrefix)
+	if useNewInstallTest(release) {
+		testPrefixes.Insert(testidentification.InstallTestNamePrefix)
+	} else {
+		exactTestNames = exactTestNames.Insert(testidentification.InstallTestName)
+	}
 
 	variantColumns, tests, err := VariantTestsReport(dbc, release, v1.CurrentReport,
-		exactTestNames, testPrefixes, sets.NewString())
+		exactTestNames, testPrefixes, sets.NewString(), excludedVariants)
 	if err != nil {
 		log.WithError(err).Error("could not generate install report")
 		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": "Could not generate install report: " + err.Error()})
@@ -53,7 +56,7 @@ func PrintInstallJSONReportFromDB(w http.ResponseWriter, dbc *db.DB, release str
 // VariantTestsReport returns a set of all variant columns plus "All", and a map of testName to variant column to test results for that variant.
 // Caller can provide exact test names to match, test name prefixes, or test substrings.
 func VariantTestsReport(dbc *db.DB, release string, reportType v1.ReportType,
-	testNames, testPrefixes, testSubStrings sets.String) (sets.String, map[string]map[string]apitype.Test, error) {
+	testNames, testPrefixes, testSubStrings sets.String, excludedVariants []string) (sets.String, map[string]map[string]apitype.Test, error) {
 
 	// Build a list of all sub-strings to search for, we'll sort out exact matches later as these
 	// can pickup unintented tests.
@@ -102,7 +105,7 @@ func VariantTestsReport(dbc *db.DB, release string, reportType v1.ReportType,
 
 	// Add in the All column for each test:
 	for testName := range tests {
-		allReport, err := query.TestReportExcludeVariants(dbc, release, testName, []string{})
+		allReport, err := query.TestReportExcludeVariants(dbc, release, testName, excludedVariants)
 		if err != nil {
 			return variantColumns, tests, err
 		}

--- a/pkg/api/upgrade.go
+++ b/pkg/api/upgrade.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"net/http"
 
+	log "github.com/sirupsen/logrus"
+
 	v1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/testidentification"
 	"github.com/openshift/sippy/pkg/util/sets"
-	log "github.com/sirupsen/logrus"
 )
 
 // PrintUpgradeJSONReportFromDB reports on the success/fail of operator upgrades.
@@ -29,7 +30,7 @@ func PrintUpgradeJSONReportFromDB(w http.ResponseWriter, req *http.Request, dbc 
 	)
 
 	variantColumns, tests, err := VariantTestsReport(dbc, release, v1.CurrentReport,
-		exactTestNames, testPrefixes, testSubStrings)
+		exactTestNames, testPrefixes, testSubStrings, testidentification.DefaultExcludedVariants)
 	if err != nil {
 		log.WithError(err).Error("could not generate upgrade report")
 		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": "Could not generate install report: " + err.Error()})

--- a/pkg/testidentification/test_identification.go
+++ b/pkg/testidentification/test_identification.go
@@ -44,6 +44,9 @@ const (
 )
 
 var (
+	// DefaultExcludedVariants is used to exclude particular variants in reporting
+	DefaultExcludedVariants = []string{"aggregated", "never-stable"}
+
 	// TODO: add [sig-sippy] here as well so we can more clearly identify and substring search
 	// OperatorInstallPrefix is used when sippy adds synthetic tests to report if each operator installed correct.
 	OperatorInstallPrefix = "operator install "

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -120,6 +120,21 @@ export function pathForExactJobAnalysis(release, job) {
   return `/jobs/${release}/analysis?${single(filterFor('name', 'equals', job))}`
 }
 
+export function pathForExactTestAnalysis(release, test, excludedVariants) {
+  console.log(excludedVariants)
+
+  let filters = [filterFor('name', 'equals', test)]
+  if (Array.isArray(excludedVariants)) {
+    excludedVariants.forEach((variant) => {
+      filters.push(not(filterFor('variants', 'contains', variant)))
+    })
+  }
+
+  return `/tests/${release}/analysis?test=${safeEncodeURIComponent(
+    test
+  )}&${multiple(...filters)}`
+}
+
 export function pathForExactTest(release, test) {
   return `/tests/${release}?${single(filterFor('name', 'equals', test))}`
 }

--- a/sippy-ng/src/releases/Install.js
+++ b/sippy-ng/src/releases/Install.js
@@ -109,6 +109,11 @@ export default function Install(props) {
                     release={props.release}
                     colorScale={[90, 100]}
                     data={data}
+                    excludedVariants={[
+                      'upgrade-minor',
+                      'aggregated',
+                      'never-stable',
+                    ]}
                   />
                 </Route>
                 <Redirect from="/" to={url + '/operators'} />

--- a/sippy-ng/src/tests/TestAnalysis.js
+++ b/sippy-ng/src/tests/TestAnalysis.js
@@ -53,7 +53,6 @@ export function TestAnalysis(props) {
         filterFor('name', 'equals', testName),
         not(filterFor('variants', 'contains', 'aggregated')),
         not(filterFor('variants', 'contains', 'never-stable')),
-        filterFor('current_runs', '>', '0'),
       ],
     },
     setFilterModel,

--- a/sippy-ng/src/tests/TestByVariantTable.js
+++ b/sippy-ng/src/tests/TestByVariantTable.js
@@ -1,6 +1,6 @@
 import './TestByVariantTable.css'
 import { Link } from 'react-router-dom'
-import { pathForExactTest } from '../helpers'
+import { pathForExactTestAnalysis } from '../helpers'
 import { scale } from 'chroma-js'
 import { TableContainer, Tooltip, Typography } from '@material-ui/core'
 import { useTheme } from '@material-ui/core/styles'
@@ -121,7 +121,15 @@ function Row(props) {
     <TableCell className={'cell-name'} key={testName}>
       <Tooltip title={testName}>
         <Typography className="cell-name">
-          <Link to={pathForExactTest(props.release, testName)}>{testName}</Link>
+          <Link
+            to={pathForExactTestAnalysis(
+              props.release,
+              testName,
+              props.excludedVariants
+            )}
+          >
+            {testName}
+          </Link>
         </Typography>
       </Tooltip>
     </TableCell>
@@ -149,6 +157,7 @@ function Row(props) {
 
 Row.propTypes = {
   briefTable: PropTypes.bool,
+  excludedVariants: PropTypes.array,
   results: PropTypes.object,
   columnNames: PropTypes.array.isRequired,
   testName: PropTypes.string.isRequired,
@@ -239,6 +248,7 @@ export default function TestByVariantTable(props) {
                 showFull={showFull}
                 key={test}
                 testName={test}
+                excludedVariants={props.excludedVariants}
                 columnNames={props.data.column_names}
                 results={props.data.tests[test]}
                 release={props.release}
@@ -254,10 +264,12 @@ export default function TestByVariantTable(props) {
 TestByVariantTable.defaultProps = {
   briefTable: false,
   colorScale: [60, 100],
+  excludedVariants: ['never-stable', 'aggregated'],
 }
 
 TestByVariantTable.propTypes = {
   briefTable: PropTypes.bool,
+  excludedVariants: PropTypes.array,
   columnNames: PropTypes.array,
   current: PropTypes.number,
   data: PropTypes.object,


### PR DESCRIPTION
[TRT-565](https://issues.redhat.com//browse/TRT-565)

We were not correctly excluding upgrade-minor and aggregated from install statistics in many places.

- upgrade-minor installs the previous release and should not be counted.

- The reason for excluding aggregated is a little more subtle, but it injects unwanted hysteresis that will cause changes to pass rates to lag behind if we do not filter it out.

Here's an example:

The follow test runs 10x and passes 7.

    [sig-pizza] Pizza should be delivered within 30 minutes

It has a pass rate of 70%, in line with historical results.

If it is aggregated, we have an 11th entry in Sippy of a pass. Sippy actually thinks the test passed 8 times out of 11 -- a pass rate of 72.7%.