### PR TITLE
Parallelize job gcs bucket processing

### DIFF
--- a/config/e2e-openshift.yaml
+++ b/config/e2e-openshift.yaml
@@ -1,8 +1,8 @@
 prow:
   url: https://prow.ci.openshift.org/prowjobs.js
 releases:
-  "4.13":
+  "4.14":
     jobs:
-      periodic-ci-openshift-release-master-nightly-4.13-e2e-aws-sdn-serial: true
-      periodic-ci-openshift-release-master-ci-4.13-e2e-azure-ovn-upgrade: true
-      periodic-ci-openshift-release-master-nightly-4.13-e2e-gcp-sdn: true
+      periodic-ci-openshift-release-master-nightly-4.14-e2e-aws-sdn-serial: true
+      periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade: true
+      periodic-ci-openshift-release-master-nightly-4.14-e2e-gcp-sdn: true

--- a/e2e-scripts/sippy-e2e-sippy-e2e-setup-commands.sh
+++ b/e2e-scripts/sippy-e2e-sippy-e2e-setup-commands.sh
@@ -190,7 +190,7 @@ spec:
         terminationMessagePolicy: File
         command:  ["/bin/sh", "-c"]
         args:
-          - /bin/sippy --init-database --load-database --log-level=debug --load-prow=true --load-testgrid=false --release 4.13 --skip-bug-lookup --database-dsn=postgresql://postgres:password@postgres.sippy-e2e.svc.cluster.local:5432/postgres --mode=ocp --config ./config/e2e-openshift.yaml --google-service-account-credential-file /tmp/secrets/gcs-cred
+          - /bin/sippy --init-database --load-database --log-level=debug --load-prow=true --load-testgrid=false --release 4.14 --skip-bug-lookup --database-dsn=postgresql://postgres:password@postgres.sippy-e2e.svc.cluster.local:5432/postgres --mode=ocp --config ./config/e2e-openshift.yaml --google-service-account-credential-file /tmp/secrets/gcs-cred
         env:
         - name: GCS_SA_JSON_PATH
           value: /tmp/secrets/gcs-cred

--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -60,7 +60,7 @@ func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release 
 	// Infrastructure
 	infraIndicator, err := query.TestReportExcludeVariants(dbc, release, infraTestName, excludedVariants)
 	if err != nil {
-		log.WithError(err).Error("error querying test report")
+		log.WithError(err).Error("error querying infrastructure test report")
 		return
 	}
 	indicators["infrastructure"] = infraIndicator
@@ -68,7 +68,7 @@ func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release 
 	// Install Configuration
 	installConfigIndicator, err := query.TestReportExcludeVariants(dbc, release, testidentification.InstallConfigTestName, excludedInstallVariants)
 	if err != nil {
-		log.WithError(err).Error("error querying test report")
+		log.WithError(err).Error("error querying install test report")
 		return
 	}
 	indicators["installConfig"] = installConfigIndicator
@@ -76,7 +76,7 @@ func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release 
 	// Bootstrap
 	bootstrapIndicator, err := query.TestReportExcludeVariants(dbc, release, testidentification.InstallBootstrapTestName, excludedInstallVariants)
 	if err != nil {
-		log.WithError(err).Error("error querying test report")
+		log.WithError(err).Error("error querying bootstrap test report")
 		return
 	}
 	indicators["bootstrap"] = bootstrapIndicator
@@ -84,7 +84,7 @@ func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release 
 	// Install Other
 	installOtherIndicator, err := query.TestReportExcludeVariants(dbc, release, testidentification.InstallOtherTestName, excludedInstallVariants)
 	if err != nil {
-		log.WithError(err).Error("error querying test report")
+		log.WithError(err).Error("error querying install (other) test report")
 		return
 	}
 	indicators["installOther"] = installOtherIndicator
@@ -92,7 +92,7 @@ func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release 
 	// Install
 	installIndicator, err := query.TestReportExcludeVariants(dbc, release, installTestName, excludedInstallVariants)
 	if err != nil {
-		log.WithError(err).Error("error querying test report")
+		log.WithError(err).Error("error querying install test report")
 		return
 	}
 	indicators["install"] = installIndicator
@@ -100,7 +100,7 @@ func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release 
 	// Upgrade
 	upgradeIndicator, err := query.TestReportExcludeVariants(dbc, release, testidentification.UpgradeTestName, excludedVariants)
 	if err != nil {
-		log.WithError(err).Error("error querying test report")
+		log.WithError(err).Error("error querying upgrade test report")
 		return
 	}
 	indicators["upgrade"] = upgradeIndicator

--- a/pkg/prowloader/prow.go
+++ b/pkg/prowloader/prow.go
@@ -776,6 +776,7 @@ func (pl *ProwLoader) prowJobRunTestsFromGCS(ctx context.Context, pj *prow.ProwJ
 
 	syntheticSuite, jobResult := testconversion.ConvertProwJobRunToSyntheticTests(*pj, testCases, pl.syntheticTestManager)
 	pl.extractTestCases(syntheticSuite, testCases)
+	log.Infof("synthetic suite had %d tests", syntheticSuite.NumTests)
 
 	results := make([]*models.ProwJobRunTest, 0)
 	for k, v := range testCases {

--- a/pkg/prowloader/prow.go
+++ b/pkg/prowloader/prow.go
@@ -189,10 +189,10 @@ func (pl *ProwLoader) LoadProwJobsToDB() []error {
 				}
 				if err := pl.processProwJob(ctx, job); err != nil {
 					errsCh <- err
-				} else {
-					pl.jobsImportedCount.Add(1)
-					log.Infof("%d of %d job runs completed", pl.jobsImportedCount.Load(), total)
+					log.WithError(err).Warningf("couldn't import job %s/%s, continuing", job.Spec.Job, job.Status.BuildID)
 				}
+				pl.jobsImportedCount.Add(1)
+				log.Infof("%d of %d job runs processed", pl.jobsImportedCount.Load(), total)
 			}
 		}(pl.ctx)
 	}

