### PR TITLE
Bump golangci-lint and fix new issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ run:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - depguard
     - dupl
     - errcheck
@@ -22,11 +21,9 @@ linters:
     - misspell
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
     - unparam
-    - varcheck
 linters-settings:
   gofmt:
     simplify: false # do not require the -s flag
@@ -72,7 +69,6 @@ linters-settings:
       - regexpMust
       - singleCaseSwitch
       - sloppyLen
-      - stringXbytes
       - switchTrue
       - typeAssertChain
       - typeSwitchVar

--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -4,7 +4,7 @@
 # [1] https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image
 #
 FROM registry.access.redhat.com/ubi9/ubi:latest
-ARG GOLANGCI_LINT_VERSION="1.45.0"
+ARG GOLANGCI_LINT_VERSION="1.49.0"
 RUN curl -Lso /tmp/golangci-lint.rpm \
           "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64.rpm" && \
       dnf module enable nodejs:18 -y && \

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -20,6 +20,6 @@ else
   $DOCKER run --rm \
     --volume "${PWD}:/go/src/github.com/openshift/sippy:z" \
     --workdir /go/src/github.com/openshift/sippy \
-    docker.io/golangci/golangci-lint:v1.45 \
+    docker.io/golangci/golangci-lint:v1.49 \
     golangci-lint "${@}"
 fi

