### PR TITLE
trt-1167: add check for valid priorRiskAnalysis

### DIFF
--- a/pkg/sippyserver/pr_commenting_processor.go
+++ b/pkg/sippyserver/pr_commenting_processor.go
@@ -865,7 +865,7 @@ func buildRiskSummary(riskAnalysis, priorRiskAnalysis *api.ProwJobRunRiskAnalysi
 
 		// If this is one of the levels that doesn't have tests associated and it matches the prior risk analysis then return the summary
 		if riskSummary.OverallRisk.Level == api.FailureRiskLevelIncompleteTests || riskSummary.OverallRisk.Level == api.FailureRiskLevelMissingData {
-			if riskSummary.OverallRisk.Level == priorRiskAnalysis.OverallRisk.Level {
+			if priorRiskAnalysis != nil && riskSummary.OverallRisk.Level == priorRiskAnalysis.OverallRisk.Level {
 				return riskSummary
 			}
 		}

--- a/pkg/sippyserver/pr_commenting_processor_test.go
+++ b/pkg/sippyserver/pr_commenting_processor_test.go
@@ -57,6 +57,11 @@ func TestMatchPriorRiskAnalysisTest(t *testing.T) {
 			expectedRiskLevel:        api.FailureRiskLevelNone,
 			expectedSummaryTestCount: 0,
 		},
+		"NoMatchIncompletesNoPrior": {
+			riskAnalysisJSON:         `{"ProwJobName":"pull-ci-openshift-origin-master-e2e-aws-ovn-serial","ProwJobRunID":1684985307130236928,"Release":"Presubmits","CompareRelease":"4.14","Tests":[],"OverallRisk":{"Level":{"Name":"IncompleteTests","Level":75},"Reasons":["Tests for this run (57) are below the historical average (709):IncompleteTests"]},"OpenBugs":[]}`,
+			expectedRiskLevel:        api.FailureRiskLevelNone,
+			expectedSummaryTestCount: 0,
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
Observed after recent update:

`panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x1459e6e]

goroutine 109 [running]:
github.com/openshift/sippy/pkg/sippyserver.buildRiskSummary(0xc0012920c0?, 0x0)
	/go/src/sippy/pkg/sippyserver/pr_commenting_processor.go:868 +0x1ae`
	
Created test case to reproduce and added nil check