### PR TITLE
Adjust stacked chart axes

### DIFF
--- a/sippy-ng/src/jobs/JobStackedChart.js
+++ b/sippy-ng/src/jobs/JobStackedChart.js
@@ -226,6 +226,7 @@ export function JobStackedChart(props) {
         },
       },
       y: {
+        suggestedMin: 0,
         grid: {
           z: 1,
         },

--- a/sippy-ng/src/tests/TestStackedChart.js
+++ b/sippy-ng/src/tests/TestStackedChart.js
@@ -163,6 +163,7 @@ export function TestStackedChart(props) {
         },
       },
       y: {
+        suggestedMax: 80,
         grid: {
           z: 1,
         },


### PR DESCRIPTION
Sets constraints on the stacked chart axes. This makes it a little less panic inducing when a test drops from 99.9% to 99.6% and the chart axis goes from 99.5 to 100.

- Job stacked chart should always start at 0

- Test stacked charts are relative, but will never be less than 80 (so no drastic-looking drops)