### PR TITLE
Ignore tests that have namespace in their names

### DIFF
--- a/pkg/testidentification/test_identification.go
+++ b/pkg/testidentification/test_identification.go
@@ -175,6 +175,7 @@ var (
 	openshiftTestsRegex         = regexp.MustCompile(`(?:^openshift-tests\.|\[Suite:openshift|\[k8s\.io\]|\[sig-|\[bz-)`)
 	APIsRemainAvailTest         = "APIs remain available"
 	ignoreTestRegex             = regexp.MustCompile(`^$|Run multi-stage test|operator.Import the release payload|operator.Import a release payload|operator.Run template|operator.Build image|Monitor cluster while tests execute|Overall|job.initialize|\[sig-arch\]\[Feature:ClusterUpgrade\] Cluster should remain functional during upgrade`)
+	ignoreSuiteRegex            = regexp.MustCompile(`test/e2e_`)
 )
 
 func IsCuratedTest(bugzillaRelease, testName string) bool {
@@ -278,6 +279,12 @@ func IsUpgradeRelatedTest(testName string) bool {
 
 	return false
 
+}
+
+// IsIgnoredSuite is used to ignore test problematic test suites such as those that include namespaces or other
+// dynamic information in their names.
+func IsIgnoredSuite(suiteName string) bool {
+	return ignoreSuiteRegex.MatchString(suiteName)
 }
 
 // IsIgnoredTest is used to strip out tests that don't have predictive or diagnostic value.  We don't want to show these in our data.


### PR DESCRIPTION
The Kafka test suites contain the namespace name in many of the tests,
we now have 8,000+ of these tests in the DB.

Going to ignore them here and delete them from the DB. The suites
all start with `test/e2e_`, which as far as I can tell is unique to
these jobs.

Tested and confirmed to work:

```
INFO[2023-09-14T11:41:38.494-04:00] creating new ProwJobRun                       buildID=1701146412781146112 job=pull-ci-openshift-knative-serverless-operator-main-4.13-upstream-e2e-kafka-aws-ocp-413 progress=14138/81025 start="2023-09-11 08:11:24 +0000 UTC"
INFO[2023-09-14T11:41:38.818-04:00] ignoring tests from ignored suite "test/e2e_channel/conformance"
INFO[2023-09-14T11:41:38.985-04:00] ignoring tests from ignored suite "test/e2e_source"
INFO[2023-09-14T11:41:39.273-04:00] ignoring tests from ignored suite "test/e2e_new_channel"
INFO[2023-09-14T11:41:39.476-04:00] ignoring tests from ignored suite "test/e2e_channel"
INFO[2023-09-14T11:41:39.904-04:00] ignoring tests from ignored suite "test/e2e_new"
INFO[2023-09-14T11:41:39.904-04:00] ignoring tests from ignored suite "test/e2e_new/bogus_config"
INFO[2023-09-14T11:41:39.904-04:00] ignoring tests from ignored suite "test/e2e_new/multiple_partition_config"
INFO[2023-09-14T11:41:39.904-04:00] ignoring tests from ignored suite "test/e2e_new/single_partition_config"
INFO[2023-09-14T11:41:40.231-04:00] ignoring tests from ignored suite "test/e2e_sink"
DEBU[2023-09-14T11:41:40.339-04:00] findOrAddPullRequests nil githubclient
INFO[2023-09-14T11:41:40.509-04:00] creating new ProwJobRun                       buildID=1701226078426632192 job=pull-ci-openshift-knative-serverless-operator-main-4.13-upstream-e2e-kafka-aws-ocp-413 progress=19485/81025 start="2023-09-11 13:27:58 +0000 UTC"
INFO[2023-09-14T11:41:40.886-04:00] ignoring tests from ignored suite "test/e2e_new_channel"
INFO[2023-09-14T11:41:41.276-04:00] ignoring tests from ignored suite "test/e2e_sink"
INFO[2023-09-14T11:41:41.461-04:00] ignoring tests from ignored suite "test/e2e_channel/conformance"
INFO[2023-09-14T11:41:41.589-04:00] ignoring tests from ignored suite "test/e2e_source"
INFO[2023-09-14T11:41:41.714-04:00] ignoring tests from ignored suite "test/e2e_channel"
INFO[2023-09-14T11:41:41.933-04:00] ignoring tests from ignored suite "test/e2e_new"
INFO[2023-09-14T11:41:41.933-04:00] ignoring tests from ignored suite "test/e2e_new/bogus_config"
INFO[2023-09-14T11:41:41.933-04:00] ignoring tests from ignored suite "test/e2e_new/multiple_partition_config"
INFO[2023-09-14T11:41:41.933-04:00] ignoring tests from ignored suite "test/e2e_new/single_partition_config"
```