### PR TITLE
TRT-1443: Add etcd-leaders section from openshift/origin repo to sippy intervals chart

### DIFF
--- a/pkg/apis/api/interval.go
+++ b/pkg/apis/api/interval.go
@@ -29,8 +29,8 @@ type EventInterval struct {
 	StructuredLocator Locator `json:"tempStructuredLocator"`
 	StructuredMessage Message `json:"tempStructuredMessage"`
 
-	From time.Time `json:"from"`
-	To   time.Time `json:"to"`
+	From *time.Time `json:"from"`
+	To   *time.Time `json:"to"`
 	// Filename is the base filename we read the intervals from in gcs. If multiple,
 	// that usually means one for upgrade and one for conformance portions of the job run.
 	// TODO: this may need to be revisited once we're further along with the UI/new schema.

--- a/sippy-ng/src/components/TimelineChart.js
+++ b/sippy-ng/src/components/TimelineChart.js
@@ -48,6 +48,11 @@ export default function TimelineChart({ eventIntervals, data }) {
       'PodLogInfo',
       'PodLogWarning',
       'PodLogError',
+      'EtcdOther',
+      'EtcdLeaderFound',
+      'EtcdLeaderLost',
+      'EtcdLeaderElected',
+      'EtcdLeaderMissing',
       'GracefulShutdownInterval',
       'CloudMetric',
     ])
@@ -90,6 +95,11 @@ export default function TimelineChart({ eventIntervals, data }) {
       '#96cbff',
       '#fada5e',
       '#d0312d',
+      '#d3d3de',
+      '#03fc62',
+      '#fc0303',
+      '#fada5e',
+      '#8c5efa',
       '#6E6E6E', // GracefulShutdownInterval
       '#6E6E6E', // CloudMetric
     ])

--- a/sippy-ng/src/prow_job_runs/ProwJobRun.js
+++ b/sippy-ng/src/prow_job_runs/ProwJobRun.js
@@ -1011,10 +1011,7 @@ function createTimelineData(
       startDate = earliest
     }
     let endDate = new Date(item.to)
-
-    // When go unmarshalls a null "to", the date is 0001-01-01T00:00:00Z which
-    // we're assuming is null.
-    if (!item.to || endDate.getTime() === -62135596800000) {
+    if (!item.to) {
       endDate = latest
     }
     let label = item.locator


### PR DESCRIPTION
This change takes the changes from [e2e-chart-template.html](https://github.com/openshift/origin/blob/511023f1e1edc796973ce37fbeab5b25078b9abd/e2echart/e2e-chart-template.html) for charting the etcd-leaders and puts them in sippy's intervals chart.

Samples:

* [An older job](http://localhost:3000/sippy-ng/job_runs/1747942857647329280/periodic-ci-openshift-release-master-nightly-4.16-e2e-aws-sdn-upgrade/intervals)
  * Same job but with [smaller number of interval sections](http://localhost:3000/sippy-ng/job_runs/1747942857647329280/periodic-ci-openshift-release-master-nightly-4.16-e2e-aws-sdn-upgrade/intervals?categories=operator_unavailable&categories=operator_progressing&categories=operator_degraded&categories=pod_logs&categories=node_state&categories=e2e_test_failed&categories=disruption&categories=apiserver_shutdown&categories=etcd_leaders&categories=cloud_metrics&filterText=&intervalFiles=e2e-events_20240118-121532.json)
* [A recent job](http://localhost:3000/sippy-ng/job_runs/1749274636379492352/periodic-ci-openshift-release-master-nightly-4.16-e2e-aws-sdn-upgrade/intervals)
