### PR TITLE
Use GA dates in component readiness

### DIFF
--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -710,8 +710,9 @@ type TestOutput struct {
 }
 
 type Releases struct {
-	Releases    []string  `json:"releases"`
-	LastUpdated time.Time `json:"last_updated"`
+	Releases    []string             `json:"releases"`
+	GADates     map[string]time.Time `json:"ga_dates"`
+	LastUpdated time.Time            `json:"last_updated"`
 }
 
 type Indicator struct {

--- a/pkg/releasesync/release_dates.go
+++ b/pkg/releasesync/release_dates.go
@@ -1,0 +1,14 @@
+package releasesync
+
+import "time"
+
+var GADateMap = map[string]time.Time{
+	"4.13": time.Date(2023, 5, 17, 0, 0, 0, 0, time.UTC),
+	"4.12": time.Date(2023, 1, 17, 0, 0, 0, 0, time.UTC),
+	"4.11": time.Date(2022, 8, 10, 0, 0, 0, 0, time.UTC),
+	"4.10": time.Date(2022, 3, 10, 0, 0, 0, 0, time.UTC),
+	"4.9":  time.Date(2021, 10, 18, 0, 0, 0, 0, time.UTC),
+	"4.8":  time.Date(2021, 7, 27, 0, 0, 0, 0, time.UTC),
+	"4.7":  time.Date(2021, 2, 24, 0, 0, 0, 0, time.UTC),
+	"4.6":  time.Date(2020, 10, 27, 0, 0, 0, 0, time.UTC),
+}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/openshift/sippy/pkg/api/jobrunintervals"
 	"github.com/openshift/sippy/pkg/apis/cache"
+	"github.com/openshift/sippy/pkg/releasesync"
 
 	"github.com/openshift/sippy/pkg/db/models"
 
@@ -823,7 +824,9 @@ func (s *Server) jsonTestDetailsReportFromDB(w http.ResponseWriter, req *http.Re
 }
 
 func (s *Server) jsonReleasesReportFromDB(w http.ResponseWriter, _ *http.Request) {
-	response := apitype.Releases{}
+	response := apitype.Releases{
+		GADates: releasesync.GADateMap,
+	}
 	releases, err := query.ReleasesFromDB(s.db)
 	if err != nil {
 		log.WithError(err).Error("error querying releases from db")

--- a/sippy-ng/src/component_readiness/CompReadyMainInputs.js
+++ b/sippy-ng/src/component_readiness/CompReadyMainInputs.js
@@ -113,70 +113,22 @@ export default function CompReadyMainInputs(props) {
           label="Release to Evaluate"
           version={sampleRelease}
           onChange={setSampleRelease}
+          startTime={sampleStartTime}
+          setStartTime={setSampleStartTime}
+          endTime={sampleEndTime}
+          setEndTime={setSampleEndTime}
         ></ReleaseSelector>
-        <MuiPickersUtilsProvider utils={GridToolbarFilterDateUtils}>
-          <DatePicker
-            showTodayButton
-            disableFuture
-            label="From"
-            format={dateFormat}
-            ampm={false}
-            value={sampleStartTime}
-            onChange={(e) => {
-              const formattedTime = formatLongDate(e, dateFormat)
-              setSampleStartTime(formattedTime)
-            }}
-          />
-        </MuiPickersUtilsProvider>
-        <MuiPickersUtilsProvider utils={GridToolbarFilterDateUtils}>
-          <DatePicker
-            showTodayButton
-            disableFuture
-            label="To"
-            format={dateEndFormat}
-            ampm={false}
-            value={sampleEndTime}
-            onChange={(e) => {
-              const formattedTime = formatLongDate(e, dateEndFormat)
-              setSampleEndTime(formattedTime)
-            }}
-          />
-        </MuiPickersUtilsProvider>
       </div>
       <div className="cr-release-historical">
         <ReleaseSelector
           version={baseRelease}
           label="Historical Release"
           onChange={setBaseRelease}
+          startTime={baseStartTime}
+          setStartTime={setBaseStartTime}
+          endTime={baseEndTime}
+          setEndTime={setBaseEndTime}
         ></ReleaseSelector>
-        <MuiPickersUtilsProvider utils={GridToolbarFilterDateUtils}>
-          <DatePicker
-            showTodayButton
-            disableFuture
-            label="From"
-            format={dateFormat}
-            ampm={false}
-            value={baseStartTime}
-            onChange={(e) => {
-              const formattedTime = formatLongDate(e, dateFormat)
-              setBaseStartTime(formattedTime)
-            }}
-          />
-        </MuiPickersUtilsProvider>
-        <MuiPickersUtilsProvider utils={GridToolbarFilterDateUtils}>
-          <DatePicker
-            showTodayButton
-            disableFuture
-            label="To"
-            format={dateEndFormat}
-            ampm={false}
-            value={baseEndTime}
-            onChange={(e) => {
-              const formattedTime = formatLongDate(e, dateEndFormat)
-              setBaseEndTime(formattedTime)
-            }}
-          />
-        </MuiPickersUtilsProvider>
       </div>
       <div>
         <CheckBoxList

--- a/sippy-ng/src/component_readiness/ReleaseSelector.js
+++ b/sippy-ng/src/component_readiness/ReleaseSelector.js
@@ -1,6 +1,18 @@
-import { FormControl, InputLabel, MenuItem, Select } from '@material-ui/core'
+import { dateEndFormat, dateFormat, formatLongDate } from './CompReadyUtils'
+import { DatePicker, MuiPickersUtilsProvider } from '@material-ui/pickers'
+import { Filter2, Filter4, LocalShipping } from '@material-ui/icons'
+import {
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  Tooltip,
+} from '@material-ui/core'
+import { Fragment, useEffect } from 'react'
+import { GridToolbarFilterDateUtils } from '../datagrid/GridToolbarFilterDateUtils'
 import { makeStyles } from '@material-ui/core/styles'
-import { useEffect } from 'react'
+import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -20,29 +32,70 @@ const useStyles = makeStyles((theme) => ({
 
 function ReleaseSelector(props) {
   const classes = useStyles()
-  const [versions, setVersions] = React.useState([])
-  const { label, version, onChange } = props
+  const [versions, setVersions] = React.useState({})
+  const {
+    label,
+    version,
+    onChange,
+    startTime,
+    setStartTime,
+    endTime,
+    setEndTime,
+  } = props
+
+  const days = 24 * 60 * 60 * 1000
+  const twoWeeksStart = new Date(new Date().getTime() - 2 * 7 * days)
+  const fourWeeksStart = new Date(new Date().getTime() - 4 * 7 * days)
+  const defaultEndTime = new Date(new Date().getTime())
 
   const fetchData = () => {
-    const useLocal = false
-    if (useLocal) {
-      console.log('quick mode...')
-      const data = { releases: ['4.10', '4.11', '4.12', '4.13', '4.14'] }
-      setVersions(data.releases)
-    } else {
-      fetch(process.env.REACT_APP_API_URL + '/api/releases')
-        .then((response) => response.json())
-        .then((data) => {
-          setVersions(
-            data.releases.filter((aVersion) => {
-              // We won't process Presubmits or 3.11
-              return aVersion !== 'Presubmits' && aVersion != '3.11'
-            })
-          )
-        })
-        .catch((error) => console.error(error))
-    }
+    fetch(process.env.REACT_APP_API_URL + '/api/releases')
+      .then((response) => response.json())
+      .then((data) => {
+        let tmpRelease = {}
+        data.releases
+          .filter((aVersion) => {
+            // We won't process Presubmits or 3.11
+            return aVersion !== 'Presubmits' && aVersion != '3.11'
+          })
+          .forEach((r) => {
+            tmpRelease[r] = data.ga_dates[r]
+          })
+        setVersions(tmpRelease)
+        if (tmpRelease[version] !== undefined && tmpRelease[version] !== null) {
+          let start = new Date(tmpRelease[version])
+          setStartTime(formatLongDate(start.setDate(start.getDate() - 28)))
+          setEndTime(formatLongDate(tmpRelease[version]))
+        } else {
+          set4Weeks()
+        }
+      })
+      .catch((error) => console.error(error))
   }
+
+  const setGADate = () => {
+    let start = new Date(versions[version])
+    setStartTime(formatLongDate(start.setDate(start.getDate() - 28)))
+    setEndTime(formatLongDate(versions[version]))
+  }
+
+  const set4Weeks = () => {
+    setStartTime(fourWeeksStart)
+    setEndTime(defaultEndTime)
+  }
+
+  const set2Weeks = () => {
+    setStartTime(twoWeeksStart)
+    setEndTime(defaultEndTime)
+  }
+
+  useEffect(() => {
+    if (versions[version] !== undefined && versions[version] !== null) {
+      setGADate()
+    } else {
+      set4Weeks()
+    }
+  }, [version])
 
   useEffect(() => {
     fetchData()
@@ -53,25 +106,93 @@ function ReleaseSelector(props) {
   }
 
   // Ensure that versions has a list of versions before trying to display the Form
-  if (versions.length === 0) {
+  if (Object.keys(versions).length === 0) {
     return <p>Loading Releases...</p>
   }
 
   return (
-    <FormControl className={classes.formControl}>
-      <InputLabel className={classes.label}>{label}</InputLabel>
-      <Select value={version} onChange={handleChange}>
-        {versions.map((v) => (
-          <MenuItem key={v} value={v}>
-            {v}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
+    <Fragment>
+      <Grid container justifyContent="center" alignItems="center">
+        <Grid item md={12}>
+          <FormControl className={classes.formControl}>
+            <InputLabel className={classes.label}>{label}</InputLabel>
+            <Select value={version} onChange={handleChange}>
+              {Object.keys(versions).map((v) => (
+                <MenuItem key={v} value={v}>
+                  {v}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <MuiPickersUtilsProvider utils={GridToolbarFilterDateUtils}>
+            <DatePicker
+              showTodayButton
+              disableFuture
+              label="From"
+              format={dateFormat}
+              ampm={false}
+              value={startTime}
+              onChange={(e) => {
+                const formattedTime = formatLongDate(e, dateFormat)
+                setStartTime(formattedTime)
+              }}
+            />
+          </MuiPickersUtilsProvider>
+          <MuiPickersUtilsProvider utils={GridToolbarFilterDateUtils}>
+            <DatePicker
+              showTodayButton
+              disableFuture
+              label="To"
+              format={dateEndFormat}
+              ampm={false}
+              value={endTime}
+              onChange={(e) => {
+                const formattedTime = formatLongDate(e, dateEndFormat)
+                setEndTime(formattedTime)
+              }}
+            />
+          </MuiPickersUtilsProvider>
+        </Grid>
+        <Grid item sm={12} md={6} style={{ marginTop: 5 }}>
+          <ToggleButtonGroup size="small" ria-label="release-dates">
+            <Tooltip title="Last 2 weeks">
+              <ToggleButton onClick={set2Weeks} aria-label="filter-2">
+                <Filter2 fontSize="small" />
+              </ToggleButton>
+            </Tooltip>
+            <Tooltip title="Last 4 weeks">
+              <ToggleButton onClick={set4Weeks} aria-label="filter-4">
+                <Filter4 fontSize="small" />
+              </ToggleButton>
+            </Tooltip>
+            <Tooltip title="4 weeks before GA">
+              <ToggleButton
+                onClick={setGADate}
+                aria-label="ga-date"
+                fontSize="small"
+                style={{
+                  visibility:
+                    versions[version] === undefined ||
+                    versions[version] === null
+                      ? 'hidden'
+                      : 'visible',
+                }}
+              >
+                <LocalShipping />
+              </ToggleButton>
+            </Tooltip>
+          </ToggleButtonGroup>
+        </Grid>
+      </Grid>
+    </Fragment>
   )
 }
 
 ReleaseSelector.propTypes = {
+  startTime: PropTypes.string,
+  setStartTime: PropTypes.func,
+  endTime: PropTypes.string,
+  setEndTime: PropTypes.func,
   label: PropTypes.string,
   version: PropTypes.string,
   versions: PropTypes.array,


### PR DESCRIPTION
[TRT-1065](https://issues.redhat.com//browse/TRT-1065)

- Adds GA dates to Sippy's release API
- Uses those dates by default for GA'd releases in component readiness
- Add quick links for 2 weeks, 4 weeks, and GA - 4 weeks
