### PR TITLE
Adjust release selector background color

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyMainInputs.js
+++ b/sippy-ng/src/component_readiness/CompReadyMainInputs.js
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor:
       theme.palette.mode == 'dark'
         ? theme.palette.grey[800]
-        : theme.palette.grey[500],
+        : theme.palette.grey[300],
   },
 }))
 


### PR DESCRIPTION
In light mode, the background is too dark.

Old: 
<img width="241" alt="Release to Evaluate" src="https://github.com/openshift/sippy/assets/429763/61221a8a-21d1-4754-ba1d-1f2c64b1d0f8">

New:
<img width="236" alt="Release to Evaluate" src="https://github.com/openshift/sippy/assets/429763/807df455-5c6d-4f4d-80bc-450b3c14e7c3">
