### PR TITLE
WIP: introduced a shadowing condition for linter

### DIFF
--- a/sippy-ng/.eslintrc.js
+++ b/sippy-ng/.eslintrc.js
@@ -30,5 +30,6 @@ module.exports = {
         memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single'],
       },
     ],
+    'no-shadow': ['error'],
   },
 }

--- a/sippy-ng/.eslintrc.js
+++ b/sippy-ng/.eslintrc.js
@@ -30,6 +30,11 @@ module.exports = {
         memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single'],
       },
     ],
-    'no-shadow': ['error'],
+    'no-shadow': [
+      'error',
+      {
+        builtinGlobals: true,
+      },
+    ],
   },
 }

--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -137,30 +137,30 @@ export default function App(props) {
       fetch(process.env.REACT_APP_API_URL + '/api/capabilities'),
       fetch(process.env.REACT_APP_API_URL + '/api/report_date'),
     ])
-      .then(([releases, capabilities, reportDate]) => {
-        if (releases.status !== 200) {
-          throw new Error('server returned ' + releases.status)
+      .then(([fetchedReleases, fetchedCapabilities, fetchedReportDate]) => {
+        if (fetchedReleases.status !== 200) {
+          throw new Error('server returned ' + fetchedReleases.status)
         }
 
-        if (capabilities.status !== 200) {
-          throw new Error('server returned ' + capabilities.status)
+        if (fetchedCapabilities.status !== 200) {
+          throw new Error('server returned ' + fetchedCapabilities.status)
         }
 
-        if (reportDate.status !== 200) {
-          throw new Error('server returned ' + reportDate.status)
+        if (fetchedReportDate.status !== 200) {
+          throw new Error('server returned ' + fetchedReportDate.status)
         }
 
         return Promise.all([
-          releases.json(),
-          capabilities.json(),
-          reportDate.json(),
+          fetchedReleases.json(),
+          fetchedCapabilities.json(),
+          fetchedReportDate.json(),
         ])
       })
-      .then(([releases, capabilities, reportDate]) => {
-        setReleases(releases)
-        setCapabilities(capabilities)
-        setReportDate(reportDate['pinnedDateTime'])
-        setLastUpdated(new Date(releases.last_updated))
+      .then(([jsonReleases, jsonCapabilities, jsonReportDate]) => {
+        setReleases(jsonReleases)
+        setCapabilities(jsonCapabilities)
+        setReportDate(jsonReportDate['pinnedDateTime'])
+        setLastUpdated(new Date(jsonReleases.last_updated))
         setLoaded(true)
       })
       .catch((error) => {
@@ -288,116 +288,122 @@ export default function App(props) {
 
                     <Route
                       path="/release/:release/tags/:tag"
-                      render={(props) => (
+                      render={(theProps) => (
                         <ReleasePayloadDetails
-                          key={'release-details-' + props.match.params.release}
-                          release={props.match.params.release}
-                          releaseTag={props.match.params.tag}
+                          key={
+                            'release-details-' + theProps.match.params.release
+                          }
+                          release={theProps.match.params.release}
+                          releaseTag={theProps.match.params.tag}
                         />
                       )}
                     />
 
                     <Route
                       path="/release/:release/streams/:arch/:stream"
-                      render={(props) => (
+                      render={(theProps) => (
                         <PayloadStream
-                          release={props.match.params.release}
-                          arch={props.match.params.arch}
-                          stream={props.match.params.stream}
+                          release={theProps.match.params.release}
+                          arch={theProps.match.params.arch}
+                          stream={theProps.match.params.stream}
                         />
                       )}
                     />
 
                     <Route
                       path="/release/:release/streams"
-                      render={(props) => (
+                      render={(theProps) => (
                         <PayloadStreams
-                          key={'release-streams-' + props.match.params.release}
-                          release={props.match.params.release}
+                          key={
+                            'release-streams-' + theProps.match.params.release
+                          }
+                          release={theProps.match.params.release}
                         />
                       )}
                     />
 
                     <Route
                       path="/release/:release/tags"
-                      render={(props) => (
+                      render={(theProps) => (
                         <ReleasePayloads
-                          key={'release-tags-' + props.match.params.release}
-                          release={props.match.params.release}
+                          key={'release-tags-' + theProps.match.params.release}
+                          release={theProps.match.params.release}
                         />
                       )}
                     />
 
                     <Route
                       path="/release/:release"
-                      render={(props) => (
+                      render={(theProps) => (
                         <ReleaseOverview
-                          key={'release-overview-' + props.match.params.release}
-                          release={props.match.params.release}
+                          key={
+                            'release-overview-' + theProps.match.params.release
+                          }
+                          release={theProps.match.params.release}
                         />
                       )}
                     />
 
                     <Route
                       path="/variants/:release/:variant"
-                      render={(props) => (
+                      render={(theProps) => (
                         <VariantStatus
-                          release={props.match.params.release}
-                          variant={props.match.params.variant}
+                          release={theProps.match.params.release}
+                          variant={theProps.match.params.variant}
                         />
                       )}
                     />
 
                     <Route
                       path="/jobs/:release/analysis"
-                      render={(props) => (
-                        <JobAnalysis release={props.match.params.release} />
+                      render={(theProps) => (
+                        <JobAnalysis release={theProps.match.params.release} />
                       )}
                     />
 
                     <Route
                       path="/jobs/:release"
-                      render={(props) => (
+                      render={(theProps) => (
                         <Jobs
-                          key={'jobs-' + props.match.params.release}
+                          key={'jobs-' + theProps.match.params.release}
                           title={
-                            'Job results for ' + props.match.params.release
+                            'Job results for ' + theProps.match.params.release
                           }
-                          release={props.match.params.release}
+                          release={theProps.match.params.release}
                         />
                       )}
                     />
 
                     <Route
                       path="/tests/:release/analysis"
-                      render={(props) => (
-                        <TestAnalysis release={props.match.params.release} />
+                      render={(theProps) => (
+                        <TestAnalysis release={theProps.match.params.release} />
                       )}
                     />
 
                     <Route
                       path="/tests/:release"
-                      render={(props) => (
+                      render={(theProps) => (
                         <Tests
-                          key={'tests-' + props.match.params.release}
-                          release={props.match.params.release}
+                          key={'tests-' + theProps.match.params.release}
+                          release={theProps.match.params.release}
                         />
                       )}
                     />
 
                     <Route
                       path="/upgrade/:release"
-                      render={(props) => (
+                      render={(theProps) => (
                         <Upgrades
-                          key={'upgrades-' + props.match.params.release}
-                          release={props.match.params.release}
+                          key={'upgrades-' + theProps.match.params.release}
+                          release={theProps.match.params.release}
                         />
                       )}
                     />
 
                     <Route
                       path="/component_readiness"
-                      render={(props) => {
+                      render={(theProps) => {
                         return (
                           <CompReadyVarsProvider>
                             <ComponentReadiness key={window.location.href} />
@@ -408,20 +414,20 @@ export default function App(props) {
 
                     <Route
                       path="/install/:release"
-                      render={(props) => (
+                      render={(theProps) => (
                         <Install
-                          key={'install-' + props.match.params.release}
-                          release={props.match.params.release}
+                          key={'install-' + theProps.match.params.release}
+                          release={theProps.match.params.release}
                         />
                       )}
                     />
 
                     <Route
                       path="/build_clusters/:cluster"
-                      render={(props) => (
+                      render={(theProps) => (
                         <BuildClusterDetails
-                          key={'cluster-' + props.match.params.cluster}
-                          cluster={props.match.params.cluster}
+                          key={'cluster-' + theProps.match.params.cluster}
+                          cluster={theProps.match.params.cluster}
                         />
                       )}
                     />
@@ -433,40 +439,40 @@ export default function App(props) {
 
                     <Route
                       path="/repositories/:release/:org/:repo"
-                      render={(props) => (
+                      render={(theProps) => (
                         <RepositoryDetails
-                          release={props.match.params.release}
-                          org={props.match.params.org}
-                          repo={props.match.params.repo}
+                          release={theProps.match.params.release}
+                          org={theProps.match.params.org}
+                          repo={theProps.match.params.repo}
                         />
                       )}
                     />
 
                     <Route
                       path="/repositories/:release"
-                      render={(props) => (
-                        <Repositories release={props.match.params.release} />
+                      render={(theProps) => (
+                        <Repositories release={theProps.match.params.release} />
                       )}
                     />
 
                     <Route
                       path="/pull_requests/:release"
-                      render={(props) => (
+                      render={(theProps) => (
                         <PullRequests
-                          key={'pr-' + props.match.params.release}
-                          release={props.match.params.release}
+                          key={'pr-' + theProps.match.params.release}
+                          release={theProps.match.params.release}
                         />
                       )}
                     />
 
                     <Route
                       path="/job_runs/:jobrunid/:jobname?/:repoinfo?/:pullnumber?/intervals"
-                      render={(props) => (
+                      render={(theProps) => (
                         <ProwJobRun
-                          jobRunID={props.match.params.jobrunid}
-                          jobName={props.match.params.jobname}
-                          repoInfo={props.match.params.repoinfo}
-                          pullNumber={props.match.params.pullnumber}
+                          jobRunID={theProps.match.params.jobrunid}
+                          jobName={theProps.match.params.jobname}
+                          repoInfo={theProps.match.params.repoinfo}
+                          pullNumber={theProps.match.params.pullnumber}
                         />
                       )}
                     />

--- a/sippy-ng/src/bugs/BugTable.js
+++ b/sippy-ng/src/bugs/BugTable.js
@@ -26,14 +26,14 @@ export default function BugTable(props) {
         }/api/tests/bugs?test=${safeEncodeURIComponent(props.testName)}`
       ),
     ])
-      .then(([bugs]) => {
-        if (bugs.status !== 200) {
-          throw new Error('server returned ' + bugs.status)
+      .then(([bugsParam]) => {
+        if (bugsParam.status !== 200) {
+          throw new Error('server returned ' + bugsParam.status)
         }
-        return Promise.all([bugs.json()])
+        return Promise.all([bugsParam.json()])
       })
-      .then(([bugs]) => {
-        setBugs(bugs)
+      .then(([bugsParam]) => {
+        setBugs(bugsParam)
         setLoaded(true)
       })
       .catch((error) => {

--- a/sippy-ng/src/build_clusters/BuildClusterTable.js
+++ b/sippy-ng/src/build_clusters/BuildClusterTable.js
@@ -153,8 +153,8 @@ function BuildClusterTable(props) {
         setRows(json)
         setLoaded(true)
       })
-      .catch((error) => {
-        setError('Could not retrieve build cluster health: ' + error)
+      .catch((errorParam) => {
+        setError('Could not retrieve build cluster health: ' + errorParam)
       })
   }
 

--- a/sippy-ng/src/component_readiness/AdvancedOptions.js
+++ b/sippy-ng/src/component_readiness/AdvancedOptions.js
@@ -52,19 +52,19 @@ export default function AdvancedOptions(props) {
 
   const classes = useStyles()
 
-  const handleChangeConfidence = (event, newValue) => {
+  const handleChangeConfidence = (theEvent, newValue) => {
     setConfidence(newValue)
   }
-  const handleChangePity = (event, newValue) => {
+  const handleChangePity = (theEvent, newValue) => {
     setPity(newValue)
   }
-  const handleChangeMinFail = (event, newValue) => {
+  const handleChangeMinFail = (theEvent, newValue) => {
     setMinFail(newValue)
   }
-  const handleChangeIgnoreMissing = (event, newValue) => {
+  const handleChangeIgnoreMissing = (theEvent, newValue) => {
     setIgnoreMissing(newValue)
   }
-  const handleChangeIgnoreDisruption = (event, newValue) => {
+  const handleChangeIgnoreDisruption = (theEvent, newValue) => {
     setIgnoreDisruption(newValue)
   }
 

--- a/sippy-ng/src/component_readiness/CheckboxList.js
+++ b/sippy-ng/src/component_readiness/CheckboxList.js
@@ -38,9 +38,9 @@ export default function CheckBoxList(props) {
   const classes = useStyles()
   const checkedItems = props.checkedItems
   const setCheckedItems = props.setCheckedItems
-  const handleChange = (event) => {
-    const item = event.target.name
-    const isChecked = event.target.checked
+  const handleChange = (theEvent) => {
+    const item = theEvent.target.name
+    const isChecked = theEvent.target.checked
     if (isChecked) {
       setCheckedItems([...checkedItems, item])
     } else {

--- a/sippy-ng/src/component_readiness/CompReadyCapCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCapCell.js
@@ -13,7 +13,7 @@ import React, { useContext } from 'react'
 import TableCell from '@material-ui/core/TableCell'
 
 export default function CompReadyCapCell(props) {
-  const { status, environment, testId, filterVals, component, capability } =
+  const { colStatus, environment, testId, filterVals, component, capability } =
     props
   const theme = useTheme()
 
@@ -36,17 +36,17 @@ export default function CompReadyCapCell(props) {
   // Construct a URL with all existing filters plus testId and environment.
   // This is the url used when you click inside a TableCell.
   function testReport(
-    testId,
+    testIdent,
     environmentVal,
-    filterVals,
+    filtVals,
     componentName,
     capabilityName
   ) {
     const safeComponentName = safeEncodeURIComponent(componentName)
-    const safeTestId = safeEncodeURIComponent(testId)
+    const safeTestId = safeEncodeURIComponent(testIdent)
     const retUrl =
       '/component_readiness/env_test' +
-      filterVals +
+      filtVals +
       `&testId=${safeTestId}` +
       expandEnvironment(environmentVal) +
       `&component=${safeComponentName}` +
@@ -55,7 +55,7 @@ export default function CompReadyCapCell(props) {
     return sortQueryParams(retUrl)
   }
 
-  if (status === undefined) {
+  if (colStatus === undefined) {
     return (
       <Tooltip title="No data">
         <TableCell
@@ -87,7 +87,7 @@ export default function CompReadyCapCell(props) {
             capability
           )}
         >
-          <CompSeverityIcon status={status} />
+          <CompSeverityIcon status={colStatus} />
         </Link>
       </TableCell>
     )
@@ -95,7 +95,7 @@ export default function CompReadyCapCell(props) {
 }
 
 CompReadyCapCell.propTypes = {
-  status: PropTypes.number.isRequired,
+  colStatus: PropTypes.number.isRequired,
   environment: PropTypes.string.isRequired,
   testId: PropTypes.string.isRequired,
   filterVals: PropTypes.string.isRequired,

--- a/sippy-ng/src/component_readiness/CompReadyCapsCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCapsCell.js
@@ -13,7 +13,7 @@ import React, { useContext } from 'react'
 import TableCell from '@material-ui/core/TableCell'
 
 export default function CompReadyCapsCell(props) {
-  const { status, environment, capabilityName, filterVals } = props
+  const { colStatus, environment, capabilityName, filterVals } = props
   const theme = useTheme()
 
   const [capabilityParam, setCapabilityParam] = useQueryParam(
@@ -30,17 +30,17 @@ export default function CompReadyCapsCell(props) {
   // Construct an URL with all existing filters plus capability and environment
   // (environment seems to already be there because of where this is called from)
   // This is the url used when you click inside a TableCell on the right.
-  function capabilityReport(capabilityName, environmentVal, filterVals) {
+  function capabilityReport(capName, environmentVal, filtVals) {
     const retUrl =
       '/component_readiness/env_capability' +
-      filterVals +
+      filtVals +
       '&capability=' +
-      safeEncodeURIComponent(capabilityName) +
+      safeEncodeURIComponent(capName) +
       expandEnvironment(environmentVal)
     return sortQueryParams(retUrl)
   }
 
-  if (status === undefined) {
+  if (colStatus === undefined) {
     return (
       <Tooltip title="No data">
         <TableCell
@@ -64,7 +64,7 @@ export default function CompReadyCapsCell(props) {
         }}
       >
         <Link to={capabilityReport(capabilityName, environment, filterVals)}>
-          <CompSeverityIcon status={status} />
+          <CompSeverityIcon status={colStatus} />
         </Link>
       </TableCell>
     )
@@ -72,7 +72,7 @@ export default function CompReadyCapsCell(props) {
 }
 
 CompReadyCapsCell.propTypes = {
-  status: PropTypes.number.isRequired,
+  colStatus: PropTypes.number.isRequired,
   environment: PropTypes.string.isRequired,
   capabilityName: PropTypes.string.isRequired,
   filterVals: PropTypes.string.isRequired,

--- a/sippy-ng/src/component_readiness/CompReadyCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCell.js
@@ -13,7 +13,8 @@ import React, { useContext } from 'react'
 import TableCell from '@material-ui/core/TableCell'
 
 export default function CompReadyCell(props) {
-  const { status, environment, componentName, filterVals, grayFactor } = props
+  const { colStatus, environment, componentName, filterVals, grayFactor } =
+    props
   const theme = useTheme()
 
   const [componentParam, setComponentParam] = useQueryParam(
@@ -30,18 +31,18 @@ export default function CompReadyCell(props) {
   // Construct an URL with all existing filters plus component and environment.
   // This is the url used when you click inside a TableCell.
   // Note that we are keeping the environment value so we can use it later for displays.
-  function componentReport(componentName, environmentVal, filterVals) {
+  function componentReport(compName, environmentVal, filtVals) {
     const retUrl =
       '/component_readiness/env_capabilities' +
-      filterVals +
+      filtVals +
       '&component=' +
-      safeEncodeURIComponent(componentName) +
+      safeEncodeURIComponent(compName) +
       expandEnvironment(environmentVal)
 
     return sortQueryParams(retUrl)
   }
 
-  if (status === undefined) {
+  if (colStatus === undefined) {
     return (
       <Tooltip title="No data">
         <TableCell
@@ -65,7 +66,7 @@ export default function CompReadyCell(props) {
         }}
       >
         <Link to={componentReport(componentName, environment, filterVals)}>
-          <CompSeverityIcon status={status} grayFactor={grayFactor} />
+          <CompSeverityIcon status={colStatus} grayFactor={grayFactor} />
         </Link>
       </TableCell>
     )
@@ -73,7 +74,7 @@ export default function CompReadyCell(props) {
 }
 
 CompReadyCell.propTypes = {
-  status: PropTypes.number.isRequired,
+  colStatus: PropTypes.number.isRequired,
   environment: PropTypes.string.isRequired,
   componentName: PropTypes.string.isRequired,
   filterVals: PropTypes.string.isRequired,

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilities.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilities.js
@@ -63,14 +63,14 @@ export default function CompReadyEnvCapabilities(props) {
     setIsLoaded(false)
     fetch(apiCallStr, { signal: abortController.signal })
       .then((response) => response.json())
-      .then((data) => {
-        if (data.code < 200 || data.code >= 300) {
-          const errorMessage = data.message
-            ? `${data.message}`
+      .then((jsonData) => {
+        if (jsonData.code < 200 || jsonData.code >= 300) {
+          const errorMessage = jsonData.message
+            ? `${jsonData.message}`
             : 'No error message'
-          throw new Error(`Return code = ${data.code} (${errorMessage})`)
+          throw new Error(`Return code = ${jsonData.code} (${errorMessage})`)
         }
-        return data
+        return jsonData
       })
       .then((json) => {
         if (Object.keys(json).length === 0 || json.rows.length === 0) {

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapability.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapability.js
@@ -62,14 +62,14 @@ export default function CompReadyEnvCapability(props) {
     setIsLoaded(false)
     fetch(apiCallStr, { signal: abortController.signal })
       .then((response) => response.json())
-      .then((data) => {
-        if (data.code < 200 || data.code >= 300) {
-          const errorMessage = data.message
-            ? `${data.message}`
+      .then((jsonData) => {
+        if (jsonData.code < 200 || jsonData.code >= 300) {
+          const errorMessage = jsonData.message
+            ? `${jsonData.message}`
             : 'No error message'
-          throw new Error(`Return code = ${data.code} (${errorMessage})`)
+          throw new Error(`Return code = ${jsonData.code} (${errorMessage})`)
         }
-        return data
+        return jsonData
       })
       .then((json) => {
         if (Object.keys(json).length === 0 || json.rows.length === 0) {

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
@@ -63,14 +63,14 @@ export default function CompReadyEnvCapabilityTest(props) {
     setIsLoaded(false)
     fetch(apiCallStr, { signal: abortController.signal })
       .then((response) => response.json())
-      .then((data) => {
-        if (data.code < 200 || data.code >= 300) {
-          const errorMessage = data.message
-            ? `${data.message}`
+      .then((jsonData) => {
+        if (jsonData.code < 200 || jsonData.code >= 300) {
+          const errorMessage = jsonData.message
+            ? `${jsonData.message}`
             : 'No error message'
-          throw new Error(`Return code = ${data.code} (${errorMessage})`)
+          throw new Error(`Return code = ${jsonData.code} (${errorMessage})`)
         }
-        return data
+        return jsonData
       })
       .then((json) => {
         if (Object.keys(json).length === 0 || json.rows.length === 0) {

--- a/sippy-ng/src/component_readiness/CompReadyTestCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestCell.js
@@ -15,7 +15,7 @@ import TableCell from '@material-ui/core/TableCell'
 // CompReadyTestCall is for rendering the cells on the right of page4 or page4a
 export default function CompReadyTestCell(props) {
   const {
-    status,
+    colStatus,
     environment,
     testId,
     filterVals,
@@ -49,19 +49,19 @@ export default function CompReadyTestCell(props) {
   // This is the url used when you click inside a TableCell on page4 on the right.
   // We pass these arguments to the component that generates the test details report.
   function generateTestReport(
-    testId,
+    testIdent,
     environmentVal,
-    filterVals,
+    filtVals,
     componentName,
     capabilityName,
-    testName
+    nameOfTest
   ) {
     const safeComponentName = safeEncodeURIComponent(componentName)
-    const safeTestId = safeEncodeURIComponent(testId)
-    const safeTestName = safeEncodeURIComponent(testName)
+    const safeTestId = safeEncodeURIComponent(testIdent)
+    const safeTestName = safeEncodeURIComponent(nameOfTest)
     const retUrl =
       '/component_readiness/test_details' +
-      filterVals +
+      filtVals +
       `&testId=${safeTestId}` +
       expandEnvironment(environmentVal) +
       `&component=${safeComponentName}` +
@@ -71,7 +71,7 @@ export default function CompReadyTestCell(props) {
     return sortQueryParams(retUrl)
   }
 
-  if (status === undefined) {
+  if (colStatus === undefined) {
     return (
       <Tooltip title="No data">
         <TableCell
@@ -104,7 +104,7 @@ export default function CompReadyTestCell(props) {
             testName
           )}
         >
-          <CompSeverityIcon status={status} />
+          <CompSeverityIcon status={colStatus} />
         </Link>
       </TableCell>
     )
@@ -112,7 +112,7 @@ export default function CompReadyTestCell(props) {
 }
 
 CompReadyTestCell.propTypes = {
-  status: PropTypes.number.isRequired,
+  colStatus: PropTypes.number.isRequired,
   environment: PropTypes.string.isRequired,
   testId: PropTypes.string.isRequired,
   filterVals: PropTypes.string.isRequired,

--- a/sippy-ng/src/component_readiness/CompReadyTestDetailRow.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestDetailRow.js
@@ -38,24 +38,24 @@ export default function CompReadyTestDetailRow(props) {
   // showOnlyFailures: says to focus on job failures
   const { element, idx, showOnlyFailures } = props
 
-  const testJobDetailCell = (element, statsKind) => {
-    let item
+  const testJobDetailCell = (item, statsKind) => {
+    let itemStats
     if (statsKind === 'base') {
-      item = element.base_job_run_stats
+      itemStats = item.base_job_run_stats
     } else if (statsKind === 'sample') {
-      item = element.sample_job_run_stats
+      itemStats = item.sample_job_run_stats
     } else {
-      item = 'unknown statsKind in testDetailJobRow'
+      itemStats = 'unknown statsKind in testDetailJobRow'
       console.log('ERROR in testDetailJobRow')
     }
 
-    let filtered = item
+    let filtered = itemStats
 
     // If we only care to see failures, then remove anything else
     // Protect against empty/undefined data
     if (showOnlyFailures) {
-      filtered = item
-        ? item.filter((jstat) => jstat.test_stats.failure_count > 0)
+      filtered = itemStats
+        ? itemStats.filter((jstat) => jstat.test_stats.failure_count > 0)
         : []
     }
 

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -93,14 +93,14 @@ export default function CompReadyTestReport(props) {
 
     fetch(apiCallStr, { signal: abortController.signal })
       .then((response) => response.json())
-      .then((data) => {
-        if (data.code < 200 || data.code >= 300) {
-          const errorMessage = data.message
-            ? `${data.message}`
+      .then((jsonData) => {
+        if (jsonData.code < 200 || jsonData.code >= 300) {
+          const errorMessage = jsonData.message
+            ? `${jsonData.message}`
             : 'No error message'
-          throw new Error(`Return code = ${data.code} (${errorMessage})`)
+          throw new Error(`Return code = ${jsonData.code} (${errorMessage})`)
         }
-        return data
+        return jsonData
       })
       .then((json) => {
         // If the basics are not present, consider it no data
@@ -164,8 +164,8 @@ export default function CompReadyTestReport(props) {
     )
   }
 
-  const handleFailuresOnlyChange = (event) => {
-    setShowOnlyFailures(event.target.checked)
+  const handleFailuresOnlyChange = (theEvent) => {
+    setShowOnlyFailures(theEvent.target.checked)
   }
 
   const probabilityStr = (statusStr, fisherNumber) => {
@@ -209,19 +209,19 @@ export default function CompReadyTestReport(props) {
 
   // getSummaryDate attempts to translate a date into text relative to the version GA
   // dates we know about.  If there are no versions, there is no translation.
-  const getSummaryDate = (from, to, version, versions) => {
+  const getSummaryDate = (from, to, version, versionsTable) => {
     const fromDate = new Date(from)
     const toDate = new Date(to)
 
     // Go through the versions map from latest release to earliest; ensure that
     // the ordering is by version (e.g., 4.6 is considered earlier than 4.10).
-    const sortedVersions = Object.keys(versions).sort((a, b) => {
+    const sortedVersions = Object.keys(versionsTable).sort((a, b) => {
       const itemA = parseInt(a.toString().replace(/\./g, ''))
       const itemB = parseInt(b.toString().replace(/\./g, ''))
       return itemB - itemA
     })
 
-    if (!versions[version]) {
+    if (!versionsTable[version]) {
       // Handle the case where GA date is undefined (implies under development and not GA)
       const weeksBefore = Math.floor(
         (toDate - fromDate) / (1000 * 60 * 60 * 24 * 7)
@@ -244,12 +244,12 @@ export default function CompReadyTestReport(props) {
       }
     }
 
-    for (const version of sortedVersions) {
-      if (!versions[version]) {
+    for (const currVersion of sortedVersions) {
+      if (!versionsTable[currVersion]) {
         // We already dealt with a version with no GA date above.
         continue
       }
-      const gaDateStr = versions[version]
+      const gaDateStr = versionsTable[currVersion]
       const gaDate = new Date(gaDateStr)
 
       // Widen the window by 20 weeks prior to GA (because releases seems to be that long) and give
@@ -264,7 +264,7 @@ export default function CompReadyTestReport(props) {
           (gaDate - fromDate) / (1000 * 60 * 60 * 24 * 7)
         )
         return weeksBefore
-          ? `About ${weeksBefore} week(s) before '${version}' GA date`
+          ? `About ${weeksBefore} week(s) before '${currVersion}' GA date`
           : null
       }
     }

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -93,12 +93,12 @@ export function gotFetchError(fetchError) {
 
 // getStatusAndIcon returns a status string and icon to display to denote a visual and textual
 // meaning of a 'status' value.  We optionally allow a grayscale mode for the red colors.
-export function getStatusAndIcon(status, grayFactor = 0) {
+export function getStatusAndIcon(colStatus, grayFactor = 0) {
   let icon = ''
 
-  let statusStr = status + ': '
+  let statusStr = colStatus + ': '
 
-  if (status >= 3) {
+  if (colStatus >= 3) {
     statusStr =
       statusStr + 'SignificantImprovement detected (improved sample rate)'
     icon = (
@@ -109,7 +109,7 @@ export function getStatusAndIcon(status, grayFactor = 0) {
         style={{ filter: `grayscale(${grayFactor}%)` }}
       />
     )
-  } else if (status == 2) {
+  } else if (colStatus == 2) {
     statusStr =
       statusStr + 'Missing Basis And Sample (basis and sample data missing)'
     icon = (
@@ -121,7 +121,7 @@ export function getStatusAndIcon(status, grayFactor = 0) {
         style={{ filter: `grayscale(${grayFactor}%)` }}
       />
     )
-  } else if (status == 1) {
+  } else if (colStatus == 1) {
     statusStr = statusStr + 'Missing Basis (basis data missing)'
     icon = (
       <img
@@ -132,7 +132,7 @@ export function getStatusAndIcon(status, grayFactor = 0) {
         style={{ filter: `grayscale(${grayFactor}%)` }}
       />
     )
-  } else if (status == 0) {
+  } else if (colStatus == 0) {
     statusStr = statusStr + 'NoSignificantDifference detected'
     icon = (
       <img
@@ -141,7 +141,7 @@ export function getStatusAndIcon(status, grayFactor = 0) {
         style={{ filter: `grayscale(${grayFactor}%)` }}
       />
     )
-  } else if (status == -1) {
+  } else if (colStatus == -1) {
     statusStr = statusStr + 'Missing Sample (sample data missing)'
     icon = (
       <img
@@ -152,10 +152,10 @@ export function getStatusAndIcon(status, grayFactor = 0) {
         style={{ filter: `grayscale(${grayFactor}%)` }}
       />
     )
-  } else if (status == -2) {
+  } else if (colStatus == -2) {
     statusStr = statusStr + 'SignificantRegression detected'
     icon = <img src={red} alt="SignificantRegression" />
-  } else if (status <= -3) {
+  } else if (colStatus <= -3) {
     statusStr =
       statusStr + 'ExtremeRegression detected ( >15% pass rate change)'
     icon = <img src={red_3d} alt="ExtremRegressio >15%n" />

--- a/sippy-ng/src/component_readiness/CompSeverityIcon.js
+++ b/sippy-ng/src/component_readiness/CompSeverityIcon.js
@@ -7,13 +7,13 @@ import React from 'react'
 
 export default function CompSeverityIcon(props) {
   const theme = useTheme()
-  const { status, grayFactor } = props
+  const { colStatus, grayFactor } = props
 
-  const [statusStr, icon] = getStatusAndIcon(status, grayFactor)
+  const [statusStr, icon] = getStatusAndIcon(colStatus, grayFactor)
   return <Tooltip title={statusStr}>{icon}</Tooltip>
 }
 
 CompSeverityIcon.propTypes = {
-  status: PropTypes.number,
+  colStatus: PropTypes.number,
   grayFactor: PropTypes.number,
 }

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -162,8 +162,8 @@ export default function ComponentReadiness(props) {
   const initialBaseEndTime = getReleaseDate(defaultSampleRelease)
   const initialBaseStartTime = initialBaseEndTime.getTime() - 4 * weeks
 
-  const setBaseReleaseWithDates = (event) => {
-    let release = event.target.value
+  const setBaseReleaseWithDates = (theEvent) => {
+    let release = theEvent.target.value
     let endTime = getReleaseDate(release)
     let startTime = endTime.getTime() - 30 * days
     setBaseRelease(release)
@@ -171,8 +171,8 @@ export default function ComponentReadiness(props) {
     setBaseEndTime(formatLongDate(endTime))
   }
 
-  const setSampleReleaseWithDates = (event) => {
-    let release = event.target.value
+  const setSampleReleaseWithDates = (theEvent) => {
+    let release = theEvent.target.value
     setSampleRelease(release)
     setSampleStartTime(formatLongDate(initialSampleStartTime))
     setSampleEndTime(formatLongDate(initialSampleEndTime))
@@ -183,19 +183,19 @@ export default function ComponentReadiness(props) {
   const theme = useTheme()
 
   const [searchComponentRegex, setSearchComponentRegex] = useState('')
-  const handleSearchComponentRegexChange = (event) => {
-    const searchValue = event.target.value
+  const handleSearchComponentRegexChange = (theEvent) => {
+    const searchValue = theEvent.target.value
     setSearchComponentRegex(searchValue)
   }
   const [searchColumnRegex, setSearchColumnRegex] = useState('')
-  const handleSearchColumnRegexChange = (event) => {
-    const searchValue = event.target.value
+  const handleSearchColumnRegexChange = (theEvent) => {
+    const searchValue = theEvent.target.value
     setSearchColumnRegex(searchValue)
   }
 
   const [redOnlyChecked, setRedOnlyChecked] = React.useState(false)
-  const handleRedOnlyCheckboxChange = (event) => {
-    setRedOnlyChecked(event.target.checked)
+  const handleRedOnlyCheckboxChange = (theEvent) => {
+    setRedOnlyChecked(theEvent.target.checked)
   }
 
   const [drawerOpen, setDrawerOpen] = React.useState(true)
@@ -447,8 +447,8 @@ export default function ComponentReadiness(props) {
 
   // This runs when someone pushes the "Generate Report" button.
   // We form an api string and then call the api.
-  const handleGenerateReport = (event) => {
-    event.preventDefault()
+  const handleGenerateReport = (theEvent) => {
+    theEvent.preventDefault()
     setBaseReleaseParam(baseRelease)
     setBaseStartTimeParam(formatLongDate(baseStartTime))
     setBaseEndTimeParam(formatLongDate(baseEndTime))
@@ -494,7 +494,7 @@ export default function ComponentReadiness(props) {
     <Fragment>
       <Route
         path={path}
-        render={({ location }) => (
+        render={({ theLocation }) => (
           <Fragment>
             <Grid
               container
@@ -506,7 +506,7 @@ export default function ComponentReadiness(props) {
             <Switch>
               <Route
                 path="/component_readiness/test_details"
-                render={(props) => {
+                render={(theProps) => {
                   // We need to pass the testId and testName
                   const filterVals = getUpdatedUrlParts(
                     baseRelease,
@@ -547,7 +547,7 @@ export default function ComponentReadiness(props) {
               />
               <Route
                 path="/component_readiness/test"
-                render={(props) => {
+                render={(theProps) => {
                   // We need to pass the testId
                   const filterVals = getUpdatedUrlParts(
                     baseRelease,
@@ -584,7 +584,7 @@ export default function ComponentReadiness(props) {
               />
               <Route
                 path="/component_readiness/env_test"
-                render={(props) => {
+                render={(theProps) => {
                   // We need to pass the environment and testId
                   const filterVals = getUpdatedUrlParts(
                     baseRelease,
@@ -623,7 +623,7 @@ export default function ComponentReadiness(props) {
               />
               <Route
                 path="/component_readiness/capability"
-                render={(props) => {
+                render={(theProps) => {
                   // We need the component and capability from url
                   const filterVals = getUpdatedUrlParts(
                     baseRelease,
@@ -658,7 +658,7 @@ export default function ComponentReadiness(props) {
               />
               <Route
                 path="/component_readiness/env_capability"
-                render={(props) => {
+                render={(theProps) => {
                   // We need the component and capability and environment from url
                   const filterVals = getUpdatedUrlParts(
                     baseRelease,
@@ -692,7 +692,7 @@ export default function ComponentReadiness(props) {
               />
               <Route
                 path="/component_readiness/capabilities"
-                render={(props) => {
+                render={(theProps) => {
                   const filterVals = getUpdatedUrlParts(
                     baseRelease,
                     baseStartTime,
@@ -722,7 +722,7 @@ export default function ComponentReadiness(props) {
               />
               <Route
                 path="/component_readiness/env_capabilities"
-                render={(props) => {
+                render={(theProps) => {
                   const filterVals = getUpdatedUrlParts(
                     baseRelease,
                     baseStartTime,

--- a/sippy-ng/src/component_readiness/NotYetImplemented.js
+++ b/sippy-ng/src/component_readiness/NotYetImplemented.js
@@ -4,10 +4,10 @@ import React from 'react'
 
 export default function NotYetImplemented(props) {
   const { path } = props
-  const history = useHistory()
+  const theHistory = useHistory()
 
   const goBack = () => {
-    history.goBack()
+    theHistory.goBack()
   }
 
   return (

--- a/sippy-ng/src/components/Histogram.js
+++ b/sippy-ng/src/components/Histogram.js
@@ -12,11 +12,11 @@ Chart.register(annotationPlugin)
 
 export default function Histogram(props) {
   const theme = useTheme()
-  const history = useHistory()
+  const theHistory = useHistory()
 
   const handleClick = (e) => {
     let percentile = e[0].index * 10
-    history.push(
+    theHistory.push(
       pathForJobsInPercentile(props.release, percentile, percentile + 10)
     )
   }

--- a/sippy-ng/src/components/Sidebar.js
+++ b/sippy-ng/src/components/Sidebar.js
@@ -41,15 +41,15 @@ import SippyLogo from './SippyLogo'
 
 export default function Sidebar(props) {
   const classes = useTheme()
-  const location = useLocation()
+  const theLocation = useLocation()
 
-  const [open, setOpen] = React.useState({})
+  const [isOpen, setIsOpen] = React.useState({})
 
   useEffect(() => {
     return () => {
       // infer release from current url when loading sidebar for first time
-      let parts = location.pathname.split('/')
-      let tmpOpen = open
+      let parts = theLocation.pathname.split('/')
+      let tmpOpen = isOpen
       if (parts.length >= 3) {
         let index = props.releases.indexOf(parts[2])
         if (index !== -1) {
@@ -58,12 +58,12 @@ export default function Sidebar(props) {
       } else {
         tmpOpen[0] = true
       }
-      setOpen(tmpOpen)
+      setIsOpen(tmpOpen)
     }
   }, [props])
 
   function handleClick(id) {
-    setOpen((prevState) => ({ ...prevState, [id]: !prevState[id] }))
+    setIsOpen((prevState) => ({ ...prevState, [id]: !prevState[id] }))
   }
 
   function reportAnIssueURI() {
@@ -165,10 +165,10 @@ export default function Sidebar(props) {
               button
               onClick={() => handleClick(index)}
             >
-              {open[index] ? <ExpandLess /> : <ExpandMore />}
+              {isOpen[index] ? <ExpandLess /> : <ExpandMore />}
               <ListItemText primary={release} />
             </ListItem>
-            <Collapse in={open[index]} timeout="auto" unmountOnExit>
+            <Collapse in={isOpen[index]} timeout="auto" unmountOnExit>
               <List component="div" disablePadding>
                 <ListItem
                   key={'release-overview-' + index}

--- a/sippy-ng/src/components/SippyLogo.js
+++ b/sippy-ng/src/components/SippyLogo.js
@@ -18,20 +18,20 @@ export default function SippyLogo() {
   const classes = useStyles()
   const [anchorEl, setAnchorEl] = React.useState(null)
 
-  const handlePopoverOpen = (event) => {
-    setAnchorEl(event.currentTarget)
+  const handlePopoverOpen = (theEvent) => {
+    setAnchorEl(theEvent.currentTarget)
   }
 
   const handlePopoverClose = () => {
     setAnchorEl(null)
   }
 
-  const open = Boolean(anchorEl)
+  const isOpen = Boolean(anchorEl)
 
   return (
     <div align="center">
       <Typography
-        aria-owns={open ? 'mouse-over-popover' : undefined}
+        aria-owns={isOpen ? 'mouse-over-popover' : undefined}
         aria-haspopup="true"
         onMouseEnter={handlePopoverOpen}
         onMouseLeave={handlePopoverClose}
@@ -49,7 +49,7 @@ export default function SippyLogo() {
         classes={{
           paper: classes.paper,
         }}
-        open={open}
+        open={isOpen}
         anchorEl={anchorEl}
         anchorOrigin={{
           vertical: 'top',

--- a/sippy-ng/src/datagrid/GridToolbarAutocomplete.js
+++ b/sippy-ng/src/datagrid/GridToolbarAutocomplete.js
@@ -6,7 +6,7 @@ import React, { useEffect } from 'react'
 import TextField from '@material-ui/core/TextField'
 
 export default function GridToolbarAutocomplete(props) {
-  const [open, setOpen] = React.useState(false)
+  const [isOpen, setIsOpen] = React.useState(false)
   const [options, setOptions] = React.useState([])
   const [loading, setLoading] = React.useState(false)
 
@@ -33,12 +33,12 @@ export default function GridToolbarAutocomplete(props) {
   }
 
   useEffect(() => {
-    if (open) {
+    if (isOpen) {
       fetchOptions(props.value)
     } else {
       setOptions([])
     }
-  }, [open])
+  }, [isOpen])
 
   // Based on https://stackoverflow.com/a/61973338/1683486
   return (
@@ -46,12 +46,12 @@ export default function GridToolbarAutocomplete(props) {
       disableClearable
       id={`autocomplete-${props.id}`}
       style={{ width: 220 }}
-      open={open}
+      open={isOpen}
       onOpen={() => {
-        setOpen(true)
+        setIsOpen(true)
       }}
       onClose={() => {
-        setOpen(false)
+        setIsOpen(false)
       }}
       onChange={(e, v) => v && props.onChange(v.name)}
       defaultValue={{ name: props.value }}

--- a/sippy-ng/src/datagrid/GridToolbarBookmarkMenu.js
+++ b/sippy-ng/src/datagrid/GridToolbarBookmarkMenu.js
@@ -6,8 +6,8 @@ import React, { Fragment } from 'react'
 export default function GridToolbarBookmarkMenu(props) {
   const [anchorEl, setAnchorEl] = React.useState(null)
 
-  const handleClick = (event) => {
-    setAnchorEl(event.currentTarget)
+  const handleClick = (theEvent) => {
+    setAnchorEl(theEvent.currentTarget)
   }
 
   const handleClose = () => {

--- a/sippy-ng/src/datagrid/GridToolbarFilterMenu.js
+++ b/sippy-ng/src/datagrid/GridToolbarFilterMenu.js
@@ -74,8 +74,8 @@ export default function GridToolbarFilterMenu(props) {
     }
   })
 
-  const handleClick = (event) => {
-    setAnchorEl(event.currentTarget)
+  const handleClick = (theEvent) => {
+    setAnchorEl(theEvent.currentTarget)
   }
 
   const handleClose = () => {
@@ -102,8 +102,8 @@ export default function GridToolbarFilterMenu(props) {
     }
   }
 
-  const open = Boolean(anchorEl)
-  const id = open ? 'filter-popover' : undefined
+  const isOpen = Boolean(anchorEl)
+  const id = isOpen ? 'filter-popover' : undefined
 
   const addFilter = () => {
     let currentFilters = models
@@ -211,7 +211,7 @@ export default function GridToolbarFilterMenu(props) {
 
       <Popover
         id="filter-popover"
-        open={open}
+        open={isOpen}
         anchorEl={anchorEl}
         onClose={handleClose}
         anchorOrigin={{

--- a/sippy-ng/src/datagrid/GridToolbarPeriodSelector.js
+++ b/sippy-ng/src/datagrid/GridToolbarPeriodSelector.js
@@ -11,8 +11,8 @@ export default function GridToolbarPeriodSelector(props) {
   const [anchor, setAnchor] = React.useState('')
   const [period, setPeriod] = React.useState(props.period)
 
-  const handleClick = (event) => {
-    setAnchor(event.currentTarget)
+  const handleClick = (theEvent) => {
+    setAnchor(theEvent.currentTarget)
   }
 
   const handleClose = () => {

--- a/sippy-ng/src/datagrid/GridToolbarQueriesMenu.js
+++ b/sippy-ng/src/datagrid/GridToolbarQueriesMenu.js
@@ -10,25 +10,25 @@ export default function GridToolbarQueriesMenu(props) {
     props.initialFilters
   )
 
-  const handleClick = (event) => {
-    setAnchorEl(event.currentTarget)
+  const handleClick = (theEvent) => {
+    setAnchorEl(theEvent.currentTarget)
   }
 
   const handleClose = () => {
     setAnchorEl(null)
   }
 
-  const selectFilter = (name, conflicts) => {
+  const selectFilter = (theName, conflicts) => {
     let newFilters = []
 
-    if (selectedFilters.includes(name)) {
-      newFilters = selectedFilters.filter((e) => e !== name)
-    } else if (name === 'all') {
+    if (selectedFilters.includes(theName)) {
+      newFilters = selectedFilters.filter((e) => e !== theName)
+    } else if (theName === 'all') {
       newFilters = []
     } else {
       newFilters = selectedFilters
         .filter((e) => e !== 'all' && e !== conflicts)
-        .concat(name)
+        .concat(theName)
     }
 
     props.setFilters(newFilters)

--- a/sippy-ng/src/datagrid/GridToolbarViewSelector.js
+++ b/sippy-ng/src/datagrid/GridToolbarViewSelector.js
@@ -6,8 +6,8 @@ import React, { Fragment } from 'react'
 export default function GridToolbarViewSelector(props) {
   const [anchor, setAnchor] = React.useState('')
 
-  const handleClick = (event) => {
-    setAnchor(event.currentTarget)
+  const handleClick = (theEvent) => {
+    setAnchor(theEvent.currentTarget)
   }
 
   const handleClose = () => {

--- a/sippy-ng/src/datagrid/GridView.js
+++ b/sippy-ng/src/datagrid/GridView.js
@@ -6,11 +6,11 @@ export class GridView {
     this.setView(defaultView)
   }
 
-  setView(name) {
-    if (name in this.views) {
+  setView(theName) {
+    if (theName in this.views) {
       let columns = []
-      this.view = this.views[name]
-      this.viewName = name
+      this.view = this.views[theName]
+      this.viewName = theName
       this.view.fieldOrder.forEach((e) => {
         let field = this.allColumns[e.field]
         if (field === undefined) {
@@ -23,7 +23,7 @@ export class GridView {
       })
       this.columns = columns
     } else {
-      console.error(name + ' is not a known view')
+      console.error(theName + ' is not a known view')
     }
   }
 }

--- a/sippy-ng/src/datagrid/utils.js
+++ b/sippy-ng/src/datagrid/utils.js
@@ -24,7 +24,7 @@ export function generateClasses(threshold, invert = false) {
     theme.palette.success.light,
   ]
   if (invert) {
-    let scaleColors = [
+    scaleColors = [
       theme.palette.success.light,
       theme.palette.warning.light,
       theme.palette.error.light,

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -124,10 +124,10 @@ export function pathForExactJobAnalysis(release, job) {
   return `/jobs/${release}/analysis?${single(filterFor('name', 'equals', job))}`
 }
 
-export function pathForExactTestAnalysis(release, test, excludedVariants) {
+export function pathForExactTestAnalysis(release, theTest, excludedVariants) {
   console.log(excludedVariants)
 
-  let filters = [filterFor('name', 'equals', test)]
+  let filters = [filterFor('name', 'equals', theTest)]
   if (Array.isArray(excludedVariants)) {
     excludedVariants.forEach((variant) => {
       filters.push(not(filterFor('variants', 'contains', variant)))
@@ -135,14 +135,14 @@ export function pathForExactTestAnalysis(release, test, excludedVariants) {
   }
 
   return `/tests/${release}/analysis?test=${safeEncodeURIComponent(
-    test
+    theTest
   )}&${multiple(...filters)}`
 }
 
-export function pathForExactTestAnalysisWithFilter(release, test, filter) {
+export function pathForExactTestAnalysisWithFilter(release, theTest, filter) {
   console.log(filter)
 
-  let filters = [filterFor('name', 'equals', test)]
+  let filters = [filterFor('name', 'equals', theTest)]
   if (filter && filter.items) {
     filter.items.forEach((item) => {
       if (item.columnField === 'variants') {
@@ -151,28 +151,28 @@ export function pathForExactTestAnalysisWithFilter(release, test, filter) {
     })
   }
   return `/tests/${release}/analysis?test=${safeEncodeURIComponent(
-    test
+    theTest
   )}&${multiple(...filters)}`
 }
 
-export function pathForExactTest(release, test) {
-  return `/tests/${release}?${single(filterFor('name', 'equals', test))}`
+export function pathForExactTest(release, theTest) {
+  return `/tests/${release}?${single(filterFor('name', 'equals', theTest))}`
 }
 
 export function pathForExactJobRuns(release, job) {
   return `/jobs/${release}/runs?${single(filterFor('job', 'equals', job))}`
 }
 
-export function pathForVariantsWithTestFailure(release, variant, test) {
+export function pathForVariantsWithTestFailure(release, variant, theTest) {
   return `/jobs/${release}/runs?${multiple(
-    filterFor('failed_test_names', 'contains', test),
+    filterFor('failed_test_names', 'contains', theTest),
     filterFor('variants', 'contains', variant)
   )}`
 }
 
-export function pathForJobRunsWithTestFailure(release, test, filter) {
+export function pathForJobRunsWithTestFailure(release, theTest, filter) {
   let filters = []
-  filters.push(filterFor('failed_test_names', 'contains', test))
+  filters.push(filterFor('failed_test_names', 'contains', theTest))
   if (filter && filter.items) {
     filter.items.forEach((item) => {
       if (item.columnField === 'variants') {
@@ -184,9 +184,9 @@ export function pathForJobRunsWithTestFailure(release, test, filter) {
   return `/jobs/${release}/runs?${multiple(...filters)}`
 }
 
-export function pathForJobRunsWithTestFlake(release, test, filter) {
+export function pathForJobRunsWithTestFlake(release, theTest, filter) {
   let filters = []
-  filters.push(filterFor('flaked_test_names', 'contains', test))
+  filters.push(filterFor('flaked_test_names', 'contains', theTest))
   if (filter && filter.items) {
     filter.items.forEach((item) => {
       if (item.columnField === 'variants') {
@@ -199,6 +199,7 @@ export function pathForJobRunsWithTestFlake(release, test, filter) {
 }
 
 export function pathForJobRunsWithFilter(release, filter) {
+  // filter.items == [] will always return 'false' since JavaScript compares object by reference, not value.
   if (!filter || filter.items === []) {
     return `/jobs/${release}/runs`
   }
@@ -208,9 +209,9 @@ export function pathForJobRunsWithFilter(release, filter) {
   )}`
 }
 
-export function pathForTestByVariant(release, test) {
+export function pathForTestByVariant(release, theTest) {
   return (
-    `/tests/${release}/details?` + single(filterFor('name', 'equals', test))
+    `/tests/${release}/details?` + single(filterFor('name', 'equals', theTest))
   )
 }
 

--- a/sippy-ng/src/jobs/JobDetailTable.js
+++ b/sippy-ng/src/jobs/JobDetailTable.js
@@ -25,8 +25,8 @@ export default function JobDetailTable(props) {
     failedTestNames: [],
   })
 
-  const openTestDialog = (test) => {
-    setTestDetails(test)
+  const openTestDialog = (theTest) => {
+    setTestDetails(theTest)
     setTestDialogOpen(true)
   }
 

--- a/sippy-ng/src/jobs/JobDetailTestModal.js
+++ b/sippy-ng/src/jobs/JobDetailTestModal.js
@@ -14,12 +14,12 @@ export default function JobDetailTestModal(props) {
   }
 
   if (props.item.failedTestNames) {
-    props.item.failedTestNames.slice(0, 25).forEach((test, index) => {
+    props.item.failedTestNames.slice(0, 25).forEach((testName, index) => {
       filterModel.items.push({
         id: index,
         columnField: 'name',
         operatorValue: 'equals',
-        value: test,
+        value: testName,
       })
     })
   }

--- a/sippy-ng/src/jobs/JobStackedChart.js
+++ b/sippy-ng/src/jobs/JobStackedChart.js
@@ -33,7 +33,7 @@ export const hourFilter = (dayOffset, startDate) => {
 }
 
 export function JobStackedChart(props) {
-  const history = useHistory()
+  const theHistory = useHistory()
 
   const [isLoaded, setLoaded] = React.useState(false)
   const [analysis, setAnalysis] = React.useState({})
@@ -52,15 +52,15 @@ export function JobStackedChart(props) {
     }
 
     fetch(`${process.env.REACT_APP_API_URL}/api/jobs/analysis?${queryParams}`)
-      .then((analysis) => {
-        if (analysis.status !== 200) {
-          throw new Error('server returned ' + analysis.status)
+      .then((analysisData) => {
+        if (analysisData.status !== 200) {
+          throw new Error('server returned ' + analysisData.status)
         }
 
-        return analysis.json()
+        return analysisData.json()
       })
-      .then((analysis) => {
-        setAnalysis(analysis)
+      .then((analysisJson) => {
+        setAnalysis(analysisJson)
         setLoaded(true)
       })
       .catch((error) => {
@@ -132,7 +132,7 @@ export function JobStackedChart(props) {
   }
 
   const handleClick = (e) => {
-    history.push(
+    theHistory.push(
       `/jobs/${
         props.release
       }/analysis?period=day&filters=${safeEncodeURIComponent(

--- a/sippy-ng/src/jobs/JobTable.js
+++ b/sippy-ng/src/jobs/JobTable.js
@@ -590,7 +590,7 @@ function JobTable(props) {
         disableColumnFilter={props.briefTable}
         disableColumnMenu={true}
         checkboxSelection={!props.briefTable}
-        onSelectionModelChange={(rows) => setSelectedJobs(rows)}
+        onSelectionModelChange={(currRows) => setSelectedJobs(currRows)}
         rowsPerPageOptions={props.rowsPerPageOptions}
         pageSize={pageSize}
         onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}

--- a/sippy-ng/src/jobs/Jobs.js
+++ b/sippy-ng/src/jobs/Jobs.js
@@ -33,7 +33,7 @@ export default function Jobs(props) {
       <SimpleBreadcrumbs release={props.release} currentPage="Jobs" />
       <Route
         path="/"
-        render={({ location }) => (
+        render={({ theLocation }) => (
           <TabContext value={path}>
             <Typography align="center" variant="h4">
               Job health for {props.release}
@@ -46,8 +46,8 @@ export default function Jobs(props) {
             >
               <Paper>
                 <Tabs
-                  value={location.pathname.substring(
-                    location.pathname.lastIndexOf('/') + 1
+                  value={theLocation.pathname.substring(
+                    theLocation.pathname.lastIndexOf('/') + 1
                   )}
                   indicatorColor="primary"
                   textColor="primary"

--- a/sippy-ng/src/prow_job_runs/ProwJobRun.js
+++ b/sippy-ng/src/prow_job_runs/ProwJobRun.js
@@ -6,7 +6,6 @@ import {
   useQueryParam,
 } from 'use-query-params'
 import { Button, ButtonGroup, TextField } from '@material-ui/core'
-import { Error } from '@material-ui/icons'
 import { stringify } from 'query-string'
 import { useHistory } from 'react-router-dom'
 import Alert from '@material-ui/lab/Alert'
@@ -15,7 +14,7 @@ import React, { Fragment, useEffect, useState } from 'react'
 import TimelineChart from '../components/TimelineChart'
 
 export default function ProwJobRun(props) {
-  const history = useHistory()
+  const theHistory = useHistory()
 
   const [fetchError, setFetchError] = React.useState('')
   const [isLoaded, setLoaded] = React.useState(false)
@@ -134,7 +133,7 @@ export default function ProwJobRun(props) {
 
   useEffect(() => {
     updateFiltering()
-  }, [categories, history, intervalFiles, eventIntervals])
+  }, [categories, theHistory, intervalFiles, eventIntervals])
 
   useEffect(() => {
     // Delayed processing of the filter text input to allow the user to finish typing before
@@ -160,17 +159,17 @@ export default function ProwJobRun(props) {
     )
     console.log('queryString = ' + stringify(queryString))
 
-    history.replace({
+    theHistory.replace({
       search: stringify(queryString),
     })
 
-    let filteredIntervals = filterIntervals(
+    let tmpFilteredIntervals = filterIntervals(
       eventIntervals,
       categories,
       intervalFiles,
       filterText
     )
-    setFilteredIntervals(filteredIntervals)
+    setFilteredIntervals(tmpFilteredIntervals)
   }
 
   if (fetchError !== '') {
@@ -223,8 +222,8 @@ export default function ProwJobRun(props) {
     setIntervalFiles(newSelectedIntervalFiles)
   }
 
-  const handleFilterChange = (event) => {
-    setFilterText(event.target.value)
+  const handleFilterChange = (theEvent) => {
+    setFilterText(theEvent.target.value)
   }
 
   return (
@@ -923,8 +922,8 @@ function createTimelineData(
   for (const label in data) {
     const section = data[label]
     for (const sub in section) {
-      const data = section[sub]
-      const totalDurationSeconds = data.reduce(
+      const dataSub = section[sub]
+      const totalDurationSeconds = dataSub.reduce(
         (prev, curr) =>
           prev +
           (curr.timeRange[1].getTime() - curr.timeRange[0].getTime()) / 1000,
@@ -933,7 +932,7 @@ function createTimelineData(
 
       timelineData.push({
         label: label + sub + ' ' + getDurationString(totalDurationSeconds),
-        data: data,
+        data: dataSub,
       })
     }
   }

--- a/sippy-ng/src/prow_job_runs/ProwJobRun.js
+++ b/sippy-ng/src/prow_job_runs/ProwJobRun.js
@@ -6,6 +6,7 @@ import {
   useQueryParam,
 } from 'use-query-params'
 import { Button, ButtonGroup, TextField } from '@material-ui/core'
+import { Error } from '@material-ui/icons'
 import { stringify } from 'query-string'
 import { useHistory } from 'react-router-dom'
 import Alert from '@material-ui/lab/Alert'

--- a/sippy-ng/src/pull_requests/PullRequestsTable.js
+++ b/sippy-ng/src/pull_requests/PullRequestsTable.js
@@ -12,7 +12,7 @@ import {
   CheckCircle,
   Error as ErrorIcon,
   GitHub,
-  History,
+  History as HistoryIcon,
 } from '@material-ui/icons'
 import { DataGrid } from '@material-ui/data-grid'
 import {
@@ -66,7 +66,7 @@ export default function PullRequestsTable(props) {
   const { classes } = props
   const gridClasses = useStyles()
   const theme = useTheme()
-  const location = useLocation().pathname
+  const theLocation = useLocation().pathname
 
   const [fetchError, setFetchError] = React.useState('')
   const [isLoaded, setLoaded] = React.useState(false)
@@ -284,7 +284,7 @@ export default function PullRequestsTable(props) {
             <Button
               style={{ justifyContent: 'center' }}
               target="_blank"
-              startIcon={<History />}
+              startIcon={<HistoryIcon />}
               href={`https://prow.ci.openshift.org/pr-history/?org=${params.row.org}&repo=${params.row.repo}&pr=${params.row.number}`}
             />
           </Tooltip>

--- a/sippy-ng/src/releases/Install.js
+++ b/sippy-ng/src/releases/Install.js
@@ -27,19 +27,19 @@ export default function Install(props) {
         process.env.REACT_APP_API_URL + '/api/health?release=' + props.release
       ),
     ])
-      .then(([install, health]) => {
-        if (install.status !== 200) {
-          throw new Error('server returned ' + install.status)
+      .then(([installData, healthData]) => {
+        if (installData.status !== 200) {
+          throw new Error('server returned ' + installData.status)
         }
 
-        if (health.status !== 200) {
-          throw new Error('server returned ' + health.status)
+        if (healthData.status !== 200) {
+          throw new Error('server returned ' + healthData.status)
         }
-        return Promise.all([install.json(), health.json()])
+        return Promise.all([installData.json(), healthData.json()])
       })
-      .then(([install, health]) => {
-        setData(install)
-        setHealth(health)
+      .then(([installJson, healthJson]) => {
+        setData(installJson)
+        setHealth(healthJson)
         setLoaded(true)
       })
       .catch((error) => {
@@ -70,7 +70,7 @@ export default function Install(props) {
       <SimpleBreadcrumbs release={props.release} currentPage="Install" />
       <Route
         path="/"
-        render={({ location }) => (
+        render={({ location: theLocation }) => (
           <TabContext value={path}>
             <Typography align="center" variant="h4">
               Install health for {props.release}
@@ -88,8 +88,8 @@ export default function Install(props) {
               >
                 <Paper>
                   <Tabs
-                    value={location.pathname.substring(
-                      location.pathname.lastIndexOf('/') + 1
+                    value={theLocation.pathname.substring(
+                      theLocation.pathname.lastIndexOf('/') + 1
                     )}
                     indicatorColor="primary"
                     textColor="primary"

--- a/sippy-ng/src/releases/PayloadCalendar.js
+++ b/sippy-ng/src/releases/PayloadCalendar.js
@@ -10,7 +10,7 @@ import React, { Fragment } from 'react'
 
 export default function PayloadCalendar(props) {
   const theme = useTheme()
-  const history = useHistory()
+  const theHistory = useHistory()
 
   const eventSources = [
     {
@@ -64,7 +64,7 @@ export default function PayloadCalendar(props) {
         '_blank'
       )
     } else {
-      history.push(`/release/${props.release}/tags/${info.event.title}`)
+      theHistory.push(`/release/${props.release}/tags/${info.event.title}`)
     }
   }
 

--- a/sippy-ng/src/releases/PayloadMiniCalendar.js
+++ b/sippy-ng/src/releases/PayloadMiniCalendar.js
@@ -12,7 +12,7 @@ import React, { Fragment, useEffect } from 'react'
 
 export default function PayloadMiniCalendar(props) {
   const theme = useTheme()
-  const history = useHistory()
+  const theHistory = useHistory()
 
   const [fetchError, setFetchError] = React.useState('')
   const [isLoaded, setLoaded] = React.useState(false)
@@ -42,7 +42,7 @@ export default function PayloadMiniCalendar(props) {
       })
     )
 
-    history.push(
+    theHistory.push(
       `/release/${props.release}/streams/${props.arch}/${props.stream}/payloads?filters=${filter}`
     )
   }
@@ -75,14 +75,14 @@ export default function PayloadMiniCalendar(props) {
         // Prefer accepted payloads to make the square green if we had any accepted payload that day.
         // Rejected payloads will make the square red, and no payload at all will be an empty square.
         let eventsOnePerDay = {}
-        json.forEach((event) => {
+        json.forEach((theEvent) => {
           if (
-            event.phase === 'Accepted' ||
-            eventsOnePerDay[event.start] === undefined
+            theEvent.phase === 'Accepted' ||
+            eventsOnePerDay[theEvent.start] === undefined
           ) {
-            event.display = 'background'
-            event.title = event.phase.charAt(0) // Show 'A' for accepted for 'R' for rejected
-            eventsOnePerDay[event.start] = event
+            theEvent.display = 'background'
+            theEvent.title = theEvent.phase.charAt(0) // Show 'A' for accepted for 'R' for rejected
+            eventsOnePerDay[theEvent.start] = theEvent
           }
         })
         setAccepted(

--- a/sippy-ng/src/releases/PayloadStream.js
+++ b/sippy-ng/src/releases/PayloadStream.js
@@ -33,7 +33,7 @@ export default function PayloadStream(props) {
   const { path, url } = useRouteMatch()
 
   const [currentTab, setCurrentTab] = useState(0)
-  function handleTabChange(event, newValue) {
+  function handleTabChange(theEvent, newValue) {
     console.warn('Setting new value ' + newValue)
     setCurrentTab(newValue)
   }
@@ -68,7 +68,7 @@ export default function PayloadStream(props) {
       />
       <Route
         path="/"
-        render={({ location }) => (
+        render={({ location: theLocation }) => (
           <TabContext value={path}>
             <Fragment>
               <Typography variant="h4" gutterBottom className={classes.title}>
@@ -83,8 +83,8 @@ export default function PayloadStream(props) {
               >
                 <Paper>
                   <Tabs
-                    value={location.pathname.substring(
-                      location.pathname.lastIndexOf('/') + 1
+                    value={theLocation.pathname.substring(
+                      theLocation.pathname.lastIndexOf('/') + 1
                     )}
                     indicatorColor="primary"
                     textColor="primary"

--- a/sippy-ng/src/releases/PayloadStreamOverview.js
+++ b/sippy-ng/src/releases/PayloadStreamOverview.js
@@ -55,12 +55,12 @@ function PayloadStreamOverview(props) {
       })
       .then((json) => {
         // Find our specific stream's health in the list:
-        for (const stream of json) {
+        for (const streamJson of json) {
           if (
-            stream.architecture === props.arch &&
-            stream.stream === props.stream
+            streamJson.architecture === props.arch &&
+            streamJson.stream === props.stream
           ) {
-            setStreamHealth(stream)
+            setStreamHealth(streamJson)
           }
         }
         setLoaded(true)

--- a/sippy-ng/src/releases/ReleasePayloadDetails.js
+++ b/sippy-ng/src/releases/ReleasePayloadDetails.js
@@ -69,19 +69,19 @@ export default function ReleasePayloadDetails(props) {
         `${process.env.REACT_APP_API_URL}/api/releases/tags?filter=${filter}`
       ),
     ])
-      .then(([tag]) => {
-        if (tag.status !== 200) {
-          throw new Error('server returned ' + tag.status)
+      .then(([tagData]) => {
+        if (tagData.status !== 200) {
+          throw new Error('server returned ' + tagData.status)
         }
 
-        return Promise.all([tag.json()])
+        return Promise.all([tagData.json()])
       })
-      .then(([tag]) => {
-        if (tag.length === 0) {
-          return <Typography variant="h5">Tag #{tag} not found.</Typography>
+      .then(([tagJson]) => {
+        if (tagJson.length === 0) {
+          return <Typography variant="h5">Tag #{tagJson} not found.</Typography>
         }
 
-        setTag(tag[0])
+        setTag(tagJson[0])
         setLoaded(true)
       })
       .catch((error) => {

--- a/sippy-ng/src/releases/ReleasePayloadJobRuns.js
+++ b/sippy-ng/src/releases/ReleasePayloadJobRuns.js
@@ -1,5 +1,5 @@
 import { Button, Tooltip } from '@material-ui/core'
-import { Check, DirectionsBoat, Error } from '@material-ui/icons'
+import { Check, DirectionsBoat } from '@material-ui/icons'
 import { createTheme, makeStyles } from '@material-ui/core/styles'
 import { DataGrid } from '@material-ui/data-grid'
 import { NumberParam, StringParam, useQueryParam } from 'use-query-params'

--- a/sippy-ng/src/releases/Upgrades.js
+++ b/sippy-ng/src/releases/Upgrades.js
@@ -68,7 +68,7 @@ export default function Upgrades(props) {
       <SimpleBreadcrumbs release={props.release} currentPage="Upgrades" />
       <Route
         path="/"
-        render={({ location }) => (
+        render={({ location: theLocation }) => (
           <TabContext value={path}>
             <Typography align="center" variant="h4">
               Upgrade health for {props.release}
@@ -76,8 +76,8 @@ export default function Upgrades(props) {
             <Grid container justifyContent="center" size="xl" className="view">
               <Paper>
                 <Tabs
-                  value={location.pathname.substring(
-                    location.pathname.lastIndexOf('/') + 1
+                  value={theLocation.pathname.substring(
+                    theLocation.pathname.lastIndexOf('/') + 1
                   )}
                   indicatorColor="primary"
                   textColor="primary"

--- a/sippy-ng/src/repositories/RepositoriesTable.js
+++ b/sippy-ng/src/repositories/RepositoriesTable.js
@@ -7,7 +7,7 @@ import {
   Typography,
 } from '@material-ui/core'
 import { DataGrid } from '@material-ui/data-grid'
-import { Details, Error, Launch } from '@material-ui/icons'
+import { Details, Launch } from '@material-ui/icons'
 import { generateClasses } from '../datagrid/utils'
 import { GridView } from '../datagrid/GridView'
 import { makeStyles } from '@material-ui/core/styles'
@@ -53,7 +53,7 @@ function RepositoriesTable(props) {
 
   const { classes } = props
   const gridClasses = useStyles()
-  const history = useHistory()
+  const theHistory = useHistory()
 
   const [fetchError, setFetchError] = React.useState('')
   const [isLoaded, setLoaded] = React.useState(false)
@@ -290,7 +290,7 @@ function RepositoriesTable(props) {
           ]
         }
         onRowClick={(e) =>
-          history.push(
+          theHistory.push(
             `/repositories/${props.release}/${e.row.org}/${e.row.repo}`
           )
         }

--- a/sippy-ng/src/setupTests.js
+++ b/sippy-ng/src/setupTests.js
@@ -1,10 +1,10 @@
 /** @jest-environment setup-polly-jest/jest-environment-node */
 
 import '@testing-library/jest-dom'
+import { fetch as nodeFetch } from 'node-fetch'
 import { setupPolly } from 'setup-polly-jest'
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
 import Enzyme from 'enzyme'
-import fetch from 'node-fetch'
 import path from 'path'
 import toDiffableHtml from 'diffable-html'
 
@@ -22,7 +22,7 @@ export const withoutMuiID = (wrapper) =>
 Enzyme.configure({ adapter: new Adapter() })
 
 // To stub out fetch(), we need to use node-fetch and this line:
-global.fetch = fetch
+global.fetch = nodeFetch
 
 // See: https://github.com/vuejs/vue-test-utils/issues/974
 global.requestAnimationFrame = (cb) => cb()

--- a/sippy-ng/src/tests/TestAnalysis.js
+++ b/sippy-ng/src/tests/TestAnalysis.js
@@ -41,7 +41,7 @@ import TestTable from './TestTable'
 
 export function TestAnalysis(props) {
   const [isLoaded, setLoaded] = React.useState(false)
-  const [test, setTest] = React.useState({})
+  const [theTest, setTheTest] = React.useState({})
   const [fetchError, setFetchError] = React.useState('')
   const [testName = props.test] = useQueryParam('test', SafeStringParam)
 
@@ -75,18 +75,18 @@ export function TestAnalysis(props) {
         `${process.env.REACT_APP_API_URL}/api/tests?release=${props.release}&filter=${filter}`
       ),
     ])
-      .then(([test]) => {
-        if (test.status !== 200) {
-          throw new Error('server returned ' + test.status)
+      .then(([testData]) => {
+        if (testData.status !== 200) {
+          throw new Error('server returned ' + testData.status)
         }
 
-        return Promise.all([test.json()])
+        return Promise.all([testData.json()])
       })
-      .then(([test]) => {
-        if (test.length === 0) {
+      .then(([testJson]) => {
+        if (testJson.length === 0) {
           throw new Error('test not found')
         }
-        setTest(test[0])
+        setTheTest(testJson[0])
         setLoaded(true)
       })
       .catch((error) => {
@@ -137,20 +137,24 @@ export function TestAnalysis(props) {
               key="test-summary"
               threshold={TEST_THRESHOLDS}
               name="Overall"
-              success={test.current_successes}
-              flakes={test.current_flakes}
+              success={theTest.current_successes}
+              flakes={theTest.current_flakes}
               caption={
                 <Fragment>
-                  <Tooltip title={`${test.current_runs} runs`}>
-                    <span>{test.current_working_percentage.toFixed(2)}%</span>
+                  <Tooltip title={`${theTest.current_runs} runs`}>
+                    <span>
+                      {theTest.current_working_percentage.toFixed(2)}%
+                    </span>
                   </Tooltip>
-                  <PassRateIcon improvement={test.net_improvement} />
-                  <Tooltip title={`${test.previous_runs} runs`}>
-                    <span>{test.previous_working_percentage.toFixed(2)}%</span>
+                  <PassRateIcon improvement={theTest.net_improvement} />
+                  <Tooltip title={`${theTest.previous_runs} runs`}>
+                    <span>
+                      {theTest.previous_working_percentage.toFixed(2)}%
+                    </span>
                   </Tooltip>
                 </Fragment>
               }
-              fail={test.current_failures}
+              fail={theTest.current_failures}
             />
           </Grid>
           <Grid item md={8}>

--- a/sippy-ng/src/tests/TestByVariantTable.js
+++ b/sippy-ng/src/tests/TestByVariantTable.js
@@ -255,16 +255,16 @@ export default function TestByVariantTable(props) {
             </TableRow>
           </TableHead>
           <TableBody>
-            {Object.keys(props.data.tests).map((test) => (
+            {Object.keys(props.data.tests).map((theTest) => (
               <Row
                 briefTable={props.briefTable}
                 colorScale={props.colorScale}
                 showFull={showFull}
-                key={test}
-                testName={test}
+                key={theTest}
+                testName={theTest}
                 excludedVariants={props.excludedVariants}
                 columnNames={props.data.column_names}
-                results={props.data.tests[test]}
+                results={props.data.tests[theTest]}
                 release={props.release}
               />
             ))}

--- a/sippy-ng/src/tests/TestOutputs.js
+++ b/sippy-ng/src/tests/TestOutputs.js
@@ -10,7 +10,7 @@ import {
   TableRow,
   Tooltip,
 } from '@material-ui/core'
-import { DirectionsBoat, Error } from '@material-ui/icons'
+import { DirectionsBoat } from '@material-ui/icons'
 import { makeStyles } from '@material-ui/core/styles'
 import { safeEncodeURIComponent } from '../helpers'
 import Alert from '@material-ui/lab/Alert'

--- a/sippy-ng/src/tests/TestStackedChart.js
+++ b/sippy-ng/src/tests/TestStackedChart.js
@@ -27,15 +27,15 @@ export function TestStackedChart(props) {
     fetch(
       `${process.env.REACT_APP_API_URL}/api/tests/analysis/overall?${queryParams}`
     )
-      .then((analysis) => {
-        if (analysis.status !== 200) {
-          throw new Error('server returned ' + analysis.status)
+      .then((analysisData) => {
+        if (analysisData.status !== 200) {
+          throw new Error('server returned ' + analysisData.status)
         }
 
-        return analysis.json()
+        return analysisData.json()
       })
-      .then((analysis) => {
-        setAnalysis(analysis['overall'])
+      .then((analysisJson) => {
+        setAnalysis(analysisJson['overall'])
         setLoaded(true)
       })
       .catch((error) => {

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -74,7 +74,7 @@ const useStyles = makeStyles((theme) => ({
 function TestTable(props) {
   const { classes } = props
   const gridClasses = useStyles()
-  const location = useLocation().pathname
+  const theLocation = useLocation().pathname
 
   const [testDetails, setTestDetails] = React.useState({ bugs: [] })
 
@@ -810,12 +810,12 @@ function TestTable(props) {
   const prevLocation = useRef()
 
   useEffect(() => {
-    if (prevLocation.current !== location) {
+    if (prevLocation.current !== theLocation) {
       setRows([])
       setLoaded(false)
     }
     fetchData()
-    prevLocation.current = location
+    prevLocation.current = theLocation
   }, [period, filterModel, sort, sortField, props.collapse, view])
 
   const requestSearch = (searchValue) => {
@@ -850,9 +850,11 @@ function TestTable(props) {
 
   const createTestNameQuery = () => {
     const selectedIDs = new Set(selectedTests)
-    let tests = rows.filter((row) => selectedIDs.has(row.id))
-    tests = tests.map((test) => 'test=' + safeEncodeURIComponent(test.name))
-    return tests.join('&')
+    let testsLists = rows.filter((row) => selectedIDs.has(row.id))
+    testsLists = testsLists.map(
+      (theTest) => 'test=' + safeEncodeURIComponent(theTest.name)
+    )
+    return testsLists.join('&')
   }
 
   const addFilters = (filter) => {
@@ -909,7 +911,7 @@ function TestTable(props) {
           },
         ]}
         onSortModelChange={(m) => updateSortModel(m)}
-        onSelectionModelChange={(rows) => setSelectedTests(rows)}
+        onSelectionModelChange={(currRows) => setSelectedTests(currRows)}
         getRowClassName={(params) => {
           let rowClass = []
           if (params.row.name === overallTestName) {

--- a/sippy-ng/src/tests/Tests.js
+++ b/sippy-ng/src/tests/Tests.js
@@ -40,7 +40,7 @@ export default function Tests(props) {
 
       <Route
         path="/"
-        render={({ location }) => (
+        render={({ location: theLocation }) => (
           <TabContext value={path}>
             <Typography align="center" variant="h4">
               Tests for {props.release}
@@ -53,8 +53,8 @@ export default function Tests(props) {
             >
               <Paper>
                 <Tabs
-                  value={location.pathname.substring(
-                    location.pathname.lastIndexOf('/') + 1
+                  value={theLocation.pathname.substring(
+                    theLocation.pathname.lastIndexOf('/') + 1
                   )}
                   indicatorColor="primary"
                   textColor="primary"

--- a/sippy-ng/src/tests/TestsDetail.js
+++ b/sippy-ng/src/tests/TestsDetail.js
@@ -64,9 +64,9 @@ export default function TestsDetails(props) {
   }
 
   const updateFilter = () => {
-    const names = query.match(/([^\\|]|\\.)+/g)
+    const matchedNames = query.match(/([^\\|]|\\.)+/g)
     setLoaded(false)
-    setNames(names)
+    setNames(matchedNames)
   }
 
   const filterBox = (


### PR DESCRIPTION
[TRT-1343](https://issues.redhat.com//browse/TRT-1343)

Turn on variable shadowing detection using the [no-shadow ESlint setting](https://eslint.org/docs/latest/rules/no-shadow) to try to catch more shadowing problems during compile-time.

`Error`, `History`, `event`, `fetch`, `history`, `location`, `name`, `open`, `status`, `test`, show up as "already a global variable" so I renamed all usages of these to something else.