### PR TITLE
Remove overlapping Error material-ui import

### DIFF
--- a/sippy-ng/src/prow_job_runs/ProwJobRun.js
+++ b/sippy-ng/src/prow_job_runs/ProwJobRun.js
@@ -6,7 +6,6 @@ import {
   useQueryParam,
 } from 'use-query-params'
 import { Button, ButtonGroup, TextField } from '@material-ui/core'
-import { Error } from '@material-ui/icons'
 import { stringify } from 'query-string'
 import { useHistory } from 'react-router-dom'
 import Alert from '@material-ui/lab/Alert'

--- a/sippy-ng/src/pull_requests/PullRequestsTable.js
+++ b/sippy-ng/src/pull_requests/PullRequestsTable.js
@@ -8,7 +8,12 @@ import {
   Typography,
 } from '@material-ui/core'
 import { BOOKMARKS } from '../constants'
-import { CheckCircle, Error, GitHub, History } from '@material-ui/icons'
+import {
+  CheckCircle,
+  Error as ErrorIcon,
+  GitHub,
+  History,
+} from '@material-ui/icons'
 import { DataGrid } from '@material-ui/data-grid'
 import {
   getReportStartDate,
@@ -215,7 +220,7 @@ export default function PullRequestsTable(props) {
               {params.row.first_ci_payload_phase === 'Accepted' ? (
                 <CheckCircle style={{ color: theme.palette.success.light }} />
               ) : (
-                <Error style={{ color: theme.palette.error.light }} />
+                <ErrorIcon style={{ color: theme.palette.error.light }} />
               )}
             </Grid>
           )
@@ -243,7 +248,7 @@ export default function PullRequestsTable(props) {
               {params.row.first_nightly_payload_phase === 'Accepted' ? (
                 <CheckCircle style={{ color: theme.palette.success.light }} />
               ) : (
-                <Error style={{ color: theme.palette.error.light }} />
+                <ErrorIcon style={{ color: theme.palette.error.light }} />
               )}
             </Grid>
           )

--- a/sippy-ng/src/releases/PayloadStreamOverview.js
+++ b/sippy-ng/src/releases/PayloadStreamOverview.js
@@ -1,5 +1,4 @@
 import { Card, Container, Grid, Tooltip, Typography } from '@material-ui/core'
-import { Error } from '@material-ui/icons'
 import {
   getReportStartDate,
   relativeDuration,

--- a/sippy-ng/src/releases/PayloadStreamTestFailures.js
+++ b/sippy-ng/src/releases/PayloadStreamTestFailures.js
@@ -1,7 +1,6 @@
 import { BLOCKER_SCORE_THRESHOLDS } from '../constants'
 import { Box, Card, Grid, Tooltip, Typography } from '@material-ui/core'
 import { DataGrid } from '@material-ui/data-grid'
-import { Error } from '@material-ui/icons'
 import { generateClasses } from '../datagrid/utils'
 import { Link } from 'react-router-dom'
 import { NumberParam, StringParam, useQueryParam } from 'use-query-params'

--- a/sippy-ng/src/releases/PayloadStreamsTable.js
+++ b/sippy-ng/src/releases/PayloadStreamsTable.js
@@ -1,4 +1,4 @@
-import { CheckCircle, Error, Help } from '@material-ui/icons'
+import { CheckCircle, Error as ErrorIcon, Help } from '@material-ui/icons'
 import { createTheme, makeStyles } from '@material-ui/core/styles'
 import { DataGrid } from '@material-ui/data-grid'
 import { Link } from 'react-router-dom'
@@ -55,13 +55,13 @@ function PayloadStreamsTable(props) {
           if (params.row.forced === true) {
             return (
               <Tooltip title="This payload was manually force rejected.">
-                <Error style={{ fill: 'maroon' }} />
+                <ErrorIcon style={{ fill: 'maroon' }} />
               </Tooltip>
             )
           } else {
             return (
               <Tooltip title="This payload was rejected.">
-                <Error style={{ fill: 'maroon' }} />
+                <ErrorIcon style={{ fill: 'maroon' }} />
               </Tooltip>
             )
           }

--- a/sippy-ng/src/releases/PayloadTestFailures.js
+++ b/sippy-ng/src/releases/PayloadTestFailures.js
@@ -1,7 +1,6 @@
 import './PayloadTestFailures.css'
 import { Box, Card, Grid, Tooltip, Typography } from '@material-ui/core'
 import { DataGrid } from '@material-ui/data-grid'
-import { Error } from '@material-ui/icons'
 import { generateClasses } from '../datagrid/utils'
 import { NumberParam, StringParam, useQueryParam } from 'use-query-params'
 import { safeEncodeURIComponent, SafeJSONParam } from '../helpers'

--- a/sippy-ng/src/releases/ReleasePayloadAcceptance.js
+++ b/sippy-ng/src/releases/ReleasePayloadAcceptance.js
@@ -6,7 +6,12 @@ import {
   Tooltip,
   Typography,
 } from '@material-ui/core'
-import { CheckCircle, Error, Help, Warning } from '@material-ui/icons'
+import {
+  CheckCircle,
+  Error as ErrorIcon,
+  Help,
+  Warning,
+} from '@material-ui/icons'
 import { createTheme, makeStyles } from '@material-ui/core/styles'
 import {
   getReportStartDate,
@@ -92,7 +97,7 @@ function ReleasePayloadAcceptance(props) {
       } else if (row.last_phase === 'Rejected') {
         // If the last payload was rejected, we are red.
         bgColor = theme.palette.error.light
-        icon = <Error style={{ fill: 'maroon' }} />
+        icon = <ErrorIcon style={{ fill: 'maroon' }} />
       } else {
         // Otherwise we are yellow -- e.g., last release payload was accepted
         // but it's been several days.

--- a/sippy-ng/src/releases/ReleasePayloadPullRequests.js
+++ b/sippy-ng/src/releases/ReleasePayloadPullRequests.js
@@ -1,6 +1,5 @@
 import { createTheme, makeStyles } from '@material-ui/core/styles'
 import { DataGrid } from '@material-ui/data-grid'
-import { Error } from '@material-ui/icons'
 import { NumberParam, StringParam, useQueryParam } from 'use-query-params'
 import { safeEncodeURIComponent, SafeJSONParam } from '../helpers'
 import Alert from '@material-ui/lab/Alert'

--- a/sippy-ng/src/releases/ReleasePayloadTable.js
+++ b/sippy-ng/src/releases/ReleasePayloadTable.js
@@ -3,7 +3,7 @@ import { Box, Button, Container, Tooltip, Typography } from '@material-ui/core'
 import {
   CheckCircle,
   CompareArrows,
-  Error,
+  Error as ErrorIcon,
   Help,
   Warning,
 } from '@material-ui/icons'
@@ -69,13 +69,13 @@ function ReleasePayloadTable(props) {
           if (params.row.forced === true) {
             return (
               <Tooltip title="This payload was manually force rejected.">
-                <Error style={{ fill: 'maroon' }} />
+                <ErrorIcon style={{ fill: 'maroon' }} />
               </Tooltip>
             )
           } else {
             return (
               <Tooltip title="This payload was rejected.">
-                <Error style={{ fill: 'maroon' }} />
+                <ErrorIcon style={{ fill: 'maroon' }} />
               </Tooltip>
             )
           }

--- a/sippy-ng/src/tests/TestDurationChart.js
+++ b/sippy-ng/src/tests/TestDurationChart.js
@@ -1,5 +1,4 @@
 import { CircularProgress } from '@material-ui/core'
-import { Error } from '@material-ui/icons'
 import { Line } from 'react-chartjs-2'
 import { safeEncodeURIComponent } from '../helpers'
 import Alert from '@material-ui/lab/Alert'

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -1,5 +1,11 @@
 import './TestTable.css'
-import { AcUnit, BugReport, Check, Error, Search } from '@material-ui/icons'
+import {
+  AcUnit,
+  BugReport,
+  Check,
+  Error as ErrorIcon,
+  Search,
+} from '@material-ui/icons'
 import {
   Backdrop,
   Badge,
@@ -633,7 +639,7 @@ function TestTable(props) {
                   }
                   color="error"
                 >
-                  <Error />
+                  <ErrorIcon />
                 </Badge>
               </IconButton>
             </Tooltip>


### PR DESCRIPTION
[TRT-1294](https://issues.redhat.com//browse/TRT-1294)

Only the change in `sippy-ng/src/tests/TestDurationChart.js` fixes the problem mentioned in the Jira.  But, the same problem exists in the other 5 files.

The `import { Error } from '@material-ui/icons'` line overlaps with the `Error` built-in which we use for `throw/catch` so we can propagate error strings to users during error conditions.  This overlap causes React to render the `bundle.js` in a way that we didn't actually intend and hence causes mysterious errors like `TypeError: cx is not a constructor` when the code handles an error condition.  Removal of that import allows React to render the bundle.js as we intended.

I was able to reproduce this by returning a 500 status in a local version of sippy.

TODO:

- [ ] Test the other 5 files with their error conditions.