### PR TITLE
Don't set a default for the pinned time

### DIFF
--- a/pkg/flags/postgres.go
+++ b/pkg/flags/postgres.go
@@ -98,9 +98,8 @@ func NewPostgresDatabaseFlags() *PostgresFlags {
 	}
 
 	return &PostgresFlags{
-		LogLevel:   logLevel(logger.Info),
-		DSN:        dsn,
-		PinnedTime: PinnedTime(time.Now()),
+		LogLevel: logLevel(logger.Info),
+		DSN:      dsn,
 	}
 }
 


### PR DESCRIPTION
By setting this as a default, it ends up in the matview query locking them into that time stamp.