### PR TITLE
Show Fisher Exact number in tooltip

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -185,11 +185,13 @@ export default function CompReadyTestReport(props) {
         <br />
         <div style={{ display: 'block' }}>
           {/* data.fisher_exact is from 0-1; from that we calculate the probability of regression
-              expressed as a percentage */}
+              expressed as a percentage; we'll display the number in the tooltip in case a user
+              is interested */}
           <Tooltip
-            title="Test results for individual Prow Jobs may not be statistically
+            title={`Test results for individual Prow Jobs may not be statistically
           significant, but when taken in aggregate, there may be a statistically
-          significant difference compared to the historical basis"
+          significant difference compared to the historical basis.  Fisher Exact
+          Number for this basis and sample = ${data.fisher_exact}`}
           >
             <InfoIcon />
           </Tooltip>


### PR DESCRIPTION
This is part of [TRT-1040](https://issues.redhat.com//browse/TRT-1040)

For those who want to know the Fisher Exact number, they'll be able to see it in the tooltip.  This way, they can attempt to make sense of the logic for "Probability of regression".

This PR also gives a place to discuss if we're displaying this correctly.