### PR TITLE
Link to the previous_os_url when showing payloads

### DIFF
--- a/sippy-ng/src/releases/ReleasePayloadTable.js
+++ b/sippy-ng/src/releases/ReleasePayloadTable.js
@@ -223,7 +223,7 @@ function ReleasePayloadTable(props) {
       flex: 3,
       renderCell: (params) => {
         if (params.value !== '') {
-          return <a href={params.row.previous_os_version}>{params.value}</a>
+          return <a href={params.row.previous_os_url}>{params.value}</a>
         }
       },
       hide: props.briefTable,


### PR DESCRIPTION
[TRT-985](https://issues.redhat.com//browse/TRT-985)

Fix incorrect url for checking RHCOS versions in payload stream listing.