### PR TITLE
Don't generate component readiness metrics until we have a cache

### DIFF
--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -151,7 +151,12 @@ func RefreshMetricsDB(dbc *db.DB, bqc *bqclient.Client, variantManager testident
 
 func refreshComponentReadinessMetrics(client *bqclient.Client) error {
 	if client == nil || client.BQ == nil {
-		log.Infof("not generating component readiness metrics as we don't have a bigquery client")
+		log.Warningf("not generating component readiness metrics as we don't have a bigquery client")
+		return nil
+	}
+
+	if client.Cache == nil {
+		log.Warningf("not generating component readiness metrics as we don't have a cache configured")
 		return nil
 	}
 


### PR DESCRIPTION
If we don't have a cache, then we don't want component readiness metrics, because you'll end up hitting bigquery every 5 minutes ($$$).