### PR TITLE
TRT-1125: add test names, risk reasons and openbugs for pr comments

### DIFF
--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -758,6 +758,11 @@ type FailureRisk struct {
 	Reasons []string
 }
 
+type RiskSummary struct {
+	OverallRisk FailureRisk
+	Tests       []ProwJobRunTestRiskAnalysis
+}
+
 type RiskLevel struct {
 	// Name is a human readable name for the given risk level.
 	Name string


### PR DESCRIPTION
Updated commenting to include more details on the failed test, risk reasons and open bugs.
Stacking the tests/reasons/bug to utilize vertical space over horizontal:

Job Failure Risk Analysis for sha: 79d237196d93eb92ed58c66497d8718259264226

| Job Name | Failure Risk |
|:---|:---|
|[pull-ci-openshift-origin-master-e2e-gcp-ovn-upgrade](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/28075/pull-ci-openshift-origin-master-e2e-gcp-ovn-upgrade/1682395379418533888)|<b>High</b><br>[sig-api-machinery] disruption/cache-oauth-api connection/reused should be available throughout the test:<br>This test has passed 99.88% of 827 runs on jobs ['periodic-ci-openshift-release-master-nightly-4.14-e2e-gcp-ovn-upgrade' 'periodic-ci-openshift-release-master-ci-4.14-e2e-gcp-ovn-upgrade'] in the last 14 days.|
|[pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/28075/pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade/1682395377153609728)|<b>High</b><br>Cluster upgrade.[sig-apps] job-upgrade:<br>This test has passed 100.00% of 38 runs on jobs ['periodic-ci-openshift-release-master-ci-4.14-e2e-aws-ovn-upgrade'] in the last 14 days.|
|[pull-ci-openshift-origin-master-e2e-metal-ipi-ovn-ipv6](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/28075/pull-ci-openshift-origin-master-e2e-metal-ipi-ovn-ipv6/1682395380257394688)|<b>Low</b><br>[sig-network][Feature:vlan] should create pingable pods with macvlan interface on an in-container master [apigroup:k8s.cni.cncf.io] [Suite:openshift/conformance/parallel]:<br>This test has passed 72.09% of 43 runs on jobs ['periodic-ci-openshift-release-master-nightly-4.14-e2e-metal-ipi-ovn-ipv6'] in the last 14 days.<br>---<br>[sig-cli] oc idle [apigroup:apps.openshift.io][apigroup:route.openshift.io][apigroup:project.openshift.io][apigroup:image.openshift.io] by name [Suite:openshift/conformance/parallel]:<br>This test has passed 72.09% of 43 runs on jobs ['periodic-ci-openshift-release-master-nightly-4.14-e2e-metal-ipi-ovn-ipv6'] in the last 14 days.<br><br>Open Bugs<br>https://issues.redhat.com/browse/OCPBUGS-6586<br>---<br>[sig-network][Feature:tuning] pod should start with all sysctl on whitelist [apigroup:k8s.cni.cncf.io] [Suite:openshift/conformance/parallel]:<br>This test has passed 72.09% of 43 runs on jobs ['periodic-ci-openshift-release-master-nightly-4.14-e2e-metal-ipi-ovn-ipv6'] in the last 14 days.<br>---<br>[sig-network][Feature:bond] should create a pod with bond interface [apigroup:k8s.cni.cncf.io] [Suite:openshift/conformance/parallel]:<br>This test has passed 72.09% of 43 runs on jobs ['periodic-ci-openshift-release-master-nightly-4.14-e2e-metal-ipi-ovn-ipv6'] in the last 14 days.|
|[pull-ci-openshift-origin-master-e2e-aws-ovn-single-node-serial](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/28075/pull-ci-openshift-origin-master-e2e-aws-ovn-single-node-serial/1682395377082306560)|<b>Low</b><br>[sig-storage] PersistentVolumes-local  Stress with local volumes [Serial] should be able to process many pods and reuse local volumes [Suite:openshift/conformance/serial] [Suite:k8s]:<br>This test has passed 79.31% of 29 runs on jobs ['periodic-ci-openshift-release-master-nightly-4.14-e2e-aws-ovn-single-node-serial'] in the last 14 days.|