### PR TITLE
Ensure stale issues get updated for incidents

### DIFF
--- a/pkg/jiraloader/jiraloader.go
+++ b/pkg/jiraloader/jiraloader.go
@@ -13,6 +13,7 @@ import (
 	v1jira "github.com/openshift/sippy/pkg/apis/jira/v1"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/openshift/sippy/pkg/util/sets"
 )
 
 type JIRALoader struct {
@@ -29,6 +30,16 @@ const jiraTimeLayout = "2006-01-02T15:04:05.000Z0700"
 
 func (jl *JIRALoader) LoadJIRAIncidents() error {
 	start := time.Now()
+	log.Infof("populating jira incident cache...")
+	var dbIssues []string
+	jl.dbc.DB.Table("jira_incidents").Pluck("key", &dbIssues)
+	// unseenIssues contains the set of issues we have in the DB, but didn't see yet from the jira API. At the end,
+	// we'll query to see what happened to the unseen issues. Most likely, we removed the trt-incident label, so we need
+	// to dig into the changelog and find that state transition and consider the incident closed then.
+	unseenIssues := sets.NewString(dbIssues...)
+	log.Infof("cache populated in %+v", time.Since(start))
+
+	start = time.Now()
 	log.Infof("fetching incidents from jira...")
 
 	/* Note a token isn't currently required to hit the issues.redhat.com API. This gets
@@ -69,32 +80,32 @@ func (jl *JIRALoader) LoadJIRAIncidents() error {
 	}
 
 	for i, issue := range issues.Issues {
-		jiraID, err := strconv.ParseUint(issue.ID, 10, 64)
+		unseenIssues.Delete(issue.Key)
+
+		model, err := issueToDB(&issues.Issues[i])
 		if err != nil {
-			fmt.Printf("parsing error: %+v", err)
+			log.WithError(err).Errorf("couldn't convert jira issue to db model")
+			continue
+		}
+		if res := jl.dbc.DB.Save(model); res.Error != nil {
+			log.WithError(err).Errorf("couldn't save jira incident to DB")
+			return res.Error
+		}
+	}
+
+	for _, unseen := range unseenIssues.List() {
+		log.Infof("processing unseen jira incidents (trt-incident label removed?)...")
+		issue, err := queryJiraAPI(unseen)
+		if err != nil {
+			log.WithError(err).Errorf("couldn't query details for %+v", issue)
 			continue
 		}
 
-		var startTimeP *time.Time
-		if issue.Fields.Created != "" {
-			startTime, err := time.Parse(jiraTimeLayout, issue.Fields.Created)
-			if err != nil {
-				fmt.Printf("parsing error: %+v", err)
-				continue
-			}
-			startTimeP = &startTime
+		model, err := issueToDB(issue)
+		if err != nil {
+			log.WithError(err).Errorf("couldn't convert jira issue to db model")
+			continue
 		}
-
-		model := &models.JiraIncident{
-			Model: models.Model{
-				ID: uint(jiraID),
-			},
-			Key:            issue.Key,
-			Summary:        issue.Fields.Summary,
-			StartTime:      startTimeP,
-			ResolutionTime: findResolutionTime(&issues.Issues[i]),
-		}
-
 		if res := jl.dbc.DB.Save(model); res.Error != nil {
 			log.WithError(err).Errorf("couldn't save jira incident to DB")
 			return res.Error
@@ -106,15 +117,31 @@ func (jl *JIRALoader) LoadJIRAIncidents() error {
 }
 
 func findResolutionTime(issue *v1jira.Issue) *time.Time {
-	var oldestResolutionTime *time.Time
+	var resolutionTime *time.Time
 
 	changelogLayout := "2006-01-02T15:04:05.999-0700"
 
-	// OCPBUGS don't get a resolution time until it's closed which happens when a release GA's. We
-	// find the first terminal incident status changelog instead. From TRT's perspective, we don't
-	// care about OCPBUGS incidents after they go to MODIFIED.
 	for _, history := range issue.Changelog.Histories {
 		for _, item := range history.Items {
+			// If trt-incident label was removed from a jira ticket, consider that the time when the incident
+			// was resolved.
+			if !issueContainsLabel(issue, "trt-incident") && item.Field == "labels" && item.FromString == "trt-incident" && item.ToString != "trt-incident" {
+				createdTime, err := time.Parse(changelogLayout, history.Created)
+				if err != nil {
+					log.WithError(err).Warningf("parsing error: %s", history.Created)
+					continue
+				}
+				// We pick the oldest time we removed the trt-incident label (maybe we toggled back and forth a few
+				// times).
+				if resolutionTime == nil || resolutionTime.Before(createdTime) {
+					log.Debugf("trt-incident label was removed from %s at %+v", issue.Key, createdTime)
+					resolutionTime = &createdTime
+				}
+			}
+
+			// OCPBUGS don't get a resolution time until it's closed which happens when a release GA's. We
+			// find the first terminal incident status changelog instead. From TRT's perspective, we don't
+			// care about OCPBUGS incidents after they go to MODIFIED.
 			resolvedStatuses := []string{"MODIFIED", "ON_QA", "Verified", "Closed"}
 			for _, status := range resolvedStatuses {
 				if item.ToString == status {
@@ -123,9 +150,10 @@ func findResolutionTime(issue *v1jira.Issue) *time.Time {
 						log.WithError(err).Warningf("parsing error: %s", history.Created)
 						continue
 					}
-					if oldestResolutionTime == nil || oldestResolutionTime.After(createdTime) {
+					// We pick the oldest state change
+					if resolutionTime == nil || resolutionTime.After(createdTime) {
 						log.Debugf("%s to %s at %+v", issue.Key, status, createdTime)
-						oldestResolutionTime = &createdTime
+						resolutionTime = &createdTime
 					}
 				}
 			}
@@ -133,14 +161,81 @@ func findResolutionTime(issue *v1jira.Issue) *time.Time {
 	}
 
 	// Fallback to the jira resolution time
-	if issue.Fields.ResolutionDate != "" && oldestResolutionTime == nil {
-		resolutionTime, err := time.Parse(jiraTimeLayout, issue.Fields.ResolutionDate)
+	if issue.Fields.ResolutionDate != "" && resolutionTime == nil {
+		jiraResolutionTime, err := time.Parse(jiraTimeLayout, issue.Fields.ResolutionDate)
 		if err != nil {
 			fmt.Printf("parsing error: %+v", err)
 		}
-		log.Debugf("resolution time for %s is %+v", issue.Key, resolutionTime)
-		oldestResolutionTime = &resolutionTime
+		log.Debugf("resolution time for %s is %+v", issue.Key, jiraResolutionTime)
+		resolutionTime = &jiraResolutionTime
 	}
 
-	return oldestResolutionTime
+	return resolutionTime
+}
+
+func issueContainsLabel(issue *v1jira.Issue, label string) bool {
+	for _, issueLabel := range issue.Fields.Labels {
+		if issueLabel == label {
+			return true
+		}
+	}
+
+	return false
+}
+
+// queryJiraAPI returns a singular jira issue
+func queryJiraAPI(issueID string) (*v1jira.Issue, error) {
+	urlFmtStr := "https://issues.redhat.com/rest/api/2/issue/%s?expand=changelog"
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", fmt.Sprintf(urlFmtStr, issueID), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("received %s from Jira API", resp.Status)
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var issueDetails v1jira.Issue
+	err = json.Unmarshal(bodyBytes, &issueDetails)
+	if err != nil {
+		return nil, err
+	}
+
+	return &issueDetails, nil
+}
+
+func issueToDB(issue *v1jira.Issue) (*models.JiraIncident, error) {
+	jiraID, err := strconv.ParseUint(issue.ID, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	var startTimeP *time.Time
+	if issue.Fields.Created != "" {
+		startTime, err := time.Parse(jiraTimeLayout, issue.Fields.Created)
+		if err != nil {
+			return nil, err
+		}
+		startTimeP = &startTime
+	}
+
+	return &models.JiraIncident{
+		Model: models.Model{
+			ID: uint(jiraID),
+		},
+		Key:            issue.Key,
+		Summary:        issue.Fields.Summary,
+		StartTime:      startTimeP,
+		ResolutionTime: findResolutionTime(issue),
+	}, nil
 }


### PR DESCRIPTION
[TRT-1194](https://issues.redhat.com//browse/TRT-1194)

If we removed the incident label from a jira, we want to make sure we update the database row still. So, we keep track of jira incidents we didn't see yet and then query jira to figure out what happened. If the jira got the trt-incident label removed, we found out when that happened and set it as the incident resolution date.

I tested this change by:
- Syncing incidents to a local DB
- Removing the incident label from [TRT-1202](https://issues.redhat.com//browse/TRT-1202)
- Resyncing, and confirm the resolution date was set to when I removed the label
- Added label back, resynced, and confirmed issue was marked unresolved again