### PR TITLE
Fix back button in component readiness

### DIFF
--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -400,7 +400,7 @@ export default function App(props) {
                       render={(props) => {
                         return (
                           <CompReadyVarsProvider>
-                            <ComponentReadiness />
+                            <ComponentReadiness key={window.location.href} />
                           </CompReadyVarsProvider>
                         )
                       }}

--- a/sippy-ng/src/component_readiness/CompCapRow.js
+++ b/sippy-ng/src/component_readiness/CompCapRow.js
@@ -1,6 +1,7 @@
 import './ComponentReadiness.css'
 import { Fragment } from 'react'
 import { Link } from 'react-router-dom'
+import { sortQueryParams } from './CompReadyUtils'
 import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip, Typography } from '@material-ui/core'
 import CompReadyCapsCell from './CompReadyCapsCell'
@@ -16,7 +17,8 @@ function capabilityLink(filterVals, capabilityName) {
     '/component_readiness/capability' +
     filterVals +
     `&capability=${capabilityName}`
-  return retVal
+
+  return sortQueryParams(retVal)
 }
 
 // Represents a row when you clicked a cell from page 1
@@ -33,25 +35,13 @@ export default function CompCapRow(props) {
     StringParam
   )
 
-  const handleClick = (event) => {
-    event.preventDefault()
-    setCapabilityParam(capabilityName)
-    window.open(
-      '/sippy-ng' + capabilityLink(filterVals, capabilityName),
-      '_blank'
-    )
-  }
-
   // Put the capabilityName on the left side with a link to a capability specific
   // capabilities report.
   const capabilityNameColumn = (
     <TableCell className={'cr-component-name'} key={capabilityName}>
       <Tooltip title={'Capabilities report for ' + capabilityName}>
         <Typography className="cr-cell-name">
-          <Link
-            to={capabilityLink(filterVals, capabilityName)}
-            onClick={handleClick}
-          >
+          <Link to={capabilityLink(filterVals, capabilityName)}>
             {capabilityName}
           </Link>
         </Typography>

--- a/sippy-ng/src/component_readiness/CompReadyCapCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCapCell.js
@@ -2,6 +2,7 @@ import './ComponentReadiness.css'
 import { CompReadyVarsContext } from './CompReadyVars'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
+import { sortQueryParams } from './CompReadyUtils'
 import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip } from '@material-ui/core'
 import { useTheme } from '@material-ui/core/styles'
@@ -51,20 +52,7 @@ export default function CompReadyCapCell(props) {
       `&component=${safeComponentName}` +
       `&capability=${capabilityName}`
 
-    return retUrl
-  }
-
-  const handleClick = (event) => {
-    event.preventDefault()
-    setComponentParam(component)
-    setCapabilityParam(capability)
-    setTestIdParam(testId)
-    setEnvironmentParam(environment)
-    window.open(
-      '/sippy-ng' +
-        testReport(testId, environment, filterVals, component, capability),
-      '_blank'
-    )
+    return sortQueryParams(retUrl)
   }
 
   if (status === undefined) {
@@ -98,7 +86,6 @@ export default function CompReadyCapCell(props) {
             component,
             capability
           )}
-          onClick={handleClick}
         >
           <CompSeverityIcon status={status} />
         </Link>

--- a/sippy-ng/src/component_readiness/CompReadyCapsCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCapsCell.js
@@ -2,6 +2,7 @@ import './ComponentReadiness.css'
 import { CompReadyVarsContext } from './CompReadyVars'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
+import { sortQueryParams } from './CompReadyUtils'
 import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip } from '@material-ui/core'
 import { useTheme } from '@material-ui/core/styles'
@@ -36,18 +37,9 @@ export default function CompReadyCapsCell(props) {
       '&capability=' +
       safeEncodeURIComponent(capabilityName) +
       expandEnvironment(environmentVal)
-    return retUrl
+    return sortQueryParams(retUrl)
   }
 
