### PR TITLE
display the right dep info when running make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export PATH := ${HOME}/go/bin:/go/bin:${PATH}
 DOCKER := $(or $(DOCKER),podman)
 DEPS = npm go
 CHECK := $(foreach dep,$(DEPS),\
-        $(if $(shell which $(dep)),"$(dep) found",$(error "Missing $(exec) in PATH")))
+        $(if $(shell which $(dep)),"$(dep) found",$(error "Missing $(dep) in PATH")))
 
 all: test build
 


### PR DESCRIPTION
Address #1537, after this fix, 
```console
jiazha-mac:sippy jiazha$ make
Makefile:5: *** "Missing npm in PATH".  Stop.
```