### PR TITLE
Be more defensive about empty cache keys

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -60,8 +60,6 @@ const (
 )
 
 var (
-	componentReadinessCacheDuration = 8 * time.Hour
-
 	// Default filters, these are also hardcoded in the UI. Both must be updated.
 	// TODO: TRT-1237 should centralize these configurations for consumption by both the front and backends
 	DefaultExcludePlatforms = "openstack,alibaba,ibmcloud,libvirt,ovirt,unknown"

--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -2,9 +2,7 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -18,7 +16,6 @@ import (
 	"google.golang.org/api/iterator"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
-	"github.com/openshift/sippy/pkg/apis/cache"
 	bqcachedclient "github.com/openshift/sippy/pkg/bigquery"
 	"github.com/openshift/sippy/pkg/util/sets"
 )
@@ -1174,42 +1171,6 @@ func (c *componentReportGenerator) assessComponentStatus(sampleTotal, sampleSucc
 		}
 	}
 	return status, fischerExact
-}
-
-// getReportFromCacheOrGenerate attempts to find a cached record otherwise generates a new report.
-func getReportFromCacheOrGenerate[T any](c cache.Cache, cacheKey interface{}, generateFn func() (T, []error), defaultVal T) (T, []error) {
-	if c != nil {
-		cacheKey, err := json.Marshal(cacheKey)
-		if err != nil {
-			return defaultVal, []error{err}
-		}
-		if res, err := c.Get(string(cacheKey)); err == nil {
-			log.WithFields(log.Fields{
-				"key":  string(cacheKey),
-				"type": reflect.TypeOf(defaultVal).String(),
-			}).Debugf("cache hit")
-			var cr T
-			if err := json.Unmarshal(res, &cr); err != nil {
-				return defaultVal, []error{err}
-			}
-			return cr, nil
-		}
-		log.Infof("cache miss for cache key: %s", string(cacheKey))
-		result, errs := generateFn()
-		if len(errs) == 0 {
-			cr, err := json.Marshal(result)
-			if err == nil {
-				if err := c.Set(string(cacheKey), cr, componentReadinessCacheDuration); err != nil {
-					log.WithError(err).Warningf("couldn't persist new item to cache")
-				} else {
-					log.Debugf("cache set for cache key: %s", string(cacheKey))
-				}
-			}
-		}
-		return result, errs
-	}
-
-	return generateFn()
 }
 
 func init() {

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -4,10 +4,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
 	"github.com/openshift/sippy/pkg/apis/cache"
+)
+
+var (
+	cacheDuration = 8 * time.Hour
 )
 
 // getReportFromCacheOrGenerate attempts to find a cached record otherwise generates a new report.
@@ -42,7 +47,7 @@ func getReportFromCacheOrGenerate[T any](c cache.Cache, cacheKey interface{}, ge
 		if len(errs) == 0 {
 			cr, err := json.Marshal(result)
 			if err == nil {
-				if err := c.Set(string(jsonCacheKey), cr, componentReadinessCacheDuration); err != nil {
+				if err := c.Set(string(jsonCacheKey), cr, cacheDuration); err != nil {
 					log.WithError(err).Warningf("couldn't persist new item to cache")
 				} else {
 					log.Debugf("cache set for cache key: %s", string(jsonCacheKey))

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/openshift/sippy/pkg/apis/cache"
+)
+
+// getReportFromCacheOrGenerate attempts to find a cached record otherwise generates a new report.
+func getReportFromCacheOrGenerate[T any](c cache.Cache, cacheKey interface{}, generateFn func() (T, []error), defaultVal T) (T, []error) {
+	// If someone is giving us an uncacheable cacheKey, we should panic so it gets detected in testing
+	if isStructWithNoPublicFields(cacheKey) {
+		panic(fmt.Sprintf("you cannot use struct %s with no exported fields as a cache key", reflect.TypeOf(cacheKey)))
+	} else if cacheKey == "" {
+		panic(fmt.Sprintf("you cannot use empty string as a cache key for %s", reflect.TypeOf(defaultVal)))
+	} else if cacheKey == nil {
+		panic(fmt.Sprintf("cache key is nil for %s", reflect.TypeOf(defaultVal)))
+	}
+
+	if c != nil {
+		jsonCacheKey, err := json.Marshal(cacheKey)
+		if err != nil {
+			return defaultVal, []error{err}
+		}
+		if res, err := c.Get(string(jsonCacheKey)); err == nil {
+			log.WithFields(log.Fields{
+				"key":  string(jsonCacheKey),
+				"type": reflect.TypeOf(defaultVal).String(),
+			}).Debugf("cache hit")
+			var cr T
+			if err := json.Unmarshal(res, &cr); err != nil {
+				return defaultVal, []error{err}
+			}
+			return cr, nil
+		}
+		log.Infof("cache miss for cache key: %s", string(jsonCacheKey))
+		result, errs := generateFn()
+		if len(errs) == 0 {
+			cr, err := json.Marshal(result)
+			if err == nil {
+				if err := c.Set(string(jsonCacheKey), cr, componentReadinessCacheDuration); err != nil {
+					log.WithError(err).Warningf("couldn't persist new item to cache")
+				} else {
+					log.Debugf("cache set for cache key: %s", string(jsonCacheKey))
+				}
+			}
+		}
+		return result, errs
+	}
+
+	return generateFn()
+}
+
+// isStructWithNoPublicFields checks if the given interface is a struct with no public fields.
+func isStructWithNoPublicFields(v interface{}) bool {
+	val := reflect.ValueOf(v)
+	if val.Kind() != reflect.Struct {
+		return false
+	}
+	for i := 0; i < val.NumField(); i++ {
+		if val.Type().Field(i).IsExported() {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Easy to introduce bug, this should help detect it. It triggered on the initial version of https://github.com/openshift/sippy/pull/1330/files with:

```
panic: you cannot use struct api.disruptionReportGenerator with no exported fields as a cache key
```