-  const handleClick = (event) => {
-    event.preventDefault()
-    setCapabilityParam(capabilityName)
-    setEnvironmentParam(environment)
-    window.open(
-      '/sippy-ng' + capabilityReport(capabilityName, environment, filterVals),
-      '_blank'
-    )
-  }
   if (status === undefined) {
     return (
       <Tooltip title="No data">
@@ -71,10 +63,7 @@ export default function CompReadyCapsCell(props) {
           backgroundColor: 'white',
         }}
       >
-        <Link
-          to={capabilityReport(capabilityName, environment, filterVals)}
-          onClick={handleClick}
-        >
+        <Link to={capabilityReport(capabilityName, environment, filterVals)}>
           <CompSeverityIcon status={status} />
         </Link>
       </TableCell>

--- a/sippy-ng/src/component_readiness/CompReadyCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCell.js
@@ -2,6 +2,7 @@ import './ComponentReadiness.css'
 import { CompReadyVarsContext } from './CompReadyVars'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
+import { sortQueryParams } from './CompReadyUtils'
 import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip } from '@material-ui/core'
 import { useTheme } from '@material-ui/core/styles'
@@ -37,17 +38,7 @@ export default function CompReadyCell(props) {
       safeEncodeURIComponent(componentName) +
       expandEnvironment(environmentVal)
 
-    return retUrl
-  }
-
-  const handleClick = (event) => {
-    event.preventDefault()
-    setComponentParam(componentName)
-    setEnvironmentParam(environment)
-    window.open(
-      '/sippy-ng' + componentReport(componentName, environment, filterVals),
-      '_blank'
-    )
+    return sortQueryParams(retUrl)
   }
 
   if (status === undefined) {
@@ -73,10 +64,7 @@ export default function CompReadyCell(props) {
           backgroundColor: 'white',
         }}
       >
