### PR TITLE
Example of allowing a regression

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -17,6 +17,7 @@ import (
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	bqcachedclient "github.com/openshift/sippy/pkg/bigquery"
+	"github.com/openshift/sippy/pkg/regressionallowances"
 	"github.com/openshift/sippy/pkg/util/sets"
 )
 
@@ -909,7 +910,8 @@ func (c *componentReportGenerator) generateComponentTestReport(baseStatus map[ap
 		if !ok {
 			reportStatus = apitype.MissingSample
 		} else {
-			reportStatus, _ = c.assessComponentStatus(sampleStats.TotalCount, sampleStats.SuccessCount, sampleStats.FlakeCount, baseStats.TotalCount, baseStats.SuccessCount, baseStats.FlakeCount)
+			approvedRegression := regressionallowances.IntentionalRegressionFor(c.SampleRelease.Release, testID.ComponentReportColumnIdentification, testID.TestID)
+			reportStatus, _ = c.assessComponentStatus(sampleStats.TotalCount, sampleStats.SuccessCount, sampleStats.FlakeCount, baseStats.TotalCount, baseStats.SuccessCount, baseStats.FlakeCount, approvedRegression)
 		}
 		delete(sampleStatus, testIdentification)
 
@@ -1058,6 +1060,8 @@ func (c *componentReportGenerator) generateComponentTestDetailsReport(baseStatus
 			},
 		},
 	}
+	approvedRegression := regressionallowances.IntentionalRegressionFor(c.SampleRelease.Release, result.ComponentReportColumnIdentification, c.TestID)
+
 	var totalBaseFailure, totalBaseSuccess, totalBaseFlake, totalSampleFailure, totalSampleSuccess, totalSampleFlake int
 	var perJobBaseFailure, perJobBaseSuccess, perJobBaseFlake, perJobSampleFailure, perJobSampleSuccess, perJobSampleFlake int
 	for prowJob, baseStatsList := range baseStatus {
@@ -1166,14 +1170,16 @@ func (c *componentReportGenerator) generateComponentTestDetailsReport(baseStatus
 		totalSampleFlake,
 		totalBaseSuccess+totalBaseFailure+totalBaseFlake,
 		totalBaseSuccess,
-		totalBaseFlake)
+		totalBaseFlake,
+		approvedRegression,
+	)
 	sort.Slice(result.JobStats, func(i, j int) bool {
 		return result.JobStats[i].JobName < result.JobStats[j].JobName
 	})
 	return result
 }
 
