### PR TITLE
Enable metrics for component readiness

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -64,6 +64,18 @@ const (
 
 var (
 	componentReadinessCacheDuration = 8 * time.Hour
+
+	// Default filters, these are also hardcoded in the UI. Both must be updated.
+	// TODO: TRT-1237 should centralize these configurations for consumption by both the front and backends
+	DefaultExcludePlatforms = "openstack,alibaba,ibmcloud,libvirt,ovirt,unknown"
+	DefaultExcludeArches    = "arm64,heterogeneous,ppc64le,s390x"
+	DefaultExcludeVariants  = "hypershift,osd,microshift,techpreview,single-node,assisted,compact"
+	DefaultGroupBy          = "cloud,arch,network"
+	DefaultMinimumFailure   = 3
+	DefaultConfidence       = 95
+	DefaultPityFactor       = 5
+	DefaultIgnoreMissing    = false
+	DefaultIgnoreDisruption = true
 )
 
 func getSingleColumnResultToSlice(query *bigquery.Query) ([]string, error) {

--- a/pkg/api/component_report_test.go
+++ b/pkg/api/component_report_test.go
@@ -2,9 +2,11 @@
 package api
 
 import (
-	apitype "github.com/openshift/sippy/pkg/apis/api"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	apitype "github.com/openshift/sippy/pkg/apis/api"
 )
 
 func fakeComponentAndCapabilityGetter(test apitype.ComponentTestIdentification, stats apitype.ComponentTestStatus) (string, []string) {
@@ -789,7 +791,7 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		Variant:  testDetailsGenerator.Variant,
 	}
 	sampleReleaseStatsTwoHigh := apitype.ComponentReportTestDetailsReleaseStats{
-		Release: testDetailsGenerator.sampleRelease.Release,
+		Release: testDetailsGenerator.SampleRelease.Release,
 		ComponentReportTestDetailsTestStats: apitype.ComponentReportTestDetailsTestStats{
 			SuccessRate:  0.9203539823008849,
 			SuccessCount: 200,
@@ -798,7 +800,7 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		},
 	}
 	baseReleaseStatsTwoHigh := apitype.ComponentReportTestDetailsReleaseStats{
-		Release: testDetailsGenerator.baseRelease.Release,
+		Release: testDetailsGenerator.BaseRelease.Release,
 		ComponentReportTestDetailsTestStats: apitype.ComponentReportTestDetailsTestStats{
 			SuccessRate:  0.9130434782608695,
 			SuccessCount: 2000,
@@ -831,7 +833,7 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		FlakeCount:   50,
 	}
 	sampleReleaseStatsOneHigh := apitype.ComponentReportTestDetailsReleaseStats{
-		Release: testDetailsGenerator.sampleRelease.Release,
+		Release: testDetailsGenerator.SampleRelease.Release,
 		ComponentReportTestDetailsTestStats: apitype.ComponentReportTestDetailsTestStats{
 			SuccessRate:  0.9203539823008849,
 			SuccessCount: 100,
@@ -840,7 +842,7 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		},
 	}
 	baseReleaseStatsOneHigh := apitype.ComponentReportTestDetailsReleaseStats{
-		Release: testDetailsGenerator.baseRelease.Release,
+		Release: testDetailsGenerator.BaseRelease.Release,
 		ComponentReportTestDetailsTestStats: apitype.ComponentReportTestDetailsTestStats{
 			SuccessRate:  0.9130434782608695,
 			SuccessCount: 1000,
@@ -849,7 +851,7 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		},
 	}
 	sampleReleaseStatsOneLow := apitype.ComponentReportTestDetailsReleaseStats{
-		Release: testDetailsGenerator.sampleRelease.Release,
+		Release: testDetailsGenerator.SampleRelease.Release,
 		ComponentReportTestDetailsTestStats: apitype.ComponentReportTestDetailsTestStats{
 			SuccessRate:  0.4778761061946903,
 			SuccessCount: 50,
@@ -858,7 +860,7 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		},
 	}
 	baseReleaseStatsOneLow := apitype.ComponentReportTestDetailsReleaseStats{
-		Release: testDetailsGenerator.baseRelease.Release,
+		Release: testDetailsGenerator.BaseRelease.Release,
 		ComponentReportTestDetailsTestStats: apitype.ComponentReportTestDetailsTestStats{
 			SuccessRate:  0.4782608695652174,
 			SuccessCount: 500,

--- a/pkg/bigquery/client.go
+++ b/pkg/bigquery/client.go
@@ -1,0 +1,19 @@
+package bigquery
+
+import (
+	"cloud.google.com/go/bigquery"
+
+	"github.com/openshift/sippy/pkg/apis/cache"
+)
+
+type Client struct {
+	BQ    *bigquery.Client
+	Cache cache.Cache
+}
+
+func New(client *bigquery.Client, cache cache.Cache) *Client {
+	return &Client{
+		BQ:    client,
+		Cache: cache,
+	}
+}

--- a/pkg/bigquery/client.go
+++ b/pkg/bigquery/client.go
@@ -11,9 +11,9 @@ type Client struct {
 	Cache cache.Cache
 }
 
-func New(client *bigquery.Client, cache cache.Cache) *Client {
+func New(bqc *bigquery.Client, c cache.Cache) *Client {
 	return &Client{
-		BQ:    client,
-		Cache: cache,
+		BQ:    bqc,
+		Cache: c,
 	}
 }

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -195,22 +195,21 @@ func refreshComponentReadinessMetrics(client *bqclient.Client) error {
 		End: today.Add(24 * time.Hour).Add(-1 * time.Second),
 	}
 
-	// Defaults - these are also hardcoded in the UI side
 	testIDOption := apitype.ComponentReportRequestTestIdentificationOptions{}
 	excludeOption := apitype.ComponentReportRequestExcludeOptions{
-		ExcludePlatforms: "openstack,alibaba,ibmcloud,libvirt,ovirt,unknown",
-		ExcludeArches:    "arm64,heterogeneous,ppc64le,s390x",
-		ExcludeVariants:  "hypershift,osd,microshift,techpreview,single-node,assisted,compact",
+		ExcludePlatforms: api.DefaultExcludePlatforms,
+		ExcludeArches:    api.DefaultExcludeArches,
+		ExcludeVariants:  api.DefaultExcludeVariants,
 	}
 	variantOption := apitype.ComponentReportRequestVariantOptions{
-		GroupBy: "cloud,arch,network",
+		GroupBy: api.DefaultGroupBy,
 	}
 	advancedOption := apitype.ComponentReportRequestAdvancedOptions{
-		MinimumFailure:   3,
-		Confidence:       95,
-		PityFactor:       5,
-		IgnoreMissing:    false,
-		IgnoreDisruption: true,
+		MinimumFailure:   api.DefaultMinimumFailure,
+		Confidence:       api.DefaultConfidence,
+		PityFactor:       api.DefaultPityFactor,
+		IgnoreMissing:    api.DefaultIgnoreMissing,
+		IgnoreDisruption: api.DefaultIgnoreDisruption,
 	}
 
 	// Get report


### PR DESCRIPTION
[TRT-1321](https://issues.redhat.com//browse/TRT-1321)

- Moves the caching layer for component readiness into the data layer, so it works for the API and the metrics gathering
- Adds metrics for component readiness, reports last GA vs dev release

Example metrics:

```promql
sippy_component_readiness{arch="amd64",component="Cloud Compute / Other Provider",network="sdn",platform="azure"} -2
sippy_component_readiness{arch="amd64",component="Cloud Compute / Other Provider",network="sdn",platform="gcp"} -3
sippy_component_readiness{arch="amd64",component="Cloud Compute / Other Provider",network="sdn",platform="metal-ipi"} -1
sippy_component_readiness{arch="amd64",component="Cloud Compute / Other Provider",network="sdn",platform="vsphere"} 0
```

Alerts PR: https://github.com/openshift/continuous-release-jobs/pull/1350