-        <Link
-          to={componentReport(componentName, environment, filterVals)}
-          onClick={handleClick}
-        >
+        <Link to={componentReport(componentName, environment, filterVals)}>
           <CompSeverityIcon status={status} grayFactor={grayFactor} />
         </Link>
       </TableCell>

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilities.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilities.js
@@ -44,7 +44,8 @@ export default function CompReadyEnvCapabilities(props) {
 
   // Set the browser tab title
   document.title =
-    'Sippy > ComponentReadiness > Capabilities' + (environment ? `Env` : '')
+    'Sippy > Component Readiness > Capabilities' +
+    (environment ? ` by Environment` : '')
 
   const { expandEnvironment } = useContext(CompReadyVarsContext)
   const safeComponent = safeEncodeURIComponent(component)

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapability.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapability.js
@@ -45,8 +45,8 @@ export default function CompReadyEnvCapability(props) {
 
   // Set the browser tab title
   document.title =
-    'Sippy > ComponentReadiness > Capabilities > Tests' +
-    (environment ? `Env` : '')
+    'Sippy > Component Readiness > Capabilities > Tests' +
+    (environment ? ` by Environment` : '')
   const safeComponent = safeEncodeURIComponent(component)
   const safeCapability = safeEncodeURIComponent(capability)
 

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
@@ -44,8 +44,8 @@ export default function CompReadyEnvCapabilityTest(props) {
 
   // Set the browser tab title
   document.title =
-    'Sippy > ComponentReadiness > Capabilities > Tests > Capability Tests' +
-    (environment ? `Env` : '')
+    'Sippy > Component Readiness > Capabilities > Tests > Capability Tests' +
+    (environment ? ` by Environment` : '')
   const safeComponent = safeEncodeURIComponent(component)
   const safeCapability = safeEncodeURIComponent(capability)
   const safeTestId = safeEncodeURIComponent(testId)

--- a/sippy-ng/src/component_readiness/CompReadyProgress.js
+++ b/sippy-ng/src/component_readiness/CompReadyProgress.js
@@ -9,10 +9,8 @@ import React from 'react'
 // wrong.
 export default function CompReadyProgress(props) {
   const { apiLink, cancelFunc } = props
-  const currentTitle = document.title
 
-  // Make the title different so you can tell it's loading
-  document.title = 'Loading ...'
+  document.title = 'Loading...'
 
   return (
     <Fragment>

--- a/sippy-ng/src/component_readiness/CompReadyRow.js
+++ b/sippy-ng/src/component_readiness/CompReadyRow.js
@@ -33,25 +33,13 @@ export default function CompReadyRow(props) {
     StringParam
   )
 
-  const handleClick = (event) => {
-    event.preventDefault()
-    setComponentParam(componentName)
-    window.open(
-      '/sippy-ng' + capabilitiesReport(filterVals, componentName),
-      '_blank'
-    )
-  }
-
   // Put the componentName on the left side with a link to a component specific
   // capabilities report.
   const componentNameColumn = (
     <TableCell className={'cr-component-name'} key={componentName}>
       <Tooltip title={'Component report for ' + componentName}>
         <Typography className="cr-cell-name">
-          <Link
-            to={capabilitiesReport(filterVals, componentName)}
-            onClick={handleClick}
-          >
+          <Link to={capabilitiesReport(filterVals, componentName)}>
             {componentName}
           </Link>
         </Typography>

--- a/sippy-ng/src/component_readiness/CompReadyTestCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestCell.js
@@ -2,6 +2,7 @@ import './ComponentReadiness.css'
 import { CompReadyVarsContext } from './CompReadyVars'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
+import { sortQueryParams } from './CompReadyUtils'
 import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip } from '@material-ui/core'
 import { useTheme } from '@material-ui/core/styles'
@@ -67,28 +68,7 @@ export default function CompReadyTestCell(props) {
       `&capability=${capabilityName}` +
       `&testName=${safeTestName}`
 
-    return retUrl
-  }
-
-  const handleClick = (event) => {
-    event.preventDefault()
-    setComponentParam(component)
-    setCapabilityParam(capability)
-    setTestIdParam(testId)
-    setEnvironmentParam(environment)
-    setTestNameParam(testName)
-    window.open(
-      '/sippy-ng' +
-        generateTestReport(
-          testId,
-          environment,
-          filterVals,
-          component,
-          capability,
-          testName
-        ),
-      '_blank'
-    )
+    return sortQueryParams(retUrl)
   }
 
   if (status === undefined) {
@@ -123,7 +103,6 @@ export default function CompReadyTestCell(props) {
             capability,
             testName
           )}
-          onClick={handleClick}
         >
           <CompSeverityIcon status={status} />
         </Link>

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -72,7 +72,7 @@ export default function CompReadyTestReport(props) {
 
   // Set the browser tab title
   document.title =
-    'Sippy > ComponentReadiness > Capabilities > Tests > Capability Tests > TestDetails' +
+    'Sippy > Component Readiness > Capabilities > Tests > Capability Tests > Test Details' +
     (environment ? `Env` : '')
   const safeComponent = safeEncodeURIComponent(component)
   const safeCapability = safeEncodeURIComponent(capability)

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -306,9 +306,34 @@ export function getUpdatedUrlParts(
   })
 
   // Stringify and put the begin param character.
-  const queryString = queryParams.toString()
+  queryParams.sort() // ensure they always stay in sorted order to prevent url history changes
+
+  // When using URLSearchParams to construct a query string, it follows the application/x-www-form-urlencoded format,
+  // which uses + to represent space characters. The rest of Sippy uses the URI encoding tools in JS, which relies on
+  // %20 for spaces. This makes URL's change (and creates additional history entries, breaking the back button.
+  const queryString = queryParams.toString().replace(/\+/g, '%20')
   const retVal = `?${queryString}`
   return retVal
+}
+
+// sortQueryParams sorts a query parameters order so we don't screw up the history when they change
+export function sortQueryParams(path) {
+  // Split the path into base path and query string
+  const [basePath, queryString] = path.split('?')
+
+  if (!queryString) {
+    return path
+  }
+
+  // Use URLSearchParams to parse and sort the query parameters
+  const params = new URLSearchParams(queryString)
+  const sortedParams = new URLSearchParams([...params.entries()].sort())
+
+  // Re-assemble the path with sorted query parameters.
+  // When using URLSearchParams to construct a query string, it follows the application/x-www-form-urlencoded format,
+  // which uses + to represent space characters. The rest of Sippy uses the URI encoding tools in JS, which relies on
+  // %20 for spaces. This makes URL's change (and creates additional history entries, breaking the back button.
+  return basePath + '?' + sortedParams.toString().replace(/\+/g, '%20')
 }
 
 // Single place to make titles so they look consistent as well as capture the

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -310,7 +310,7 @@ export function getUpdatedUrlParts(
 
   // When using URLSearchParams to construct a query string, it follows the application/x-www-form-urlencoded format,
   // which uses + to represent space characters. The rest of Sippy uses the URI encoding tools in JS, which relies on
-  // %20 for spaces. This makes URL's change (and creates additional history entries, breaking the back button.
+  // %20 for spaces. This makes URL's change, which creates additional history entries, and breaks the back button.
   const queryString = queryParams.toString().replace(/\+/g, '%20')
   const retVal = `?${queryString}`
   return retVal
@@ -332,7 +332,7 @@ export function sortQueryParams(path) {
   // Re-assemble the path with sorted query parameters.
   // When using URLSearchParams to construct a query string, it follows the application/x-www-form-urlencoded format,
   // which uses + to represent space characters. The rest of Sippy uses the URI encoding tools in JS, which relies on
-  // %20 for spaces. This makes URL's change (and creates additional history entries, breaking the back button.
+  // %20 for spaces. This makes URL's change, which creates additional history entries, and breaks the back button.
   return basePath + '?' + sortedParams.toString().replace(/\+/g, '%20')
 }
 

--- a/sippy-ng/src/component_readiness/CompTestRow.js
+++ b/sippy-ng/src/component_readiness/CompTestRow.js
@@ -2,6 +2,7 @@ import './ComponentReadiness.css'
 import { Fragment } from 'react'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
+import { sortQueryParams } from './CompReadyUtils'
 import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip, Typography } from '@material-ui/core'
 import CompReadyCapCell from './CompReadyCapCell'
@@ -22,7 +23,7 @@ function testLink(filterVals, componentName, capabilityName, testId) {
     `&component=${safeComponentName}` +
     `&capability=${safeCapability}` +
     `&testId=${safeTestId}`
-  return retVal
+  return sortQueryParams(retVal)
 }
 
 // Represents a row when you clicked a capability on page2
@@ -55,27 +56,13 @@ export default function CompTestRow(props) {
   )
   const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
 
-  const handleClick = (event) => {
-    event.preventDefault()
-    setComponentParam(component)
-    setCapabilityParam(capability)
-    setTestIdParam(testId)
-    window.open(
-      '/sippy-ng' + testLink(filterVals, component, capability, testId),
-      '_blank'
-    )
-  }
-
   // Put the testName on the left side with a link to a test specific
   // test report.
   const testNameColumn = (
     <TableCell className={'cr-component-name'} key={testName}>
       <Tooltip title={'Capabilities report for ' + testName}>
         <Typography className="cr-cell-name">
-          <Link
-            to={testLink(filterVals, component, capability, testId)}
-            onClick={handleClick}
-          >
+          <Link to={testLink(filterVals, component, capability, testId)}>
             {[testSuite, testName].filter(Boolean).join('.')}
           </Link>
         </Typography>

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -359,6 +359,8 @@ export default function ComponentReadiness(props) {
   const [isLoaded, setIsLoaded] = React.useState(false)
   const [data, setData] = React.useState({})
 
+  useEffect(() => {}, [isLoaded])
+
   useEffect(() => {
     setData(initialPageTable)
     setIsLoaded(true)
@@ -682,9 +684,6 @@ export default function ComponentReadiness(props) {
                     ignoreDisruption,
                     ignoreMissing
                   )
-                  setComponentParam(component)
-                  setCapabilityParam(capability)
-                  setEnvironmentParam(environment)
                   return (
                     <CompReadyEnvCapability
                       key="capabilities"
@@ -718,7 +717,6 @@ export default function ComponentReadiness(props) {
                     ignoreDisruption,
                     ignoreMissing
                   )
-                  setComponentParam(component)
                   return (
                     <CompReadyEnvCapabilities
                       filterVals={filterVals}

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -359,13 +359,6 @@ export default function ComponentReadiness(props) {
   const [isLoaded, setIsLoaded] = React.useState(false)
   const [data, setData] = React.useState({})
 
-  useEffect(() => {}, [isLoaded])
-
-  useEffect(() => {
-    setData(initialPageTable)
-    setIsLoaded(true)
-  }, [])
-
   document.title = `Sippy > Component Readiness`
   if (fetchError !== '') {
     return gotFetchError(fetchError)
@@ -399,15 +392,6 @@ export default function ComponentReadiness(props) {
     return formattedApiCallStr
   }
 
-  if (!isLoaded) {
-    return (
-      <CompReadyProgress
-        apiLink={showValuesForReport()}
-        cancelFunc={cancelFetch}
-      />
-    )
-  }
-
   const columnNames = getColumns(data)
   if (columnNames[0] === 'Cancelled' || columnNames[0] === 'None') {
     return (
@@ -424,34 +408,8 @@ export default function ComponentReadiness(props) {
     data.rows.length > 1 &&
     getKeeperColumns(data, columnNames, redOnlyChecked)
 
-  // This runs when someone pushes the "Generate Report" button.
-  // We form an api string and then call the api.
-  const handleGenerateReport = (event) => {
-    event.preventDefault()
-    setBaseReleaseParam(baseRelease)
-    setBaseStartTimeParam(formatLongDate(baseStartTime))
-    setBaseEndTimeParam(formatLongDate(baseEndTime))
-    setSampleReleaseParam(sampleRelease)
-    setSampleStartTimeParam(formatLongDate(sampleStartTime))
-    setSampleEndTimeParam(formatLongDate(sampleEndTime))
-    setGroupByCheckedItemsParam(groupByCheckedItems)
-    setExcludeCloudsCheckedItemsParam(excludeCloudsCheckedItems)
-    setExcludeArchesCheckedItemsParam(excludeArchesCheckedItems)
-    setExcludeNetworksCheckedItemsParam(excludeNetworksCheckedItems)
-    setExcludeUpgradesCheckedItemsParam(excludeUpgradesCheckedItems)
-    setExcludeVariantsCheckedItemsParam(excludeVariantsCheckedItems)
-    setConfidenceParam(confidence)
-    setPityParam(pity)
-    setMinFailParam(minFail)
-    setIgnoreDisruptionParam(ignoreDisruption)
-    setIgnoreMissingParam(ignoreMissing)
-    setComponentParam(component)
-    setEnvironmentParam(environment)
-    setCapabilityParam(capability)
-
+  const fetchData = () => {
     const formattedApiCallStr = showValuesForReport()
-
-    setIsLoaded(false)
     fetch(formattedApiCallStr, { signal: abortController.signal })
       .then((response) => {
         if (response.status !== 200) {
@@ -483,7 +441,44 @@ export default function ComponentReadiness(props) {
       })
   }
 
-  //console.log('ComponentReadiness end')
+  useEffect(() => {
+    fetchData()
+  }, [])
+
+  // This runs when someone pushes the "Generate Report" button.
+  // We form an api string and then call the api.
+  const handleGenerateReport = (event) => {
+    event.preventDefault()
+    setBaseReleaseParam(baseRelease)
+    setBaseStartTimeParam(formatLongDate(baseStartTime))
+    setBaseEndTimeParam(formatLongDate(baseEndTime))
+    setSampleReleaseParam(sampleRelease)
+    setSampleStartTimeParam(formatLongDate(sampleStartTime))
+    setSampleEndTimeParam(formatLongDate(sampleEndTime))
+    setGroupByCheckedItemsParam(groupByCheckedItems)
+    setExcludeCloudsCheckedItemsParam(excludeCloudsCheckedItems)
+    setExcludeArchesCheckedItemsParam(excludeArchesCheckedItems)
+    setExcludeNetworksCheckedItemsParam(excludeNetworksCheckedItems)
+    setExcludeUpgradesCheckedItemsParam(excludeUpgradesCheckedItems)
+    setExcludeVariantsCheckedItemsParam(excludeVariantsCheckedItems)
+    setConfidenceParam(confidence)
+    setPityParam(pity)
+    setMinFailParam(minFail)
+    setIgnoreDisruptionParam(ignoreDisruption)
+    setIgnoreMissingParam(ignoreMissing)
+    setComponentParam(component)
+    setEnvironmentParam(environment)
+    setCapabilityParam(capability)
+  }
+
+  if (!isLoaded) {
+    return (
+      <CompReadyProgress
+        apiLink={showValuesForReport()}
+        cancelFunc={cancelFetch}
+      />
+    )
+  }
 
   const pageTitle = makePageTitle(
     `Component Readiness for ${baseRelease} vs. ${sampleRelease}`,


### PR DESCRIPTION
[TRT-1278](https://issues.redhat.com//browse/TRT-1278)

Fixes the back button, and removes the requirement to press "Generate report" on the first page load.

There were 2 problems with the back button:

- When a component links to itself, React doesn't automatically unmount
  and remount the component so old state stays around, this is why in
  places there were extra set state calls to update the app state
  resulting in split calls to state setting, meaning we ended up with
  different history entries for each state call.  The `key` param in
  App.js on ComponentReadiness fixes this and makes it update whenever the
  URL changes, thus re-reading the state from the URL parameters. This
  avoids the need for the extra state setting calls.

- In a few places, we reply on URLSearchParams, a browser built-in for
  serializing query parameters. it follows the
  application/x-www-form-urlencoded format, which uses + to represent
  space characters. JS URI encoding uses '%20' for spaces, meaning we
  trigger another url change (and history entry) when we use
  URLSearchParams.  The replace of `+` to `%20` fixes it.
