### PR TITLE
Make incident colors black

### DIFF
--- a/sippy-ng/src/releases/PayloadCalendar.js
+++ b/sippy-ng/src/releases/PayloadCalendar.js
@@ -52,7 +52,7 @@ export default function PayloadCalendar(props) {
     {
       url: process.env.REACT_APP_API_URL + '/api/incidents',
       method: 'GET',
-      color: theme.palette.error.dark,
+      color: theme.palette.common.black,
       textColor: theme.palette.error.contrastText,
     },
   ]

--- a/sippy-ng/src/releases/PayloadCalendarLegend.js
+++ b/sippy-ng/src/releases/PayloadCalendarLegend.js
@@ -49,7 +49,7 @@ export default function PayloadCalendarLegend() {
       <Box className={classes.legendItem}>
         <Box
           className={classes.square}
-          style={{ backgroundColor: theme.palette.error.dark }}
+          style={{ backgroundColor: theme.palette.common.black }}
         />
         <Typography variant="body2">Incident</Typography>
       </Box>


### PR DESCRIPTION
Black reminds me of a payload "blackout".

<img width="730" alt="scr1" src="https://github.com/openshift/sippy/assets/93946516/9f4c107b-64cf-4f2f-bf07-fbc0089df8f1">
