### PR TITLE
Cast argument instead of partitioned field

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -50,8 +50,8 @@ const (
 					END) AS row_num
 			FROM
 				ci_analysis_us.junit
-			WHERE TIMESTAMP(modified_time) >= @From
-			AND TIMESTAMP(modified_time) < @To
+			WHERE modified_time >= DATETIME(@From)
+			AND modified_time < DATETIME(@To)
 		)
 		SELECT * FROM deduped_testcases WHERE row_num = 1`
 )


### PR DESCRIPTION
[TRT-1083](https://issues.redhat.com//browse/TRT-1083)

Courtesy of David:

```
This sub-query:

SELECT  *,
			ROW_NUMBER() OVER(PARTITION BY file_path, test_name, testsuite ORDER BY
				CASE
					WHEN flake_count > 0 THEN 0
					WHEN success_val > 0 THEN 1
					ELSE 2
				END) AS row_num
		FROM
			openshift-gce-devel.ci_analysis_us.junit
		WHERE TIMESTAMP(modified_time) >= "2023-09-01"
		AND TIMESTAMP(modified_time) < "2023-09-27"

explodes to a full table scan due to the casting of your partitioned
field modified_time. Cast the argument instead and you'll drop from from
776GB per query to 85 GB per query.
```