### PR TITLE
rapid resolve for the monitoring events problem

### DIFF
--- a/pkg/componentreadiness/resolvedissues/resolved_4.15_issues.go
+++ b/pkg/componentreadiness/resolvedissues/resolved_4.15_issues.go
@@ -96,4 +96,38 @@ func init() {
 			},
 		},
 	})
+	mustAddResolvedIssue(release415, ResolvedIssue{
+		TestID:   "openshift-tests-upgrade:567152bb097fa9ce13dd2fb6885e094a",
+		TestName: "[sig-arch] events should not repeat pathologically for ns/openshift-monitoring",
+		Variant: apitype.ComponentReportColumnIdentification{
+			Network:  "ovn",
+			Upgrade:  "upgrade-minor",
+			Arch:     "amd64",
+			Platform: "metal-ipi",
+		},
+		Issue: Issue{
+			IssueType: "PayloadBug",
+			PayloadBug: &PayloadIssue{
+				PullRequestURL: "https://github.com/openshift/origin/pull/28549",
+				ResolutionDate: mustTime("2024-01-24T23:54:33Z"), // date is after all those jobruns were over
+			},
+		},
+		ImpactedJobRuns: []JobRun{
+			{
+				// RecreatingTerminatedPod and SuccessfulDelete
+				URL:       "https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.15-upgrade-from-stable-4.14-e2e-metal-ipi-upgrade-ovn-ipv6/1750230625601720320",
+				StartTime: mustTime("2024-01-24T18:54:33Z"),
+			},
+			{
+				// RecreatingTerminatedPod
+				URL:       "https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.15-upgrade-from-stable-4.14-e2e-metal-ipi-upgrade-ovn-ipv6/1749463575023325184",
+				StartTime: mustTime("2024-01-22T16:06:32Z"),
+			},
+			{
+				// RecreatingTerminatedPod
+				URL:       "https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.15-upgrade-from-stable-4.14-e2e-metal-ipi-upgrade-ovn-ipv6/1748875328249401344",
+				StartTime: mustTime("2024-01-21T01:09:05Z"),
+			},
+		},
+	})
 }


### PR DESCRIPTION
[readiness link](https://sippy.dptools.openshift.org/sippy-ng/component_readiness/test_details?arch=amd64&arch=amd64&baseEndTime=2023-10-31%2023%3A59%3A59&baseRelease=4.14&baseStartTime=2023-10-04%2000%3A00%3A00&capability=Other&component=Monitoring&confidence=95&environment=ovn%20upgrade-minor%20amd64%20metal-ipi%20standard&excludeArches=arm64%2Cheterogeneous%2Cppc64le%2Cs390x&excludeClouds=openstack%2Cibmcloud%2Clibvirt%2Covirt%2Cunknown&excludeVariants=hypershift%2Cosd%2Cmicroshift%2Ctechpreview%2Csingle-node%2Cassisted%2Ccompact&groupBy=cloud%2Carch%2Cnetwork&ignoreDisruption=true&ignoreMissing=false&minFail=3&network=ovn&network=ovn&pity=5&platform=metal-ipi&platform=metal-ipi&sampleEndTime=2024-01-25%2023%3A59%3A59&sampleRelease=4.15&sampleStartTime=2024-01-19%2000%3A00%3A00&testId=openshift-tests-upgrade%3A567152bb097fa9ce13dd2fb6885e094a&testName=%5Bsig-arch%5D%20events%20should%20not%20repeat%20pathologically%20for%20ns%2Fopenshift-monitoring&upgrade=upgrade-minor&upgrade=upgrade-minor&variant=standard&variant=standard)

with [4.15 merged fix](https://github.com/openshift/origin/pull/28549/files)

If correct, the square will green up.