### PR TITLE
Remove uses of Error when overlapping with "new Error()"

### DIFF
--- a/sippy-ng/src/releases/ReleasePayloadJobRuns.js
+++ b/sippy-ng/src/releases/ReleasePayloadJobRuns.js
@@ -1,5 +1,5 @@
 import { Button, Tooltip } from '@material-ui/core'
-import { Check, DirectionsBoat, Error } from '@material-ui/icons'
+import { Check, DirectionsBoat } from '@material-ui/icons'
 import { createTheme, makeStyles } from '@material-ui/core/styles'
 import { DataGrid } from '@material-ui/data-grid'
 import { NumberParam, StringParam, useQueryParam } from 'use-query-params'

--- a/sippy-ng/src/repositories/RepositoriesTable.js
+++ b/sippy-ng/src/repositories/RepositoriesTable.js
@@ -7,7 +7,7 @@ import {
   Typography,
 } from '@material-ui/core'
 import { DataGrid } from '@material-ui/data-grid'
-import { Details, Error, Launch } from '@material-ui/icons'
+import { Details, Launch } from '@material-ui/icons'
 import { generateClasses } from '../datagrid/utils'
 import { GridView } from '../datagrid/GridView'
 import { makeStyles } from '@material-ui/core/styles'

--- a/sippy-ng/src/tests/TestOutputs.js
+++ b/sippy-ng/src/tests/TestOutputs.js
@@ -10,7 +10,7 @@ import {
   TableRow,
   Tooltip,
 } from '@material-ui/core'
-import { DirectionsBoat, Error } from '@material-ui/icons'
+import { DirectionsBoat } from '@material-ui/icons'
 import { makeStyles } from '@material-ui/core/styles'
 import { safeEncodeURIComponent } from '../helpers'
 import Alert from '@material-ui/lab/Alert'


### PR DESCRIPTION
Added this to `eslintrc.js` and found 3 more occurrences of `Error` shadow:

```js
    'no-shadow': [
      'error',
      {
        builtinGlobals: true,
      },
    ],
```

Adding that option for now is a bit too intrusive as seen in [PR1273](https://github.com/openshift/sippy/pull/1273) so we skip it for now.