### PR TITLE
Embed the URL for the API call for convenient access for debugging

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyPageTitle.js
+++ b/sippy-ng/src/component_readiness/CompReadyPageTitle.js
@@ -5,6 +5,11 @@ import React from 'react'
 // CompReadyPageTitle is used to print the title of the pages and the accompanying
 // api call string for debugging.  This allows us to have consistent page titles
 // and on page1, we can see the api call string change dynamically.
+// The call string is also embedded, but not displayed, so that it can still be
+// retrieved without a modified version of sippy (where debugMode is set to true).
+// The "callStr" id is there so that you can run:
+//   const x = document.getElementById('callStr'); x.innerText
+// in the javascript console to see the value.
 // We can remove the part that prints the curl once debugging is no longer needed.
 export default function CompReadyPageTitle(props) {
   const { pageTitle, apiCallStr } = props
@@ -14,6 +19,9 @@ export default function CompReadyPageTitle(props) {
     <div>
       {pageTitle}
       {debugMode ? <p>curl -sk &apos;{callStr}&apos;</p> : null}
+      <div id="callStr" style={{ display: 'none' }}>
+        <p>{callStr}</p>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
[TRT-1144](https://issues.redhat.com//browse/TRT-1144)

If there's a problem in ComponentReadiness, we often need the URL for the api call to verify the call and resulting data.  We can set `debugMode` to display these on the page while developing; but for those who just need the URL, this would entail some setup time.  This will allow you to retrieve the URL by way of the javascript console which is more convenient.

I added an `id="callStr"` to facility easy search manually or programmatically.

