### PR TITLE
Show revert count in repositories API

### DIFF
--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -48,10 +48,11 @@ type Pagination struct {
 }
 
 type Repository struct {
-	ID       int    `json:"id"`
-	Org      string `json:"org"`
-	Repo     string `json:"repo"`
-	JobCount int    `json:"job_count"`
+	ID          int    `json:"id"`
+	Org         string `json:"org"`
+	Repo        string `json:"repo"`
+	JobCount    int    `json:"job_count"`
+	RevertCount int    `json:"revert_count"`
 
 	// WorstPremergeJobFailures is the average number of tries on the worst
 	// performing presubmit job. For example, if e2e-aws-upgrade takes 7 tries

--- a/pkg/db/query/repository_queries.go
+++ b/pkg/db/query/repository_queries.go
@@ -3,24 +3,31 @@ package query
 import (
 	"time"
 
+	"gorm.io/gorm"
+
 	"github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/filter"
 )
 
 func RepositoryReport(dbc *db.DB, filterOpts *filter.FilterOptions, release string, reportEnd time.Time) ([]api.Repository, error) {
-	start := reportEnd.Add(-14 * 24 * time.Hour)
 	end := reportEnd
-	averageByJob := PullRequestAveragePremergeFailures(dbc, &start, &end)
+
+	premergeFailureStart := reportEnd.Add(-14 * 24 * time.Hour)
+	averageByJob := PullRequestAveragePremergeFailures(dbc, &premergeFailureStart, &end)
+
+	revertCountStart := reportEnd.Add(-90 * 24 * time.Hour)
+	revertCount := RepositoryRevertCount(dbc, &revertCountStart, &end)
 
 	repos := dbc.DB.Table("prow_pull_requests").
 		Joins("INNER JOIN prow_job_run_prow_pull_requests ON prow_job_run_prow_pull_requests.prow_pull_request_id = prow_pull_requests.id").
 		Joins("INNER JOIN prow_job_runs on prow_job_run_prow_pull_requests.prow_job_run_id = prow_job_runs.id").
 		Joins("INNER JOIN prow_jobs on prow_job_runs.prow_job_id = prow_jobs.id").
+		Joins("LEFT JOIN (?) revert_count ON revert_count.org = prow_pull_requests.org AND revert_count.repo = prow_pull_requests.repo", revertCount).
 		Joins("LEFT JOIN (?) premerge_failures ON premerge_failures.prow_job_ID = prow_jobs.id", averageByJob).
 		Where("prow_jobs.release = ?", release).
 		Group("prow_pull_requests.org, prow_pull_requests.repo").
-		Select("ROW_NUMBER() OVER() as id, prow_pull_requests.org, prow_pull_requests.repo, coalesce(max(average_premerge_job_failures), 0) as worst_premerge_job_failures, count(distinct(prow_jobs.id)) as job_count")
+		Select("ROW_NUMBER() OVER() as id, prow_pull_requests.org, prow_pull_requests.repo, max(revert_count) as revert_count, coalesce(max(average_premerge_job_failures), 0) as worst_premerge_job_failures, count(distinct(prow_jobs.id)) as job_count")
 
 	results := make([]api.Repository, 0)
 	q, err := filter.FilterableDBResult(dbc.DB.Table("(?) as repos", repos), filterOpts, api.Repository{})
@@ -29,4 +36,22 @@ func RepositoryReport(dbc *db.DB, filterOpts *filter.FilterOptions, release stri
 	}
 	q.Scan(&results)
 	return results, nil
+}
+
+func RepositoryRevertCount(dbc *db.DB, start, end *time.Time) *gorm.DB {
+	query := dbc.DB.Table("prow_pull_requests").
+		Where("title ILIKE '%Revert%'").
+		Where("title NOT ILIKE '%Unrevert%'").
+		Group("org, repo").
+		Select("org, repo, COUNT(DISTINCT link) AS revert_count")
+
+	if start != nil {
+		query = query.Where("prow_pull_requests.merged_at >= ?", start)
+	}
+
+	if end != nil {
+		query = query.Where("prow_pull_requests.merged_at <= ?", end)
+	}
+
+	return query
 }

--- a/pkg/filter/filterable.go
+++ b/pkg/filter/filterable.go
@@ -78,9 +78,9 @@ func (f FilterItem) orFilterToSQL(db *gorm.DB, filterable Filterable) (orFilter 
 			return fmt.Sprintf("? = ANY(%s)", field), f.Value
 		}
 		if f.Not {
-			return fmt.Sprintf("%s NOT LIKE ?", field), fmt.Sprintf("%%%s%%", f.Value)
+			return fmt.Sprintf("%s NOT ILIKE ?", field), fmt.Sprintf("%%%s%%", f.Value)
 		}
-		return fmt.Sprintf("%s LIKE ?", field), fmt.Sprintf("%%%s%%", f.Value)
+		return fmt.Sprintf("%s ILIKE ?", field), fmt.Sprintf("%%%s%%", f.Value)
 	case OperatorEquals, OperatorArithmeticEquals:
 
 		if f.Not {
@@ -114,14 +114,14 @@ func (f FilterItem) orFilterToSQL(db *gorm.DB, filterable Filterable) (orFilter 
 		return fmt.Sprintf("%s <> ?", field), f.Value
 	case OperatorStartsWith:
 		if f.Not {
-			return fmt.Sprintf("%s NOT LIKE ?", field), fmt.Sprintf("%s%%", f.Value)
+			return fmt.Sprintf("%s NOT ILIKE ?", field), fmt.Sprintf("%s%%", f.Value)
 		}
-		return fmt.Sprintf("%s LIKE ?", field), fmt.Sprintf("%s%%", f.Value)
+		return fmt.Sprintf("%s ILIKE ?", field), fmt.Sprintf("%s%%", f.Value)
 	case OperatorEndsWith:
 		if f.Not {
-			return fmt.Sprintf("%s NOT LIKE ?", field), fmt.Sprintf("%%%s", f.Value)
+			return fmt.Sprintf("%s NOT ILIKE ?", field), fmt.Sprintf("%%%s", f.Value)
 		}
-		return fmt.Sprintf("%s LIKE ?", field), fmt.Sprintf("%%%s", f.Value)
+		return fmt.Sprintf("%s ILIKE ?", field), fmt.Sprintf("%%%s", f.Value)
 	case OperatorIsEmpty:
 		if f.Not {
 			return fmt.Sprintf("%s IS NOT NULL", field), nil
@@ -153,9 +153,9 @@ func (f FilterItem) andFilterToSQL(db *gorm.DB, filterable Filterable) *gorm.DB 
 			}
 		} else {
 			if f.Not {
-				db = db.Not(fmt.Sprintf("%s LIKE ?", field), fmt.Sprintf("%%%s%%", f.Value))
+				db = db.Not(fmt.Sprintf("%s ILIKE ?", field), fmt.Sprintf("%%%s%%", f.Value))
 			} else {
-				db = db.Where(fmt.Sprintf("%s LIKE ?", field), fmt.Sprintf("%%%s%%", f.Value))
+				db = db.Where(fmt.Sprintf("%s ILIKE ?", field), fmt.Sprintf("%%%s%%", f.Value))
 			}
 		}
 	case OperatorEquals, OperatorArithmeticEquals:
@@ -196,15 +196,15 @@ func (f FilterItem) andFilterToSQL(db *gorm.DB, filterable Filterable) *gorm.DB 
 		}
 	case OperatorStartsWith:
 		if f.Not {
-			db = db.Not(fmt.Sprintf("%s LIKE ?", field), fmt.Sprintf("%s%%", f.Value))
+			db = db.Not(fmt.Sprintf("%s ILIKE ?", field), fmt.Sprintf("%s%%", f.Value))
 		} else {
-			db = db.Where(fmt.Sprintf("%s LIKE ?", field), fmt.Sprintf("%s%%", f.Value))
+			db = db.Where(fmt.Sprintf("%s ILIKE ?", field), fmt.Sprintf("%s%%", f.Value))
 		}
 	case OperatorEndsWith:
 		if f.Not {
-			db = db.Not(fmt.Sprintf("%s LIKE ?", field), fmt.Sprintf("%%%s", f.Value))
+			db = db.Not(fmt.Sprintf("%s ILIKE ?", field), fmt.Sprintf("%%%s", f.Value))
 		} else {
-			db = db.Where(fmt.Sprintf("%s LIKE ?", field), fmt.Sprintf("%%%s", f.Value))
+			db = db.Where(fmt.Sprintf("%s ILIKE ?", field), fmt.Sprintf("%%%s", f.Value))
 		}
 	case OperatorIsEmpty:
 		if f.Not {

--- a/sippy-ng/src/repositories/RepositoriesTable.js
+++ b/sippy-ng/src/repositories/RepositoriesTable.js
@@ -51,6 +51,9 @@ function RepositoriesTable(props) {
     'Failures exclude developer pushes or successful retests due to code changes.  It only looks ' +
     'at failures on merged commit shas.'
 
+  const REVERT_COUNT_TOOLTIP =
+    'Revert count is our best guess for how many reverts this repo has had merged over the last 90 days.'
+
   const { classes } = props
   const gridClasses = useStyles()
   const history = useHistory()
@@ -90,6 +93,10 @@ function RepositoriesTable(props) {
           flex: 2,
         },
         {
+          field: 'revert_count',
+          flex: 2,
+        },
+        {
           field: 'worst_premerge_job_failures',
           flex: 2,
         },
@@ -115,6 +122,20 @@ function RepositoriesTable(props) {
     job_count: {
       field: 'job_count',
       headerName: 'Job count',
+      type: 'number',
+    },
+    revert_count: {
+      field: 'revert_count',
+      headerName: (
+        <Fragment>
+          <Tooltip title={REVERT_COUNT_TOOLTIP}>
+            <Typography>
+              Revert count
+              <InfoIcon />
+            </Typography>
+          </Tooltip>
+        </Fragment>
+      ),
       type: 'number',
     },
     worst_premerge_job_failures: {

--- a/sippy-ng/src/repositories/RepositoryDetails.js
+++ b/sippy-ng/src/repositories/RepositoryDetails.js
@@ -117,6 +117,26 @@ export default function RepositoryDetails(props) {
                 />
               </Card>
             </Grid>
+
+            <Grid item md={12} sm={12}>
+              <Card elevation={5} style={{ padding: 20, height: '100%' }}>
+                <Typography variant="h6">Recent Reverts</Typography>
+                <PullRequestsTable
+                  view="Summary"
+                  pageSize={5}
+                  hideControls={true}
+                  release={props.release}
+                  filterModel={{
+                    items: [
+                      filterFor('org', 'equals', props.org),
+                      filterFor('repo', 'equals', props.repo),
+                      filterFor('merged_at', 'is not empty'),
+                      filterFor('title', 'contains', 'revert'),
+                    ],
+                  }}
+                />
+              </Card>
+            </Grid>
           </Grid>
         </Container>
       </div>


### PR DESCRIPTION
TRT-1288

This adds a revert count into the repositories API based on data in the Sippy DB.

*Note*:: this also changes the behavior of partial SQL filters "contains", "starts with", "ends with" to use case-insensitive matching.  That seems like a better behavior anyway.