### PR TITLE
TRT-1434: exclude skipped test cases

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -55,6 +55,7 @@ const (
 				ci_analysis_us.junit
 			WHERE modified_time >= DATETIME(@From)
 			AND modified_time < DATETIME(@To)
+			AND skipped = false
 		)
 		SELECT * FROM deduped_testcases WHERE row_num = 1`
 )


### PR DESCRIPTION
The flattened junit CTE doesn't exclude skipped tests, so since the failure field isn't set we are considering it a success.