### PR TITLE
TRT-1331:  Use precomputed tables for component readiness  [2]

### DIFF
--- a/pkg/bigquery/client.go
+++ b/pkg/bigquery/client.go
@@ -1,19 +1,35 @@
 package bigquery
 
 import (
+	"context"
+
 	"cloud.google.com/go/bigquery"
+	"github.com/pkg/errors"
+	"google.golang.org/api/option"
 
 	"github.com/openshift/sippy/pkg/apis/cache"
 )
 
 type Client struct {
-	BQ    *bigquery.Client
-	Cache cache.Cache
+	BQ      *bigquery.Client
+	Cache   cache.Cache
+	Dataset string
 }
 
-func New(bqc *bigquery.Client, c cache.Cache) *Client {
-	return &Client{
-		BQ:    bqc,
-		Cache: c,
+func New(ctx context.Context, credentialFile, project, dataset string, c cache.Cache) (*Client, error) {
+	bqc, err := bigquery.NewClient(ctx, project, option.WithCredentialsFile(credentialFile))
+	if err != nil {
+		return nil, err
 	}
+	// Enable Storage API usage for fetching data
+	err = bqc.EnableStorageReadClient(context.Background(), option.WithCredentialsFile(credentialFile))
+	if err != nil {
+		return nil, errors.WithMessage(err, "couldn't enable storage API")
+	}
+
+	return &Client{
+		BQ:      bqc,
+		Cache:   c,
+		Dataset: dataset,
+	}, nil
 }

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -76,7 +76,7 @@ func NewServer(
 		cache:                cacheClient,
 	}
 
-	if bigQueryClient.BQ != nil {
+	if bigQueryClient != nil {
 		go api.GetComponentTestVariantsFromBigQuery(bigQueryClient, gcsBucket)
 	}
 


### PR DESCRIPTION
Merge after https://github.com/openshift/sippy/pull/1405.

This moves to using views, and scheduled queries that precompute some data for component readiness.  This is an improvement in code readability by moving the complex SQL queries out as well.

I'll have another PR later that makes Sippy create/update these views

There are some new views/queries:
- component_mapping_latest [View]: the latest mappings for components from the table
- junit_deduped [View]: the flattened junit table in the format CR expects (one row per-test result-per-job)
- junit_precomputed_by_test_and_day [Scheduled query]:  runs every 8 hours to sum the results by day (the most granular time period CR cares about), performance and cost savings