### PR TITLE
TRT-1442: Fix CR toolbar buttons on mobile devices

### DIFF
--- a/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
+++ b/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
@@ -149,7 +149,7 @@ export default function ComponentReadinessToolBar(props) {
               </Tooltip>
             </IconButton>
             <Box sx={{ flexGrow: 1 }} />
-            <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
+            <Box sx={{ display: { md: 'flex' } }}>
               <IconButton
                 size="large"
                 aria-label="Show Regressed Tests"
@@ -163,7 +163,7 @@ export default function ComponentReadinessToolBar(props) {
                 </Badge>
               </IconButton>
             </Box>
-            <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
+            <Box sx={{ display: { md: 'flex' } }}>
               <IconButton
                 size="large"
                 aria-label="Help"


### PR DESCRIPTION
For some reason I set display: none on `xs` screens. Maybe came from the MUI example in the docs.