### PR TITLE
[wip] Remember the last update for expensive metrics

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -137,6 +137,10 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 		return err
 	}
 
+	if err := d.DB.AutoMigrate(&models.MetricsRefresh{}); err != nil {
+		return err
+	}
+
 	if err := d.DB.AutoMigrate(&models.TestOwnership{}); err != nil {
 		return err
 	}

--- a/pkg/db/models/metrics.go
+++ b/pkg/db/models/metrics.go
@@ -1,0 +1,6 @@
+package models
+
+type MetricsRefresh struct {
+	Model
+	Name string `gorm:"index"`
+}


### PR DESCRIPTION
Don't update component readiness more than every 6 hours.