### PR TITLE
Show test suite and name in component readiness

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -11,11 +11,12 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	fischer "github.com/glycerine/golang-fisher-exact"
-	apitype "github.com/openshift/sippy/pkg/apis/api"
-	"github.com/openshift/sippy/pkg/util/sets"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
+
+	apitype "github.com/openshift/sippy/pkg/apis/api"
+	"github.com/openshift/sippy/pkg/util/sets"
 )
 
 func getSingleColumnResultToSlice(query *bigquery.Query) ([]string, error) {
@@ -226,6 +227,7 @@ func (c *componentReportGenerator) getJobRunTestStatusFromBigQuery() (
 								FROM openshift-gce-devel.ci_analysis_us.component_mapping))
 					SELECT
 						ANY_VALUE(test_name) AS test_name,
+						ANY_VALUE(testsuite) AS test_suite,
 						file_path,
 						ANY_VALUE(prowjob_name) AS prowjob_name,
 						COUNT(*) AS total_count,
@@ -353,6 +355,7 @@ func (c *componentReportGenerator) getTestStatusFromBigQuery() (
 								FROM openshift-gce-devel.ci_analysis_us.component_mapping))
 					SELECT
 						ANY_VALUE(test_name) AS test_name,
+						ANY_VALUE(testsuite) AS test_suite,
 						cm.id as test_id,
 						network,
 						upgrade,
@@ -572,6 +575,7 @@ func (c *componentReportGenerator) getRowColumnIdentifications(test apitype.Comp
 				Component: component,
 				TestID:    test.TestID,
 				TestName:  stats.TestName,
+				TestSuite: stats.TestSuite,
 			}
 			if c.Capability != "" {
 				row.Capability = c.Capability
@@ -586,6 +590,7 @@ func (c *componentReportGenerator) getRowColumnIdentifications(test apitype.Comp
 							Component:  component,
 							TestID:     test.TestID,
 							TestName:   stats.TestName,
+							TestSuite:  stats.TestSuite,
 							Capability: capability,
 						}
 						rows = append(rows, row)
@@ -706,6 +711,7 @@ func (c *componentReportGenerator) fetchTestStatus(query *bigquery.Query) (map[a
 		}
 		status[testIdentification] = apitype.ComponentTestStatus{
 			TestName:     testStatus.TestName,
+			TestSuite:    testStatus.TestSuite,
 			Component:    testStatus.Component,
 			Capabilities: testStatus.Capabilities,
 			Variants:     testStatus.Variants,

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -806,6 +806,7 @@ type ComponentReportRequestAdvancedOptions struct {
 
 type ComponentTestStatus struct {
 	TestName     string
+	TestSuite    string
 	Component    string
 	Capabilities []string
 	Variants     []string
@@ -825,6 +826,7 @@ type ComponentTestIdentification struct {
 
 type ComponentTestStatusRow struct {
 	TestName     string   `bigquery:"test_name"`
+	TestSuite    string   `bigquery:"test_suite"`
 	TestID       string   `bigquery:"test_id"`
 	Network      string   `bigquery:"network"`
 	Upgrade      string   `bigquery:"upgrade"`
@@ -852,6 +854,7 @@ type ComponentReportRowIdentification struct {
 	Component  string `json:"component"`
 	Capability string `json:"capability,omitempty"`
 	TestName   string `json:"test_name,omitempty"`
+	TestSuite  string `json:"test_suite,omitempty"`
 	TestID     string `json:"test_id,omitempty"`
 }
 

--- a/sippy-ng/src/component_readiness/CompCapTestRow.js
+++ b/sippy-ng/src/component_readiness/CompCapTestRow.js
@@ -20,6 +20,7 @@ export default function CompCapTestRow(props) {
   // component, capability: these are passed because we need them in the /test endpoint
   const {
     testName,
+    testSuite,
     testId,
     results,
     columnNames,
@@ -32,7 +33,9 @@ export default function CompCapTestRow(props) {
   const testNameColumn = (
     <TableCell className={'cr-component-name'} key={testName}>
       <Tooltip title={testId}>
-        <Typography className="cr-cell-name">{testName}</Typography>
+        <Typography className="cr-cell-name">
+          {[testSuite, testName].filter(Boolean).join('.')}
+        </Typography>
       </Tooltip>
     </TableCell>
   )
@@ -60,6 +63,7 @@ export default function CompCapTestRow(props) {
 
 CompCapTestRow.propTypes = {
   testName: PropTypes.string.isRequired,
+  testSuite: PropTypes.string.isRequired,
   testId: PropTypes.string.isRequired,
   results: PropTypes.array.isRequired,
   columnNames: PropTypes.array.isRequired,

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapability.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapability.js
@@ -158,6 +158,7 @@ export default function CompReadyEnvCapability(props) {
                 return (
                   <CompTestRow
                     key={componentIndex}
+                    testSuite={data.rows[componentIndex].test_suite}
                     testName={data.rows[componentIndex].test_name}
                     testId={data.rows[componentIndex].test_id}
                     results={data.rows[componentIndex].columns}

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
@@ -159,6 +159,7 @@ export default function CompReadyEnvCapabilityTest(props) {
                 return (
                   <CompCapTestRow
                     key={componentIndex}
+                    testSuite={data.rows[componentIndex].test_suite}
                     testName={data.rows[componentIndex].test_name}
                     testId={data.rows[componentIndex].test_id}
                     results={data.rows[componentIndex].columns}

--- a/sippy-ng/src/component_readiness/CompTestRow.js
+++ b/sippy-ng/src/component_readiness/CompTestRow.js
@@ -36,6 +36,7 @@ export default function CompTestRow(props) {
   // component, capability: these are passed because we need them in the /test endpoint
   const {
     testName,
+    testSuite,
     testId,
     results,
     columnNames,
@@ -75,7 +76,7 @@ export default function CompTestRow(props) {
             to={testLink(filterVals, component, capability, testId)}
             onClick={handleClick}
           >
-            {testName}
+            {[testSuite, testName].filter(Boolean).join('.')}
           </Link>
         </Typography>
       </Tooltip>
@@ -104,6 +105,7 @@ export default function CompTestRow(props) {
 
 CompTestRow.propTypes = {
   testName: PropTypes.string.isRequired,
+  testSuite: PropTypes.string.isRequired,
   testId: PropTypes.string.isRequired,
   results: PropTypes.array.isRequired,
   columnNames: PropTypes.array.isRequired,


### PR DESCRIPTION
If you look at this page:

https://sippy.dptools.openshift.org/sippy-ng/component_readiness/capability?baseEndTime=2023-05-16%2023%3A59%3A59&baseRelease=4.13&baseStartTime=2023-04-18%2000%3A00%3A00&capability=Other&component=Networking%20%2F%20cluster-network-operator&confidence=95&groupBy=cloud%2Carch%2Cnetwork&ignoreDisruption=true&ignoreMissing=false&minFail=3&pity=5&sampleEndTime=2023-06-05%2023%3A59%3A59&sampleRelease=4.14&sampleStartTime=2023-05-08%2000%3A00%3A00

You'll notice a lot of duplicate tests. It's because we consider same named tests from different suites as different tests (it's possible two suites could define a generic test like "TestClusterCreate" and we want to make sure we're not combining results from different suites).

This adds the suite name to the API, and shows it in the UI.