### PR TITLE
Component readiness should prioritize showing regressions first

### DIFF
--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -926,12 +926,6 @@ export default function ComponentReadiness(props) {
                                   new RegExp(searchComponentRegex, 'i')
                                 )
                               )
-                              .sort((a, b) =>
-                                data.rows[a].component.toLowerCase() >
-                                data.rows[b].component.toLowerCase()
-                                  ? 1
-                                  : -1
-                              )
                               .filter((componentIndex) =>
                                 redOnlyChecked
                                   ? data.rows[componentIndex].columns.some(


### PR DESCRIPTION
Currently, when looking at a component readiness report, it can be difficult to find which square was red.  For example [on this page](https://sippy.dptools.openshift.org/sippy-ng/component_readiness/env_capability?arch=amd64&arch=amd64&baseEndTime=2023-10-30%2023%3A59%3A59&baseRelease=4.14&baseStartTime=2023-10-02%2000%3A00%3A00&capability=Other&component=kube-apiserver&confidence=95&environment=ovn%20amd64%20metal-ipi&environment=ovn%20amd64%20metal-ipi&excludeArches=arm64%2Cheterogeneous%2Cppc64le%2Cs390x&excludeClouds=openstack%2Calibaba%2Cibmcloud%2Clibvirt%2Covirt%2Cunknown&excludeVariants=hypershift%2Cosd%2Cmicroshift%2Ctechpreview%2Csingle-node%2Cassisted%2Ccompact&groupBy=cloud%2Carch%2Cnetwork&ignoreDisruption=true&ignoreMissing=false&minFail=3&network=ovn&network=ovn&pity=5&platform=metal-ipi&platform=metal-ipi&sampleEndTime=2023-11-01%2023%3A59%3A59&sampleRelease=4.15&sampleStartTime=2023-10-25%2000%3A00%3A00) you have to scroll quite far, almost to the bottom.

With this change, regressions will appear first in the list on all CR pages, like this:

![image](https://github.com/openshift/sippy/assets/429763/118fdad0-e0cd-461c-92e3-80675b58bfd9)
