### PR TITLE
Add a new view for each test that failed in all jobs on a payload

### DIFF
--- a/pkg/db/matviews.go
+++ b/pkg/db/matviews.go
@@ -65,6 +65,8 @@ var PostgresMatViews = []PostgresMaterializedView{
 		},
 	},
 	{
+		// TODO: this probably doesn't need to be a matview anymore since we only keep 3 months of data,
+		// metrics show this refreshing in .6s a lot of the time, occasionally up to 5s.
 		Name:           "payload_test_failures_14d_matview",
 		Definition:     payloadTestFailuresMatView,
 		IndexColumns:   []string{"release", "architecture", "stream", "prow_job_run_id", "test_id", "suite_id"},

--- a/pkg/db/models/releases.go
+++ b/pkg/db/models/releases.go
@@ -134,3 +134,18 @@ type PayloadStatistics struct {
 	MeanSecondsBetween int64 `json:"mean_seconds_between"`
 	MaxSecondsBetween  int64 `json:"max_seconds_between"`
 }
+
+type PayloadFailedTest struct {
+	ID            uint
+	Release       string
+	Architecture  string
+	Stream        string
+	ReleaseTag    string
+	TestID        uint
+	SuiteID       uint
+	Status        int
+	Name          string
+	ProwJobRunID  uint
+	ProwJobRunURL string
+	ProwJobName   string
+}

--- a/sippy-ng/package-lock.json
+++ b/sippy-ng/package-lock.json
@@ -10772,20 +10772,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -31221,13 +31207,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/sippy-ng/src/releases/PayloadTestFailures.css
+++ b/sippy-ng/src/releases/PayloadTestFailures.css
@@ -1,0 +1,11 @@
+.clamped {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 20;
+
+    line-height: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: break-spaces;
+    word-wrap: break-word;
+}

--- a/sippy-ng/src/releases/PayloadTestFailures.js
+++ b/sippy-ng/src/releases/PayloadTestFailures.js
@@ -1,0 +1,281 @@
+import './PayloadTestFailures.css'
+import { Box, Card, Grid, Tooltip, Typography } from '@material-ui/core'
+import { DataGrid } from '@material-ui/data-grid'
+import { Error } from '@material-ui/icons'
+import { generateClasses } from '../datagrid/utils'
+import { NumberParam, StringParam, useQueryParam } from 'use-query-params'
+import { safeEncodeURIComponent, SafeJSONParam } from '../helpers'
+import { withStyles } from '@material-ui/styles'
+import Alert from '@material-ui/lab/Alert'
+import GridToolbar from '../datagrid/GridToolbar'
+import InfoIcon from '@material-ui/icons/Info'
+import PropTypes from 'prop-types'
+import React, { Fragment, useEffect } from 'react'
+
+function PayloadTestFailures(props) {
+  const { classes } = props
+
+  // Most things not filterable here, as we are not querying them directly from db,
+  // but test name is, and that is likely the most important.
+  const columns = [
+    {
+      field: 'id',
+      headerName: 'Test ID',
+      hide: true,
+      filterable: false,
+      sortable: false,
+    },
+    {
+      field: 'name',
+      headerName: 'Test',
+      flex: 5,
+      sortable: false,
+    },
+    {
+      field: 'failure_count',
+      headerName: 'Failures',
+      flex: 1,
+      filterable: false,
+      sortable: false,
+    },
+    {
+      // We're working with this field, but in this case there will be only one item in the list of failed payloads,
+      // and we want to render the failed jobs beneath it.
+      field: 'failed_payloads',
+      headerName: 'Failed Jobs',
+      sortable: false,
+      filterable: false,
+      flex: 4,
+      renderCell: (params) => {
+        const renderJobRunLinks = () => {
+          let pl = []
+          for (let key of Object.keys(params.value)) {
+            var i
+            for (i = 0; i < params.value[key].failed_jobs.length; i++) {
+              /* Assume the jobs and job runs are the same length and match positionally */
+              pl.push(
+                <Fragment>
+                  <a href={params.value[key].failed_job_runs[i]}>
+                    {params.value[key].failed_jobs[i] + '  '}
+                  </a>
+                  <br />
+                </Fragment>
+              )
+            }
+          }
+          return pl
+        }
+
+        return <Box className="clamped">{renderJobRunLinks()}</Box>
+      },
+    },
+  ]
+
+  const [payload = props.payload, setPayload] = useQueryParam(
+    'payload',
+    StringParam
+  )
+  const [fetchError, setFetchError] = React.useState('')
+  const [isLoaded, setLoaded] = React.useState(false)
+  const [rows, setRows] = React.useState([])
+
+  const [filterModel = props.filterModel, setFilterModel] = useQueryParam(
+    'filters',
+    SafeJSONParam
+  )
+
+  const [sortField = props.sortField, setSortField] = useQueryParam(
+    'sortField',
+    StringParam
+  )
+  const [sort = props.sort, setSort] = useQueryParam('sort', StringParam)
+
+  const [pageSize = props.pageSize, setPageSize] = useQueryParam(
+    'pageSize',
+    NumberParam
+  )
+
+  const requestSearch = (searchValue) => {
+    const currentFilters = filterModel
+    currentFilters.items = currentFilters.items.filter(
+      (f) => f.columnField !== 'name'
+    )
+    currentFilters.items.push({
+      id: 99,
+      columnField: 'name',
+      operatorValue: 'contains',
+      value: searchValue,
+    })
+    setFilterModel(currentFilters)
+  }
+
+  const addFilters = (filter) => {
+    const currentFilters = filterModel.items.filter((item) => item.value !== '')
+
+    filter.forEach((item) => {
+      if (item.value && item.value !== '') {
+        currentFilters.push(item)
+      }
+    })
+    setFilterModel({
+      items: currentFilters,
+      linkOperator: filterModel.linkOperator || 'and',
+    })
+  }
+
+  const updateSortModel = (model) => {
+    if (model.length === 0) {
+      return
+    }
+
+    if (sort !== model[0].sort) {
+      setSort(model[0].sort)
+    }
+
+    if (sortField !== model[0].field) {
+      setSortField(model[0].field)
+    }
+  }
+
+  const fetchData = () => {
+    let queryString = ''
+    if (filterModel && filterModel.items.length > 0) {
+      queryString +=
+        '&filter=' + safeEncodeURIComponent(JSON.stringify(filterModel))
+    }
+
+    Promise.all([
+      fetch(
+        `${process.env.REACT_APP_API_URL}/api/payloads/test_failures?payload=${payload}` +
+          queryString
+      ),
+    ])
+      .then(([analysis]) => {
+        if (analysis.status !== 200) {
+          throw new Error('server returned ' + analysis.status)
+        }
+
+        return Promise.all([analysis.json()])
+      })
+      .then(([analysis]) => {
+        setRows(analysis)
+        setLoaded(true)
+      })
+      .catch((error) => {
+        setFetchError(
+          'Could not retrieve payload analysis for ' +
+            props.payload +
+            ': ' +
+            error
+        )
+      })
+  }
+
+  useEffect(() => {
+    fetchData()
+  }, [filterModel, sort, sortField])
+
+  if (fetchError !== '') {
+    return <Alert severity="error">Failed to load data, {fetchError}</Alert>
+  }
+
+  if (!isLoaded) {
+    return <p>Loading...</p>
+  }
+
+  if (rows.length === 0) {
+    return <Typography variant="h5">Analysis not found.</Typography>
+  }
+
+  console.log('hello world')
+
+  return (
+    <Grid item md={12}>
+      <Card className="test-failure-card" elevation={5}>
+        <Typography variant="h5">
+          Payload Test Failures
+          <Tooltip
+            title={
+              <p>
+                Displays all test failures in this payload across all jobs, both
+                blocking and informing.
+              </p>
+            }
+          >
+            <InfoIcon />
+          </Tooltip>
+        </Typography>
+        <DataGrid
+          components={{ Toolbar: props.hideControls ? '' : GridToolbar }}
+          rows={rows}
+          columns={columns}
+          autoHeight={true}
+          rowHeight={125}
+          disableColumnFilter={props.briefTable}
+          disableColumnMenu={true}
+          pageSize={pageSize}
+          onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}
+          rowsPerPageOptions={[5, 10, 25, 50]}
+          filterMode="server"
+          sortingMode="server"
+          sortingOrder={['desc', 'asc']}
+          sortModel={[
+            {
+              field: sortField,
+              sort: sort,
+            },
+          ]}
+          onSortModelChange={(m) => updateSortModel(m)}
+          getRowClassName={(params) =>
+            classes['row-percent-' + params.row.failure_count]
+          }
+          componentsProps={{
+            toolbar: {
+              columns: columns,
+              clearSearch: () => requestSearch(''),
+              doSearch: requestSearch,
+              addFilters: addFilters,
+              filterModel: filterModel,
+              setFilterModel: setFilterModel,
+            },
+          }}
+        />
+      </Card>
+    </Grid>
+  )
+}
+
+PayloadTestFailures.defaultProps = {
+  limit: 0,
+  hideControls: false,
+  pageSize: 25,
+  briefTable: false,
+  filterModel: {
+    items: [],
+  },
+  sortField: 'kind',
+  sort: 'asc',
+}
+
+PayloadTestFailures.propTypes = {
+  briefTable: PropTypes.bool,
+  hideControls: PropTypes.bool,
+  limit: PropTypes.number,
+  pageSize: PropTypes.number,
+  filterModel: PropTypes.object,
+  sort: PropTypes.string,
+  sortField: PropTypes.string,
+  classes: PropTypes.object,
+
+  payload: PropTypes.string,
+}
+
+const TEST_FAILURES_IN_PAYLOAD_THRESHOLDS = {
+  success: 0,
+  warning: 2,
+  error: 5,
+}
+
+export default withStyles(
+  generateClasses(TEST_FAILURES_IN_PAYLOAD_THRESHOLDS, true)
+)(PayloadTestFailures)

