### PR TITLE
[wip] Derive releases from config, not command line

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -2,6 +2,8 @@
 prow:
   url: https://prow.ci.openshift.org/prowjobs.js
 releases:
+  "4.15":
+    hidden: true,
   "4.13":
     gaDate: 2023-05-17
   "4.12":

--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -2,6 +2,22 @@
 prow:
   url: https://prow.ci.openshift.org/prowjobs.js
 releases:
+  "4.13":
+    gaDate: 2023-05-17
+  "4.12":
+    gaDate: 2023-01-17
+  "4.11":
+    gaDate: 2022-08-10
+  "4.10":
+    gaDate: 2022-03-10
+  "4.9":
+    gaDate: 2021-10-18
+  "4.8":
+    gaDate: 2021-07-27
+  "4.7":
+    gaDate: 2021-02-24
+  "4.6":
+    gaDate: 2020-10-27
   "3.11":
     jobs:
       periodic-ci-openshift-openshift-ansible-release-3.11-e2e-aws-nightly: true

--- a/main.go
+++ b/main.go
@@ -638,7 +638,6 @@ func (o *Options) loadProwJobs(dbc *db.DB, sippyConfig v1.SippyConfig) []error {
 		githubClient,
 		o.getVariantManager(),
 		o.getSyntheticTestManager(),
-		o.OpenshiftReleases,
 		&sippyConfig,
 		ghCommenter)
 	errs := prowLoader.LoadProwJobsToDB()

--- a/main.go
+++ b/main.go
@@ -572,7 +572,7 @@ func (o *Options) Run() error { //nolint:gocyclo
 	}
 
 	if o.Server {
-		return o.runServerMode(pinnedTime, gormLogLevel)
+		return o.runServerMode(pinnedTime, gormLogLevel, sippyConfig)
 	}
 
 	return nil
@@ -650,7 +650,7 @@ func (o *Options) loadJiraIncidents(dbc *db.DB) error {
 	return jiraLoader.LoadJIRAIncidents()
 }
 
-func (o *Options) runServerMode(pinnedDateTime *time.Time, gormLogLevel gormlogger.LogLevel) error {
+func (o *Options) runServerMode(pinnedDateTime *time.Time, gormLogLevel gormlogger.LogLevel, config v1.SippyConfig) error {
 	var dbc *db.DB
 	var err error
 	if o.DSN != "" {
@@ -716,6 +716,7 @@ func (o *Options) runServerMode(pinnedDateTime *time.Time, gormLogLevel gormlogg
 		o.ListenAddr,
 		o.getSyntheticTestManager(),
 		o.getVariantManager(),
+		config,
 		webRoot,
 		&static,
 		dbc,

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -712,9 +712,9 @@ type TestOutput struct {
 }
 
 type Releases struct {
-	Releases    []string             `json:"releases"`
-	GADates     map[string]time.Time `json:"ga_dates"`
-	LastUpdated time.Time            `json:"last_updated"`
+	Releases    []string              `json:"releases"`
+	GADates     map[string]*time.Time `json:"ga_dates"`
+	LastUpdated time.Time             `json:"last_updated"`
 }
 
 type Indicator struct {

--- a/pkg/apis/config/v1/types.go
+++ b/pkg/apis/config/v1/types.go
@@ -1,5 +1,7 @@
 package v1
 
+import "time"
+
 type SippyConfig struct {
 	Prow     ProwConfig               `yaml:"prow"`
 	Releases map[string]ReleaseConfig `yaml:"releases"`
@@ -12,6 +14,9 @@ type ProwConfig struct {
 }
 
 type ReleaseConfig struct {
+	// GADate contains the GA date for this release, if any.
+	GADate *time.Time
+
 	// Jobs is a set of jobs that should be considered part of the release.
 	Jobs map[string]bool `yaml:"jobs,omitempty"`
 

--- a/pkg/apis/config/v1/types.go
+++ b/pkg/apis/config/v1/types.go
@@ -14,6 +14,9 @@ type ProwConfig struct {
 }
 
 type ReleaseConfig struct {
+	// Hidden determines if a release is shown in the sippy sidebar
+	Hidden bool
+
 	// GADate contains the GA date for this release, if any.
 	GADate *time.Time
 

--- a/pkg/db/query/release_queries.go
+++ b/pkg/db/query/release_queries.go
@@ -1,8 +1,9 @@
 package query
 
 import (
-	"github.com/openshift/sippy/pkg/db"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/openshift/sippy/pkg/db"
 )
 
 type Release struct {
@@ -11,11 +12,18 @@ type Release struct {
 
 func ReleasesFromDB(dbClient *db.DB) ([]Release, error) {
 	var releases []Release
-	// The string_to_array trick ensures releases are sorted in version order, descending
-	res := dbClient.DB.Raw(`
-		SELECT DISTINCT(release), case when position('.' in release) != 0 then string_to_array(release, '.')::int[] end as sortable_release
-                FROM prow_jobs
-                ORDER BY sortable_release desc NULLS LAST`).Scan(&releases)
+	// The string_to_array trick ensures releases are sorted in version order, descending where suffixed releases (-okd)
+	// are at the bottom.
+	res := dbClient.DB.Raw(`SELECT DISTINCT(release),
+    CASE 
+        WHEN position('.' in release) != 0 
+        THEN string_to_array(split_part(release, '-', 1), '.')::int[] 
+    END AS sortable_release, 
+    CASE
+        WHEN position('-' in release) != 0
+        THEN split_part(release, '-', 2)
+        ELSE ''
+    END AS release_suffix from prow_jobs ORDER BY release_suffix, sortable_release DESC NULLS LAST`).Scan(&releases)
 	if res.Error != nil {
 		log.Errorf("error querying releases from db: %v", res.Error)
 		return releases, res.Error

--- a/pkg/prowloader/prow.go
+++ b/pkg/prowloader/prow.go
@@ -63,7 +63,6 @@ func New(
 	githubClient *github.Client,
 	variantManager testidentification.VariantManager,
 	syntheticTestManager synthetictests.SyntheticTestManager,
-	releases []string,
 	config *v1config.SippyConfig,
 	ghCommenter *commenter.GitHubCommenter) *ProwLoader {
 
@@ -81,7 +80,6 @@ func New(
 		suiteCache:           make(map[string]*uint),
 		syntheticTestManager: syntheticTestManager,
 		variantManager:       variantManager,
-		releases:             releases,
 		config:               config,
 		ghCommenter:          ghCommenter,
 	}
@@ -155,13 +153,7 @@ func (pl *ProwLoader) LoadProwJobsToDB() []error {
 
 	var newJobRunsCtr int
 	for i, pj := range prowJobs {
-		for _, release := range pl.releases {
-			cfg, ok := pl.config.Releases[release]
-			if !ok {
-				log.Warningf("configuration not found for release %q", release)
-				continue
-			}
-
+		for release, cfg := range pl.config.Releases {
 			if val, ok := cfg.Jobs[pj.Spec.Job]; val && ok {
 				if err := pl.prowJobToJobRun(pj, release, &newJobRunsCtr, i, len(prowJobs)); err != nil {
 					err = errors.Wrapf(err, "error converting prow job to job run: %s", pj.Spec.Job)


### PR DESCRIPTION
This makes OKD releases start showing up in Sippy.

The Sippy config already contains the release/job mapping, use it and not the command line flags. We should eventually remove the command line flags for `--release` and just read it from the config, but it's a little messy until we rip out TestGrid legacy code.