### PR TITLE
Updating the location of `ci-search`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ report.sh
 /sippy
 /data
 .vscode/
+.idea/
 /sippy-ng/build/*

--- a/pkg/db/loader/issues.go
+++ b/pkg/db/loader/issues.go
@@ -139,7 +139,7 @@ func findBugs(isRegex bool, testNames []string) (map[string][]jira.Issue, error)
 	}
 
 	bzQueryStart := time.Now()
-	searchURL := "https://search.ci.openshift.org/v2/search"
+	searchURL := "https://search.dptools.openshift.org/v2/search"
 
 	// Set the timeout to something other than 0, which is the default and means no timeout.
 	// This prevents waiting for too long in case search.ci is responding slower than usual.

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -93,7 +93,7 @@ export function escapeRegex(str) {
 
 export function searchCI(query) {
   query = safeEncodeURIComponent(escapeRegex(query))
-  return `https://search.ci.openshift.org/?search=${query}&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job`
+  return `https://search.dptools.openshift.org/?search=${query}&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job`
 }
 
 // A set of functions for getting paths to specific tests and jobs:

--- a/sippy-ng/src/jobs/JobTable.js
+++ b/sippy-ng/src/jobs/JobTable.js
@@ -180,7 +180,7 @@ export const getColumns = (config, openBugzillaDialog) => {
               target="_blank"
               startIcon={<BugReport />}
               href={
-                'https://search.ci.openshift.org/?search=' +
+                'https://search.dptools.openshift.org/?search=' +
                 safeEncodeURIComponent(escapeRegex(params.row.name)) +
                 '&maxAge=336h&context=1&type=bug&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job'
               }

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -629,7 +629,7 @@ function TestTable(props) {
               <IconButton
                 target="_blank"
                 href={
-                  'https://search.ci.openshift.org/?search=' +
+                  'https://search.dptools.openshift.org/?search=' +
                   safeEncodeURIComponent(escapeRegex(params.row.name)) +
                   '&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job'
                 }


### PR DESCRIPTION
We have migrated `ci-search` over to the CR Cluster as it's new location to run.  It can be accessed via the following URL:
https://search.dptools.openshift.org/

We are currently planning on replacing the resources behind `search.ci.openshift.org` with a redirector pointing over to `search.dptools.openshift.org`.  To minimize any disruptions to TRT, this PR updates the various references from: `search.ci.openshift.org` directly to: `search.dptools.openshift.org`.