--- a/main.go
+++ b/main.go
@@ -574,7 +574,7 @@ func (o *Options) runDaemonServer(processes []sippyserver.DaemonProcess) {
 	// Serve our metrics endpoint for prometheus to scrape
 	go func() {
 		http.Handle("/metrics", promhttp.Handler())
-		err := http.ListenAndServe(o.MetricsAddr, nil)
+		err := http.ListenAndServe(o.MetricsAddr, nil) //nolint
 		if err != nil {
 			panic(err)
 		}
@@ -709,7 +709,7 @@ func (o *Options) runServerMode(pinnedDateTime *time.Time, gormLogLevel gormlogg
 	// Serve our metrics endpoint for prometheus to scrape
 	go func() {
 		http.Handle("/metrics", promhttp.Handler())
-		err := http.ListenAndServe(o.MetricsAddr, nil)
+		err := http.ListenAndServe(o.MetricsAddr, nil) //nolint
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/apis/junit/types.go
+++ b/pkg/apis/junit/types.go
@@ -44,7 +44,7 @@ type TestSuite struct {
 	TestCases []*TestCase `xml:"testcase"`
 
 	// Children holds nested test suites
-	Children []*TestSuite `xml:"testsuite"`
+	Children []*TestSuite `xml:"testsuite"` //nolint
 }
 
 // TestSuiteProperty contains a mapping of a property name to a value

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -155,10 +155,11 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 // wins problems with concurrent development.
 //
 // desiredSchema should be the full SQL command we would issue to create the resource fresh. It will be hashed and
-//   compared to a pre-existing value in the db of the given name and type, if any exists. If none exists, or the hashes
-//   have changed, the resource will be recreated.
+// compared to a pre-existing value in the db of the given name and type, if any exists. If none exists, or the hashes
+// have changed, the resource will be recreated.
+//
 // dropSQL is the full SQL command we will run if we detect that the resource needs updating. It should include
-//   "IF EXISTS" as it will be attempted even when no previous resource exists. (i.e. new databases)
+// "IF EXISTS" as it will be attempted even when no previous resource exists. (i.e. new databases)
 //
 // This function does not check for existence of the resource in the db, thus if you ever delete something manually, it will
 // not be recreated until you also delete the corresponding row from schema_hashes.

--- a/pkg/filter/filterable.go
+++ b/pkg/filter/filterable.go
@@ -327,12 +327,12 @@ func FilterableDBResult(dbClient *gorm.DB, filterOpts *FilterOptions, filterable
 // Split extracts certain filter items into their own filter. Can be used
 // for rare occurrences  when filters need to be applied separately, i.e.
 // as part of pre and post-processing.
-func (filters Filter) Split(fields []string) (new, old *Filter) {
-	new = &Filter{
+func (filters Filter) Split(fields []string) (newFilter, oldFilter *Filter) {
+	newFilter = &Filter{
 		Items:        []FilterItem{},
 		LinkOperator: filters.LinkOperator,
 	}
-	old = &Filter{
+	oldFilter = &Filter{
 		Items:        []FilterItem{},
 		LinkOperator: filters.LinkOperator,
 	}
@@ -341,14 +341,14 @@ filterOuterLoop:
 	for _, item := range filters.Items {
 		for _, field := range fields {
 			if item.Field == field {
-				new.Items = append(new.Items, item)
+				newFilter.Items = append(newFilter.Items, item)
 				continue filterOuterLoop
 			}
 		}
-		old.Items = append(old.Items, item)
+		oldFilter.Items = append(oldFilter.Items, item)
 	}
 
-	return new, old
+	return newFilter, oldFilter
 }
 
 func (filters Filter) ToSQL(db *gorm.DB, filterable Filterable) *gorm.DB {

--- a/pkg/perfscaleanalysis/perfscalehelpers.go
+++ b/pkg/perfscaleanalysis/perfscalehelpers.go
@@ -5,16 +5,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
 	es7 "github.com/elastic/go-elasticsearch/v7"
-	workloadmetricsv1 "github.com/openshift/sippy/pkg/apis/workloadmetrics/v1"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
+
+	workloadmetricsv1 "github.com/openshift/sippy/pkg/apis/workloadmetrics/v1"
 )
 
 const (
@@ -89,7 +91,7 @@ func DownloadPerfScaleData(storagePath string, reportEnd time.Time) error {
 		return err
 	}
 
-	bb, err := ioutil.ReadAll(res.Body)
+	bb, err := io.ReadAll(res.Body)
 	if err != nil {
 		return errors.Wrap(err, "error reading elasticsearch response")
 	}
@@ -120,7 +122,7 @@ func DownloadPerfScaleData(storagePath string, reportEnd time.Time) error {
 	if err != nil {
 		return errors.Wrap(err, "error marshalling scale jobs")
 	}
-	err = ioutil.WriteFile(filepath.Join(storagePath, ScaleJobsFilename), file, 0o600)
+	err = os.WriteFile(filepath.Join(storagePath, ScaleJobsFilename), file, 0o600)
 	if err != nil {
 		return errors.Wrap(err, "error writing scalejobs.json")
 	}

--- a/pkg/prowloader/gcs/gcs_authentication.go
+++ b/pkg/prowloader/gcs/gcs_authentication.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -22,7 +21,7 @@ func NewGCSClient(ctx context.Context, googleServiceAccountCredentialFile, googl
 		)
 	}
 
-	b, err := ioutil.ReadFile(googleOAuthClientCredentialFile)
+	b, err := os.ReadFile(googleOAuthClientCredentialFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/prowloader/gcs/gcs_jobrun.go
+++ b/pkg/prowloader/gcs/gcs_jobrun.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"regexp"
 
 	"cloud.google.com/go/storage"
@@ -148,7 +148,7 @@ func (j *GCSJobRun) GetContent(ctx context.Context, path string) ([]byte, error)
 	}
 	defer gcsReader.Close()
 
-	return ioutil.ReadAll(gcsReader)
+	return io.ReadAll(gcsReader)
 }
 
 func (j *GCSJobRun) ContentExists(ctx context.Context, path string) bool {

--- a/pkg/prowloader/prow.go
+++ b/pkg/prowloader/prow.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -266,7 +266,7 @@ func fetchJobsJSON(prowURL string) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func jobsJSONToProwJobs(jobJSON []byte) ([]prow.ProwJob, error) {

--- a/pkg/releasesync/releasesync_test.go
+++ b/pkg/releasesync/releasesync_test.go
@@ -2,7 +2,7 @@ package releasesync
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -173,7 +173,7 @@ func buildReleaseDetails(hasFailedBlockingJobs bool) ReleaseDetails {
 
 func TestChangeLog(t *testing.T) {
 
-	data, err := ioutil.ReadFile(`OCPCRT-74-pr-test.json`)
+	data, err := os.ReadFile(`OCPCRT-74-pr-test.json`)
 	if err != nil {
 		t.Fatal("Failed to read test file")
 	}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -12,10 +12,11 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/openshift/sippy/pkg/api/jobrunintervals"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/push"
+
+	"github.com/openshift/sippy/pkg/api/jobrunintervals"
 
 	"github.com/openshift/sippy/pkg/db/models"
 
@@ -1087,8 +1088,9 @@ func (s *Server) Serve() {
 
 	// Store a pointer to the HTTP server for later retrieval.
 	s.httpServer = &http.Server{
-		Addr:    s.listenAddr,
-		Handler: handler,
+		Addr:              s.listenAddr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	log.Infof("Serving reports on %s ", s.listenAddr)

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -3,7 +3,7 @@ package snapshot
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/jackc/pgtype"
@@ -122,7 +122,7 @@ func get(url string, data interface{}) (pgtype.JSONB, error) {
 		return pgtype.JSONB{}, err
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return pgtype.JSONB{}, err
 	}

--- a/pkg/testgridanalysis/testgridconversion/to_raw_data.go
+++ b/pkg/testgridanalysis/testgridconversion/to_raw_data.go
@@ -138,6 +138,7 @@ func cleanTestName(testName string) string {
 }
 
 // processTestToJobRunResults adds the tests to the provided JobResult and returns the passed, failed, flaked for the test
+//
 //nolint:gocyclo // TODO: Break this function up, see: https://github.com/fzipp/gocyclo
 func processTestToJobRunResults(jobResult *v1.RawJobResult, job testgridv1.JobDetails, test testgridv1.Test, startCol, endCol int) (passed, failed, flaked int) {
 	col := 0

--- a/pkg/testgridanalysis/testgridhelpers/testgridhelpers.go
+++ b/pkg/testgridanalysis/testgridhelpers/testgridhelpers.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	gourl "net/url"
@@ -13,9 +12,10 @@ import (
 	"regexp"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	testgridv1 "github.com/openshift/sippy/pkg/apis/testgrid/v1"
 	"github.com/openshift/sippy/pkg/util"
-	log "github.com/sirupsen/logrus"
 )
 
 func DownloadData(dashboards []string, filter, storagePath string) {
@@ -90,7 +90,7 @@ func loadJobDetails(dashboard, jobName, storagePath string) (testgridv1.JobDetai
 
 	var buf *bytes.Buffer
 	filename := storagePath + "/" + normalizeURL(url.String())
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return details, fmt.Errorf("could not read local data file %s: %v", filename, err)
 	}
@@ -110,7 +110,7 @@ func loadJobSummaries(dashboard, storagePath string) (map[string]testgridv1.JobS
 
 	var buf *bytes.Buffer
 	filename := storagePath + "/" + normalizeURL(url.String())
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return jobs, time.Time{}, fmt.Errorf("could not read local data file %s (holds %s): %v", filename, url.String(), err)
 	}

--- a/test/e2e/util/e2erequest.go
+++ b/test/e2e/util/e2erequest.go
@@ -3,7 +3,7 @@ package util
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -42,7 +42,7 @@ func SippyRequest(path string, data interface{}) error {
 		return err
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
golangci-lint is too old for go1.19, so we need to bump it, and fix all the new issues. This needs to merge first since buildroot changes aren't tested in presubmits.