### PR TITLE
Encode curly brances as well

### DIFF
--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -32,7 +32,11 @@ export const SafeStringParam = {
 // square brackets.  Square brackets are NOT unsafe per RFC1738, but Google and
 // others mishandle them.
 export function safeEncodeURIComponent(value) {
-  return encodeURIComponent(value).replace('[', '%5B').replace(']', '%5D')
+  return encodeURIComponent(value)
+    .replace('[', '%5B')
+    .replace(']', '%5D')
+    .replace('{', '%7B')
+    .replace('}', '%7D')
 }
 
 // relativeTime shows a plain English rendering of a time, e.g. "30 minutes ago".


### PR DESCRIPTION
JIRA's behavior has changed, and it's now eating URL's with curly braces in them. These should get encoded too.