### PR TITLE
e2e interval charts: limit tooltip width to first word width

### DIFF
--- a/sippy-ng/src/components/TimelineChart.js
+++ b/sippy-ng/src/components/TimelineChart.js
@@ -106,6 +106,20 @@ export default function TimelineChart({ eventIntervals, data }) {
         .maxLineHeight(20)
         .maxHeight(10000)
         .zColorScale(ordinalScale)
+        .segmentTooltipContent((d) => {
+          return (
+            '<span·style="max-inline-size:·min-content;·display:·inline-block;">' +
+            '<strong>' +
+            d.labelVal +
+            '</strong><br/>' +
+            '<strong>From: </strong>' +
+            new Date(d.timeRange[0]).toUTCString() +
+            '<br>' +
+            '<strong>To: </strong>' +
+            new Date(d.timeRange[1]).toUTCString() +
+            '</span>'
+          )
+        })
       if (eventIntervals.length > 0) {
         chart.zoomX([
           new Date(eventIntervals[0].from),

--- a/sippy-ng/src/components/TimelineChart.js
+++ b/sippy-ng/src/components/TimelineChart.js
@@ -120,6 +120,10 @@ export default function TimelineChart({ eventIntervals, data }) {
             '</span>'
           )
         })
+        .onSegmentClick((seg) => {
+          // Copy hover popup label to clipboard
+          navigator.clipboard.writeText(seg.labelVal)
+        })
       if (eventIntervals.length > 0) {
         chart.zoomX([
           new Date(eventIntervals[0].from),


### PR DESCRIPTION
Two quality-of-life improvements for e2e charts:

*  wrap tooltips in e2e chart to make sure that tooltips don't overflow X when a long label is used.
*  copy segment label contents to clipboard when its clicked

Ref: https://github.com/openshift/origin/pull/27965
