### PR TITLE
trt-1231: update vsphere-upi regex to handle missed matches

### DIFF
--- a/pkg/testidentification/ocp_variants.go
+++ b/pkg/testidentification/ocp_variants.go
@@ -76,7 +76,7 @@ var (
 	upgradeRegex      = regexp.MustCompile(`(?i)-upgrade`)
 	// some vsphere jobs do not have a trailing -version segment
 	vsphereRegex    = regexp.MustCompile(`(?i)-vsphere`)
-	vsphereUPIRegex = regexp.MustCompile(`(?i)-vsphere-upi`)
+	vsphereUPIRegex = regexp.MustCompile(`(?i)-vsphere.*-upi`)
 
 	allOpenshiftVariants = sets.NewString(
 		"alibaba",

--- a/pkg/testidentification/ocp_variants_test.go
+++ b/pkg/testidentification/ocp_variants_test.go
@@ -50,6 +50,16 @@ func Test_openshiftVariants_IdentifyVariants(t *testing.T) {
 			want:    []string{"aws", "amd64", "ha"},
 		},
 		{
+			name:    "periodic-ci-openshift-release-master-nightly-4.13-e2e-vsphere-upi-zones",
+			release: "4.13",
+			want:    []string{"vsphere-upi", "amd64", "ovn", "ha"},
+		},
+		{
+			name:    "periodic-ci-openshift-release-master-nightly-4.14-e2e-vsphere-ovn-upi",
+			release: "4.13",
+			want:    []string{"vsphere-upi", "amd64", "ovn", "ha"},
+		},
+		{
 			name:        "periodic-ci-openshift-release-master-ci-e2e-aws-cluster-release",
 			release:     "4.13",
 			clusterData: models.ClusterData{Release: "4.13"},


### PR DESCRIPTION
Currently missing cases like:
periodic-ci-openshift-release-master-nightly-4.14-e2e-vsphere-ovn-upi
periodic-ci-openshift-release-master-nightly-4.14-e2e-vsphere-ovn-upi-serial