### PR TITLE
TRT-1351: Unrevert ignore disruption change and fix typo

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -247,7 +247,7 @@ func (c *componentReportGenerator) getJobRunTestStatusFromBigQuery() (
 						ANY_VALUE(cm.jira_component) AS jira_component,
 						ANY_VALUE(cm.jira_component_id) AS jira_component_id,
 						COUNT(*) AS total_count,
-						cm.cababilities as capabilities,
+						ANY_VALUE(cm.capabilities) as capabilities,
 						SUM(success_val) AS success_count,
 						SUM(flake_count) AS flake_count,
 					FROM (%s)

--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -247,6 +247,7 @@ func (c *componentReportGenerator) getJobRunTestStatusFromBigQuery() (
 						ANY_VALUE(cm.jira_component) AS jira_component,
 						ANY_VALUE(cm.jira_component_id) AS jira_component_id,
 						COUNT(*) AS total_count,
+						cm.cababilities as capabilities,
 						SUM(success_val) AS success_count,
 						SUM(flake_count) AS flake_count,
 					FROM (%s)
@@ -409,7 +410,7 @@ func (c *componentReportGenerator) getTestStatusFromBigQuery() (
 		},
 	}
 	if c.IgnoreDisruption {
-		queryString += ` AND test_name NOT LIKE '%disruption/%'`
+		queryString += ` AND NOT 'Disruption' in UNNEST(capabilities)`
 	}
 	if c.Upgrade != "" {
 		queryString += ` AND upgrade = @Upgrade`


### PR DESCRIPTION
This unreverts the change that uses capabilities rather than string matching to filter disruption.  There was a typo in one of the SQL queries in the original PR, this fixes it.