### PR TITLE
Prevent panic on bad google-service-account-credential-file file

### DIFF
--- a/pkg/prowloader/gcs/gcs_jobrun.go
+++ b/pkg/prowloader/gcs/gcs_jobrun.go
@@ -170,7 +170,9 @@ func (j *GCSJobRun) FindFirstFile(root string, filename *regexp.Regexp) []byte {
 		if err == iterator.Done {
 			break
 		}
-
+		if err != nil {
+			log.Fatal(err)
+		}
 		if filename.MatchString(attrs.Name) {
 			data, err := j.GetContent(context.Background(), attrs.Name)
 
@@ -205,7 +207,9 @@ func (j *GCSJobRun) FindAllMatches(filenames []*regexp.Regexp) [][]string {
 		if err == iterator.Done {
 			break
 		}
-
+		if err != nil {
+			log.Fatal(err)
+		}
 		for i, filename := range filenames {
 			if matches[i] == nil {
 				matches[i] = make([]string, 0)

--- a/pkg/sippyserver/pr_commenting_processor.go
+++ b/pkg/sippyserver/pr_commenting_processor.go
@@ -642,7 +642,9 @@ func (aw *AnalysisWorker) buildPRJobRiskAnalysis(prRoot string, dryrun bool) (bo
 		if err == iterator.Done {
 			break
 		}
-
+		if err != nil {
+			log.Fatal(err)
+		}
 		// want empty Name indicating a folder
 		if len(attrs.Name) > 0 {
 			continue


### PR DESCRIPTION
I got this using a bad credential file (I didn't think I needed credentials but I apparently do and authentication is checked very late (when `it.Next()` is called):

```
$ ./sippy --load-database   --init-database   --load-prow=true   --load-testgrid=false \
   --release 4.12  \
   --database-dsn="postgresql://postgres:<redacted>@localhost:${myPort}/postgres" \
   --mode=ocp   --config ./config/openshift.yaml \
   --google-service-account-credential-file ~/redhat_keys/something.json

INFO[2023-08-10T11:09:58.456-04:00] db schema updated                            
INFO[2023-08-10T11:09:58.469-04:00] Loading release streams...                   
INFO[2023-08-10T11:09:58.469-04:00] Fetching release 4.12.0-0.nightly from release controller... 
INFO[2023-08-10T11:09:58.469-04:00] Fetching release 4.12.0-0.ci from release controller... 
INFO[2023-08-10T11:09:58.487-04:00] job cache created with 193 entries from database 
INFO[2023-08-10T11:09:58.487-04:00] No GitHub client, skipping PR sync           
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x200c538]

goroutine 1 [running]:
github.com/openshift/sippy/pkg/prowloader/gcs.(*GCSJobRun).FindAllMatches(0xc00059f000, {0xc00059ef80, 0x2, 0xe?})
	/Users/dperique/mygit/dperique/NG/Dennis/Redhat/PR/sippy/pkg/prowloader/gcs/gcs_jobrun.go:213 +0x218
github.com/openshift/sippy/pkg/prowloader.(*ProwLoader).prowJobToJobRun(0xc000b24a00, {{{0xc000a1d788, 0x8}, {0xc000a1d7a0, 0x7}, {0xc0009f6be0, 0x44}, 0x0}, {{0x0, 0xedc66ea79, ...}, ...}}, ...)
	/Users/dperique/mygit/dperique/NG/Dennis/Redhat/PR/sippy/pkg/prowloader/prow.go:447 +0x50d
github.com/openshift/sippy/pkg/prowloader.(*ProwLoader).LoadProwJobsToDB(0xc000b24a00)
	/Users/dperique/mygit/dperique/NG/Dennis/Redhat/PR/sippy/pkg/prowloader/prow.go:166 +0x4ab
main.(*Options).loadProwJobs(0xc000576800, 0x9?, {{{0xc0001403f0, 0x29}}, 0xc000abe540})
	/Users/dperique/mygit/dperique/NG/Dennis/Redhat/PR/sippy/main.go:644 +0x64e
main.(*Options).Run(0xc000576800)
	/Users/dperique/mygit/dperique/NG/Dennis/Redhat/PR/sippy/main.go:493 +0x115f
main.main.func1(0xc0000f8000?, {0x24a274b?, 0xc?, 0xc?})
	/Users/dperique/mygit/dperique/NG/Dennis/Redhat/PR/sippy/main.go:126 +0x173
github.com/spf13/cobra.(*Command).execute(0xc0000f8000, {0xc0001225c0, 0xc, 0xc})
	/Users/dperique/mygit/dperique/NG/Dennis/Redhat/PR/sippy/vendor/github.com/spf13/cobra/command.go:860 +0x663
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000f8000)
	/Users/dperique/mygit/dperique/NG/Dennis/Redhat/PR/sippy/vendor/github.com/spf13/cobra/command.go:974 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/dperique/mygit/dperique/NG/Dennis/Redhat/PR/sippy/vendor/github.com/spf13/cobra/command.go:902
main.main()
	/Users/dperique/mygit/dperique/NG/Dennis/Redhat/PR/sippy/main.go:188 +0xb6f
```

For bad credentials, I think it's ok to fatally exit.