### PR TITLE
Exclude recovery jobs from component readiness query

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -283,7 +283,7 @@ func (c *componentReportGenerator) getJobRunTestStatusFromBigQuery() (
 	queryString += `
 					WHERE
 						(prowjob_name LIKE 'periodic-%%' OR prowjob_name LIKE 'release-%%' OR prowjob_name LIKE 'aggregator-%%')
-						AND prowjob_name NOT LIKE '%-okd%'
+						AND prowjob_name NOT LIKE '%-okd%' AND prowjob_name NOT LIKE '%-recovery'
 						AND upgrade = @Upgrade
 						AND arch = @Arch
 						AND network = @Network
@@ -420,7 +420,7 @@ func (c *componentReportGenerator) getTestStatusFromBigQuery() (
 						cm.id `
 
 	queryString += `
-					WHERE (prowjob_name LIKE 'periodic-%%' OR prowjob_name LIKE 'release-%%' OR prowjob_name LIKE 'aggregator-%%') AND prowjob_name NOT LIKE '%-okd%' `
+					WHERE (prowjob_name LIKE 'periodic-%%' OR prowjob_name LIKE 'release-%%' OR prowjob_name LIKE 'aggregator-%%') AND prowjob_name NOT LIKE '%-okd%' AND prowjob_name NOT LIKE '%-recovery'`
 
 	commonParams := []bigquery.QueryParameter{}
 	if c.IgnoreDisruption {


### PR DESCRIPTION
[TRT-1262](https://issues.redhat.com//browse/TRT-1262)

I tested this with a [link on my local component readiness UI](http://localhost:3000/sippy-ng/component_readiness/test_details?arch=amd64&baseEndTime=2023-05-16%2023%3A59%3A59&baseRelease=4.13&baseStartTime=2023-04-18%2000%3A00%3A00&capability=Alerts&component=kube-apiserver&confidence=95&environment=ovn%20no-upgrade%20amd64%20aws%20standard&excludeArches=arm64%2Cheterogeneous%2Cppc64le%2Cs390x&excludeClouds=openstack%2Calibaba%2Cibmcloud%2Clibvirt%2Covirt%2Cunknown&excludeVariants=hypershift%2Cosd%2Cmicroshift%2Ctechpreview%2Csingle-node%2Cassisted%2Ccompact&groupBy=cloud%2Carch%2Cnetwork&ignoreDisruption=true&ignoreMissing=false&minFail=3&network=ovn&pity=5&platform=aws&sampleEndTime=2023-09-25%2023%3A59%3A59&sampleRelease=4.14&sampleStartTime=2023-09-18%2000%3A00%3A00&testId=openshift-tests%3Ad6b41cee7afca1c2a0b52f9e6975425f&testName=%5Bbz-kube-apiserver%5D%5Binvariant%5D%20alert%2FKubeAPIErrorBudgetBurn%20should%20not%20be%20at%20or%20above%20info&upgrade=no-upgrade&variant=standard) which is similar to the one in the Jira except using localhost.

You can see the "recovery" test is no longer there.