### PR TITLE
For Component Readiness, open new tab by default

### DIFF
--- a/sippy-ng/src/component_readiness/CompCapRow.js
+++ b/sippy-ng/src/component_readiness/CompCapRow.js
@@ -34,12 +34,12 @@ export default function CompCapRow(props) {
   )
 
   const handleClick = (event) => {
-    if (!event.metaKey) {
-      event.preventDefault()
-      setCapabilityParam(capabilityName)
-      window.location.href =
-        '/sippy-ng' + capabilityLink(filterVals, capabilityName)
-    }
+    event.preventDefault()
+    setCapabilityParam(capabilityName)
+    window.open(
+      '/sippy-ng' + capabilityLink(filterVals, capabilityName),
+      '_blank'
+    )
   }
 
   // Put the capabilityName on the left side with a link to a capability specific

--- a/sippy-ng/src/component_readiness/CompReadyCapCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCapCell.js
@@ -55,16 +55,16 @@ export default function CompReadyCapCell(props) {
   }
 
   const handleClick = (event) => {
-    if (!event.metaKey) {
-      event.preventDefault()
-      setComponentParam(component)
-      setCapabilityParam(capability)
-      setTestIdParam(testId)
-      setEnvironmentParam(environment)
-      window.location.href =
-        '/sippy-ng' +
-        testReport(testId, environment, filterVals, component, capability)
-    }
+    event.preventDefault()
+    setComponentParam(component)
+    setCapabilityParam(capability)
+    setTestIdParam(testId)
+    setEnvironmentParam(environment)
+    window.open(
+      '/sippy-ng' +
+        testReport(testId, environment, filterVals, component, capability),
+      '_blank'
+    )
   }
 
   if (status === undefined) {

--- a/sippy-ng/src/component_readiness/CompReadyCapsCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCapsCell.js
@@ -40,13 +40,13 @@ export default function CompReadyCapsCell(props) {
   }
 
   const handleClick = (event) => {
-    if (!event.metaKey) {
-      event.preventDefault()
-      setCapabilityParam(capabilityName)
-      setEnvironmentParam(environment)
-      window.location.href =
-        '/sippy-ng' + capabilityReport(capabilityName, environment, filterVals)
-    }
+    event.preventDefault()
+    setCapabilityParam(capabilityName)
+    setEnvironmentParam(environment)
+    window.open(
+      '/sippy-ng' + capabilityReport(capabilityName, environment, filterVals),
+      '_blank'
+    )
   }
   if (status === undefined) {
     return (

--- a/sippy-ng/src/component_readiness/CompReadyCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCell.js
@@ -41,13 +41,13 @@ export default function CompReadyCell(props) {
   }
 
   const handleClick = (event) => {
-    if (!event.metaKey) {
-      event.preventDefault()
-      setComponentParam(componentName)
-      setEnvironmentParam(environment)
-      window.location.href =
-        '/sippy-ng' + componentReport(componentName, environment, filterVals)
-    }
+    event.preventDefault()
+    setComponentParam(componentName)
+    setEnvironmentParam(environment)
+    window.open(
+      '/sippy-ng' + componentReport(componentName, environment, filterVals),
+      '_blank'
+    )
   }
 
   if (status === undefined) {

--- a/sippy-ng/src/component_readiness/CompReadyRow.js
+++ b/sippy-ng/src/component_readiness/CompReadyRow.js
@@ -34,12 +34,12 @@ export default function CompReadyRow(props) {
   )
 
   const handleClick = (event) => {
-    if (!event.metaKey) {
-      event.preventDefault()
-      setComponentParam(componentName)
-      window.location.href =
-        '/sippy-ng' + capabilitiesReport(filterVals, componentName)
-    }
+    event.preventDefault()
+    setComponentParam(componentName)
+    window.open(
+      '/sippy-ng' + capabilitiesReport(filterVals, componentName),
+      '_blank'
+    )
   }
 
   // Put the componentName on the left side with a link to a component specific

--- a/sippy-ng/src/component_readiness/CompReadyTestCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestCell.js
@@ -71,15 +71,14 @@ export default function CompReadyTestCell(props) {
   }
 
   const handleClick = (event) => {
-    if (!event.metaKey) {
-      event.preventDefault()
-      setComponentParam(component)
-      setCapabilityParam(capability)
-      setTestIdParam(testId)
-      setEnvironmentParam(environment)
-      setTestNameParam(testName)
-      window.location.href =
-        '/sippy-ng' +
+    event.preventDefault()
+    setComponentParam(component)
+    setCapabilityParam(capability)
+    setTestIdParam(testId)
+    setEnvironmentParam(environment)
+    setTestNameParam(testName)
+    window.open(
+      '/sippy-ng' +
         generateTestReport(
           testId,
           environment,
@@ -87,8 +86,9 @@ export default function CompReadyTestCell(props) {
           component,
           capability,
           testName
-        )
-    }
+        ),
+      '_blank'
+    )
   }
 
   if (status === undefined) {

--- a/sippy-ng/src/component_readiness/CompTestRow.js
+++ b/sippy-ng/src/component_readiness/CompTestRow.js
@@ -56,14 +56,14 @@ export default function CompTestRow(props) {
   const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
 
   const handleClick = (event) => {
-    if (!event.metaKey) {
-      event.preventDefault()
-      setComponentParam(component)
-      setCapabilityParam(capability)
-      setTestIdParam(testId)
-      window.location.href =
-        '/sippy-ng' + testLink(filterVals, component, capability, testId)
-    }
+    event.preventDefault()
+    setComponentParam(component)
+    setCapabilityParam(capability)
+    setTestIdParam(testId)
+    window.open(
+      '/sippy-ng' + testLink(filterVals, component, capability, testId),
+      '_blank'
+    )
   }
 
   // Put the testName on the left side with a link to a test specific


### PR DESCRIPTION
[TRT-1063](https://issues.redhat.com//browse/TRT-1063)

This gives us what a proper "Back" button would give us (i.e., the ability to refer back to where we came from by going to the previous tab).

We are choosing to implement this way because getting the "Back" button to work properly has been problematic.

Once merged, the Component Readiness UI behavior will be such that for every link that is clicked, a new browser tab is opened. 