### PR TITLE
Avoid gorm bug with smallint postgres column

### DIFF
--- a/pkg/db/models/pr_commenting.go
+++ b/pkg/db/models/pr_commenting.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-type CommentType int8
+type CommentType int
 
 const (
 	CommentTypeRiskAnalysis CommentType = 0
@@ -14,7 +14,7 @@ type PullRequestComment struct {
 	CreatedAt             time.Time
 	UpdatedAt             time.Time
 	PullNumber            int       `json:"pullNumber" gorm:"primaryKey"`
-	CommentType           int8      `json:"commentType" gorm:"primaryKey"`
+	CommentType           int       `json:"commentType" gorm:"primaryKey"`
 	SHA                   string    `json:"sha" gorm:"primaryKey"`
 	Org                   string    `json:"org" gorm:"primaryKey"`
 	Repo                  string    `json:"repo" gorm:"primaryKey"`

--- a/pkg/github/commenter/ghcommenter.go
+++ b/pkg/github/commenter/ghcommenter.go
@@ -198,7 +198,7 @@ func (ghc *GitHubCommenter) UpdatePendingCommentRecords(org, repo string, number
 	if !foundExistingPRC && sha == prEntry.SHA && mergedAt == nil {
 
 		var pullRequestComment = &models.PullRequestComment{}
-		pullRequestComment.CommentType = int8(commentType)
+		pullRequestComment.CommentType = int(commentType)
 		pullRequestComment.PullNumber = number
 		pullRequestComment.SHA = sha
 		pullRequestComment.Org = org

--- a/pkg/sippyserver/pr_commenting_processor.go
+++ b/pkg/sippyserver/pr_commenting_processor.go
@@ -98,7 +98,7 @@ type PendingComment struct {
 	org         string
 	repo        string
 	number      int
-	commentType int8
+	commentType int
 }
 
 type CommentWorker struct {
@@ -378,7 +378,7 @@ func (cw *CommentWorker) writeComment(ghCommenter *commenter.GitHubCommenter, pe
 		return nil
 	}
 
-	if pendingComment.commentType == int8(models.CommentTypeRiskAnalysis) && prEntry.MergedAt != nil {
+	if pendingComment.commentType == int(models.CommentTypeRiskAnalysis) && prEntry.MergedAt != nil {
 		logger.Warning("PR has merged, skipping risk analysis comment")
 		return nil
 	}
@@ -462,7 +462,7 @@ func (aw *AnalysisWorker) Run() {
 	// exit when closed
 	for i := range aw.pendingAnalysis {
 
-		if i.CommentType == int8(models.CommentTypeRiskAnalysis) {
+		if i.CommentType == int(models.CommentTypeRiskAnalysis) {
 			aw.processRiskAnalysisComment(i)
 		} else {
 			log.Warningf("Unsupported comment type: %d for %s/%s/%d/%s", i.CommentType, i.Org, i.Repo, i.PullNumber, i.SHA)
@@ -481,7 +481,7 @@ func (aw *AnalysisWorker) processRiskAnalysisComment(prPendingComment models.Pul
 	start := time.Now()
 	logger.Debug("Processing item")
 
-	if prPendingComment.CommentType != int8(models.CommentTypeRiskAnalysis) {
+	if prPendingComment.CommentType != int(models.CommentTypeRiskAnalysis) {
 		logger.Warningf("Unsupported comment type: %d", prPendingComment.CommentType)
 		return
 	}


### PR DESCRIPTION
Gorm appears to have a bug with detecting smallint/tinyint columns, it
thinks they always need their schema updated, whereas using an
int/bigint does not hit this.

Combined with a rollout of the deployment during our long running backup
job, this deadlocks the db somehow, but we need to remember this could
happen on any schema change if it ran into our backup in the middle of
the night.

[TRT-1228](https://issues.redhat.com//browse/TRT-1228)