-func (c *componentReportGenerator) assessComponentStatus(sampleTotal, sampleSuccess, sampleFlake, baseTotal, baseSuccess, baseFlake int) (apitype.ComponentReportStatus, float64) {
+func (c *componentReportGenerator) assessComponentStatus(sampleTotal, sampleSuccess, sampleFlake, baseTotal, baseSuccess, baseFlake int, approvedRegression *regressionallowances.IntentionalRegression) (apitype.ComponentReportStatus, float64) {
 	status := apitype.MissingBasis
 	fischerExact := 0.0
 	if baseTotal != 0 {
@@ -1188,10 +1194,19 @@ func (c *componentReportGenerator) assessComponentStatus(sampleTotal, sampleSucc
 			if c.MinimumFailure != 0 && (sampleTotal-sampleSuccess-sampleFlake) < c.MinimumFailure {
 				return apitype.NotSignificant, fischerExact
 			}
+
 			basisPassPercentage := float64(baseSuccess+baseFlake) / float64(baseTotal)
 			samplePassPercentage := float64(sampleSuccess+sampleFlake) / float64(sampleTotal)
+			effectivePityFactor := c.PityFactor
+			if approvedRegression != nil && approvedRegression.RegressedPassPercentage < int(basisPassPercentage) {
+				// product owner chose a required pass percentage, so we all pity to cover that approved pass percent
+				// plus the existing pity factor to limit, "well, it's just *barely* lower" arguments.
+				effectivePityFactor = int(basisPassPercentage) - approvedRegression.RegressedPassPercentage + c.PityFactor
+			}
+
 			significant := false
 			improved := samplePassPercentage >= basisPassPercentage
+
 			if improved {
 				_, _, r, _ := fischer.FisherExactTest(baseTotal-baseSuccess-baseFlake,
 					baseSuccess+baseFlake,
@@ -1199,7 +1214,7 @@ func (c *componentReportGenerator) assessComponentStatus(sampleTotal, sampleSucc
 					sampleSuccess+sampleFlake)
 				significant = r < 1-float64(c.Confidence)/100
 				fischerExact = r
-			} else if basisPassPercentage-samplePassPercentage > float64(c.PityFactor)/100 {
+			} else if basisPassPercentage-samplePassPercentage > float64(effectivePityFactor)/100 {
 				_, _, r, _ := fischer.FisherExactTest(sampleTotal-sampleSuccess-sampleFlake,
 					sampleSuccess+sampleFlake,
 					baseTotal-baseSuccess-baseFlake,

--- a/pkg/regressionallowances/OWNERS
+++ b/pkg/regressionallowances/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# Disable inheritance as this is an api owners file
+options:
+  no_parent_owners: true
+filters:
+  ".*":
+    approvers:
+      - deads2k # for the code to manage them
+      - scuppett # to approve intentional regressions in the OCP product.

--- a/pkg/regressionallowances/intentional_4.15_regressions.go
+++ b/pkg/regressionallowances/intentional_4.15_regressions.go
@@ -1,24 +1,24 @@
 package regressionallowances
 
+import "github.com/openshift/sippy/pkg/apis/api"
+
 func init() {
-	/*
-		mustAddIntentionalRegression(
-			release415,
-			IntentionalRegression{
-				JiraComponent: "", // Jira Component,  not team name
-				TestID:        "", // ask TRT for the ID for your TestName
-				TestName:      "", // this helps approvers recognize at a glance
-				Variant: api.ComponentReportColumnIdentification{ // this indicates the selectivity of the choice
-					Network:  "",
-					Upgrade:  "",
-					Arch:     "",
-					Platform: "",
-				},
-				PreviousPassPercentage:    0,
-				PreviousSampleSize:        0, // number of runs used for the percentage
-				RegressedPassPercentage:   0,
-				RegressedSampleSize:       0, // number of runs used for the percentage
-				ReasonToAllowInsteadOfFix: "",
-			})
-	*/
+	mustAddIntentionalRegression(
+		release415,
+		IntentionalRegression{
+			JiraComponent: "Networking / openshift-sdn",                       // Jira Component,  not team name
+			TestID:        "cluster install:0cb1bb27e418491b1ffdacab58c5c8c0", // ask TRT for the ID for your TestName
+			TestName:      "install should succeed: overall",                  // this helps approvers recognize at a glance
+			Variant: api.ComponentReportColumnIdentification{ // this indicates the selectivity of the choice
+				Network:  "sdn",
+				Upgrade:  "upgrade-micro",
+				Arch:     "amd64",
+				Platform: "metal-ipi",
+			},
+			PreviousPassPercentage:    100,
+			PreviousSampleSize:        61, // number of runs used for the percentage
+			RegressedPassPercentage:   50,
+			RegressedSampleSize:       12, // number of runs used for the percentage
+			ReasonToAllowInsteadOfFix: "I can't explain this, but Ben Bennett maybe?",
+		})
 }

--- a/pkg/regressionallowances/intentional_4.15_regressions.go
+++ b/pkg/regressionallowances/intentional_4.15_regressions.go
@@ -1,0 +1,24 @@
+package regressionallowances
+
+func init() {
+	/*
+		mustAddIntentionalRegression(
+			release415,
+			IntentionalRegression{
+				JiraComponent: "", // Jira Component,  not team name
+				TestID:        "", // ask TRT for the ID for your TestName
+				TestName:      "", // this helps approvers recognize at a glance
+				Variant: api.ComponentReportColumnIdentification{ // this indicates the selectivity of the choice
+					Network:  "",
+					Upgrade:  "",
+					Arch:     "",
+					Platform: "",
+				},
+				PreviousPassPercentage:    0,
+				PreviousSampleSize:        0, // number of runs used for the percentage
+				RegressedPassPercentage:   0,
+				RegressedSampleSize:       0, // number of runs used for the percentage
+				ReasonToAllowInsteadOfFix: "",
+			})
+	*/
+}

--- a/pkg/regressionallowances/types.go
+++ b/pkg/regressionallowances/types.go
@@ -1,0 +1,123 @@
+package regressionallowances
+
+import (
+	"fmt"
+
+	"github.com/openshift/sippy/pkg/apis/api"
+)
+
+type IntentionalRegression struct {
+	JiraComponent             string
+	TestID                    string
+	TestName                  string
+	Variant                   api.ComponentReportColumnIdentification
+	PreviousPassPercentage    int
+	PreviousSampleSize        int
+	RegressedPassPercentage   int
+	RegressedSampleSize       int
+	ReasonToAllowInsteadOfFix string
+}
+
+func IntentionalRegressionFor(releaseString string, variant api.ComponentReportColumnIdentification, testID string) *IntentionalRegression {
+	var targetMap map[regressionKey]IntentionalRegression
+	switch release(releaseString) {
+	case release415:
+		targetMap = regressions_415
+	default:
+		return nil
+	}
+
+	inKey := keyFor(testID, variant)
+	t := targetMap[inKey]
+	return &t
+}
+
+type release string
+
+var (
+	release415 release = "4.15"
+)
+
+var (
+	regressions_415 = map[regressionKey]IntentionalRegression{}
+)
+
+type regressionKey struct {
+	testID  string
+	variant api.ComponentReportColumnIdentification
+}
+
+func keyFor(testID string, variant api.ComponentReportColumnIdentification) regressionKey {
+	return regressionKey{
+		testID: testID,
+		variant: api.ComponentReportColumnIdentification{
+			Network:  variant.Network,
+			Upgrade:  variant.Upgrade,
+			Arch:     variant.Arch,
+			Platform: variant.Platform,
+		},
+	}
+}
+
+func mustAddIntentionalRegression(release release, in IntentionalRegression) {
+	if err := addIntentionalRegression(release, in); err != nil {
+		panic(err)
+	}
+}
+
+func addIntentionalRegression(release release, in IntentionalRegression) error {
+	if len(in.JiraComponent) == 0 {
+		return fmt.Errorf("JiraComponent must be specified.")
+	}
+	if len(in.TestID) == 0 {
+		return fmt.Errorf("TestID must be specified.")
+	}
+	if len(in.TestName) == 0 {
+		return fmt.Errorf("TestName must be specified.")
+	}
+	if in.PreviousPassPercentage <= 0 {
+		return fmt.Errorf("PreviousPassPercentage must be specified.")
+	}
+	if in.RegressedPassPercentage <= 0 {
+		return fmt.Errorf("RegressedPassPercentage must be specified.")
+	}
+	if in.PreviousSampleSize <= 0 {
+		return fmt.Errorf("PreviousSampleSize must be specified.")
+	}
+	if in.RegressedSampleSize <= 0 {
+		return fmt.Errorf("RegressedSampleSize must be specified.")
+	}
+	if len(in.ReasonToAllowInsteadOfFix) == 0 {
+		return fmt.Errorf("ReasonToAllowInsteadOfFix must be specified.")
+	}
+	if len(in.Variant.Network) == 0 {
+		return fmt.Errorf("Network must be specified.")
+	}
+	if len(in.Variant.Arch) == 0 {
+		return fmt.Errorf("Arch must be specified.")
+	}
+	if len(in.Variant.Platform) == 0 {
+		return fmt.Errorf("Platform must be specified.")
+	}
+	if len(in.Variant.Upgrade) == 0 {
+		return fmt.Errorf("Upgrade must be specified.")
+	}
+
+	var targetMap map[regressionKey]IntentionalRegression
+
+	switch release {
+	case release415:
+		targetMap = regressions_415
+	default:
+		fmt.Errorf("unknown release: %q", release)
+	}
+
+	inKey := keyFor(in.TestID, in.Variant)
+	if _, ok := targetMap[inKey]; ok {
+		return fmt.Errorf("test %q was already added", in.TestID)
+	}
+
+	targetMap[inKey] = in
+
+	return nil
+}


### PR DESCRIPTION
/hold

example of how to use https://github.com/openshift/sippy/pull/1433 using a current example.