### PR TITLE
Skip bug lookup in e2e

### DIFF
--- a/e2e-scripts/sippy-e2e-sippy-e2e-setup-commands.sh
+++ b/e2e-scripts/sippy-e2e-sippy-e2e-setup-commands.sh
@@ -190,7 +190,7 @@ spec:
         terminationMessagePolicy: File
         command:  ["/bin/sh", "-c"]
         args:
-          - /bin/sippy --init-database --load-database --log-level=debug --load-prow=true --load-testgrid=false --release 4.13 --database-dsn=postgresql://postgres:password@postgres.sippy-e2e.svc.cluster.local:5432/postgres --mode=ocp --config ./config/e2e-openshift.yaml --google-service-account-credential-file /tmp/secrets/gcs-cred
+          - /bin/sippy --init-database --load-database --log-level=debug --load-prow=true --load-testgrid=false --release 4.13 --skip-bug-lookup --database-dsn=postgresql://postgres:password@postgres.sippy-e2e.svc.cluster.local:5432/postgres --mode=ocp --config ./config/e2e-openshift.yaml --google-service-account-credential-file /tmp/secrets/gcs-cred
         env:
         - name: GCS_SA_JSON_PATH
           value: /tmp/secrets/gcs-cred


### PR DESCRIPTION
Bug lookup hits search.ci, and it's quite an intensive operation. With the quantity of PR's we landed today, I think we're hammering it a bit too hard and it's affecting production Sippy's bug syncing.

We can re-instate this once we figure out how to reduce our load on search.ci, there's an existing jira card for that.