--- a/pkg/prowloader/prow.go
+++ b/pkg/prowloader/prow.go
@@ -780,7 +780,7 @@ func (pl *ProwLoader) prowJobRunTestsFromGCS(ctx context.Context, pj *prow.ProwJ
 	log.Infof("synthetic suite had %d tests", syntheticSuite.NumTests)
 
 	results := make([]*models.ProwJobRunTest, 0)
-	for k, _ := range testCases {
+	for k := range testCases {
 		if testidentification.IsIgnoredTest(k) {
 			continue
 		}

--- a/pkg/prowloader/prow.go
+++ b/pkg/prowloader/prow.go
@@ -182,9 +182,9 @@ func (pl *ProwLoader) LoadProwJobsToDB() []error {
 		go func(ctx context.Context) {
 			defer wg.Done()
 			for job := range queue {
-				if ctx.Err() != nil {
-					errsCh <- ctx.Err()
-					fmt.Println("consumer exiting, got error")
+				if err := ctx.Err(); err != nil {
+					errsCh <- err
+					log.WithError(err).Warningf("consumer exiting, got error")
 					break
 				}
 				if err := pl.processProwJob(ctx, job); err != nil {
@@ -561,7 +561,6 @@ func (pl *ProwLoader) prowJobToJobRun(ctx context.Context, pj *prow.ProwJob, rel
 			}
 		}
 		if saveDB {
-			fmt.Println("update")
 			if res := pl.dbc.DB.WithContext(ctx).Save(&dbProwJob); res.Error != nil {
 				return res.Error
 			}

--- a/pkg/prowloader/testconversion/testconversion.go
+++ b/pkg/prowloader/testconversion/testconversion.go
@@ -1,8 +1,6 @@
 package testconversion
 
 import (
-	"sync"
-
 	"github.com/openshift/sippy/pkg/apis/junit"
 	"github.com/openshift/sippy/pkg/apis/prow"
 	v1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
@@ -12,7 +10,7 @@ import (
 	"github.com/openshift/sippy/pkg/testidentification"
 )
 
-func ConvertProwJobRunToSyntheticTests(pj *prow.ProwJob, tests *sync.Map, manager synthetictests.SyntheticTestManager) (*junit.TestSuite, v1.JobOverallResult) {
+func ConvertProwJobRunToSyntheticTests(pj prow.ProwJob, tests map[string]*models.ProwJobRunTest, manager synthetictests.SyntheticTestManager) (*junit.TestSuite, v1.JobOverallResult) {
 	jrr := v1.RawJobRunResult{
 		Job:       pj.Spec.Job,
 		Errored:   pj.Status.State == prow.ErrorState,
@@ -25,11 +23,8 @@ func ConvertProwJobRunToSyntheticTests(pj *prow.ProwJob, tests *sync.Map, manage
 	return syntheticTests, jrr.OverallResult
 }
 
-func testsToRawJobRunResult(jrr *v1.RawJobRunResult, tests *sync.Map) {
-	tests.Range(func(k any, v any) bool {
-		name := k.(string)
-		test := v.(*models.ProwJobRunTest)
-
+func testsToRawJobRunResult(jrr *v1.RawJobRunResult, tests map[string]*models.ProwJobRunTest) {
+	for name, test := range tests {
 		switch testgridv1.TestStatus(test.Status) {
 		case testgridv1.TestStatusSuccess, testgridv1.TestStatusFlake: // success, flake(failed one or more times but ultimately succeeded)
 			switch {
@@ -87,7 +82,5 @@ func testsToRawJobRunResult(jrr *v1.RawJobRunResult, tests *sync.Map) {
 				jrr.OpenShiftTestsStatus = testidentification.Failure
 			}
 		}
-
-		return true
-	})
+	}
 }

--- a/test/e2e/util/e2erequest.go
+++ b/test/e2e/util/e2erequest.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -46,6 +48,7 @@ func SippyRequest(path string, data interface{}) error {
 	if err != nil {
 		return err
 	}
+	log.Infof("Received Response: %s", string(body))
 	err = json.Unmarshal(body, data)
 	if err != nil {
 		return err

--- a/test/e2e/util/e2erequest.go
+++ b/test/e2e/util/e2erequest.go
@@ -13,7 +13,7 @@ import (
 const (
 	// Needs to match what we import in the e2e sh scripts and the
 	// config/e2e-openshift.yaml.
-	Release = "4.13"
+	Release = "4.14"
 
 	// APIPort is the port e2e.sh launches the sippy API on. These values must be kept in sync.
 	APIPort = 18080


### PR DESCRIPTION
[TRT-1190](https://issues.redhat.com//browse/TRT-1190)

We're spending a lot of time processing gcs buckets and importing jobs, such that when combined with the matview refreshes we're regularly approaching or exceeding the 60 minute window. This changes the gcs importer code to import up to 10 jobs in parallel.  Gorm is (mostly) thread safe, and I think I've protected all the places in our code that isn't.