### PR TITLE
Add a sql script demonstrating how to calculate test duration percentiles

### DIFF
--- a/scripts/sql/test-duration-stats.sql
+++ b/scripts/sql/test-duration-stats.sql
@@ -1,0 +1,48 @@
+--- Creates a temporary function for calculating the percentile of test durations by an array of 3-tuple variants.
+CREATE OR REPLACE FUNCTION pg_temp.calculate_percentiles(testName TEXT) RETURNS TABLE (
+    platform TEXT,
+    cni TEXT,
+    upgrade TEXT,
+    percentile_50 NUMERIC,
+    percentile_99 NUMERIC,
+    percentile_100 NUMERIC
+) AS $$
+DECLARE
+    variant_sets TEXT[][] := '{{"aws","ovn","upgrade-minor"},{"aws","sdn","upgrade-minor"},{"aws","ovn","upgrade-micro"},{"aws","sdn","upgrade-micro"},{"azure","ovn","upgrade-minor"},{"azure","sdn","upgrade-minor"},{"azure","ovn","upgrade-micro"},{"azure","sdn","upgrade-micro"},{"gcp","ovn","upgrade-minor"},{"gcp","sdn","upgrade-minor"},{"gcp","ovn","upgrade-micro"},{"gcp","sdn","upgrade-micro"},{"metal-ipi","ovn","upgrade-minor"},{"metal-ipi","sdn","upgrade-minor"},{"metal-ipi","ovn","upgrade-micro"},{"metal-ipi","sdn","upgrade-micro"},{"vsphere-ipi","ovn","upgrade-minor"},{"vsphere-ipi","sdn","upgrade-minor"},{"vsphere-ipi","ovn","upgrade-micro"},{"vsphere-ipi","sdn","upgrade-micro"}}';
+BEGIN
+    FOR i IN 1..array_length(variant_sets, 1) LOOP
+        SELECT
+            variant_sets[i][1] as platform,
+            variant_sets[i][2] as cni,
+            variant_sets[i][3] as upgrade,
+            (percentile_disc(0.5) within group (order by pjt.duration asc)) / 60 as percentile_50,
+            (percentile_disc(0.99) within group (order by pjt.duration asc)) / 60  as percentile_99,
+            (percentile_disc(1.0) within group (order by pjt.duration asc)) / 60 as percentile_100
+        INTO
+            platform,
+            cni,
+            upgrade,
+            percentile_50,
+            percentile_99,
+            percentile_100
+        FROM
+            prow_job_run_tests pjt
+            INNER JOIN prow_job_runs pjr ON pjr.id = pjt.prow_job_run_id
+            INNER JOIN prow_jobs pj ON pj.id = pjr.prow_job_id
+        WHERE
+            pjt.status = 1
+            AND pjr.timestamp > current_date - interval '30' day
+            AND pjt.test_id = (SELECT id FROM tests WHERE name = testName)
+            AND pj.release = '4.14'
+            AND variant_sets[i][1] = ANY(pj.variants)
+            AND variant_sets[i][2] = ANY(pj.variants)
+            AND variant_sets[i][3] = ANY(pj.variants)
+            AND 'amd64' = ANY(pj.variants)
+            AND 'single-node' != ALL(pj.variants)
+        GROUP BY pj.variants;        RETURN NEXT;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Example:
+SELECT * from pg_temp.calculate_percentiles('Cluster upgrade.[sig-cluster-lifecycle] Cluster completes upgrade');


### PR DESCRIPTION
For [TRT-1003](https://issues.redhat.com//browse/TRT-1003)

Example output:

```
$ sippy_openshift=> select * from pg_temp.calculate_percentiles('Cluster upgrade.[sig-cluster-lifecycle] Cluster completes upgrade');
  platform   | cni |    upgrade    |  percentile_50   |  percentile_99   |  percentile_100
-------------+-----+---------------+------------------+------------------+------------------
 aws         | ovn | upgrade-minor | 75.5037481587333 | 91.1699486471667 | 148.836387897583
 aws         | sdn | upgrade-minor | 66.3346064770833 | 130.001002921867 | 133.506777134567
 aws         | ovn | upgrade-micro |    46.6700414857 | 77.6712774810667 | 77.6712774810667
 aws         | sdn | upgrade-micro |    40.8344902655 | 69.3367003545333 |    70.1701065424
 azure       | ovn | upgrade-minor |    78.8371284821 | 95.6693310651667 | 95.6693310651667
 azure       | sdn | upgrade-minor |    65.8347501505 | 96.5026210284333 |  109.66963137935
 azure       | ovn | upgrade-micro | 50.1690638869167 |   89.00202980395 |    98.0030100352
 azure       | sdn | upgrade-micro |   43.66869074415 | 68.8352261229333 | 68.8352261229333
 gcp         | ovn | upgrade-minor |    80.6686121068 | 90.5020522017833 | 90.5020522017833
 gcp         | sdn | upgrade-minor | 42.8352234802333 | 73.0020238840167 | 73.0020238840167
 gcp         | ovn | upgrade-micro |   71.83525863615 | 84.8353793551833 | 95.5019887463333
 gcp         | sdn | upgrade-micro |   46.50229574945 |   70.83531838245 |   70.83531838245
 metal-ipi   | ovn | upgrade-minor | 76.1671040201333 | 79.6680000668833 | 79.6680000668833
 metal-ipi   | sdn | upgrade-minor |    65.0010867379 | 72.0010812398167 | 72.0010812398167
 metal-ipi   | ovn | upgrade-micro | 55.6671407204833 | 77.1670776264667 | 77.1670776264667
 metal-ipi   | sdn | upgrade-micro | 44.8346138121333 | 67.3345947869333 | 67.3345947869333
 vsphere-ipi | ovn | upgrade-minor | 75.6699197234667 | 92.3377611734833 | 92.3377611734833
```