### PR TITLE
Fix GCS path for intervals for presubmits

### DIFF
--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1179,7 +1179,7 @@ func (s *Server) jsonJobRunIntervals(w http.ResponseWriter, req *http.Request) {
 	if len(jobName) > 0 {
 		if len(repoInfo) > 0 {
 			// GCS bucket path for presubmits
-			gcsPath = fmt.Sprintf("pr-logs/pull/%s/%s/%s/%s", repoInfo, pullNumber, jobName, jobRunIDStr)
+			gcsPath = fmt.Sprintf("pr-logs/pull/%s/%s/%s", pullNumber, jobName, jobRunIDStr)
 		} else {
 			// GCS bucket for periodics
 			gcsPath = fmt.Sprintf("logs/%s/%s", jobName, jobRunIDStr)


### PR DESCRIPTION
When you goto a [presubmit job](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/28327/pull-ci-openshift-origin-release-4.12-e2e-aws-ovn-single-node-upgrade/1712788098988904448) and try to click the Intervals link under Debug Tools, it shows as blank.

The GCS path for presubmits looks like this:

```
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/28327/pull-ci-openshift-origin-release-4.12-e2e-aws-ovn-single-node-upgrade/1712788098988904448/
```

The repo is not in that path and so the code to fetch the intervals from the bucket will never work.

This fixes that path so it should now work.

Two test cases:

* Intervals for Presubmit job: http://localhost:3000/sippy-ng/job_runs/1712198215459147776/pull-ci-openshift-origin-master-e2e-aws-ovn-single-node-upgrade/openshift_origin/28311/intervals?categories=operator_unavailable&categories=operator_progressing&categories=operator_degraded&categories=pod_logs&categories=interesting_events&categories=alerts&categories=node_state&categories=e2e_test_failed&categories=disruption&filterText=&intervalFiles=e2e-events_20231011-204810.json
* Intervals for Periodic job: http://localhost:3000/sippy-ng/job_runs/1712803291928203264/periodic-ci-openshift-release-master-ci-4.15-e2e-azure-ovn-upgrade/intervals?categories=operator_unavailable&categories=operator_progressing&categories=operator_degraded&categories=pod_logs&categories=interesting_events&categories=alerts&categories=node_state&categories=e2e_test_failed&categories=disruption&filterText=&intervalFiles=e2e-events_20231013-130602.json