### PR TITLE
Fix date picker for filters

### DIFF
--- a/sippy-ng/src/datagrid/GridToolbarFilterItem.js
+++ b/sippy-ng/src/datagrid/GridToolbarFilterItem.js
@@ -1,3 +1,4 @@
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 import {
   Button,
   Checkbox,
@@ -10,7 +11,7 @@ import {
   TextField,
 } from '@mui/material'
 import { Close } from '@mui/icons-material'
-import { DateTimePicker } from '@mui/x-date-pickers'
+import { DateTimePicker, LocalizationProvider } from '@mui/x-date-pickers'
 import { makeStyles } from '@mui/styles'
 import GridToolbarAutocomplete from './GridToolbarAutocomplete'
 import PropTypes from 'prop-types'
@@ -87,26 +88,31 @@ export default function GridToolbarFilterItem(props) {
       case 'date':
         return (
           <Fragment>
-            <DateTimePicker
-              disabled={disabled}
-              showTodayButton
-              disableFuture
-              label="Value"
-              format="yyyy-MM-dd HH:mm 'UTC'"
-              ampm={false}
-              value={
-                props.filterModel.value === ''
-                  ? null
-                  : new Date(parseInt(props.filterModel.value))
-              }
-              onChange={(e) => {
-                props.setFilterModel({
-                  columnField: props.filterModel.columnField,
-                  operatorValue: props.filterModel.operatorValue,
-                  value: e.getTime().toString(),
-                })
-              }}
-            />
+            <LocalizationProvider dateAdapter={AdapterDateFns}>
+              <DateTimePicker
+                disabled={disabled}
+                showTodayButton
+                disableFuture
+                label="Value"
+                format="yyyy-MM-dd HH:mm 'UTC'"
+                ampm={false}
+                value={
+                  props.filterModel.value === ''
+                    ? null
+                    : new Date(parseInt(props.filterModel.value))
+                }
+                onChange={(e) => {
+                  props.setFilterModel({
+                    columnField: props.filterModel.columnField,
+                    operatorValue: props.filterModel.operatorValue,
+                    value: e.getTime().toString(),
+                  })
+                }}
+                renderInput={(props) => (
+                  <TextField variant="standard" {...props} />
+                )}
+              />
+            </LocalizationProvider>
             <FormHelperText error={operatorValueError}>Required</FormHelperText>
           </Fragment>
         )


### PR DESCRIPTION
Bug from the v5 upgrade. Job analysis page date filters aren't working, it needed to be wrapped with the LocalizationProvider like I did for component readiness.