### PR TITLE
Fix the logs to get better idea of search.ci calls

### DIFF
--- a/pkg/db/loader/issues.go
+++ b/pkg/db/loader/issues.go
@@ -102,10 +102,11 @@ func findBugsForSearchStrings(isRegex bool, searchFor ...string) (map[string][]j
 		}
 		if err != nil {
 			lastUpdateError = err
+			log.Warnf("findBugsForSearchStrings got error in findBugs '%v' after %d requests", err, queryCtr)
 		}
 		batchSearchStrs = []string{}
 	}
-	log.Debugf("findBugsForSearchStrings made %d search.ci requests", queryCtr)
+	log.Infof("findBugsForSearchStrings made %d search.ci requests", queryCtr)
 
 	return ret, lastUpdateError
 }

--- a/pkg/sippyserver/dbloader.go
+++ b/pkg/sippyserver/dbloader.go
@@ -465,7 +465,7 @@ func LoadBugs(dbc *db.DB) []error {
 
 	jobIssues, err := loader.FindIssuesForJobs(sets.StringKeySet(jobCache).List()...)
 	if err != nil {
-		log.WithError(err).Warning("Issue Lookup Error: an error was encountered looking up existing bugs for failing tests, some test failures may have associated bugs that are not listed below.")
+		log.WithError(err).Warning("Issue Lookup Error: an error was encountered looking up existing bugs for failing jobs, some job failures may have associated bugs that are not listed below.")
 		err = errors.Wrap(err, "error querying bugs for jobs")
 		errs = append(errs, err)
 	}


### PR DESCRIPTION
This helps us get better logging re: TRT-970.

Log the number of requests to tell us how many batches (of 50) were successfully processed.

Use log messages specific to tests vs. jobs so we can tell where the errors actually came from.