### PR TITLE
trt-1439: observability dashboards link

### DIFF
--- a/sippy-ng/src/components/Sidebar.js
+++ b/sippy-ng/src/components/Sidebar.js
@@ -136,13 +136,13 @@ export default function Sidebar(props) {
                   <ListItem
                     component="a"
                     target="_blank"
-                    href="https://grafana-loki.ci.openshift.org/d/ISnBj4LVk/disruption?orgId=1"
-                    key="DisruptionDashboard"
+                    href="https://grafana-loki.ci.openshift.org/dashboards/f/4X8Jfhs4z/openshift-ci-observability"
+                    key="ObservabilityDashboard"
                   >
                     <ListItemIcon>
                       <Dashboard />
                     </ListItemIcon>
-                    <ListItemText primary="Disruption Dashboard" />
+                    <ListItemText primary="CI Observability Dashboards" />
                   </ListItem>
                   <CapabilitiesContext.Consumer>
                     {(value) => {


### PR DESCRIPTION
Changes the Disruption Dashboard link to the CI Observability Dashboards folder

![image](https://github.com/openshift/sippy/assets/36795216/ef69469d-fda3-4637-a103-7a14cdc70b40)
