### PR TITLE
Allow multiple reasons for a payload reject in script and UI

### DIFF
--- a/pkg/db/models/releases.go
+++ b/pkg/db/models/releases.go
@@ -2,6 +2,8 @@ package models
 
 import (
 	"time"
+
+	"github.com/lib/pq"
 )
 
 type ReleaseTag struct {
@@ -65,6 +67,9 @@ type ReleaseTag struct {
 
 	// RejectReasonNote is a description from TRT as to why the payload was categorized as it was.
 	RejectReasonNote string `json:"reject_reason_note" gorm:"column:reject_reason_note"`
+
+	// RejectReasons represents multiple RejectReasons; the value of RejectReason is the first array element.
+	RejectReasons pq.StringArray `json:"reject_reasons" gorm:"type:text[]"`
 }
 
 // ReleasePullRequest represents a pull request that was included for the first time

--- a/scripts/rejected-payloads.md
+++ b/scripts/rejected-payloads.md
@@ -21,6 +21,10 @@ Use pip to install the following dependencies:
 
 `pip install argparse sqlalchemy`
 
+or use
+
+`pip install -r requirements.txt`
+
 Or if you are on Fedora:
 
 `sudo dnf install python3-sqlalchemy+postgresql`
@@ -37,7 +41,8 @@ If no release_tag is specified, it will find all uncategorized release tags and 
   -t RELEASE_TAG, --release_tag RELEASE_TAG     Specifies a release payload tag, like 4.11.0-0.nightly-2022-06-25-081133
   -r RELEASE, --release RELEASE                 Specifies a release, like 4.11
   -s STREAM, --stream STREAM                    Specifies a stream, like nightly or ci
-  -a, --all                                     List all rejected payloads. If not specified , list only uncategorized ones.
+  -a ARCH, --arch ARCH                          Specifies an architecture, like amd64
+  --all                                         List all rejected payloads. If not specified , list only uncategorized ones.
 ```
 
 To list most recent failed payloads in a stream, and select one to categorize interactively:
@@ -54,7 +59,7 @@ Please choose the reject reason for tag 4.11.0-0.ci-2022-06-29-121424 from the f
          3:             RH_INFRA
          4:   PRODUCT_REGRESSION
          5:      TEST_REGRESSION
-Enter your selection between 1 and 5: 3
+Enter one or more selections between 1 and 5 separated by spaces: 3
 index     release tag                                       phase               reject reason
 1         4.11.0-0.ci-2022-06-28-211909                     Rejected            None
 Select tag between 1 and 1 to categorize, enter q to exit: q
@@ -70,7 +75,7 @@ Please choose the reject reason for tag 4.11.0-0.nightly-2022-06-28-111405 from 
          3:             RH_INFRA
          4:   PRODUCT_REGRESSION
          5:      TEST_REGRESSION
-Enter your selection between 1 and 5: 2
+Enter one or more selections between 1 and 5 separated by spaces: 2
 ```
 
 ### List
@@ -81,7 +86,8 @@ Additional options can be provided to limit the scope of the query.
 ```
   -r RELEASE, --release RELEASE    Specifies a release, like 4.11
   -s STREAM, --stream STREAM       Specifies a stream, like nightly or ci
-  -a, --all                        List all rejected payloads. If not specified , list only uncategorized ones.
+  -a ARCH, --arch ARCH             Specifies an architecture, like amd64
+  --all                            List all rejected payloads. If not specified , list only uncategorized ones.
 ```
 
 The following example lists all uncategorized release tags for 4.11 ci payloads:

--- a/scripts/rejected-payloads.md
+++ b/scripts/rejected-payloads.md
@@ -37,18 +37,10 @@ Categorize is used to update the reject-reason in the DB.
 It can be used to update a single release tag when -t or --release_tag is specified.
 If no release_tag is specified, it will find all uncategorized release tags and provide an interactive prompt to update each release tag.
 
-```
-  -t RELEASE_TAG, --release_tag RELEASE_TAG     Specifies a release payload tag, like 4.11.0-0.nightly-2022-06-25-081133
-  -r RELEASE, --release RELEASE                 Specifies a release, like 4.11
-  -s STREAM, --stream STREAM                    Specifies a stream, like nightly or ci
-  -a ARCH, --arch ARCH                          Specifies an architecture, like amd64
-  --all                                         List all rejected payloads. If not specified , list only uncategorized ones.
-```
-
 To list most recent failed payloads in a stream, and select one to categorize interactively:
 
 ```
-% python ./rejected-payloads.py -d "your-dsn" categorize -s ci -r 4.12
+% python ./rejected-payloads.py -d "your-dsn" categorize -s ci -r 4.12 -a amd64
 index     release tag                                       phase               reject reason
 1         4.11.0-0.ci-2022-06-29-121424                     Rejected            None
 2         4.11.0-0.ci-2022-06-28-211909                     Rejected            None
@@ -68,7 +60,7 @@ Select tag between 1 and 1 to categorize, enter q to exit: q
 If you already know the payload tag you'd like to categorize:
 
 ```
-% python ./rejected-payloads.py -d "your-dsn" categorize -t 4.11.0-0.nightly-2022-06-28-111405
+% python ./rejected-payloads.py -d "your-dsn" categorize -t 4.11.0-0.nightly-2022-06-28-111405 -a amd64
 Please choose the reject reason for tag 4.11.0-0.nightly-2022-06-28-111405 from the following list:
          1:           TEST_FLAKE
          2:          CLOUD_INFRA
@@ -83,17 +75,10 @@ Enter one or more selections between 1 and 5 separated by spaces: 2
 List command can be used to list uncategorized release tags.
 Additional options can be provided to limit the scope of the query.
 
-```
-  -r RELEASE, --release RELEASE    Specifies a release, like 4.11
-  -s STREAM, --stream STREAM       Specifies a stream, like nightly or ci
-  -a ARCH, --arch ARCH             Specifies an architecture, like amd64
-  --all                            List all rejected payloads. If not specified , list only uncategorized ones.
-```
-
 The following example lists all uncategorized release tags for 4.11 ci payloads:
 
 ```
-% python ./rejected-payloads.py -d "your-dsn" list -s ci -r 4.11
+% python ./rejected-payloads.py -d "your-dsn" list -s ci -r 4.11 -a amd64
 index     release tag                                       phase               reject reason
 1         4.11.0-0.ci-2022-06-29-121424                     Rejected            None
 2         4.11.0-0.ci-2022-06-28-211909                     Rejected            None

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+argparse
+sqlalchemy
+psycopg2

--- a/sippy-ng/src/releases/ReleasePayloadTable.js
+++ b/sippy-ng/src/releases/ReleasePayloadTable.js
@@ -124,13 +124,43 @@ function ReleasePayloadTable(props) {
     },
     {
       field: 'reject_reason',
-      headerName: 'Reject reason',
+      headerName: 'Reject reasons',
       flex: 1.5,
       hide: props.briefTable,
       renderCell: (params) => {
+        let display_reasons = []
+
+        // Until we migrate to just reject_reasons, we'll display the current value
+        // of reject_reason if present.
+        if (params.row.reject_reason) {
+          display_reasons.push(params.row.reject_reason)
+        }
+
+        // Since the reject_reason will be the first element, we only need anything after that.
+        if (params.row.reject_reasons && params.row.reject_reasons.length > 1) {
+          display_reasons = display_reasons.concat(
+            params.row.reject_reasons.slice(1)
+          )
+        }
+
+        // Make the font a little smaller in case there are many reasons.  Display only
+        // the first three and then Etc... in case there are more.
         return (
           <Tooltip title={`${params.row.reject_reason_note}`}>
-            <Typography>{params.value}</Typography>
+            <Typography style={{ fontSize: '12px' }}>
+              {display_reasons.slice(0, 3).map((reason, index) => (
+                <Fragment key={index}>
+                  {reason}
+                  <br />
+                </Fragment>
+              ))}
+              {display_reasons.length > 3 ? (
+                <Fragment>
+                  Etc...
+                  <br />
+                </Fragment>
+              ) : null}
+            </Typography>
           </Tooltip>
         )
       },


### PR DESCRIPTION
[TRT-1186](https://issues.redhat.com//browse/TRT-1186)

TODO:

- [x] Test DB migration to introduce the new `reject_reasons` column (test locally; repeat with `ALTER TABLE release_tags; DROP COLUMN reject_reasons;`)
- [x] Test `rejected-payloads.py` script:
  - [x] ensure it can read the new `reject_reasons` column (using `list` subcommand)
  - [x] ensure it can write to the new `reject_reasons` column (using `categorize` subcommand)
- [x] Ensure the sippy UI displays correctly
  - [x] handle case for no reject_reason
  - [x] handle case for reject_reason present
  - [x] handle case for reject_reasons with 1 element
  - [x] handle case for reject_reasons with multiple elements
  - [x] handle case for reject_reasons greater than 3 elements

sample output for multiple reasons:

```
$ ./rejected-payloads.py -d $DSN --days 4 list -s nightly -r 4.12 --all
index     release tag                                       phase               reject reasons      note
1         4.12.0-0.nightly-2023-08-08-180643                Rejected            TEST_FLAKE          test flakes are flaky
2         4.12.0-0.nightly-2023-08-08-180641                Rejected            TEST_FLAKE          this is multiple lines
                                                                                PRODUCT_REGRESSION  
                                                                                TEST_REGRESSION     
                                                                                CLOUD_QUOTA         
```

<img width="1578" alt="Screenshot 2023-08-10 at 3 48 55 PM" src="https://github.com/openshift/sippy/assets/93946516/6e2f1c49-548d-42ba-9e12-a2a2e5690eb1">
