### PR TITLE
Reduce materialized views concurrency from 3 to 2

### DIFF
--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -164,7 +164,7 @@ func refreshMaterializedViews(dbc *db.DB, refreshMatviewOnlyIfEmpty bool) {
 	wg := sync.WaitGroup{}
 
 	// allow concurrent workers for refreshing matviews in parallel
-	for t := 0; t < 3; t++ {
+	for t := 0; t < 2; t++ {
 		wg.Add(1)
 		go refreshMatview(dbc, refreshMatviewOnlyIfEmpty, ch, &wg)
 	}


### PR DESCRIPTION
We're having problems with disk iops suddenly as of Sep 12 and not
totally sure why. To help calm it down we will reduce our matview
concurrency for refreshes to see if that helps.
