### PR TITLE
Enable batching for query params (back button)

### DIFF
--- a/sippy-ng/src/index.js
+++ b/sippy-ng/src/index.js
@@ -1,4 +1,5 @@
 import './index.css'
+import { QueryParamProvider } from 'use-query-params'
 import { BrowserRouter as Router } from 'react-router-dom'
 import App from './App'
 import React from 'react'
@@ -7,7 +8,9 @@ import ReactDOM from 'react-dom'
 ReactDOM.render(
   <React.StrictMode>
     <Router basename="/sippy-ng/">
-      <App />
+      <QueryParamProvider options={{ enableBatching: true }}>
+        <App />
+      </QueryParamProvider>
     </Router>
   </React.StrictMode>,
   document.getElementById('root')


### PR DESCRIPTION
Not a complete fix for the back button, but partially fixes it. One issue is successive calls to set query params each create a history entry. This turns on batching which makes consecutive calls only affect the URL once.  Not all our calls are consecutive so we'd have to fix that to get the back button working completely I think.