### PR TITLE
Allow passing in a jobName for sippy intervals

### DIFF
--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -460,9 +460,14 @@ export default function App(props) {
                     />
 
                     <Route
-                      path="/job_runs/:jobrunid/intervals"
+                      path="/job_runs/:jobrunid/:jobname?/:repoinfo?/:pullnumber?/intervals"
                       render={(props) => (
-                        <ProwJobRun jobRunID={props.match.params.jobrunid} />
+                        <ProwJobRun
+                          jobRunID={props.match.params.jobrunid}
+                          jobName={props.match.params.jobname}
+                          repoInfo={props.match.params.repoinfo}
+                          pullNumber={props.match.params.pullnumber}
+                        />
                       )}
                     />
 

--- a/sippy-ng/src/prow_job_runs/ProwJobRun.js
+++ b/sippy-ng/src/prow_job_runs/ProwJobRun.js
@@ -60,12 +60,24 @@ export default function ProwJobRun(props) {
 
   const fetchData = () => {
     let queryString = ''
-    console.log('hello world we got the prow job run id of ' + props.jobRunID)
+    console.log(
+      'We got the prow job run id of ' +
+        props.jobRunID +
+        ', jobName=' +
+        props.jobName +
+        ', pullNumber=' +
+        props.pullNumber +
+        ', repoInfo=' +
+        props.repoInfo
+    )
 
     fetch(
       process.env.REACT_APP_API_URL +
         '/api/jobs/runs/intervals?prow_job_run_id=' +
         props.jobRunID +
+        (props.jobName ? '&job_name=' + props.jobName : '') +
+        (props.repoInfo ? '&repo_info=' + props.repoInfo : '') +
+        (props.pullNumber ? '&pull_number=' + props.pullNumber : '') +
         queryString
     )
       .then((response) => {
@@ -102,7 +114,16 @@ export default function ProwJobRun(props) {
       })
       .catch((error) => {
         setFetchError(
-          'Could not retrieve intervals for ' + props.jobRunID + ', ' + error
+          'Could not retrieve intervals for ' +
+            'jobRunID=' +
+            props.jobRunID +
+            ' jobName=' +
+            props.jobName +
+            ' pullNumber=' +
+            props.pullNumber +
+            ' repoInfo=' +
+            ', ' +
+            error
         )
       })
   }
@@ -157,7 +178,13 @@ export default function ProwJobRun(props) {
   }
 
   if (isLoaded === false) {
-    return <p>Loading intervals for job run {props.jobRunID}...</p>
+    return (
+      <p>
+        Loading intervals for job run: jobRunID={props.jobRunID}, jobName=
+        {props.jobName}, pullNumber={props.pullNumber}, repoInfo=
+        {props.repoInfo}
+      </p>
+    )
   }
 
   let chartData = groupIntervals(filteredIntervals)
@@ -275,6 +302,9 @@ ProwJobRun.propTypes = {
 
 ProwJobRun.propTypes = {
   jobRunID: PropTypes.string.isRequired,
+  jobName: PropTypes.string,
+  repoInfo: PropTypes.string,
+  pullNumber: PropTypes.string,
   filterModel: PropTypes.object,
 }
 


### PR DESCRIPTION
[TRT-1215](https://issues.redhat.com//browse/TRT-1215)

Today, when you click on the Intervals button on a prow job under the Debug section, only the jobID is passed.  From the jobID, we can get the GCS bucket url via the sippy database, but only after that prow job is added to the sippyDB (which happens hourly).

This change allows us to make use of a prow job name (if passed in as a parameter).  This obviates the need to wait for the sippyDB to be populated with the prow job; as such, we can get the intervals immediately.

https://github.com/openshift/release/pull/43064 will make use of this functionality.

Test:

- [x] Test links for new rehearse and presubmit jobs (both of these are of type "presubmit") (i.e., where jobName, repoInfo and pullNumber is passed)
- [x] Test links for new periodic jobs (i.e., where jobName is passed)
- [x] Ensure backward compatibility for rehearse, presubmit, and periodic jobs (i.e., when just jobID is passed)
- [x] Ensure `curl 'http://localhost:8080/api/jobs/runs/intervals?prow_job_run_id=1697965504431394816&prow_job_name=periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade'` gets data
- [x] Ensure `http://localhost:3000/sippy-ng/job_runs/1697965504431394816/periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade/intervals?categories=operator_unavailable&categories=operator_progressing&categories=operator_degraded&categories=pod_logs&categories=interesting_events&categories=alerts&categories=node_state&categories=e2e_test_failed&categories=disruption&filterText=&intervalFiles=e2e-events_20230902-143224.json` results in rendered intervals.