### PR TITLE
Fix typo in Symptom Detection suite

### DIFF
--- a/pkg/db/suites.go
+++ b/pkg/db/suites.go
@@ -34,7 +34,7 @@ var testSuites = []string{
 	"Kubernetes e2e suite",
 	"Log Metrics",
 	"Operator results",
-	"Symptom detection",
+	"Symptom Detection",
 	"Tests Suite",
 	"cluster install",
 	"cluster nodes ready",


### PR DESCRIPTION
I'll need to run updatesuites.go again, but it's only a small number of tests.  I removed the stuff from updatesuites.go that was invasive (removing indexes) so this should be able to just be run safely with Sippy online.