### PR TITLE
Fix sippy builds (remove axios, fix OOMKilled for golangci-lint)

### DIFF
--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -4,7 +4,7 @@
 # [1] https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image
 #
 FROM registry.access.redhat.com/ubi9/ubi:latest
-ARG GOLANGCI_LINT_VERSION="1.49.0"
+ARG GOLANGCI_LINT_VERSION="1.51.2"
 RUN curl -Lso /tmp/golangci-lint.rpm \
           "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64.rpm" && \
       dnf module enable nodejs:18 -y && \

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -7,6 +7,8 @@ set -ex
 
 if [ "$CI" = "true" ];
 then
+  go version
+  golangci-lint version -v
   golangci-lint "${@}"
 else
   DOCKER=${DOCKER:-podman}
@@ -20,6 +22,6 @@ else
   $DOCKER run --rm \
     --volume "${PWD}:/go/src/github.com/openshift/sippy:z" \
     --workdir /go/src/github.com/openshift/sippy \
-    docker.io/golangci/golangci-lint:v1.49 \
+    docker.io/golangci/golangci-lint:v1.51.2 \
     golangci-lint "${@}"
 fi

--- a/pkg/sippyserver/pr_commenting_processor.go
+++ b/pkg/sippyserver/pr_commenting_processor.go
@@ -792,15 +792,6 @@ func (aw *AnalysisWorker) buildProwJobMap(prJobRoot string) (map[time.Time]prow.
 			continue
 		}
 
-		// jobName
-		// pr-logs/pull/org_repo/1555/pull-ci-openshift-origin-master-e2e-aws-csi/
-		// jobPath := strings.Split(attrs.Prefix, "/")
-
-		// last string is "" so -2
-		// jobName := jobPath[len(jobPath)-2]
-
-		// https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/openshift-cluster-node-tuning-operator-771-ci-4.14-upgrade-from-stable-4.13-e2e-gcp-ovn-rt-upgrade/1693982822663983104/prowjob.json
-
 		bytes, err := jobRun.GetContent(context.TODO(), fmt.Sprintf("%s%s", attrs.Prefix, "prowjob.json"))
 		if err != nil {
 			log.WithError(err).Errorf("Failed to get prowjob for: %s", attrs.Prefix)

--- a/sippy-ng/package-lock.json
+++ b/sippy-ng/package-lock.json
@@ -21,7 +21,6 @@
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",
-        "axios": "^0.21.4",
         "chart.js": "^3.5.1",
         "chartjs-plugin-annotation": "^1.0.2",
         "chartjs-plugin-trendline": "^0.1.1",
@@ -6590,14 +6589,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "node_modules/axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -10481,6 +10472,7 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
       "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -28059,14 +28051,6 @@
       "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==",
       "dev": true
     },
-    "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "requires": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -31016,7 +31000,8 @@
     "follow-redirects": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "dev": true
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "6.5.2",

--- a/sippy-ng/package.json
+++ b/sippy-ng/package.json
@@ -16,7 +16,6 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
-    "axios": "^0.21.4",
     "chart.js": "^3.5.1",
     "chartjs-plugin-annotation": "^1.0.2",
     "chartjs-plugin-trendline": "^0.1.1",


### PR DESCRIPTION
- We don't actually use axios anywhere, and there's now a CVE in it, which is preventing builds https://github.com/advisories/GHSA-wf5p-g6vw-rhxx
- Once we get past that, golangci-lint is OOMKilled because ubi9 updated their golang version... update golangci-lint to 1.52.1, this should prevent the oom (golangci-lint and golang versions have to be compatible)