### PR TITLE
Revert "Add to/from dates to test report page plus human readable message"

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -35,6 +35,20 @@ const cancelFetch = () => {
   abortController.abort()
 }
 
+const printStats = (statsLabel, stats) => {
+  return (
+    <Fragment>
+      {statsLabel} Release: {stats.release}
+      <ul>
+        <li>Success Rate: {(stats.success_rate * 100).toFixed(2)}%</li>
+        <li>Successes: {stats.success_count}</li>
+        <li>Failures: {stats.failure_count}</li>
+        <li>Flakes: {stats.flake_count}</li>
+      </ul>
+    </Fragment>
+  )
+}
+
 const tableCell = (label, idx) => {
   return (
     <TableCell className={'cr-col-result'} key={'column' + '-' + idx}>
@@ -65,7 +79,6 @@ export default function CompReadyTestReport(props) {
   const [isLoaded, setIsLoaded] = React.useState(false)
   const [data, setData] = React.useState({})
   const [showOnlyFailures, setShowOnlyFailures] = React.useState(false)
-  const [versions, setVersions] = React.useState({})
 
   // Set the browser tab title
   document.title =
@@ -87,16 +100,6 @@ export default function CompReadyTestReport(props) {
 
   useEffect(() => {
     setIsLoaded(false)
-
-    const checkFetchesDone = () => {
-      if (isReportDone && isVersionFetchDone) {
-        setIsLoaded(true)
-      }
-    }
-
-    let isReportDone = false
-    let isVersionFetchDone = false
-
     fetch(apiCallStr, { signal: abortController.signal })
       .then((response) => {
         if (response.status !== 200) {
@@ -124,28 +127,8 @@ export default function CompReadyTestReport(props) {
         }
       })
       .finally(() => {
-        isReportDone = true
-        checkFetchesDone()
-      })
-
-    fetch(process.env.REACT_APP_API_URL + '/api/releases')
-      .then((response) => response.json())
-      .then((data) => {
-        let tmpRelease = {}
-        data.releases
-          .filter((aVersion) => {
-            // We won't process Presubmits or 3.11
-            return aVersion !== 'Presubmits' && aVersion != '3.11'
-          })
-          .forEach((r) => {
-            tmpRelease[r] = data.ga_dates[r]
-          })
-        setVersions(tmpRelease)
-      })
-      .catch((error) => console.error(error))
-      .finally(() => {
-        isVersionFetchDone = true
-        checkFetchesDone()
+        // Mark the attempt as finished whether successful or not.
+        setIsLoaded(true)
       })
   }, [])
 
@@ -223,74 +206,6 @@ export default function CompReadyTestReport(props) {
   significant difference compared to the historical basis
   `
 
-  const url = new URL(apiCallStr)
-  const params = new URLSearchParams(url.search)
-  const baseStartTime = params.get('baseStartTime')
-  const baseEndTime = params.get('baseEndTime')
-  const sampleStartTime = params.get('sampleStartTime')
-  const sampleEndTime = params.get('sampleEndTime')
-
-  // getSummaryDate attempts to translate a date into text relative to the version GA
-  // dates we know about.  If there are no versions, there is no translation.
-  const getSummaryDate = (from, to, versions) => {
-    const fromDate = new Date(from)
-    const toDate = new Date(to)
-
-    // Go through the versions map from latest release to earliest; ensure that
-    // the ordering is by version (e.g., 4.6 is considered earlier than 4.10).
-    const sortedVersions = Object.keys(versions).sort((a, b) => {
-      const itemA = parseInt(a.toString().replace(/\./g, ''))
-      const itemB = parseInt(b.toString().replace(/\./g, ''))
-      return itemB - itemA
-    })
-
-    for (const version of sortedVersions) {
-      const gaDateStr = versions[version]
-      // For items with no date string (i.e., not GA'ed yet, we use a date very far out).
-      const gaDate = gaDateStr ? new Date(gaDateStr) : new Date('2100-12-31')
-
-      // Widen the window by 1 day on each side to account for timezone offsets
-      // because we only need granularity of a day.
-      const fourWeeksPreGA = new Date(gaDate.getTime())
-      fourWeeksPreGA.setDate(fourWeeksPreGA.getDate() - 28 - 1)
-      gaDate.setDate(gaDate.getDate() + 1)
-
-      if (fromDate >= fourWeeksPreGA && toDate <= gaDate) {
-        // Calculate the time (in milliseconds) to weeks
-        const weeksBefore = Math.floor(
-          (gaDate - fromDate) / (1000 * 60 * 60 * 24 * 7)
-        )
-        return `${weeksBefore} week(s) before '${version}' GA date`
-      }
-    }
-    return null
-  }
-
-  const printStats = (statsLabel, stats, from, to) => {
-    const summaryDate = getSummaryDate(from, to, versions)
-    return (
-      <Fragment>
-        {statsLabel} Release: <strong>{stats.release}</strong>
-        <br />
-        &nbsp;&nbsp;Start Time: <strong>{from}</strong>
-        <br />
-        &nbsp;&nbsp;End Time: <strong>{to}</strong>
-        {summaryDate && (
-          <Fragment>
-            <br />
-            &nbsp;&nbsp;<strong>{summaryDate}</strong>
-          </Fragment>
-        )}
-        <ul>
-          <li>Success Rate: {(stats.success_rate * 100).toFixed(2)}%</li>
-          <li>Successes: {stats.success_count}</li>
-          <li>Failures: {stats.failure_count}</li>
-          <li>Flakes: {stats.flake_count}</li>
-        </ul>
-      </Fragment>
-    )
-  }
-
   return (
     <Fragment>
       <CompReadyPageTitle pageTitle={pageTitle} apiCallStr={apiCallStr} />
@@ -302,18 +217,8 @@ export default function CompReadyTestReport(props) {
       </h3>
       Test Name: {testName}
       <hr />
-      {printStats(
-        'Sample (being evaluated)',
-        data.sample_stats,
-        sampleStartTime,
-        sampleEndTime
-      )}
-      {printStats(
-        'Base (historical)',
-        data.base_stats,
-        baseStartTime,
-        baseEndTime
-      )}
+      {printStats('Sample (being evaluated)', data.sample_stats)}
+      {printStats('Base (historical)', data.base_stats)}
       <Fragment>
         <div style={{ display: 'block' }}>Environment: {environment}</div>
         <br />


### PR DESCRIPTION
Reverts openshift/sippy#1057

I tried to navigate a [link](https://sippy.dptools.openshift.org/sippy-ng/component_readiness/capabilities?baseEndTime=2023-05-16%2023%3A59%3A59&baseRelease=4.13&baseStartTime=2023-04-18%2000%3A00%3A00&component=Node%20%2F%20Autoscaler%20%28HPA%2C%20VPA%2C%20CMA%29&confidence=95&excludeArches=heterogeneous%2Cppc64le%2Cs390x%2Carm64&excludeClouds=alibaba&excludeVariants=hypershift%2Csingle-node%2Cmicroshift%2Cassisted&groupBy=cloud%2Carch%2Cnetwork&ignoreDisruption=true&ignoreMissing=false&minFail=3&pity=5&sampleEndTime=2023-06-26%2023%3A59%3A59&sampleRelease=4.14&sampleStartTime=2023-05-29%2000%3A00%3A00) to see a test report and got a blank page.

The console led me to a place where I changed in this PR.

I filed https://issues.redhat.com/browse/TRT-1110