### PR TITLE
Align test detail rows on top

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyTestDetailRow.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestDetailRow.js
@@ -63,7 +63,13 @@ export default function CompReadyTestDetailRow(props) {
     // so you see the most recent jobRuns first.
     return (
       <TableCell className="cr-jobrun-table-wrapper">
-        <div style={{ display: 'flex', maxWidth: '205px', flexWrap: 'wrap' }}>
+        <div
+          style={{
+            display: 'flex',
+            maxWidth: '205px',
+            flexWrap: 'wrap',
+          }}
+        >
           {filtered &&
             filtered.length > 0 &&
             filtered
@@ -96,11 +102,15 @@ export default function CompReadyTestDetailRow(props) {
         <TableCell className={'cr-col-result'} key={'column' + '-' + idx}>
           <Typography className="cr-cell-name">{element.job_name}</Typography>
         </TableCell>
-        <TableCell>{infoCell(element.base_stats)}</TableCell>
+        <TableCell style={{ verticalAlign: 'top' }}>
+          {infoCell(element.base_stats)}
+        </TableCell>
         {testJobDetailCell(element, 'base')}
-        <TableCell>{infoCell(element.sample_stats)}</TableCell>
+        <TableCell style={{ verticalAlign: 'top' }}>
+          {infoCell(element.sample_stats)}
+        </TableCell>
         {testJobDetailCell(element, 'sample')}
-        <TableCell>
+        <TableCell style={{ verticalAlign: 'top' }}>
           <Typography className="cr-cell-name">
             {element.significant ? 'True' : 'False'}
           </Typography>

--- a/sippy-ng/src/component_readiness/ComponentReadiness.css
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.css
@@ -49,6 +49,7 @@
 
 .cr-jobrun-table-wrapper {
   width: 205px;
+  vertical-align: top !important;
 }
 
 .cr-cell-capab-col {
@@ -58,6 +59,7 @@
 
 .cr-col-result {
     hyphens: auto;
+    vertical-align: top !important;
 }
 
 .cr-col-result-full {


### PR DESCRIPTION
It's a little easier for me to read if all the cell data is aligned to the top.

Before:
![old](https://github.com/bparees/sippy/assets/429763/5a1f7935-6c76-4326-984a-b81f83572a3a)


After:
![new](https://github.com/bparees/sippy/assets/429763/75b3f4e2-91ff-4deb-b186-e174e8148f2c)
