### PR TITLE
trt-1465: cache query data

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -103,8 +103,9 @@ func getSingleColumnResultToSlice(query *bigquery.Query) ([]string, error) {
 
 func GetComponentTestVariantsFromBigQuery(client *bqcachedclient.Client, gcsBucket string) (apitype.ComponentReportTestVariants, []error) {
 	generator := componentReportGenerator{
-		client:    client,
-		gcsBucket: gcsBucket,
+		GeneratorVersion: 1,
+		client:           client,
+		gcsBucket:        gcsBucket,
 	}
 
 	return getDataFromCacheOrGenerate[apitype.ComponentReportTestVariants](client.Cache, cache.RequestOptions{}, "component_readiness_variants", generator.GenerateVariants, apitype.ComponentReportTestVariants{})
@@ -119,12 +120,12 @@ func GetComponentReportFromBigQuery(client *bqcachedclient.Client, gcsBucket str
 	cacheOption cache.RequestOptions,
 ) (apitype.ComponentReport, []error) {
 	generator := componentReportGenerator{
-		CacheType:     "data",
-		client:        client,
-		gcsBucket:     gcsBucket,
-		cacheOption:   cacheOption,
-		BaseRelease:   baseRelease,
-		SampleRelease: sampleRelease,
+		GeneratorVersion: 1,
+		client:           client,
+		gcsBucket:        gcsBucket,
+		cacheOption:      cacheOption,
+		BaseRelease:      baseRelease,
+		SampleRelease:    sampleRelease,
 		ComponentReportRequestTestIdentificationOptions: testIDOption,
 		ComponentReportRequestVariantOptions:            variantOption,
 		ComponentReportRequestExcludeOptions:            excludeOption,
@@ -142,12 +143,12 @@ func GetComponentReportTestDetailsFromBigQuery(client *bqcachedclient.Client, gc
 	advancedOption apitype.ComponentReportRequestAdvancedOptions,
 	cacheOption cache.RequestOptions) (apitype.ComponentReportTestDetails, []error) {
 	generator := componentReportGenerator{
-		CacheType:     "data",
-		client:        client,
-		gcsBucket:     gcsBucket,
-		cacheOption:   cacheOption,
-		BaseRelease:   baseRelease,
-		SampleRelease: sampleRelease,
+		GeneratorVersion: 1,
+		client:           client,
+		gcsBucket:        gcsBucket,
+		cacheOption:      cacheOption,
+		BaseRelease:      baseRelease,
+		SampleRelease:    sampleRelease,
 		ComponentReportRequestTestIdentificationOptions: testIDOption,
 		ComponentReportRequestVariantOptions:            variantOption,
 		ComponentReportRequestExcludeOptions:            excludeOption,
@@ -159,16 +160,17 @@ func GetComponentReportTestDetailsFromBigQuery(client *bqcachedclient.Client, gc
 
 // componentReportGenerator contains the information needed to generate a CR report. Do
 // not add public fields to this struct if they are not valid as a cache key.
-// CacheType is used to differentiate cached objects using the
-// same componentReportGenerator (report vs. data, etc.) and used when the struct
-// is marshalled for the cache key
+// GeneratorVersion is used to indicate breaking changes in the versions of
+// the cached data.  It is used when the struct
+// is marshalled for the cache key and should be changed when the object being
+// cached changes in a way that will no longer be compatible with any prior cached version.
 type componentReportGenerator struct {
-	CacheType     string
-	client        *bqcachedclient.Client
-	gcsBucket     string
-	cacheOption   cache.RequestOptions
-	BaseRelease   apitype.ComponentReportRequestReleaseOptions
-	SampleRelease apitype.ComponentReportRequestReleaseOptions
+	GeneratorVersion int
+	client           *bqcachedclient.Client
+	gcsBucket        string
+	cacheOption      cache.RequestOptions
+	BaseRelease      apitype.ComponentReportRequestReleaseOptions
+	SampleRelease    apitype.ComponentReportRequestReleaseOptions
 	apitype.ComponentReportRequestTestIdentificationOptions
 	apitype.ComponentReportRequestVariantOptions
 	apitype.ComponentReportRequestExcludeOptions

--- a/pkg/api/disruption_report.go
+++ b/pkg/api/disruption_report.go
@@ -20,7 +20,7 @@ func GetDisruptionVsPrevGAReportFromBigQuery(client *bqcachedclient.Client) (api
 		ViewName: "BackendDisruptionPercentilesDeltaCurrentVsPrevGA",
 	}
 
-	return getReportFromCacheOrGenerate[apitype.DisruptionReport](client.Cache, cache.RequestOptions{}, generator, generator.GenerateReport, apitype.DisruptionReport{})
+	return getDataFromCacheOrGenerate[apitype.DisruptionReport](client.Cache, cache.RequestOptions{}, generator, generator.GenerateReport, apitype.DisruptionReport{})
 }
 
 func GetDisruptionVsTwoWeeksAgoReportFromBigQuery(client *bqcachedclient.Client) (apitype.DisruptionReport, []error) {
@@ -29,7 +29,7 @@ func GetDisruptionVsTwoWeeksAgoReportFromBigQuery(client *bqcachedclient.Client)
 		ViewName: "BackendDisruptionPercentilesDeltaCurrentVs14DaysAgo",
 	}
 
-	return getReportFromCacheOrGenerate[apitype.DisruptionReport](client.Cache, cache.RequestOptions{}, generator, generator.GenerateReport, apitype.DisruptionReport{})
+	return getDataFromCacheOrGenerate[apitype.DisruptionReport](client.Cache, cache.RequestOptions{}, generator, generator.GenerateReport, apitype.DisruptionReport{})
 }
 
 type disruptionReportGenerator struct {

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -2,6 +2,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -817,23 +818,40 @@ type ComponentReportRequestAdvancedOptions struct {
 }
 
 type ComponentTestStatus struct {
-	TestName     string
-	TestSuite    string
-	Component    string
-	Capabilities []string
-	Variants     []string
-	TotalCount   int
-	SuccessCount int
-	FlakeCount   int
+	TestName     string   `json:"test_name"`
+	TestSuite    string   `json:"test_suite"`
+	Component    string   `json:"component"`
+	Capabilities []string `json:"capabilities"`
+	Variants     []string `json:"variants"`
+	TotalCount   int      `json:"total_count"`
+	SuccessCount int      `json:"success_count"`
+	FlakeCount   int      `json:"flake_count"`
+}
+
+type ComponentReportTestStatus struct {
+	BaseStatus   map[ComponentTestIdentification]ComponentTestStatus `json:"base_status"`
+	SampleStatus map[ComponentTestIdentification]ComponentTestStatus `json:"sample_status"`
+	GeneratedAt  *time.Time                                          `json:"generated_at"`
 }
 
 type ComponentTestIdentification struct {
-	TestID       string
-	Network      string
-	Upgrade      string
-	Arch         string
-	Platform     string
-	FlatVariants string
+	TestID       string `json:"test_id"`
+	Network      string `json:"network"`
+	Upgrade      string `json:"upgrade"`
+	Arch         string `json:"arch"`
+	Platform     string `json:"platform"`
+	FlatVariants string `json:"flat_variants"`
+}
+
+// implement encoding.TextMarshaler for json map key marshalling support
+func (s ComponentTestIdentification) MarshalText() (text []byte, err error) {
+	type t ComponentTestIdentification
+	return json.Marshal(t(s))
+}
+
+func (s *ComponentTestIdentification) UnmarshalText(text []byte) error {
+	type t ComponentTestIdentification
+	return json.Unmarshal(text, (*t)(s))
 }
 
 type ComponentTestStatusRow struct {
@@ -967,6 +985,12 @@ type ComponentJobRunTestStatusRow struct {
 	FlakeCount      int      `bigquery:"flake_count"`
 	JiraComponent   string   `bigquery:"jira_component"`
 	JiraComponentID *big.Rat `bigquery:"jira_component_id"`
+}
+
+type ComponentJobRunTestReportStatus struct {
+	BaseStatus   map[string][]ComponentJobRunTestStatusRow `json:"base_status"`
+	SampleStatus map[string][]ComponentJobRunTestStatusRow `json:"sample_status"`
+	GeneratedAt  *time.Time                                `json:"generated_at"`
 }
 
 const (


### PR DESCRIPTION
Refactor to allow the report to be regenerated reusing cached bigquery results.