### PR TITLE
DO NOT MERGE: Always exclude alibaba but avoid displaying it as an option

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyMainInputs.js
+++ b/sippy-ng/src/component_readiness/CompReadyMainInputs.js
@@ -7,7 +7,7 @@ import AdvancedOptions from './AdvancedOptions'
 import Button from '@material-ui/core/Button'
 import CheckBoxList from './CheckboxList'
 import PropTypes from 'prop-types'
-import React, { useContext } from 'react'
+import React, { useContext, useEffect } from 'react'
 import ReleaseSelector from './ReleaseSelector'
 import Tooltip from '@material-ui/core/Tooltip'
 
@@ -51,6 +51,16 @@ export default function CompReadyMainInputs(props) {
     setIgnoreMissing,
     setIgnoreDisruption,
   } = props
+
+  // Alibaba is no longer supported so ensure it's always excluded.
+  useEffect(() => {
+    if (!excludeCloudsCheckedItems.includes('alibaba')) {
+      setExcludeCloudsCheckedItems((currCheckedItems) => [
+        ...currCheckedItems,
+        'alibaba',
+      ])
+    }
+  }, [excludeCloudsCheckedItems, setExcludeCloudsCheckedItems])
 
   const {
     excludeNetworksList,
@@ -146,7 +156,9 @@ export default function CompReadyMainInputs(props) {
         ></CheckBoxList>
         <CheckBoxList
           headerName="Exclude Clouds"
-          displayList={excludeCloudsList}
+
+          // Since we no longer support alibaba, don't display it.
+          displayList={excludeCloudsList.filter((item) => item !== 'alibaba')}
           checkedItems={excludeCloudsCheckedItems}
           setCheckedItems={setExcludeCloudsCheckedItems}
         ></CheckBoxList>


### PR DESCRIPTION
[TRT-1151](https://issues.redhat.com//browse/TRT-1151)

This is one way to avoid having alibaba the ComponentReadiness UI -- we exclude it by default without giving the option to not exclude it.

You can probably also do this in the backend.

Seeking opinions. 