### PR TITLE
TRT-1357: Publish disruption delta metrics

### DIFF
--- a/pkg/api/disruption_report.go
+++ b/pkg/api/disruption_report.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	apitype "github.com/openshift/sippy/pkg/apis/api"
+	bqcachedclient "github.com/openshift/sippy/pkg/bigquery"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/api/iterator"
+)
+
+func GetDisruptionVsPrevGAReportFromBigQuery(client *bqcachedclient.Client) (apitype.DisruptionReport, []error) {
+	generator := disruptionReportGenerator{
+		client:   client.BQ,
+		ViewName: "BackendDisruptionPercentilesDeltaCurrentVsPrevGA",
+	}
+
+	return getReportFromCacheOrGenerate[apitype.DisruptionReport](client.Cache, generator, generator.GenerateReport, apitype.DisruptionReport{})
+}
+
+func GetDisruptionVsTwoWeeksAgoReportFromBigQuery(client *bqcachedclient.Client) (apitype.DisruptionReport, []error) {
+	generator := disruptionReportGenerator{
+		client:   client.BQ,
+		ViewName: "BackendDisruptionPercentilesDeltaCurrentVs14DaysAgo",
+	}
+
+	return getReportFromCacheOrGenerate[apitype.DisruptionReport](client.Cache, generator, generator.GenerateReport, apitype.DisruptionReport{})
+}
+
+type disruptionReportGenerator struct {
+	client   *bigquery.Client
+	ViewName string
+}
+
+func (c *disruptionReportGenerator) GenerateReport() (apitype.DisruptionReport, []error) {
+	before := time.Now()
+	disruptionReport, err := c.getDisruptionDeltasFromBigQuery()
+	if err != nil {
+		return apitype.DisruptionReport{}, []error{err}
+	}
+	log.Infof("Disruption report fetched from bigquery in %s with %d rows", time.Since(before), len(disruptionReport.Rows))
+
+	return disruptionReport, nil
+}
+
+func (c *disruptionReportGenerator) getDisruptionDeltasFromBigQuery() (apitype.DisruptionReport, error) {
+	// We'll publish a metric for whatever is in the views, which need to be updated for each GA release:
+	queryString := fmt.Sprintf(`
+						SELECT *
+						FROM openshift-ci-data-analysis.ci_data.%s`, c.ViewName)
+
+	query := c.client.Query(queryString)
+	it, err := query.Read(context.TODO())
+	if err != nil {
+		log.WithError(err).Error("error querying disruption data from bigquery")
+		return apitype.DisruptionReport{}, err
+	}
+
+	// Using a set since sometimes bigquery has multiple copies of the same prow job
+	rows := []apitype.DisruptionReportRow{}
+	for {
+		r := apitype.DisruptionReportRow{}
+		err := it.Next(&r)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.WithError(err).Error("error parsing disruption report row from bigquery")
+			return apitype.DisruptionReport{}, err
+		}
+		rows = append(rows, r)
+	}
+	return apitype.DisruptionReport{
+		Rows: rows,
+	}, nil
+}

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -990,3 +990,27 @@ var FailureRiskLevelMedium = RiskLevel{Name: "Medium", Level: 50}
 var FailureRiskLevelIncompleteTests = RiskLevel{Name: "IncompleteTests", Level: 75}
 var FailureRiskLevelMissingData = RiskLevel{Name: "MissingData", Level: 76}
 var FailureRiskLevelHigh = RiskLevel{Name: "High", Level: 100}
+
+type DisruptionReportDeltaRequestOptions struct {
+	Release string
+}
+
+type DisruptionReport struct {
+	Rows []DisruptionReportRow `json:"rows,omitempty"`
+}
+
+type DisruptionReportRow struct {
+	P50Delta                 float32 `json:"p50_delta"`
+	P75Delta                 float32 `json:"p75_delta"`
+	P95Delta                 float32 `json:"p95_delta"`
+	PercentageAboveZeroDelta float32 `json:"percentage_above_zero_delta"`
+	Release                  string  `json:"release"`
+	CompareRelease           string  `json:"compare_release,omitempty"` // only present in the vs prev GA view
+	BackendName              string  `json:"backend_name"`
+	Platform                 string  `json:"platform"`
+	UpgradeType              string  `json:"upgrade_type"`
+	MasterNodesUpdated       string  `json:"master_nodes_updated"`
+	Network                  string  `json:"network"`
+	Topology                 string  `json:"topology"`
+	Architecture             string  `json:"architecture"`
+}


### PR DESCRIPTION
Query new views in BigQuery which contain the complex logic, whatever is
in those views, we publish a metric for. One of them will need to be
updated as part of the GA date tasks.

Metrics published for the P50/75/95 delta now compared to both 30 days
prior to previous GA, and two weeks prior to two weeks ago.

We'll alert on these to notify ourselves of regressions in either.