--- a/sippy-ng/src/releases/ReleasePayloadDetails.js
+++ b/sippy-ng/src/releases/ReleasePayloadDetails.js
@@ -26,6 +26,7 @@ import InfoIcon from '@material-ui/icons/Info'
 import JobRunsTable from '../jobs/JobRunsTable'
 import JobsDetail from '../jobs/JobsDetail'
 import JobTable from '../jobs/JobTable'
+import PayloadTestFailures from './PayloadTestFailures'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
 import ReleasePayloadJobRuns from './ReleasePayloadJobRuns'
@@ -129,7 +130,7 @@ export default function ReleasePayloadDetails(props) {
         previousPage={<Link to={`/release/${props.release}/tags`}>Tags</Link>}
         currentPage={releaseTag}
       />
-      <Container xl>
+      <Container maxWidth={'xl'}>
         <Typography variant="h4" gutterBottom className={classes.title}>
           {releaseTag}{' '}
         </Typography>
@@ -153,6 +154,12 @@ export default function ReleasePayloadDetails(props) {
                 value={releaseTag}
                 component={Link}
                 to={url}
+              />
+              <Tab
+                label="Test Failures"
+                value="failures"
+                component={Link}
+                to={url + '/testfailures'}
               />
               <Tab
                 label="Pull requests"
@@ -185,6 +192,15 @@ export default function ReleasePayloadDetails(props) {
                   items: [filterFor('release_tag', 'equals', releaseTag)],
                 }}
               />
+            </Card>
+          </Route>
+
+          <Route path={path + '/testfailures'}>
+            <Card
+              elevation={5}
+              style={{ margin: 20, padding: 20, height: '100%' }}
+            >
+              <PayloadTestFailures payload={props.releaseTag} />
             </Card>
           </Route>
 


### PR DESCRIPTION
New Tab on the page to view a particular payload, that lists all tests that failed across all jobs in the payload, how many times, and which jobs it failed in. 

Helpful just to quickly show the tests that may be failing in multiple
jobs.
