### PR TITLE
TRT-1125: Add escape for - in links

### DIFF
--- a/pkg/sippyserver/pr_commenting_processor.go
+++ b/pkg/sippyserver/pr_commenting_processor.go
@@ -611,7 +611,8 @@ func buildComment(sortedAnalysis RiskAnalysisEntryList, sha string) string {
 
 						riskSb.WriteString("Open Bugs")
 					}
-					riskSb.WriteString(fmt.Sprintf("<br>[%s](%s)", html.EscapeString(b.Summary), b.URL))
+					// prevent the openshift-ci bot from detecting JIRA references in the link by replacing - with html escaped sequence
+					riskSb.WriteString(fmt.Sprintf("<br>[%s](%s)", strings.ReplaceAll(html.EscapeString(b.Summary), "-", "&#45;"), b.URL))
 				}
 			}
 		}


### PR DESCRIPTION
Substitutes &#45; for - in links to prevent openshift-ci bot from updating the comment when it detects a valid JIRA reference.

Job Failure Risk Analysis for sha: e2cad6663c9186b487ec56daf33c671e69e09475

| Job Name | Failure Risk |
|:---|:---|
|[pull-ci-openshift-origin-master-e2e-openstack-ovn](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/28120/pull-ci-openshift-origin-master-e2e-openstack-ovn/1686778922848489472)|**High**<br>28 tests failed in this run: High|
|[pull-ci-openshift-origin-master-e2e-gcp-ovn](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/28120/pull-ci-openshift-origin-master-e2e-gcp-ovn/1686778918683545600)|**Medium**<br>*[sig-instrumentation] Prometheus [apigroup:image.openshift.io] when installed on the cluster should report telemetry [Late] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]*<br>This test has passed 96.55% of 29 runs on release 4.14 [amd64 gcp ha ovn] in the last week.<br><br>Open Bugs<br>[Prometheus reporting telemetry test intermittent failures due to server side rate limiting](https://issues.redhat.com/browse/OCPBUGS-16615)|
|[pull-ci-openshift-origin-master-e2e-aws-ovn-serial](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/28120/pull-ci-openshift-origin-master-e2e-aws-ovn-serial/1686778918226366464)|**Medium**<br>*[sig-arch] events should not repeat pathologically*<br>This test has passed 95.41% of 109 runs on release 4.14 [amd64 aws ha ovn serial] in the last week.<br><br>Open Bugs<br>[Excessive TopologyAwareHintsDisabled events due to service/dns&#45;default with topology aware hints activated.](https://issues.redhat.com/browse/OCPBUGS-11449)<br>[Pathological test failing on reason/FailedMount in openshift&#45;monitoring](https://issues.redhat.com/browse/OCPBUGS-15192)<br>[DNS operator prone to spamming TopologyAwareHintsDisable events on GCP/Azure since May 5](https://issues.redhat.com/browse/OCPBUGS-13366)<br>[Excessive TopologyAwareHintsDisabled events due to service/dns&#45;default with topology aware hints activated.](https://issues.redhat.com/browse/OCPBUGS-5943)<br>[CI fails on &#34;events should not repeat pathologically&#34;, reason &#34;FailedAttachVolume&#34;](https://issues.redhat.com/browse/OCPBUGS-14400)<br>[Fix TRT&#45;596 in master (4.13)](https://issues.redhat.com/browse/OCPBUGS-3640)|
|[pull-ci-openshift-origin-master-e2e-aws-ovn-single-node-serial](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/28120/pull-ci-openshift-origin-master-e2e-aws-ovn-single-node-serial/1686778918368972800)|**Low**<br>*[sig-arch][Late] operators should not create watch channels very often [apigroup:apiserver.openshift.io] [Suite:openshift/conformance/parallel]*<br>This test has passed 76.19% of 21 runs on release 4.14 [amd64 aws ovn serial single-node] in the last week.<br>---<br>*[sig-network-edge] ns/openshift-authentication route/oauth-openshift disruption/ingress-to-oauth-server connection/reused should be available throughout the test*<br>This test has passed 4.76% of 21 runs on release 4.14 [amd64 aws ovn serial single-node] in the last week.<br>---<br>*[sig-network-edge] ns/openshift-console route/console disruption/ingress-to-console connection/new should be available throughout the test*<br>This test has passed 4.76% of 21 runs on release 4.14 [amd64 aws ovn serial single-node] in the last week.<br>---<br>*[sig-network-edge] ns/openshift-console route/console disruption/ingress-to-console connection/reused should be available throughout the test*<br>This test has passed 4.76% of 21 runs on release 4.14 [amd64 aws ovn serial single-node] in the last week.<br>---<br>Showing 4 of 5 test results|