### PR TITLE
Widen date window for more human readable date summaries

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -239,7 +239,7 @@ export default function CompReadyTestReport(props) {
 
   // getSummaryDate attempts to translate a date into text relative to the version GA
   // dates we know about.  If there are no versions, there is no translation.
-  const getSummaryDate = (from, to, versions) => {
+  const getSummaryDate = (from, to, version, versions) => {
     const fromDate = new Date(from)
     const toDate = new Date(to)
 
@@ -251,30 +251,41 @@ export default function CompReadyTestReport(props) {
       return itemB - itemA
     })
 
+    if (!versions[version]) {
+      // Handle the case where GA date is undefined (implies under development and not GA)
+      const weeksBefore = Math.floor(
+        (toDate - fromDate) / (1000 * 60 * 60 * 24 * 7)
+      )
+      return `Recent ${weeksBefore} week(s) of ${version}`
+    }
+
     for (const version of sortedVersions) {
+      if (!versions[version]) {
+        // We already dealt with a version with no GA date above.
+        continue
+      }
       const gaDateStr = versions[version]
-      // For items with no date string (i.e., not GA'ed yet, we use a date very far out).
-      const gaDate = gaDateStr ? new Date(gaDateStr) : new Date('2100-12-31')
+      const gaDate = new Date(gaDateStr)
 
-      // Widen the window by 1 day on each side to account for timezone offsets
-      // because we only need granularity of a day.
-      const fourWeeksPreGA = new Date(gaDate.getTime())
-      fourWeeksPreGA.setDate(fourWeeksPreGA.getDate() - 28 - 1)
-      gaDate.setDate(gaDate.getDate() + 1)
+      // Widen the window by 20 weeks prior to GA (because releases seems to be that long) and give
+      // a buffer of 1 week after GA.
+      const twentyWeeksPreGA = new Date(gaDate.getTime())
+      twentyWeeksPreGA.setDate(twentyWeeksPreGA.getDate() - 20 * 7)
+      gaDate.setDate(gaDate.getDate() + 7)
 
-      if (fromDate >= fourWeeksPreGA && toDate <= gaDate) {
+      if (fromDate >= twentyWeeksPreGA && toDate <= gaDate) {
         // Calculate the time (in milliseconds) to weeks
         const weeksBefore = Math.floor(
           (gaDate - fromDate) / (1000 * 60 * 60 * 24 * 7)
         )
-        return `${weeksBefore} week(s) before '${version}' GA date`
+        return `About ${weeksBefore} week(s) before '${version}' GA date`
       }
     }
     return null
   }
 
   const printStats = (statsLabel, stats, from, to) => {
-    const summaryDate = getSummaryDate(from, to, versions)
+    const summaryDate = getSummaryDate(from, to, stats.release, versions)
     return (
       <Fragment>
         {statsLabel} Release: <strong>{stats.release}</strong>

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -242,11 +242,15 @@ export default function CompReadyTestReport(props) {
       const hoursDifference = Math.abs(now - toDate) / (1000 * 60 * 60)
 
       if (hoursDifference <= 72) {
-        return weeksBefore ? `Recent ${weeksBefore} week(s) of ${version}` : null
+        return weeksBefore
+          ? `Recent ${weeksBefore} week(s) of ${version}`
+          : null
       } else {
         // Convert toDate to human-readable format
         const toDateFormatted = new Date(toDate).toLocaleDateString()
-        return weeksBefore ? `${weeksBefore} week(s) before ${toDateFormatted} of ${version}` : null
+        return weeksBefore
+          ? `${weeksBefore} week(s) before ${toDateFormatted} of ${version}`
+          : null
       }
     }
 
@@ -269,7 +273,9 @@ export default function CompReadyTestReport(props) {
         const weeksBefore = Math.floor(
           (gaDate - fromDate) / (1000 * 60 * 60 * 24 * 7)
         )
-        return weeksBefore ? `About ${weeksBefore} week(s) before '${version}' GA date` : null
+        return weeksBefore
+          ? `About ${weeksBefore} week(s) before '${version}' GA date`
+          : null
       }
     }
     return null

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -174,26 +174,6 @@ export default function CompReadyTestReport(props) {
     )
   }
 
-  // Customize the maxJobNumFactor based on number of potential number of JobRuns.
-  // The display will get wide so max out at 100 jobs.
-  let maxLength = 0
-  data.job_stats.forEach((item) => {
-    if (item.base_job_run_stats && item.base_job_run_stats.length > maxLength) {
-      maxLength = item.base_job_run_stats.length
-    }
-    if (
-      item.sample_job_run_stats &&
-      item.sample_job_run_stats.length > maxLength
-    ) {
-      maxLength = item.sample_job_run_stats.length
-    }
-  })
-  const maxJobNumFactor = Math.min(maxLength / 10 + 1, 10)
-  const marks = Array.from({ length: maxJobNumFactor }, (_, index) => ({
-    value: index + 1,
-    label: (index + 1).toString(),
-  }))
-
   const handleFailuresOnlyChange = (event) => {
     setShowOnlyFailures(event.target.checked)
   }
@@ -253,8 +233,9 @@ export default function CompReadyTestReport(props) {
 
     if (!versions[version]) {
       // Handle the case where GA date is undefined (implies under development and not GA)
+      const today = new Date()
       const weeksBefore = Math.floor(
-        (toDate - fromDate) / (1000 * 60 * 60 * 24 * 7)
+        (today - fromDate) / (1000 * 60 * 60 * 24 * 7)
       )
       return `Recent ${weeksBefore} week(s) of ${version}`
     }

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -233,11 +233,21 @@ export default function CompReadyTestReport(props) {
 
     if (!versions[version]) {
       // Handle the case where GA date is undefined (implies under development and not GA)
-      const today = new Date()
       const weeksBefore = Math.floor(
-        (today - fromDate) / (1000 * 60 * 60 * 24 * 7)
+        (toDate - fromDate) / (1000 * 60 * 60 * 24 * 7)
       )
-      return `Recent ${weeksBefore} week(s) of ${version}`
+
+      // Calculate the difference between now and toDate in hours
+      const now = new Date()
+      const hoursDifference = Math.abs(now - toDate) / (1000 * 60 * 60)
+
+      if (hoursDifference <= 72) {
+        return `Recent ${weeksBefore} week(s) of ${version}`
+      } else {
+        // Convert toDate to human-readable format
+        const toDateFormatted = new Date(toDate).toLocaleDateString()
+        return `${weeksBefore} week(s) before ${toDateFormatted} of ${version}`
+      }
     }
 
     for (const version of sortedVersions) {

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -242,11 +242,11 @@ export default function CompReadyTestReport(props) {
       const hoursDifference = Math.abs(now - toDate) / (1000 * 60 * 60)
 
       if (hoursDifference <= 72) {
-        return `Recent ${weeksBefore} week(s) of ${version}`
+        return weeksBefore ? `Recent ${weeksBefore} week(s) of ${version}` : null
       } else {
         // Convert toDate to human-readable format
         const toDateFormatted = new Date(toDate).toLocaleDateString()
-        return `${weeksBefore} week(s) before ${toDateFormatted} of ${version}`
+        return weeksBefore ? `${weeksBefore} week(s) before ${toDateFormatted} of ${version}` : null
       }
     }
 
@@ -269,7 +269,7 @@ export default function CompReadyTestReport(props) {
         const weeksBefore = Math.floor(
           (gaDate - fromDate) / (1000 * 60 * 60 * 24 * 7)
         )
-        return `About ${weeksBefore} week(s) before '${version}' GA date`
+        return weeksBefore ? `About ${weeksBefore} week(s) before '${version}' GA date` : null
       }
     }
     return null


### PR DESCRIPTION
Release GA dates seem spread across about 5 months so I use 20 weeks as the window before GA and 1 week after GA.  This will allow us to translate more date ranges to human consumable verbiage like "x weeks before 4.y GA date".

Releases under development (not GA yet) are also handled.

[Example url](http://localhost:3002/sippy-ng/component_readiness/test_details?arch=amd64&baseEndTime=2023-05-16%2023%3A59%3A59&baseRelease=4.13&baseStartTime=2023-04-16%2000%3A00%3A00&capability=Other&component=Monitoring&confidence=95&environment=ovn%20no-upgrade%20amd64%20vsphere-upi%20standard&excludeArches=ppc64le%2Cs390x%2Carm64&excludeClouds=alibaba%2Covirt%2Copenstack&excludeVariants=single-node%2Ctechpreview&groupBy=cloud%2Carch%2Cnetwork&ignoreDisruption=true&ignoreMissing=false&minFail=3&network=ovn&pity=5&platform=vsphere-upi&sampleEndTime=2023-06-28%2023%3A59%3A59&sampleRelease=4.14&sampleStartTime=2023-06-21%2000%3A00%3A00&testId=openshift-tests%3Ac1f54790201ec8f4241eca902f854b79&testName=%5Bsig-instrumentation%5D%20Prometheus%20%5Bapigroup%3Aimage.openshift.io%5D%20when%20installed%20on%20the%20cluster%20shouldn%27t%20report%20any%20alerts%20in%20firing%20state%20apart%20from%20Watchdog%20and%20AlertmanagerReceiversNotConfigured%20%5BEarly%5D%5Bapigroup%3Aconfig.openshift.io%5D%20%5BSkipped%3ADisconnected%5D%20%5BSuite%3Aopenshift%2Fconformance%2Fparallel%5D&upgrade=no-upgrade&variant=standard):

<img width="304" alt="Screen Shot 2023-06-28 at 2 46 51 PM" src="https://github.com/openshift/sippy/assets/93946516/e6a240a7-d587-47f3-b247-592cb1403af3">

Also removed some dead code which got a stack trace when given a [bad url](https://sippy.dptools.openshift.org/sippy-ng/component_readiness/test_details?arch=amd64&baseEndTime=2023-05-16%2023%3A59%3A59&baseRelease=4.13&baseStartTime=2023-04-16%2000%3A00%3A00&capability=Other&component=kube-apiserver&confidence=95&environment=ovn%20no-upgrade%20amd64%20aws%20hypershift&groupBy=cloud%2Carch%2Cnetwork&ignoreDisruption=true&ignoreMissing=false&minFail=3&network=ovn&pity=5&platform=aws&sampleEndTime=2023-06-28%2023%3A59%3A59&sampleRelease=4.14&sampleStart).