### PR TITLE
Exclude obsolete tests from component readiness

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -383,7 +383,7 @@ func (c *componentReportGenerator) getTestStatusFromBigQuery() (
 						cm.id `
 
 	queryString += `
-					WHERE (prowjob_name LIKE 'periodic-%%' OR prowjob_name LIKE 'release-%%' OR prowjob_name LIKE 'aggregator-%%') AND NOT REGEXP_CONTAINS(prowjob_name, @IgnoredJobs)`
+					WHERE cm.staff_approved_obsolete = false AND (prowjob_name LIKE 'periodic-%%' OR prowjob_name LIKE 'release-%%' OR prowjob_name LIKE 'aggregator-%%') AND NOT REGEXP_CONTAINS(prowjob_name, @IgnoredJobs)`
 
 	commonParams := []bigquery.QueryParameter{
 		{


### PR DESCRIPTION
[TRT-1410](https://issues.redhat.com//browse/TRT-1410)

If a test is marked obsolete, don't show it in component readiness.