### PR TITLE
Allow selecting only red components

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCell.js
@@ -25,7 +25,7 @@ function componentReport(componentName, environmentVal, filterVals) {
   return retUrl
 }
 export default function CompReadyCell(props) {
-  const { status, environment, componentName, filterVals } = props
+  const { status, environment, componentName, filterVals, grayFactor } = props
   const theme = useTheme()
 
   const [componentParam, setComponentParam] = useQueryParam(
@@ -74,7 +74,7 @@ export default function CompReadyCell(props) {
           to={componentReport(componentName, environment, filterVals)}
           onClick={handleClick}
         >
-          <CompSeverityIcon status={status} />
+          <CompSeverityIcon status={status} grayFactor={grayFactor} />
         </Link>
       </TableCell>
     )
@@ -86,4 +86,5 @@ CompReadyCell.propTypes = {
   environment: PropTypes.string.isRequired,
   componentName: PropTypes.string.isRequired,
   filterVals: PropTypes.string.isRequired,
+  grayFactor: PropTypes.number.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompReadyRow.js
+++ b/sippy-ng/src/component_readiness/CompReadyRow.js
@@ -26,7 +26,7 @@ export default function CompReadyRow(props) {
   // results is an array of columns and contains the status value per columnName
   // columnNames is the calculated array of columns
   // filterVals: the parts of the url containing input values
-  const { componentName, results, columnNames, filterVals } = props
+  const { componentName, results, columnNames, filterVals, grayFactor } = props
 
   const [componentParam, setComponentParam] = useQueryParam(
     'component',
@@ -70,6 +70,7 @@ export default function CompReadyRow(props) {
             environment={columnNames[idx]}
             componentName={componentName}
             filterVals={filterVals}
+            grayFactor={grayFactor}
           />
         ))}
       </TableRow>
@@ -82,4 +83,5 @@ CompReadyRow.propTypes = {
   results: PropTypes.array.isRequired,
   columnNames: PropTypes.array.isRequired,
   filterVals: PropTypes.string.isRequired,
+  grayFactor: PropTypes.number.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -93,8 +93,8 @@ export function gotFetchError(fetchError) {
 }
 
 // getStatusAndIcon returns a status string and icon to display to denote a visual and textual
-// meaning of a 'status' value.
-export function getStatusAndIcon(status) {
+// meaning of a 'status' value.  We optionally allow a grayscale mode for the red colors.
+export function getStatusAndIcon(status, grayFactor = 0) {
   let icon = ''
 
   let statusStr = status + ': '
@@ -107,7 +107,7 @@ export function getStatusAndIcon(status) {
         src={heart}
         width="20px"
         height="20px"
-        alt="SignificantImprovement"
+        style={{ filter: `grayscale(${grayFactor}%)` }}
       />
     )
   } else if (status == 2) {
@@ -119,6 +119,7 @@ export function getStatusAndIcon(status) {
         alt="MissingBasisAndSample"
         width="15px"
         height="15px"
+        style={{ filter: `grayscale(${grayFactor}%)` }}
       />
     )
   } else if (status == 1) {
@@ -129,11 +130,18 @@ export function getStatusAndIcon(status) {
         alt="MissingBasis"
         width="15px"
         height="15px"
+        style={{ filter: `grayscale(${grayFactor}%)` }}
       />
     )
   } else if (status == 0) {
     statusStr = statusStr + 'NoSignificantDifference detected'
-    icon = <img src={green} alt="NotSignificant" />
+    icon = (
+      <img
+        src={green}
+        alt="NotSignificant"
+        style={{ filter: `grayscale(${grayFactor}%)` }}
+      />
+    )
   } else if (status == -1) {
     statusStr = statusStr + 'Missing Sample (sample data missing)'
     icon = (
@@ -142,6 +150,7 @@ export function getStatusAndIcon(status) {
         alt="MissingBasisAndSample"
         width="15px"
         height="15px"
+        style={{ filter: `grayscale(${grayFactor}%)` }}
       />
     )
   } else if (status == -2) {

--- a/sippy-ng/src/component_readiness/CompSeverityIcon.js
+++ b/sippy-ng/src/component_readiness/CompSeverityIcon.js
@@ -7,12 +7,13 @@ import React from 'react'
 
 export default function CompSeverityIcon(props) {
   const theme = useTheme()
-  const status = props.status
+  const { status, grayFactor } = props
 
-  const [statusStr, icon] = getStatusAndIcon(status)
+  const [statusStr, icon] = getStatusAndIcon(status, grayFactor)
   return <Tooltip title={statusStr}>{icon}</Tooltip>
 }
 
 CompSeverityIcon.propTypes = {
   status: PropTypes.number,
+  grayFactor: PropTypes.number,
 }

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -22,6 +22,7 @@ import {
   noDataTable,
 } from './CompReadyUtils'
 import {
+  Checkbox,
   Drawer,
   Grid,
   TableContainer,
@@ -156,6 +157,11 @@ export default function ComponentReadiness(props) {
   const handleSearchColumnRegexChange = (event) => {
     const searchValue = event.target.value
     setSearchColumnRegex(searchValue)
+  }
+
+  const [redOnlyChecked, setRedOnlyChecked] = React.useState(false)
+  const handleRedOnlyCheckboxChange = (event) => {
+    setRedOnlyChecked(event.target.checked)
   }
 
   const [drawerOpen, setDrawerOpen] = React.useState(true)
@@ -814,6 +820,16 @@ export default function ComponentReadiness(props) {
                                   <Typography className="cr-cell-name">
                                     Name
                                   </Typography>
+                                  <Checkbox
+                                    checked={redOnlyChecked}
+                                    onChange={handleRedOnlyCheckboxChange}
+                                    color="primary"
+                                    size="small"
+                                    style={{ borderRadius: 4 }}
+                                  />
+                                  <label htmlFor="redOnlyCheckbox">
+                                    Red Only
+                                  </label>
                                 </TableCell>
                               }
                               {columnNames
@@ -857,6 +873,18 @@ export default function ComponentReadiness(props) {
                                 data.rows[b].component.toLowerCase()
                                   ? 1
                                   : -1
+                              )
+                              .filter((componentIndex) =>
+                                redOnlyChecked
+                                  ? data.rows[componentIndex].columns.some(
+                                      // Filter for rows where any of their columns have status <= -2 and accepted by the regex.
+                                      (column) =>
+                                        column.status <= -2 &&
+                                        formColumnName(column).match(
+                                          new RegExp(searchColumnRegex, 'i')
+                                        )
+                                    )
+                                  : true
                               )
                               .map((componentIndex) => (
                                 <CompReadyRow

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -807,22 +807,23 @@ export default function ComponentReadiness(props) {
                           value={searchColumnRegex}
                           onChange={handleSearchColumnRegexChange}
                         />
-                        <Checkbox
-                          checked={redOnlyChecked}
-                          onChange={handleRedOnlyCheckboxChange}
-                          color="primary"
-                          size="small"
-                          style={{ borderRadius: 1 }}
-                        />
-                        <label
+                        <FormControlLabel
+                          control={
+                            <Checkbox
+                              checked={redOnlyChecked}
+                              onChange={handleRedOnlyCheckboxChange}
+                              color="primary"
+                              size="small"
+                              style={{ borderRadius: 1 }}
+                            />
+                          }
                           htmlFor="redOnlyCheckbox"
                           style={{
                             textAlign: 'left',
                             marginTop: 15,
                           }}
-                        >
-                          Red Only
-                        </label>
+                          label="Red Only"
+                        ></FormControlLabel>
                       </div>
                       <TableContainer
                         component="div"

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -807,6 +807,22 @@ export default function ComponentReadiness(props) {
                           value={searchColumnRegex}
                           onChange={handleSearchColumnRegexChange}
                         />
+                        <Checkbox
+                          checked={redOnlyChecked}
+                          onChange={handleRedOnlyCheckboxChange}
+                          color="primary"
+                          size="small"
+                          style={{ borderRadius: 1 }}
+                        />
+                        <label
+                          htmlFor="redOnlyCheckbox"
+                          style={{
+                            textAlign: 'left',
+                            marginTop: 15,
+                          }}
+                        >
+                          Red Only
+                        </label>
                       </div>
                       <TableContainer
                         component="div"
@@ -820,16 +836,6 @@ export default function ComponentReadiness(props) {
                                   <Typography className="cr-cell-name">
                                     Name
                                   </Typography>
-                                  <Checkbox
-                                    checked={redOnlyChecked}
-                                    onChange={handleRedOnlyCheckboxChange}
-                                    color="primary"
-                                    size="small"
-                                    style={{ borderRadius: 4 }}
-                                  />
-                                  <label htmlFor="redOnlyCheckbox">
-                                    Red Only
-                                  </label>
                                 </TableCell>
                               }
                               {columnNames
@@ -904,6 +910,7 @@ export default function ComponentReadiness(props) {
                                       new RegExp(searchColumnRegex, 'i')
                                     )
                                   )}
+                                  grayFactor={redOnlyChecked ? 100 : 0}
                                   filterVals={getUpdatedUrlParts(
                                     baseRelease,
                                     baseStartTime,

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -24,6 +24,7 @@ import {
 import {
   Checkbox,
   Drawer,
+  FormControlLabel,
   Grid,
   TableContainer,
   TextField,


### PR DESCRIPTION
[TRT-1062](https://issues.redhat.com//browse/TRT-1062)

More page 1 features to allow users to focus on what they care about.

I focus only on the components/rows to avoid too many filters.  If we really want to filter on red columns, we can do that separately.