### PR TITLE
Revert #1248 "Fix GCS path for intervals for presubmits"

### DIFF
--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1179,7 +1179,7 @@ func (s *Server) jsonJobRunIntervals(w http.ResponseWriter, req *http.Request) {
 	if len(jobName) > 0 {
 		if len(repoInfo) > 0 {
 			// GCS bucket path for presubmits
-			gcsPath = fmt.Sprintf("pr-logs/pull/%s/%s/%s", pullNumber, jobName, jobRunIDStr)
+			gcsPath = fmt.Sprintf("pr-logs/pull/%s/%s/%s/%s", repoInfo, pullNumber, jobName, jobRunIDStr)
 		} else {
 			// GCS bucket for periodics
 			gcsPath = fmt.Sprintf("logs/%s/%s", jobName, jobRunIDStr)


### PR DESCRIPTION

Reverts #1248 ; tracked by TRT-9999

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

This PR accounts for only origin PRs and not other repos and breaks the Intevals link for non-origin Presubmit jobs

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
Click on Intervals link in Debug Tools for both origin and non-origin Presubmit jobs
```

CC: @DennisPeriquet

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
