### PR TITLE
Disable console.log in production

### DIFF
--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -223,6 +223,13 @@ export default function App(props) {
       })
   }
 
+  // Disable console.log in production
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      console.log = function () {}
+    }
+  }, [])
+
   useEffect(() => {
     if (!isLoaded) {
       fetchData()


### PR DESCRIPTION
It's generally accepted that JS console.log messages shouldn't be visible in production [1], this turns console.log to noops when we're running in prod mode so we don't have to remove debugging logs which might be useful later in development.

[1] https://www.google.com/search?q=disable+js+console.log+in+production