### PR TITLE
allow exception for SDN installation failure

### DIFF
--- a/pkg/regressionallowances/intentional_4.15_regressions.go
+++ b/pkg/regressionallowances/intentional_4.15_regressions.go
@@ -1,5 +1,7 @@
 package regressionallowances
 
+import "github.com/openshift/sippy/pkg/apis/api"
+
 //nolint:all
 func init() {
 	/*
@@ -22,4 +24,23 @@ func init() {
 				ReasonToAllowInsteadOfFix: "",
 			})
 	*/
+
+	mustAddIntentionalRegression(
+		release415,
+		IntentionalRegression{
+			JiraComponent: "Networking / openshift-sdn",                       // Jira Component,  not team name
+			TestID:        "cluster install:0cb1bb27e418491b1ffdacab58c5c8c0", // ask TRT for the ID for your TestName
+			TestName:      "install should succeed: overall",                  // this helps approvers recognize at a glance
+			Variant: api.ComponentReportColumnIdentification{ // this indicates the selectivity of the choice
+				Network:  "sdn",
+				Upgrade:  "upgrade-micro",
+				Arch:     "amd64",
+				Platform: "metal-ipi",
+			},
+			PreviousPassPercentage:    100,
+			PreviousSampleSize:        61, // number of runs used for the percentage
+			RegressedPassPercentage:   50,
+			RegressedSampleSize:       12, // number of runs used for the percentage
+			ReasonToAllowInsteadOfFix: "I can't explain this, but Ben Bennett maybe?",
+		})
 }


### PR DESCRIPTION

This PR demonstrates how to reduce the acceptable reliability for a particular capability in OCP.  Once merged, this change will allow installations on SDNs to go from 100% reliable to 50% reliable.  The format clearly exposes
1. What is changing
2. What the previous reliability was
3. What the new reality is
4. Why we are allowing the regression

for ease of review by the product owner (Steve Cuppett)  who can decide to regress the capability and reliability of the platform.

/hold

Publishing this as an example of a current 4.15 failure.