### PR TITLE
Add ComponentReadiness UI updates from feedback

### DIFF
--- a/sippy-ng/src/component_readiness/AdvancedOptions.js
+++ b/sippy-ng/src/component_readiness/AdvancedOptions.js
@@ -86,7 +86,7 @@ export default function AdvancedOptions(props) {
               value={confidence}
               onChange={handleChangeConfidence}
               aria-labelledby="my-slider"
-              min={1}
+              min={90}
               max={100}
             />
             <p>Pity: {pity}</p>
@@ -94,16 +94,16 @@ export default function AdvancedOptions(props) {
               value={pity}
               onChange={handleChangePity}
               aria-labelledby="my-slider"
-              min={1}
-              max={100}
+              min={0}
+              max={10}
             />
             <p>MinFail: {minFail}</p>
             <Slider
               value={minFail}
               onChange={handleChangeMinFail}
               aria-labelledby="my-slider"
-              min={1}
-              max={3}
+              min={0}
+              max={20}
             />
             <p>Missing: {ignoreMissing ? 'ignore' : 'keep'}</p>
             <Switch

--- a/sippy-ng/src/component_readiness/CompReadyProgress.js
+++ b/sippy-ng/src/component_readiness/CompReadyProgress.js
@@ -12,7 +12,7 @@ export default function CompReadyProgress(props) {
   const currentTitle = document.title
 
   // Make the title different so you can tell it's loading
-  document.title = '*' + currentTitle
+  document.title = 'Loading ...'
 
   return (
     <Fragment>

--- a/sippy-ng/src/component_readiness/CompReadyTestDetailRow.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestDetailRow.js
@@ -35,9 +35,8 @@ const infoCell = (stats) => {
 export default function CompReadyTestDetailRow(props) {
   // element: a test detail element
   // idx: array index of test detail element
-  // jobFactor: a multiplicative factor for 10 jobs
   // showOnlyFailures: says to focus on job failures
-  const { element, idx, jobFactor, showOnlyFailures } = props
+  const { element, idx, showOnlyFailures } = props
 
   const testJobDetailCell = (element, statsKind) => {
     let item
@@ -51,6 +50,7 @@ export default function CompReadyTestDetailRow(props) {
     }
 
     let filtered = item
+
     // If we only care to see failures, then remove anything else
     // Protect against empty/undefined data
     if (showOnlyFailures) {
@@ -59,27 +59,34 @@ export default function CompReadyTestDetailRow(props) {
         : []
     }
 
+    // Print out the S and F letters for job runs (20 per line) in reverse order
+    // so you see the most recent jobRuns first.
     return (
-      <div style={{ display: 'flex' }}>
-        {filtered &&
-          filtered.length > 0 &&
-          filtered.slice(0, 10 * jobFactor).map((jobRun, jobRunIndex) => {
-            return (
-              <a
-                href={jobRun.job_url}
-                key={jobRunIndex}
-                style={{
-                  color: getJobRunColor(jobRun),
-                  marginRight: '1px',
-                }}
-              >
-                <Typography className="cr-cell-name">
-                  {jobRun.test_stats.failure_count > 0 ? 'F' : 'S'}
-                </Typography>
-              </a>
-            )
-          })}
-      </div>
+      <TableCell className="cr-jobrun-table-wrapper">
+        <div style={{ display: 'flex', maxWidth: '205px', flexWrap: 'wrap' }}>
+          {filtered &&
+            filtered.length > 0 &&
+            filtered
+              .slice()
+              .reverse()
+              .map((jobRun, jobRunIndex) => {
+                return (
+                  <a
+                    href={jobRun.job_url}
+                    key={jobRunIndex}
+                    style={{
+                      color: getJobRunColor(jobRun),
+                      marginRight: '1px',
+                    }}
+                  >
+                    <Typography className="cr-cell-name">
+                      {jobRun.test_stats.failure_count > 0 ? 'F' : 'S'}
+                    </Typography>
+                  </a>
+                )
+              })}
+        </div>
+      </TableCell>
     )
   }
 
@@ -90,9 +97,9 @@ export default function CompReadyTestDetailRow(props) {
           <Typography className="cr-cell-name">{element.job_name}</Typography>
         </TableCell>
         <TableCell>{infoCell(element.base_stats)}</TableCell>
-        <TableCell>{testJobDetailCell(element, 'base')}</TableCell>
+        {testJobDetailCell(element, 'base')}
         <TableCell>{infoCell(element.sample_stats)}</TableCell>
-        <TableCell>{testJobDetailCell(element, 'sample')}</TableCell>
+        {testJobDetailCell(element, 'sample')}
         <TableCell>
           <Typography className="cr-cell-name">
             {element.significant ? 'True' : 'False'}
@@ -106,6 +113,5 @@ export default function CompReadyTestDetailRow(props) {
 CompReadyTestDetailRow.propTypes = {
   element: PropTypes.object.isRequired,
   idx: PropTypes.number.isRequired,
-  jobFactor: PropTypes.number.isRequired,
   showOnlyFailures: PropTypes.bool.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -12,10 +12,12 @@ import {
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
 import { TableContainer, Typography } from '@material-ui/core'
+import { Tooltip } from '@material-ui/core'
 import CompReadyCancelled from './CompReadyCancelled'
 import CompReadyPageTitle from './CompReadyPageTitle'
 import CompReadyProgress from './CompReadyProgress'
 import CompReadyTestDetailRow from './CompReadyTestDetailRow'
+import InfoIcon from '@material-ui/icons/Info'
 import PropTypes from 'prop-types'
 import React, { Fragment, useEffect } from 'react'
 import Slider from '@material-ui/core/Slider'
@@ -182,8 +184,19 @@ export default function CompReadyTestReport(props) {
         <div style={{ display: 'block' }}>Environment: {environment}</div>
         <br />
         <div style={{ display: 'block' }}>
-          Fisher Exact: {data.fisher_exact.toFixed(4)}
+          {/* data.fisher_exact is from 0-1; from that we calculate the probability of regression
+              expressed as a percentage */}
+          <Tooltip
+            title="Test results for individual Prow Jobs may not be statistically
+          significant, but when taken in aggregate, there may be a statistically
+          significant difference compared to the historical basis"
+          >
+            <InfoIcon />
+          </Tooltip>
+          Probability of regression:{' '}
+          {((1.0 - data.fisher_exact) * 100.0).toFixed(2)}%
         </div>
+        <br />
       </Fragment>
       <hr />
       <div style={{ marginTop: '10px', marginBottom: '10px' }}>

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -64,7 +64,6 @@ export default function CompReadyTestReport(props) {
   const [fetchError, setFetchError] = React.useState('')
   const [isLoaded, setIsLoaded] = React.useState(false)
   const [data, setData] = React.useState({})
-  const [jobFactor, setJobFactor] = React.useState(1)
   const [showOnlyFailures, setShowOnlyFailures] = React.useState(false)
 
   // Set the browser tab title
@@ -162,9 +161,6 @@ export default function CompReadyTestReport(props) {
     label: (index + 1).toString(),
   }))
 
-  const handleChangeJobFactor = (event, newValue) => {
-    setJobFactor(newValue)
-  }
   const handleFailuresOnlyChange = (event) => {
     setShowOnlyFailures(event.target.checked)
   }
@@ -190,16 +186,6 @@ export default function CompReadyTestReport(props) {
         </div>
       </Fragment>
       <hr />
-      <p>Prow JobsRuns shown : {jobFactor * 10} </p>
-      <Slider
-        value={jobFactor}
-        onChange={handleChangeJobFactor}
-        aria-labelledby="my-slider"
-        min={1}
-        max={maxJobNumFactor}
-        style={{ width: `${15 * maxJobNumFactor}px` }}
-        marks={marks}
-      />
       <div style={{ marginTop: '10px', marginBottom: '10px' }}>
         <label>
           <input
@@ -231,7 +217,6 @@ export default function CompReadyTestReport(props) {
                     key={idx}
                     element={element}
                     idx={idx}
-                    jobFactor={jobFactor}
                     showOnlyFailures={showOnlyFailures}
                   ></CompReadyTestDetailRow>
                 )

--- a/sippy-ng/src/component_readiness/ComponentReadiness.css
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.css
@@ -47,6 +47,10 @@
     font-size: 11px !important;
 }
 
+.cr-jobrun-table-wrapper {
+  width: 205px;
+}
+
 .cr-cell-capab-col {
     font-size: 11px !important;
     width: 300px;

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -811,35 +811,42 @@ export default function ComponentReadiness(props) {
                           </TableRow>
                         </TableHead>
                         <TableBody>
-                          {Object.keys(data.rows).map((componentIndex) => (
-                            <CompReadyRow
-                              key={componentIndex}
-                              componentName={
-                                data.rows[componentIndex].component
-                              }
-                              results={data.rows[componentIndex].columns}
-                              columnNames={columnNames}
-                              filterVals={getUpdatedUrlParts(
-                                baseRelease,
-                                baseStartTime,
-                                baseEndTime,
-                                sampleRelease,
-                                sampleStartTime,
-                                sampleEndTime,
-                                groupByCheckedItems,
-                                excludeCloudsCheckedItems,
-                                excludeArchesCheckedItems,
-                                excludeNetworksCheckedItems,
-                                excludeUpgradesCheckedItems,
-                                excludeVariantsCheckedItems,
-                                confidence,
-                                pity,
-                                minFail,
-                                ignoreDisruption,
-                                ignoreMissing
-                              )}
-                            />
-                          ))}
+                          {Object.keys(data.rows)
+                            .sort((a, b) =>
+                              data.rows[a].component.toLowerCase() >
+                              data.rows[b].component.toLowerCase()
+                                ? 1
+                                : -1
+                            )
+                            .map((componentIndex) => (
+                              <CompReadyRow
+                                key={componentIndex}
+                                componentName={
+                                  data.rows[componentIndex].component
+                                }
+                                results={data.rows[componentIndex].columns}
+                                columnNames={columnNames}
+                                filterVals={getUpdatedUrlParts(
+                                  baseRelease,
+                                  baseStartTime,
+                                  baseEndTime,
+                                  sampleRelease,
+                                  sampleStartTime,
+                                  sampleEndTime,
+                                  groupByCheckedItems,
+                                  excludeCloudsCheckedItems,
+                                  excludeArchesCheckedItems,
+                                  excludeNetworksCheckedItems,
+                                  excludeUpgradesCheckedItems,
+                                  excludeVariantsCheckedItems,
+                                  confidence,
+                                  pity,
+                                  minFail,
+                                  ignoreDisruption,
+                                  ignoreMissing
+                                )}
+                              />
+                            ))}
                         </TableBody>
                       </Table>
                     </TableContainer>

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -208,7 +208,7 @@ export default function ComponentReadiness(props) {
     'confidence',
     NumberParam
   )
-  const [pityParam = 0, setPityParam] = useQueryParam('pity', NumberParam)
+  const [pityParam = 5, setPityParam] = useQueryParam('pity', NumberParam)
   const [minFailParam = 3, setMinFailParam] = useQueryParam(
     'minFail',
     NumberParam


### PR DESCRIPTION
* Updated Advanced Option parameters per discussions
* Use "Loading ..." instead of asterisks to match typical look/feel of loading pages
* Display rows of 20 ProwJobRun links to allow fitting of many
* Sort rows of component names on first page (without regard to case) 