### PR TITLE
Revert "TRT-1351: Use capability to exclude disruption tests"

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -232,7 +232,6 @@ func (c *componentReportGenerator) getJobRunTestStatusFromBigQuery() (
 						ANY_VALUE(cm.jira_component) AS jira_component,
 						ANY_VALUE(cm.jira_component_id) AS jira_component_id,
 						COUNT(*) AS total_count,
-						cm.cababilities as capabilities,
 						SUM(success_val) AS success_count,
 						SUM(flake_count) AS flake_count,
 					FROM (%s)
@@ -395,7 +394,7 @@ func (c *componentReportGenerator) getTestStatusFromBigQuery() (
 		},
 	}
 	if c.IgnoreDisruption {
-		queryString += ` AND NOT 'Disruption' in UNNEST(capabilities)`
+		queryString += ` AND test_name NOT LIKE '%disruption/%'`
 	}
 	if c.Upgrade != "" {
 		queryString += ` AND upgrade = @Upgrade`


### PR DESCRIPTION
Reverts openshift/sippy#1432

This broke test details page

https://sippy.dptools.openshift.org/sippy-ng/component_readiness/test_details?arch=amd64&arch=amd64&baseEndTime=2023-10-31%2023%3A59%3A59&baseRelease=4.14&baseStartTime=2023-10-04%2000%3A00%3A00&capability=Other&component=Installer%20%2F%20openshift-installer&confidence=95&environment=ovn%20upgrade-micro%20amd64%20azure%20standard&excludeArches=arm64%2Cheterogeneous%2Cppc64le%2Cs390x&excludeClouds=openstack%2Cibmcloud%2Clibvirt%2Covirt%2Cunknown&excludeVariants=hypershift%2Cosd%2Cmicroshift%2Ctechpreview%2Csingle-node%2Cassisted%2Ccompact&groupBy=cloud%2Carch%2Cnetwork&ignoreDisruption=true&ignoreMissing=false&minFail=3&network=ovn&network=ovn&pity=5&platform=azure&platform=azure&sampleEndTime=2024-01-22%2023%3A59%3A59&sampleRelease=4.15&sampleStartTime=2024-01-16%2000%3A00%3A00&testId=cluster%20install%3A0cb1bb27e418491b1ffdacab58c5c8c0&testName=install%20should%20succeed%3A%20overall&upgrade=upgrade-micro&upgrade=upgrade-micro&variant=standard&variant=standard