### PR TITLE
Ignore disruption by default an match api parameter names in ComponentReadiness UI

### DIFF
--- a/sippy-ng/src/component_readiness/CompCapTestRow.js
+++ b/sippy-ng/src/component_readiness/CompCapTestRow.js
@@ -12,7 +12,7 @@ import TableRow from '@material-ui/core/TableRow'
 
 // Represents a row on page 4 or page4a when you clicked a testName on page3
 export default function CompCapTestRow(props) {
-  // testName is the name of the test (called test_name)
+  // testName is the name of the test (called testName)
   // testId is the unique test ID that maps to the testName
   // results is an array of columns and contains the status value per columnName
   // columnNames is the calculated array of columns

--- a/sippy-ng/src/component_readiness/CompReadyCapCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCapCell.js
@@ -25,7 +25,7 @@ function testReport(
   const retUrl =
     '/component_readiness/env_test' +
     filterVals +
-    `&test_id=${safeTestId}` +
+    `&testId=${safeTestId}` +
     expandEnvironment(environmentVal) +
     `&component=${safeComponentName}` +
     `&capability=${capabilityName}`
@@ -49,7 +49,7 @@ export default function CompReadyCapCell(props) {
     'environment',
     StringParam
   )
-  const [testIdParam, setTestIdParam] = useQueryParam('test_id', StringParam)
+  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
 
   const handleClick = (event) => {
     if (!event.metaKey) {

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
@@ -55,7 +55,7 @@ export default function CompReadyEnvCapabilityTest(props) {
     makeRFC3339Time(filterVals) +
     `&component=${safeComponent}` +
     `&capability=${safeCapability}` +
-    `&test_id=${safeTestId}` +
+    `&testId=${safeTestId}` +
     (environment ? expandEnvironment(environment) : '')
 
   useEffect(() => {

--- a/sippy-ng/src/component_readiness/CompReadyTestCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestCell.js
@@ -28,11 +28,11 @@ function generateTestReport(
   const retUrl =
     '/component_readiness/test_details' +
     filterVals +
-    `&test_id=${safeTestId}` +
+    `&testId=${safeTestId}` +
     expandEnvironment(environmentVal) +
     `&component=${safeComponentName}` +
     `&capability=${capabilityName}` +
-    `&test_name=${safeTestName}`
+    `&testName=${safeTestName}`
 
   return retUrl
 }
@@ -62,9 +62,9 @@ export default function CompReadyTestCell(props) {
     'environment',
     StringParam
   )
-  const [testIdParam, setTestIdParam] = useQueryParam('test_id', StringParam)
+  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
   const [testNameParam, setTestNameParam] = useQueryParam(
-    'test_name',
+    'testName',
     StringParam
   )
 

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -80,7 +80,7 @@ export default function CompReadyTestReport(props) {
     makeRFC3339Time(filterVals) +
     `&component=${safeComponent}` +
     `&capability=${safeCapability}` +
-    `&test_id=${safeTestId}` +
+    `&testId=${safeTestId}` +
     (environment ? expandEnvironment(environment) : '')
 
   useEffect(() => {

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -282,8 +282,8 @@ export function getUpdatedUrlParts(
     confidence: confidence,
     pity: pity,
     minFail: minFail,
-    ignoreDisruption: ignoreDisruption,
-    ignoreMissing: ignoreMissing,
+    ignore_disruption: ignoreDisruption,
+    ignore_missing: ignoreMissing,
     //component: component,
   }
 

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -282,18 +282,18 @@ export function getUpdatedUrlParts(
     confidence: confidence,
     pity: pity,
     minFail: minFail,
-    ignore_disruption: ignoreDisruption,
-    ignore_missing: ignoreMissing,
+    ignoreDisruption: ignoreDisruption,
+    ignoreMissing: ignoreMissing,
     //component: component,
   }
 
   const arraysMap = {
-    exclude_clouds: excludeCloudsCheckedItems,
-    exclude_arches: excludeArchesCheckedItems,
-    exclude_networks: excludeNetworksCheckedItems,
-    exclude_upgrades: excludeUpgradesCheckedItems,
-    exclude_variants: excludeVariantsCheckedItems,
-    group_by: groupByCheckedItems,
+    excludeClouds: excludeCloudsCheckedItems,
+    excludeArches: excludeArchesCheckedItems,
+    excludeNetworks: excludeNetworksCheckedItems,
+    excludeUpgrades: excludeUpgradesCheckedItems,
+    excludeVariants: excludeVariantsCheckedItems,
+    groupBy: groupByCheckedItems,
   }
 
   const queryParams = new URLSearchParams()

--- a/sippy-ng/src/component_readiness/CompTestRow.js
+++ b/sippy-ng/src/component_readiness/CompTestRow.js
@@ -10,7 +10,7 @@ import React from 'react'
 import TableCell from '@material-ui/core/TableCell'
 import TableRow from '@material-ui/core/TableRow'
 
-// After clicking a testName on page 3 or 3a, we add that test_id (that corresponds
+// After clicking a testName on page 3 or 3a, we add that testId (that corresponds
 // to that testName) to the api call along with all the other parts we already have.
 function testLink(filterVals, componentName, capabilityName, testId) {
   const safeComponentName = safeEncodeURIComponent(componentName)
@@ -21,14 +21,14 @@ function testLink(filterVals, componentName, capabilityName, testId) {
     filterVals +
     `&component=${safeComponentName}` +
     `&capability=${safeCapability}` +
-    `&test_id=${safeTestId}`
+    `&testId=${safeTestId}`
   return retVal
 }
 
 // Represents a row when you clicked a capability on page2
 // We display tests on the left and results on the right.
 export default function CompTestRow(props) {
-  // testName is the name of the test (called test_name)
+  // testName is the name of the test (called testName)
   // testId is the unique test ID that maps to the testName
   // results is an array of columns and contains the status value per columnName
   // columnNames is the calculated array of columns
@@ -52,7 +52,7 @@ export default function CompTestRow(props) {
     'capability',
     StringParam
   )
-  const [testIdParam, setTestIdParam] = useQueryParam('test_id', StringParam)
+  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
 
   const handleClick = (event) => {
     if (!event.metaKey) {

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -279,7 +279,7 @@ export default function ComponentReadiness(props) {
     ignoreMissingParam || false
   )
   const [ignoreDisruption, setIgnoreDisruption] = React.useState(
-    ignoreDisruptionParam || false
+    ignoreDisruptionParam || true
   )
 
   const { path, url } = useRouteMatch()

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -182,27 +182,27 @@ export default function ComponentReadiness(props) {
   const [
     groupByCheckedItemsParam = ['cloud', 'arch', 'network'],
     setGroupByCheckedItemsParam,
-  ] = useQueryParam('group_by', ArrayParam)
+  ] = useQueryParam('groupBy', ArrayParam)
   const [
     excludeCloudsCheckedItemsParam = [],
     setExcludeCloudsCheckedItemsParam,
-  ] = useQueryParam('exclude_clouds', ArrayParam)
+  ] = useQueryParam('excludeClouds', ArrayParam)
   const [
     excludeArchesCheckedItemsParam = [],
     setExcludeArchesCheckedItemsParam,
-  ] = useQueryParam('exclude_arches', ArrayParam)
+  ] = useQueryParam('excludeArches', ArrayParam)
   const [
     excludeNetworksCheckedItemsParam = [],
     setExcludeNetworksCheckedItemsParam,
-  ] = useQueryParam('exclude_networks', ArrayParam)
+  ] = useQueryParam('excludeNetworks', ArrayParam)
   const [
     excludeUpgradesCheckedItemsParam = [],
     setExcludeUpgradesCheckedItemsParam,
-  ] = useQueryParam('exclude_upgrades', ArrayParam)
+  ] = useQueryParam('excludeUpgrades', ArrayParam)
   const [
     excludeVariantsCheckedItemsParam = [],
     setExcludeVariantsCheckedItemsParam,
-  ] = useQueryParam('exclude_variants', ArrayParam)
+  ] = useQueryParam('excludeVariants', ArrayParam)
 
   const [confidenceParam = 95, setConfidenceParam] = useQueryParam(
     'confidence',
@@ -232,8 +232,8 @@ export default function ComponentReadiness(props) {
     'capability',
     StringParam
   )
-  const [testIdParam, setTestIdParam] = useQueryParam('test_id', StringParam)
-  const [testNameParam, setTestNameParam] = useQueryParam('test_name', String)
+  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
+  const [testNameParam, setTestNameParam] = useQueryParam('testName', String)
 
   // Create the variables to be used for api calls; these are initilized to the
   // value of the variables that got their values from the URL.


### PR DESCRIPTION
[TRT-1068](https://issues.redhat.com//browse/TRT-1068)

This is dependent on https://github.com/openshift/sippy/pull/1003
I tested this against PR1003 and traversed all 5 pages and got no errors from the API.