### PR TITLE
TRT-1437: Automate alert update when new releases are introduced

### DIFF
--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net/http"
@@ -11,9 +12,11 @@ import (
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/api/iterator"
 	"gorm.io/gorm"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
+	bqcachedclient "github.com/openshift/sippy/pkg/bigquery"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/query"
@@ -474,4 +477,32 @@ func releaseFilter(req *http.Request, dbc *gorm.DB) *gorm.DB {
 	}
 
 	return dbc
+}
+
+// GetReleasesFromBigQuery gets all releases defined in the Releases table in BigQuery
+func GetReleasesFromBigQuery(client *bqcachedclient.Client) ([]query.Release, error) {
+	releases := []query.Release{}
+
+	queryString := "SELECT * FROM openshift-ci-data-analysis.ci_data.Releases ORDER BY DevelStartDate DESC"
+
+	q := client.BQ.Query(queryString)
+	it, err := q.Read(context.TODO())
+	if err != nil {
+		log.WithError(err).Error("error querying releases data from bigquery")
+		return releases, err
+	}
+
+	for {
+		r := apitype.ReleaseRow{}
+		err := it.Next(&r)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.WithError(err).Error("error parsing release row from bigquery")
+			return releases, err
+		}
+		releases = append(releases, query.Release{Release: r.Release, Status: r.ReleaseStatus.String()})
+	}
+	return releases, nil
 }

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"time"
 
+	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
 	"github.com/lib/pq"
 
 	sippyv1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
@@ -1027,4 +1029,30 @@ type DisruptionReportRow struct {
 	Topology                 string  `json:"topology"`
 	Architecture             string  `json:"architecture"`
 	Relevance                int     `json:"relevance"`
+}
+
+type ReleaseRow struct {
+	// Release contains the X.Y version of the payload, e.g. 4.8
+	Release string `bigquery:"release"`
+
+	// Major contains the major part of the release, e.g. 4
+	Major int `bigquery:"Major"`
+
+	// Minor contains the minor part of the release, e.g. 8
+	Minor int `bigquery:"Minor"`
+
+	// GADate contains GA date for the release, i.e. the -YYYY-MM-DD
+	GADate bigquery.NullDate `bigquery:"GADate"`
+
+	// DevelStartDate contains start date of development of the release, i.e. the -YYYY-MM-DD
+	DevelStartDate civil.Date `bigquery:"DevelStartDate"`
+
+	// Product contains the product for the release, e.g. OCP
+	Product bigquery.NullString `bigquery:"Product"`
+
+	// Patch contains the patch version number of the release, e.g. 1
+	Patch bigquery.NullInt64 `bigquery:"Patch"`
+
+	// ReleaseStatus contains the status of the release, e.g. Full Support
+	ReleaseStatus bigquery.NullString `bigquery:"ReleaseStatus"`
 }

--- a/pkg/db/query/release_queries.go
+++ b/pkg/db/query/release_queries.go
@@ -7,6 +7,9 @@ import (
 
 type Release struct {
 	Release string
+	// Status is the release status defined in the BigQuery Releases table. SQL does not have
+	// this field
+	Status string
 }
 
 func ReleasesFromDB(dbClient *db.DB) ([]Release, error) {

--- a/pkg/sippyserver/metrics/installupgradesuccess.go
+++ b/pkg/sippyserver/metrics/installupgradesuccess.go
@@ -17,24 +17,24 @@ import (
 
 var (
 	installSuccessMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "sippy_install_success_last",
+		Name: installSuccessMetricName,
 		Help: "Successful install percentage over a period for variants we're interested in, and All.",
-	}, []string{"release", "variant", "period"})
+	}, []string{"release", "variant", "period", "releaseStatus"})
 
 	upgradeSuccessMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "sippy_upgrade_success_last",
+		Name: upgradeSuccessMetricName,
 		Help: "Successful upgrade percentage over a period for variants we're interested in, and All.",
-	}, []string{"release", "variant", "period"})
+	}, []string{"release", "variant", "period", "releaseStatus"})
 
 	installSuccessDeltaToPrevWeekMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "sippy_install_success_delta_last",
+		Name: installSuccessDeltaToPrevWeekMetricName,
 		Help: "Change in successful install percentage over the last 7 days vs previous 7 days. If positive we're improving.",
-	}, []string{"release", "variant", "period"})
+	}, []string{"release", "variant", "period", "releaseStatus"})
 
 	upgradeSuccessDeltaToPrevWeekMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "sippy_upgrade_success_delta_last",
+		Name: upgradeSuccessDeltaToPrevWeekMetricName,
 		Help: "Change in successful upgrade percentage over the last 7 days vs previous 7 days. If positive we're improving.",
-	}, []string{"release", "variant", "period"})
+	}, []string{"release", "variant", "period", "releaseStatus"})
 )
 
 // refreshInstallSuccessMetrics publishes metrics for the install success test for specific variants we care about.
@@ -49,7 +49,8 @@ func refreshUpgradeSuccessMetrics(dbc *db.DB) error {
 		testidentification.UpgradeTestName, upgradeSuccessMetric, upgradeSuccessDeltaToPrevWeekMetric, testidentification.DefaultExcludedVariants)
 }
 
-func refreshTestSuccessMetrics(dbc *db.DB, testName string, successMetric, successDeltaMetric *prometheus.GaugeVec, excludedVariants []string) error {
+func refreshTestSuccessMetrics(dbc *db.DB, testName string, successMetric, successDeltaMetric *prometheus.GaugeVec,
+	excludedVariants []string) error {
 	releases, err := query.ReleasesFromDB(dbc)
 	if err != nil {
 		return err
@@ -70,8 +71,9 @@ func refreshTestSuccessMetrics(dbc *db.DB, testName string, successMetric, succe
 			}
 
 			for variant, testReport := range testVariants {
-				successMetric.WithLabelValues(release.Release, variant, string(reportType)).Set(math.Round(testReport.CurrentPassPercentage*100) / 100)
-				successDeltaMetric.WithLabelValues(release.Release, variant, string(reportType)).Set(
+				releaseStatus := getReleaseStatus(releases, release.Release)
+				successMetric.WithLabelValues(release.Release, variant, string(reportType), releaseStatus).Set(math.Round(testReport.CurrentPassPercentage*100) / 100)
+				successDeltaMetric.WithLabelValues(release.Release, variant, string(reportType), releaseStatus).Set(
 					math.Round((testReport.CurrentPassPercentage-testReport.PreviousPassPercentage)*100) / 100)
 			}
 		}


### PR DESCRIPTION
This PR adds a mechanism to silence an alert for older releases. It uses a map to map a metric to a count. The count defines how many recent releases for which the alert should be generated for that metric. The metric for releases older than the count will be label as silenced. 

Alert definitions will be updated once this merges. We will remove specific releases in the alert definition. Instead, the current release definitions are translated into counts in this PR for any specific metrics. 

As new releases are introduced, a rollover will happen so that older releases will fall off the sliding window and have their alerts silenced automatically.


EDIT:
The above implementation is changed to add just "releaseStatus" label to all the metrics with label "release". The value of releaseStatus is obtained from the bigquery Releases table. This will leave the alert definition to filter by interested releaseStatus. 