### PR TITLE
Clean-up component readiness toolbar

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -1,6 +1,14 @@
+import {
+  alpha,
+  Checkbox,
+  FormControl,
+  InputBase,
+  Typography,
+} from '@mui/material'
 import { format } from 'date-fns'
-import { Typography } from '@mui/material'
+import { styled } from '@mui/styles'
 import Alert from '@mui/material/Alert'
+import FormControlLabel from '@mui/material/FormControlLabel'
 import green from './green-3.png'
 import green_half_data from './green-half-data.png'
 import green_missing_data from './green_no_data.png'
@@ -424,3 +432,43 @@ export function mergeRegressedTests(data) {
   regressedTests = regressedTests.map((item, index) => ({ ...item, id: index }))
   return regressedTests
 }
+
+export const Search = styled('div')(({ theme }) => ({
+  position: 'relative',
+  borderRadius: theme.shape.borderRadius,
+  backgroundColor: alpha(theme.palette.common.white, 0.15),
+  '&:hover': {
+    backgroundColor: alpha(theme.palette.common.white, 0.25),
+  },
+  marginRight: theme.spacing(2),
+  marginLeft: 0,
+  width: '100%',
+  [theme.breakpoints.up('sm')]: {
+    marginLeft: theme.spacing(0),
+    width: 'auto',
+  },
+}))
+
+export const SearchIconWrapper = styled('div')(({ theme }) => ({
+  padding: theme.spacing(0, 2),
+  height: '100%',
+  position: 'absolute',
+  pointerEvents: 'none',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}))
+
+export const StyledInputBase = styled(InputBase)(({ theme }) => ({
+  color: 'inherit',
+  '& .MuiInputBase-input': {
+    padding: theme.spacing(1, 1, 1, 0),
+    // vertical padding + font size from searchIcon
+    paddingLeft: `calc(1em + ${theme.spacing(4)})`,
+    transition: theme.transitions.create('width'),
+    width: '100%',
+    [theme.breakpoints.up('md')]: {
+      width: '20ch',
+    },
+  },
+}))

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -1,15 +1,11 @@
 import './ComponentReadiness.css'
 import {
-  ArrayParam,
-  BooleanParam,
-  NumberParam,
-  SafeStringParam,
-  StringParam,
-  useQueryParam,
-} from 'use-query-params'
-import {
+  AppBar,
+  Badge,
+  Box,
   Button,
   Checkbox,
+  Container,
   Drawer,
   FormControlLabel,
   Grid,
@@ -20,6 +16,14 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
+import {
+  ArrayParam,
+  BooleanParam,
+  NumberParam,
+  SafeStringParam,
+  StringParam,
+  useQueryParam,
+} from 'use-query-params'
 import {
   cancelledDataTable,
   dateEndFormat,
@@ -36,12 +40,29 @@ import {
   makeRFC3339Time,
   mergeRegressedTests,
   noDataTable,
+  Search,
+  SearchIconWrapper,
+  StyledCheckbox,
+  StyledFormControlLabel,
+  StyledInputBase,
 } from './CompReadyUtils'
 import { ClassNameMap } from '@mui/styles'
 import { Fragment, useContext, useEffect, useState } from 'react'
 import { Route, Switch, useRouteMatch } from 'react-router-dom'
+import SwitchControl from '@mui/material/Switch'
 
-import { Clear, FileCopy } from '@mui/icons-material'
+import {
+  AccountCircle,
+  Clear,
+  FileCopy,
+  GridView,
+  InsertLink,
+  Mail,
+  Notifications,
+  SwitchCamera,
+  ViewColumn,
+  Widgets,
+} from '@mui/icons-material'
 import { grey } from '@mui/material/colors'
 import { makeStyles, useTheme } from '@mui/styles'
 import { ReleasesContext } from '../App'
@@ -61,11 +82,13 @@ import IconButton from '@mui/material/IconButton'
 import MenuIcon from '@mui/icons-material/Menu'
 import React from 'react'
 import RegressedTestsModal from './RegressedTestsModal'
+import SearchIcon from '@mui/icons-material/Search'
 import Table from '@mui/material/Table'
 import TableBody from '@mui/material/TableBody'
 import TableCell from '@mui/material/TableCell'
 import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
+import Toolbar from '@mui/material/Toolbar'
 
 const drawerWidth = 240
 
@@ -1043,91 +1066,124 @@ export default function ComponentReadiness(props) {
                         </Typography>
                       ) : (
                         <div>
-                          <div style={{ display: 'flex', gap: '16px' }}>
-                            <TextField
-                              variant="standard"
-                              label="Search Component"
-                              value={searchComponentRegex}
-                              onChange={handleSearchComponentRegexChange}
-                            />
-                            <TextField
-                              variant="standard"
-                              label="Search Column"
-                              value={searchColumnRegex}
-                              onChange={handleSearchColumnRegexChange}
-                            />
-                            <FormControlLabel
-                              control={
-                                <Checkbox
-                                  checked={redOnlyChecked}
-                                  onChange={handleRedOnlyCheckboxChange}
-                                  color="primary"
-                                  size="small"
-                                  style={{ borderRadius: 1 }}
-                                />
-                              }
-                              htmlFor="redOnlyCheckbox"
-                              style={{
-                                textAlign: 'left',
-                                marginTop: 15,
-                              }}
-                              label="Red Only"
-                            ></FormControlLabel>
-                            <Tooltip title="Copy link to search">
-                              <IconButton
-                                size="small"
-                                color="primary"
-                                variant="contained"
-                                component={Link}
-                                href={linkToReport()}
-                                onClick={copyLinkToReport}
-                              >
-                                <FileCopy />
-                              </IconButton>
-                            </Tooltip>
-                            <Popover
-                              id="copyPopover"
-                              open={copyPopoverOpen}
-                              anchorEl={copyPopoverEl}
-                              onClose={() => setCopyPopoverEl(null)}
-                              anchorOrigin={{
-                                vertical: 'bottom',
-                                horizontal: 'center',
-                              }}
-                              transformOrigin={{
-                                vertical: 'top',
-                                horizontal: 'center',
-                              }}
-                            >
-                              Link copied!
-                            </Popover>
-                            <Tooltip title="Clear searches">
-                              <IconButton
-                                color="primary"
-                                size="small"
-                                variant="contained"
-                                onClick={clearSearches}
-                              >
-                                <Clear />
-                              </IconButton>
-                            </Tooltip>
-                            <Button
-                              style={{ marginTop: 20 }}
-                              variant="contained"
-                              color="secondary"
-                              onClick={() =>
-                                setRegressedTestDialog(true, 'replaceIn')
-                              }
-                            >
-                              Show Regressed
-                            </Button>
-                            <RegressedTestsModal
-                              regressedTests={regressedTests}
-                              filterVals={filterVals}
-                              isOpen={regressedTestDialog}
-                              close={closeRegressedTestsDialog}
-                            />
-                          </div>
+                          <Box sx={{ flexGrow: 1 }}>
+                            <AppBar position="static">
+                              <Toolbar sx={{ leftPadding: 0 }}>
+                                <Search>
+                                  <SearchIconWrapper>
+                                    <Widgets />
+                                  </SearchIconWrapper>
+                                  <StyledInputBase
+                                    placeholder="Search Component"
+                                    inputProps={{ 'aria-label': 'search' }}
+                                    value={searchComponentRegex}
+                                    onChange={handleSearchComponentRegexChange}
+                                  />
+                                </Search>
+                                <Search>
+                                  <SearchIconWrapper>
+                                    <ViewColumn />
+                                  </SearchIconWrapper>
+                                  <StyledInputBase
+                                    placeholder="Search Column"
+                                    inputProps={{ 'aria-label': 'search' }}
+                                    value={searchColumnRegex}
+                                    onChange={handleSearchColumnRegexChange}
+                                  />
+                                </Search>
+                                <Box
+                                  display="flex"
+                                  alignItems="center"
+                                  sx={{ paddingBottom: 2 }}
+                                >
+                                  <FormControlLabel
+                                    control={
+                                      <SwitchControl
+                                        checked={redOnlyChecked}
+                                        onChange={handleRedOnlyCheckboxChange}
+                                        color="primary"
+                                        size="small"
+                                        style={{ borderRadius: 1 }}
+                                      />
+                                    }
+                                    htmlFor="redOnlyCheckbox"
+                                    style={{
+                                      textAlign: 'left',
+                                      marginTop: 15,
+                                    }}
+                                    label="Red Only"
+                                  ></FormControlLabel>
+                                </Box>
+
+                                <IconButton
+                                  size="large"
+                                  aria-label="Copy Link"
+                                  color="inherit"
+                                  onClick={copyLinkToReport}
+                                >
+                                  <Tooltip title="Copy link to search">
+                                    <InsertLink />
+                                  </Tooltip>
+                                </IconButton>
+                                <IconButton
+                                  size="large"
+                                  aria-label="Clear Search"
+                                  color="inherit"
+                                  onClick={clearSearches}
+                                >
+                                  <Tooltip title="Clear searches">
+                                    <Clear />
+                                  </Tooltip>
+                                </IconButton>
+                                <Box sx={{ flexGrow: 1 }} />
+
+                                <Box
+                                  sx={{ display: { xs: 'none', md: 'flex' } }}
+                                >
+                                  <IconButton
+                                    size="large"
+                                    aria-label="Show Regressed Tests"
+                                    color="inherit"
+                                    onClick={() =>
+                                      setRegressedTestDialog(true, 'replaceIn')
+                                    }
+                                  >
+                                    <Badge
+                                      badgeContent={regressedTests.length}
+                                      color="error"
+                                    >
+                                      <Tooltip title="Show regressed tests">
+                                        <GridView />
+                                      </Tooltip>
+                                    </Badge>
+                                  </IconButton>
+                                </Box>
+                              </Toolbar>
+                            </AppBar>
+                          </Box>
+
+                          <Popover
+                            id="copyPopover"
+                            open={copyPopoverOpen}
+                            anchorEl={copyPopoverEl}
+                            onClose={() => setCopyPopoverEl(null)}
+                            anchorOrigin={{
+                              vertical: 'bottom',
+                              horizontal: 'center',
+                            }}
+                            transformOrigin={{
+                              vertical: 'top',
+                              horizontal: 'center',
+                            }}
+                          >
+                            Link copied!
+                          </Popover>
+                          <RegressedTestsModal
+                            regressedTests={regressedTests}
+                            filterVals={filterVals}
+                            isOpen={regressedTestDialog}
+                            close={closeRegressedTestsDialog}
+                          />
                           <TableContainer
                             component="div"
                             className="cr-table-wrapper"

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -1067,7 +1067,7 @@ export default function ComponentReadiness(props) {
                       ) : (
                         <div>
                           <Box sx={{ flexGrow: 1 }}>
-                            <AppBar position="static">
+                            <AppBar elevation={1} position="static">
                               <Toolbar sx={{ leftPadding: 0 }}>
                                 <Search>
                                   <SearchIconWrapper>

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -3,16 +3,11 @@ import {
   AppBar,
   Badge,
   Box,
-  Button,
-  Checkbox,
-  Container,
   Drawer,
   FormControlLabel,
   Grid,
-  Link,
   Popover,
   TableContainer,
-  TextField,
   Tooltip,
   Typography,
 } from '@mui/material'
@@ -42,29 +37,21 @@ import {
   noDataTable,
   Search,
   SearchIconWrapper,
-  StyledCheckbox,
-  StyledFormControlLabel,
   StyledInputBase,
 } from './CompReadyUtils'
-import { ClassNameMap } from '@mui/styles'
-import { Fragment, useContext, useEffect, useState } from 'react'
+import { makeStyles, useTheme } from '@mui/styles'
 import { Route, Switch, useRouteMatch } from 'react-router-dom'
+import React, { Fragment, useContext, useEffect, useState } from 'react'
 import SwitchControl from '@mui/material/Switch'
 
 import {
-  AccountCircle,
   Clear,
-  FileCopy,
   GridView,
   InsertLink,
-  Mail,
-  Notifications,
-  SwitchCamera,
   ViewColumn,
   Widgets,
 } from '@mui/icons-material'
 import { grey } from '@mui/material/colors'
-import { makeStyles, useTheme } from '@mui/styles'
 import { ReleasesContext } from '../App'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
@@ -80,9 +67,7 @@ import CompReadyRow from './CompReadyRow'
 import CompReadyTestReport from './CompReadyTestReport'
 import IconButton from '@mui/material/IconButton'
 import MenuIcon from '@mui/icons-material/Menu'
-import React from 'react'
 import RegressedTestsModal from './RegressedTestsModal'
-import SearchIcon from '@mui/icons-material/Search'
 import Table from '@mui/material/Table'
 import TableBody from '@mui/material/TableBody'
 import TableCell from '@mui/material/TableCell'

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -59,6 +59,10 @@ function generateTestReport(
 }
 
 export default function RegressedTestsModal(props) {
+  const [sortModel, setSortModel] = React.useState([
+    { field: 'component', sort: 'asc' },
+  ])
+
   // define table columns
   const columns = [
     {
@@ -162,6 +166,8 @@ export default function RegressedTestsModal(props) {
             Regressed Tests
           </Typography>
           <DataGrid
+            sortModel={sortModel}
+            onSortModelChange={setSortModel}
             components={{ Toolbar: GridToolbar }}
             rows={props.regressedTests}
             columns={columns}


### PR DESCRIPTION
When I added the copy/clear searches link buttons, it didn't look good and now doesn't fit well with the show regressed tests links. Refactor it to be an appbar.  I'm not entirely sure the light mode looks good, but it's still an improvement I think.

<img width="1107" alt="image" src="https://github.com/openshift/sippy/assets/429763/ddc67925-4a69-4446-b510-15448f24a18b">

![image](https://github.com/openshift/sippy/assets/429763/194e1e8e-4a33-4ae6-aaac-7e16c8c0b621)
