### PR TITLE
TRT-1462: Allow launching sippy without postgres

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -128,6 +128,10 @@ If you'd like to launch just Component Readiness, you can run:
     --redis-url="redis://192.168.1.215:6379"
 ```
 
+When providing BigQuery credentials, your service account needs access to the project and datasets that are being used.
+The defaults are visible in `--help`. For component readiness, you need to have access to the storage API as well
+with the permission `bigquery.readsessions.create`.
+
 ## Launch Sippy Web UI
 
 If you are developing on the front-end, you may start a development server which will update automatically when you edit

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -105,14 +105,28 @@ releases and architectures like this:
 
 ## Launch Sippy API
 
-If you are *not* loading a backup for your data, you will need to initialize and/or update the database schema. This step is done automatically when fetching data from testgrid or prow, but may not have run if you start the server before doing so.
+If you are *not* loading a backup for your data, you will need to
+initialize and/or update the database schema:
 
+```bash
+./sippy migrate
+```
+
+Then to launch the API server:
 ```bash
 ./sippy serve \
   --log-level=debug \
   --database-dsn="postgresql://postgres:password@localhost:5432/postgres" \
   --mode=ocp
 ````
+
+If you'd like to launch just Component Readiness, you can run:
+
+```
+./sippy component-readiness
+    --google-service-account-credential-file ~/google-service-account-credential-file.json
+    --redis-url="redis://192.168.1.215:6379"
+```
 
 ## Launch Sippy Web UI
 

--- a/cmd/sippy/component_readiness.go
+++ b/cmd/sippy/component_readiness.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"io/fs"
+	"net/http"
+	"os"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v3"
+
+	resources "github.com/openshift/sippy"
+	v1 "github.com/openshift/sippy/pkg/apis/config/v1"
+	"github.com/openshift/sippy/pkg/bigquery"
+	"github.com/openshift/sippy/pkg/dataloader/prowloader/gcs"
+	"github.com/openshift/sippy/pkg/flags"
+	"github.com/openshift/sippy/pkg/sippyserver"
+)
+
+type ComponentReadinessFlags struct {
+	GoogleCloudFlags *flags.GoogleCloudFlags
+	BigQueryFlags    *flags.BigQueryFlags
+	CacheFlags       *flags.CacheFlags
+
+	Config      string
+	LogLevel    string
+	ListenAddr  string
+	MetricsAddr string
+	RedisURL    string
+}
+
+func NewComponentReadinessCommand() *cobra.Command {
+	f := &ComponentReadinessFlags{
+		LogLevel:    "info",
+		ListenAddr:  ":8080",
+		MetricsAddr: ":2112",
+
+		GoogleCloudFlags: flags.NewGoogleCloudFlags(),
+		BigQueryFlags:    flags.NewBigQueryFlags(),
+		CacheFlags:       flags.NewCacheFlags(),
+	}
+
+	cmd := &cobra.Command{
+		Use: "component-readiness",
+
+		RunE: func(cmd *cobra.Command, arguments []string) error {
+
+			if err := f.Validate(); err != nil {
+				return errors.WithMessage(err, "error validating options")
+			}
+			if err := f.Run(); err != nil {
+				return errors.WithMessage(err, "error running command")
+			}
+
+			return nil
+		},
+	}
+
+	f.BindFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (f *ComponentReadinessFlags) BindFlags(flagSet *pflag.FlagSet) {
+	f.CacheFlags.BindFlags(flagSet)
+	f.BigQueryFlags.BindFlags(flagSet)
+	f.GoogleCloudFlags.BindFlags(flagSet)
+	flagSet.StringVar(&f.LogLevel, "log-level", f.LogLevel, "Log level (trace,debug,info,warn,error) (default info)")
+	flagSet.StringVar(&f.ListenAddr, "listen", f.ListenAddr, "The address to serve analysis reports on (default :8080)")
+	flagSet.StringVar(&f.MetricsAddr, "listen-metrics", f.MetricsAddr, "The address to serve prometheus metrics on (default :2112)")
+}
+
+func (f *ComponentReadinessFlags) Validate() error {
+	return nil
+}
+
+func (f *ComponentReadinessFlags) Run() error { //nolint:gocyclo
+	// Set log level
+	level, err := log.ParseLevel(f.LogLevel)
+	if err != nil {
+		log.WithError(err).Fatal("Cannot parse log-level")
+	}
+	log.SetLevel(level)
+
+	// Add some millisecond precision to log timestamps, useful for debugging performance.
+	formatter := new(log.TextFormatter)
+	formatter.TimestampFormat = "2006-01-02T15:04:05.999Z07:00"
+	formatter.FullTimestamp = true
+	formatter.DisableColors = false
+	log.SetFormatter(formatter)
+
+	log.Debug("debug logging enabled")
+	sippyConfig := v1.SippyConfig{}
+	if f.Config == "" {
+		sippyConfig.Prow = v1.ProwConfig{
+			URL: "https://prow.ci.openshift.org/prowjobs.js",
+		}
+	} else {
+		data, err := os.ReadFile(f.Config)
+		if err != nil {
+			log.WithError(err).Fatalf("could not load config")
+		}
+		if err := yaml.Unmarshal(data, &sippyConfig); err != nil {
+			log.WithError(err).Fatalf("could not unmarshal config")
+		}
+	}
+
+	return f.runServerMode()
+}
+
+func (f *ComponentReadinessFlags) runServerMode() error {
+	var err error
+
+	webRoot, err := fs.Sub(resources.SippyNG, "sippy-ng/build")
+	if err != nil {
+		log.WithError(err).Fatal("could not load frontend")
+	}
+
+	cacheClient, err := f.CacheFlags.GetCacheClient()
+	if err != nil {
+		return errors.WithMessage(err, "couldn't get cache client")
+	}
+
+	var bigQueryClient *bigquery.Client
+	var gcsClient *storage.Client
+	if f.GoogleCloudFlags.ServiceAccountCredentialFile != "" {
+		bigQueryClient, err = f.BigQueryFlags.GetBigQueryClient(context.Background(),
+			cacheClient, f.GoogleCloudFlags.ServiceAccountCredentialFile)
+		if err != nil {
+			return errors.WithMessage(err, "couldn't get bigquery client")
+		}
+
+		gcsClient, err = gcs.NewGCSClient(context.TODO(),
+			f.GoogleCloudFlags.ServiceAccountCredentialFile,
+			f.GoogleCloudFlags.OAuthClientCredentialFile,
+		)
+		if err != nil {
+			log.WithError(err).Warn("unable to create GCS client, some APIs may not work")
+		}
+	}
+
+	server := sippyserver.NewServer(
+		sippyserver.ModeOpenShift,
+		f.ListenAddr,
+		nil,
+		nil,
+		webRoot,
+		&resources.Static,
+		nil,
+		f.GoogleCloudFlags.StorageBucket,
+		gcsClient,
+		bigQueryClient,
+		nil,
+		cacheClient,
+		4*time.Hour,
+	)
+
+	// Serve our metrics endpoint for prometheus to scrape
+	go func() {
+		http.Handle("/metrics", promhttp.Handler())
+		err := http.ListenAndServe(f.MetricsAddr, nil) //nolint
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	server.Serve()
+	return nil
+}

--- a/cmd/sippy/main.go
+++ b/cmd/sippy/main.go
@@ -37,6 +37,7 @@ func main() {
 		NewLoadCommand(),
 		NewSnapshotCommand(),
 		NewRefreshCommand(),
+		NewComponentReadinessCommand(),
 	)
 
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info",

--- a/pkg/sippyserver/capabilities.go
+++ b/pkg/sippyserver/capabilities.go
@@ -1,7 +1,7 @@
 package sippyserver
 
 const (
-	// Whether this instance of sippy is capable of display OpenShift-releated data. This
+	// Whether this instance of sippy is capable of displaying OpenShift-releated data. This
 	// is basically always since we don't have a kube Sippy anymore.
 	OpenshiftCapability = "openshift_releases"
 

--- a/pkg/sippyserver/capabilities.go
+++ b/pkg/sippyserver/capabilities.go
@@ -1,0 +1,16 @@
+package sippyserver
+
+const (
+	// Whether this instance of sippy is capable of display OpenShift-releated data. This
+	// is basically always since we don't have a kube Sippy anymore.
+	OpenshiftCapability = "openshift_releases"
+
+	// LocalDB is whether we have a local DB client (currently postgres)
+	LocalDBCapability = "local_db"
+
+	// BuildclusterCapability is whether we have build cluster health data.
+	BuildClusterCapability = "build_clusters"
+
+	// ComponentReadiness capability is whether this sippy instance is configured for Component Readiness
+	ComponentReadinessCapability = "component_readiness"
+)

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -925,6 +925,7 @@ func (s *Server) jsonReleasesReportFromDB(w http.ResponseWriter, _ *http.Request
 
 		response.LastUpdated = lastUpdated.Max
 	}
+
 	api.RespondWithJSON(http.StatusOK, w, response)
 }
 
@@ -1521,7 +1522,7 @@ func (s *Server) Serve() {
 		{
 			EndpointPath: "/api/releases",
 			Description:  "Reports on releases",
-			Capabilities: []string{LocalDBCapability},
+			Capabilities: []string{},
 			HandlerFunc:  s.jsonReleasesReportFromDB,
 		},
 		{
@@ -1557,7 +1558,6 @@ func (s *Server) Serve() {
 		{
 			EndpointPath: "/api/report_date",
 			Description:  "Displays report date",
-			Capabilities: []string{LocalDBCapability},
 			HandlerFunc:  s.printReportDate,
 		},
 		{

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -17,26 +17,21 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/push"
-
-	"github.com/openshift/sippy/pkg/bigquery"
-
-	"github.com/openshift/sippy/pkg/api/jobrunintervals"
-	"github.com/openshift/sippy/pkg/apis/cache"
-	"github.com/openshift/sippy/pkg/dataloader/releaseloader"
-
-	"github.com/openshift/sippy/pkg/db/models"
-
-	apitype "github.com/openshift/sippy/pkg/apis/api"
-	"github.com/openshift/sippy/pkg/filter"
-	"github.com/openshift/sippy/pkg/synthetictests"
-	"github.com/openshift/sippy/pkg/util"
-
 	log "github.com/sirupsen/logrus"
 
 	"github.com/openshift/sippy/pkg/api"
+	"github.com/openshift/sippy/pkg/api/jobrunintervals"
+	apitype "github.com/openshift/sippy/pkg/apis/api"
+	"github.com/openshift/sippy/pkg/apis/cache"
+	"github.com/openshift/sippy/pkg/bigquery"
+	"github.com/openshift/sippy/pkg/dataloader/releaseloader"
 	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/query"
+	"github.com/openshift/sippy/pkg/filter"
+	"github.com/openshift/sippy/pkg/synthetictests"
 	"github.com/openshift/sippy/pkg/testidentification"
+	"github.com/openshift/sippy/pkg/util"
 )
 
 // Mode defines the server mode of operation, OpenShift or upstream Kubernetes.
@@ -113,6 +108,7 @@ type Server struct {
 	gcsBucket            string
 	cache                cache.Cache
 	crTimeRoundingFactor time.Duration
+	capabilities         []string
 }
 
 func (s *Server) GetReportEnd() time.Time {
@@ -223,19 +219,46 @@ func RefreshData(dbc *db.DB, pinnedDateTime *time.Time, refreshMatviewsOnlyIfEmp
 	log.Infof("Refresh complete")
 }
 
-func (s *Server) jsonCapabilitiesReport(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) hasCapabilities(capabilities []string) bool {
+	for _, cap := range capabilities {
+		found := false
+		for _, sCap := range s.capabilities {
+			if cap == sCap {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Server) determineCapabilities() {
 	capabilities := make([]string, 0)
 	if s.mode == ModeOpenShift {
-		capabilities = append(capabilities, "openshift_releases")
+		capabilities = append(capabilities, OpenshiftCapability)
 	}
 
-	if hasBuildCluster, err := query.HasBuildClusterData(s.db); hasBuildCluster {
-		capabilities = append(capabilities, "build_clusters")
-	} else if err != nil {
-		log.WithError(err).Warningf("could not fetch build cluster data")
+	if s.bigQueryClient != nil {
+		capabilities = append(capabilities, ComponentReadinessCapability)
+	}
+	if s.db != nil {
+		capabilities = append(capabilities, LocalDBCapability)
+
+		if hasBuildCluster, err := query.HasBuildClusterData(s.db); hasBuildCluster {
+			capabilities = append(capabilities, BuildClusterCapability)
+		} else if err != nil {
+			log.WithError(err).Warningf("could not fetch build cluster data")
+		}
 	}
 
-	api.RespondWithJSON(http.StatusOK, w, capabilities)
+	s.capabilities = capabilities
+}
+
+func (s *Server) jsonCapabilitiesReport(w http.ResponseWriter, _ *http.Request) {
+	api.RespondWithJSON(http.StatusOK, w, s.capabilities)
 }
 
 func (s *Server) jsonAutocompleteFromDB(w http.ResponseWriter, req *http.Request) {
@@ -1294,7 +1317,19 @@ func (s *Server) jsonJobsAnalysisFromDB(w http.ResponseWriter, req *http.Request
 	api.RespondWithJSON(http.StatusOK, w, results)
 }
 
+func (s *Server) requireCapabilities(capabilities []string, implFn func(w http.ResponseWriter, req *http.Request)) func(http.ResponseWriter, *http.Request) {
+	if s.hasCapabilities(capabilities) {
+		return implFn
+	}
+
+	return func(w http.ResponseWriter, req *http.Request) {
+		api.RespondWithJSON(http.StatusNotImplemented, w, map[string]string{"message": "This Sippy server is not capable of responding to this request."})
+	}
+}
+
 func (s *Server) Serve() {
+	s.determineCapabilities()
+
 	// Use private ServeMux to prevent tests from stomping on http.DefaultServeMux
 	serveMux := http.NewServeMux()
 
@@ -1330,53 +1365,284 @@ func (s *Server) Serve() {
 		http.Redirect(w, req, "/sippy-ng/", 301)
 	})
 
-	serveMux.HandleFunc("/api/autocomplete/", s.jsonAutocompleteFromDB)
-	serveMux.HandleFunc("/api/jobs", s.jsonJobsReportFromDB)
-	serveMux.HandleFunc("/api/jobs/runs", s.jsonJobRunsReportFromDB)
-	serveMux.HandleFunc("/api/jobs/runs/risk_analysis", s.jsonJobRunRiskAnalysis)
-	serveMux.HandleFunc("/api/jobs/runs/intervals", s.cached(4*time.Hour, s.jsonJobRunIntervals))
-	serveMux.HandleFunc("/api/jobs/analysis", s.jsonJobsAnalysisFromDB)
-	serveMux.HandleFunc("/api/jobs/details", s.jsonJobsDetailsReportFromDB)
-	serveMux.HandleFunc("/api/jobs/bugs", s.jsonJobBugsFromDB)
-	serveMux.HandleFunc("/api/pull_requests", s.cached(1*time.Hour, s.jsonPullRequestsReportFromDB))
-	serveMux.HandleFunc("/api/repositories", s.jsonRepositoriesReportFromDB)
-	serveMux.HandleFunc("/api/tests", s.jsonTestsReportFromDB)
-	serveMux.HandleFunc("/api/tests/details", s.cached(1*time.Hour, s.jsonTestDetailsReportFromDB))
-	serveMux.HandleFunc("/api/tests/analysis/overall", s.cached(1*time.Hour, s.jsonTestAnalysisOverallFromDB))
-	serveMux.HandleFunc("/api/tests/analysis/variants", s.cached(1*time.Hour, s.jsonTestAnalysisByVariantFromDB))
-	serveMux.HandleFunc("/api/tests/analysis/jobs", s.cached(1*time.Hour, s.jsonTestAnalysisByJobFromDB))
-	serveMux.HandleFunc("/api/tests/bugs", s.jsonTestBugsFromDB)
-	serveMux.HandleFunc("/api/tests/outputs", s.cached(1*time.Hour, s.jsonTestOutputsFromDB))
-	serveMux.HandleFunc("/api/tests/durations", s.cached(1*time.Hour, s.jsonTestDurationsFromDB))
-	serveMux.HandleFunc("/api/install", s.cached(1*time.Hour, s.jsonInstallReportFromDB))
-	serveMux.HandleFunc("/api/upgrade", s.cached(1*time.Hour, s.jsonUpgradeReportFromDB))
-	serveMux.HandleFunc("/api/releases", s.jsonReleasesReportFromDB)
-	serveMux.HandleFunc("/api/health/build_cluster/analysis", s.jsonBuildClusterHealthAnalysis)
-	serveMux.HandleFunc("/api/health/build_cluster", s.jsonBuildClusterHealth)
-	serveMux.HandleFunc("/api/health", s.jsonHealthReportFromDB)
-	serveMux.HandleFunc("/api/variants", s.jsonVariantsReportFromDB)
-	serveMux.HandleFunc("/api/canary", s.printCanaryReportFromDB)
-	serveMux.HandleFunc("/api/report_date", s.printReportDate)
-	// Note that component readiness is cached, but at the lower layer of report generation so we can use the cached
-	// data in metrics.
-	serveMux.HandleFunc("/api/component_readiness", s.jsonComponentReportFromBigQuery)
-	serveMux.HandleFunc("/api/component_readiness/test_details", s.jsonComponentReportTestDetailsFromBigQuery)
-	serveMux.HandleFunc("/api/component_readiness/variants", s.jsonComponentTestVariantsFromBigQuery)
+	type apiEndpoints struct {
+		EndpointPath string                                       `json:"path"`
+		Description  string                                       `json:"description"`
+		Capabilities []string                                     `json:"required_capabilities"`
+		CacheTime    time.Duration                                `json:"cache_time"`
+		HandlerFunc  func(w http.ResponseWriter, r *http.Request) `json:"-"`
+	}
 
-	serveMux.HandleFunc("/api/capabilities", s.jsonCapabilitiesReport)
-	if s.db != nil {
-		serveMux.HandleFunc("/api/releases/health", s.jsonReleaseHealthReport)
-		serveMux.HandleFunc("/api/releases/tags/events", s.jsonReleaseTagsEvent)
-		serveMux.HandleFunc("/api/releases/tags", s.jsonReleaseTagsReport)
-		serveMux.HandleFunc("/api/releases/pull_requests", s.jsonReleasePullRequestsReport)
-		serveMux.HandleFunc("/api/releases/job_runs", s.jsonListPayloadJobRuns)
-		serveMux.HandleFunc("/api/incidents", s.jsonIncidentEvent)
+	var endpoints []apiEndpoints
+	endpoints = []apiEndpoints{
+		{
+			EndpointPath: "/api",
+			Description:  "API docs",
+			HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
+				var availableEndpoints []apiEndpoints
+				for _, ep := range endpoints {
+					if s.hasCapabilities(ep.Capabilities) {
+						availableEndpoints = append(availableEndpoints, ep)
+					}
+				}
+				api.RespondWithJSON(http.StatusOK, w, availableEndpoints)
+			},
+		},
+		{
+			EndpointPath: "/api/autocomplete",
+			Description:  "Autocompletes queries from database",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonAutocompleteFromDB,
+		},
+		{
+			EndpointPath: "/api/jobs",
+			Description:  "Returns a list of jobs",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonJobsReportFromDB,
+		},
+		{
+			EndpointPath: "/api/jobs/runs",
+			Description:  "Returns a report of job runs",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonJobRunsReportFromDB,
+		},
+		{
+			EndpointPath: "/api/jobs/runs/risk_analysis",
+			Description:  "Analyzes risks of job runs",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonJobRunRiskAnalysis,
+		},
+		{
+			EndpointPath: "/api/jobs/runs/intervals",
+			Description:  "Reports intervals of job runs",
+			Capabilities: []string{LocalDBCapability},
+			CacheTime:    4 * time.Hour,
+			HandlerFunc:  s.jsonJobRunIntervals,
+		},
+		{
+			EndpointPath: "/api/jobs/analysis",
+			Description:  "Analyzes jobs from the database",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonJobsAnalysisFromDB,
+		},
+		{
+			EndpointPath: "/api/jobs/details",
+			Description:  "Reports details of jobs",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonJobsDetailsReportFromDB,
+		},
+		{
+			EndpointPath: "/api/jobs/bugs",
+			Description:  "Reports bugs related to jobs",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonJobBugsFromDB,
+		},
+		{
+			EndpointPath: "/api/pull_requests",
+			Description:  "Reports on pull requests",
+			Capabilities: []string{LocalDBCapability},
+			CacheTime:    1 * time.Hour,
+			HandlerFunc:  s.jsonPullRequestsReportFromDB,
+		},
+		{
+			EndpointPath: "/api/repositories",
+			Description:  "Reports on repositories",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonRepositoriesReportFromDB,
+		},
+		{
+			EndpointPath: "/api/tests",
+			Description:  "Reports on tests",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonTestsReportFromDB,
+		},
+		{
+			EndpointPath: "/api/tests/details",
+			Description:  "Details of tests",
+			Capabilities: []string{LocalDBCapability},
+			CacheTime:    1 * time.Hour,
+			HandlerFunc:  s.jsonTestDetailsReportFromDB,
+		},
+		{
+			EndpointPath: "/api/tests/analysis/overall",
+			Description:  "Overall analysis of tests",
+			Capabilities: []string{LocalDBCapability},
+			CacheTime:    1 * time.Hour,
+			HandlerFunc:  s.jsonTestAnalysisOverallFromDB,
+		},
+		{
+			EndpointPath: "/api/tests/analysis/variants",
+			Description:  "Analysis of test by variants",
+			Capabilities: []string{LocalDBCapability},
+			CacheTime:    1 * time.Hour,
+			HandlerFunc:  s.jsonTestAnalysisByVariantFromDB,
+		},
+		{
+			EndpointPath: "/api/tests/analysis/jobs",
+			Description:  "Analysis of tests by job",
+			Capabilities: []string{LocalDBCapability},
+			CacheTime:    1 * time.Hour,
+			HandlerFunc:  s.jsonTestAnalysisByJobFromDB,
+		},
+		{
+			EndpointPath: "/api/tests/bugs",
+			Description:  "Reports bugs in tests",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonTestBugsFromDB,
+		},
+		{
+			EndpointPath: "/api/tests/outputs",
+			Description:  "Outputs of tests",
+			Capabilities: []string{LocalDBCapability},
+			CacheTime:    1 * time.Hour,
+			HandlerFunc:  s.jsonTestOutputsFromDB,
+		},
+		{
+			EndpointPath: "/api/tests/durations",
+			Description:  "Durations of tests",
+			Capabilities: []string{LocalDBCapability},
+			CacheTime:    1 * time.Hour,
+			HandlerFunc:  s.jsonTestDurationsFromDB,
+		},
+		{
+			EndpointPath: "/api/install",
+			Description:  "Reports on installations",
+			Capabilities: []string{LocalDBCapability},
+			CacheTime:    1 * time.Hour,
+			HandlerFunc:  s.jsonInstallReportFromDB,
+		},
+		{
+			EndpointPath: "/api/upgrade",
+			Description:  "Reports on upgrades",
+			Capabilities: []string{LocalDBCapability},
+			CacheTime:    1 * time.Hour,
+			HandlerFunc:  s.jsonUpgradeReportFromDB,
+		},
+		{
+			EndpointPath: "/api/releases",
+			Description:  "Reports on releases",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonReleasesReportFromDB,
+		},
+		{
+			EndpointPath: "/api/health/build_cluster/analysis",
+			Description:  "Analyzes build cluster health",
+			Capabilities: []string{LocalDBCapability, BuildClusterCapability},
+			HandlerFunc:  s.jsonBuildClusterHealthAnalysis,
+		},
+		{
+			EndpointPath: "/api/health/build_cluster",
+			Description:  "Reports health of build cluster",
+			Capabilities: []string{LocalDBCapability, BuildClusterCapability},
+			HandlerFunc:  s.jsonBuildClusterHealth,
+		},
+		{
+			EndpointPath: "/api/health",
+			Description:  "Reports general health from DB",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonHealthReportFromDB,
+		},
+		{
+			EndpointPath: "/api/variants",
+			Description:  "Reports on variants",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonVariantsReportFromDB,
+		},
+		{
+			EndpointPath: "/api/canary",
+			Description:  "Displays canary report from database",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.printCanaryReportFromDB,
+		},
+		{
+			EndpointPath: "/api/report_date",
+			Description:  "Displays report date",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.printReportDate,
+		},
+		{
+			EndpointPath: "/api/component_readiness",
+			Description:  "Reports component readiness from BigQuery",
+			Capabilities: []string{ComponentReadinessCapability},
+			HandlerFunc:  s.jsonComponentReportFromBigQuery,
+		},
+		{
+			EndpointPath: "/api/component_readiness/test_details",
+			Description:  "Reports test details for component readiness from BigQuery",
+			Capabilities: []string{ComponentReadinessCapability},
+			HandlerFunc:  s.jsonComponentReportTestDetailsFromBigQuery,
+		},
+		{
+			EndpointPath: "/api/component_readiness/variants",
+			Description:  "Reports test variants for component readiness from BigQuery",
+			Capabilities: []string{ComponentReadinessCapability},
+			HandlerFunc:  s.jsonComponentTestVariantsFromBigQuery,
+		},
+		{
+			EndpointPath: "/api/capabilities",
+			Description:  "Lists available API capabilities",
+			Capabilities: []string{},
+			HandlerFunc:  s.jsonCapabilitiesReport,
+		},
+		{
+			EndpointPath: "/api/releases/health",
+			Description:  "Reports health of releases",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonReleaseHealthReport,
+		},
+		{
+			EndpointPath: "/api/releases/tags/events",
+			Description:  "Lists events for release tags",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonReleaseTagsEvent,
+		},
+		{
+			EndpointPath: "/api/releases/tags",
+			Description:  "Lists release tags",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonReleaseTagsReport,
+		},
+		{
+			EndpointPath: "/api/releases/pull_requests",
+			Description:  "Reports pull requests for releases",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonReleasePullRequestsReport,
+		},
+		{
+			EndpointPath: "/api/releases/job_runs",
+			Description:  "Lists job runs for releases",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonListPayloadJobRuns,
+		},
+		{
+			EndpointPath: "/api/incidents",
+			Description:  "Reports incident events",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonIncidentEvent,
+		},
+		{
+			EndpointPath: "/api/releases/test_failures",
+			Description:  "Analysis of test failures for releases",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonGetPayloadAnalysis,
+		},
+		{
+			EndpointPath: "/api/payloads/test_failures",
+			Description:  "Analysis of test failures in payloads",
+			Capabilities: []string{LocalDBCapability},
+			HandlerFunc:  s.jsonGetPayloadTestFailures,
+		},
+	}
 
-		serveMux.HandleFunc("/api/releases/test_failures",
-			s.jsonGetPayloadAnalysis)
-
-		serveMux.HandleFunc("/api/payloads/test_failures",
-			s.jsonGetPayloadTestFailures)
+	for _, ep := range endpoints {
+		fn := ep.HandlerFunc
+		if ep.CacheTime > 0 {
+			fn = s.cached(ep.CacheTime, fn)
+		}
+		if len(ep.Capabilities) > 0 {
+			fn = s.requireCapabilities(ep.Capabilities, fn)
+		}
+		serveMux.HandleFunc(ep.EndpointPath, fn)
 	}
 
 	var handler http.Handler = serveMux
@@ -1393,7 +1659,7 @@ func (s *Server) Serve() {
 
 	log.Infof("Serving reports on %s ", s.listenAddr)
 
-	if err := s.httpServer.ListenAndServe(); err != http.ErrServerClosed {
+	if err := s.httpServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
 		log.WithError(err).Error("Server exited")
 	}
 }

--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -20,7 +20,7 @@ import { makeStyles, styled } from '@mui/styles'
 import { parse, stringify } from 'query-string'
 import { QueryParamProvider } from 'use-query-params'
 import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5'
-import { Route, Switch } from 'react-router-dom'
+import { Redirect, Route, Switch } from 'react-router-dom'
 import { TestAnalysis } from './tests/TestAnalysis'
 import { useCookies } from 'react-cookie'
 import Alert from '@mui/material/Alert'
@@ -102,7 +102,9 @@ const DrawerHeader = styled('div')(({ theme }) => ({
 export const ReleasesContext = React.createContext({})
 export const CapabilitiesContext = React.createContext([])
 export const ReportEndContext = React.createContext('')
-const ColorModeContext = React.createContext({ toggleColorMode: () => {} })
+const ColorModeContext = React.createContext({
+  toggleColorMode: () => {},
+})
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -192,43 +194,34 @@ export default function App(props) {
   const [fetchError, setFetchError] = React.useState('')
 
   const fetchData = () => {
-    Promise.all([
-      fetch(process.env.REACT_APP_API_URL + '/api/releases'),
-      fetch(process.env.REACT_APP_API_URL + '/api/capabilities'),
-      fetch(process.env.REACT_APP_API_URL + '/api/report_date'),
-    ])
-      .then(([releases, capabilities, reportDate]) => {
-        if (releases.status !== 200) {
-          throw new Error('server returned ' + releases.status)
+    fetch(process.env.REACT_APP_API_URL + '/api/capabilities')
+      .then((response) => {
+        if (response.status !== 200) {
+          throw new Error('server returned ' + response.status)
         }
-
-        if (capabilities.status !== 200) {
-          throw new Error('server returned ' + capabilities.status)
-        }
-
-        if (reportDate.status !== 200) {
-          throw new Error('server returned ' + reportDate.status)
-        }
-
-        return Promise.all([
-          releases.json(),
-          capabilities.json(),
-          reportDate.json(),
-        ])
+        return response.json()
       })
-      .then(([releases, capabilities, reportDate]) => {
-        // Remove the Z from the ga_dates so that when Date objects are created,
-        // the date is not converted to a local time zone.
-        for (const key in releases.ga_dates) {
-          if (releases.ga_dates[key]) {
-            releases.ga_dates[key] = releases.ga_dates[key].replace('Z', '')
-          }
+      .then((capabilities) => {
+        if (capabilities.includes('local_db')) {
+          return Promise.all([
+            fetch(process.env.REACT_APP_API_URL + '/api/releases').then((res) =>
+              res.json()
+            ),
+            fetch(process.env.REACT_APP_API_URL + '/api/report_date').then(
+              (res) => res.json()
+            ),
+          ]).then(([releases, reportDate]) => {
+            // Process releases and reportDate here
+            setCapabilities(capabilities)
+            setReleases(releases)
+            setReportDate(reportDate['pinnedDateTime'])
+            setLastUpdated(new Date(releases.last_updated))
+            setLoaded(true)
+          })
+        } else {
+          // Handle case where 'local_db' is not in capabilities
+          setLoaded(true)
         }
-        setReleases(releases)
-        setCapabilities(capabilities)
-        setReportDate(reportDate['pinnedDateTime'])
-        setLastUpdated(new Date(releases.last_updated))
-        setLoaded(true)
       })
       .catch((error) => {
         setLoaded(true)
@@ -292,288 +285,319 @@ export default function App(props) {
                     objectToSearchString: stringify,
                   }}
                 >
-                  <div className={classes.root}>
-                    <AppBar
-                      position="fixed"
-                      open={drawerOpen}
-                      sx={{ bgcolor: '#3f51b5' }}
-                    >
-                      <Toolbar edge="start">
-                        <IconButton
-                          color="inherit"
-                          aria-label="open drawer"
-                          onClick={handleDrawerOpen}
-                          edge="start"
-                          sx={{ mr: 2, ...(drawerOpen && { display: 'none' }) }}
-                        >
-                          <MenuIcon />
-                        </IconButton>
-                        <Grid
-                          container
-                          justifyContent="space-between"
-                          alignItems="center"
-                        >
-                          <Typography variant="h6" className={classes.title}>
-                            Sippy
-                          </Typography>
-                          Last updated{' '}
-                          {lastUpdated !== null
-                            ? relativeTime(lastUpdated, startDate)
-                            : 'unknown'}
-                        </Grid>
-                      </Toolbar>
-                    </AppBar>
-
-                    <Drawer
-                      sx={{
-                        width: drawerWidth,
-                        flexShrink: 0,
-                        '& .MuiDrawer-paper': {
-                          width: drawerWidth,
-                          boxSizing: 'border-box',
-                        },
-                      }}
-                      variant="persistent"
-                      anchor="left"
-                      open={drawerOpen}
-                    >
-                      <DrawerHeader>
-                        <Tooltip
-                          title={
-                            mode === 'dark'
-                              ? 'Toggle light mode'
-                              : 'Toggle dark mode'
-                          }
-                        >
+                  {capabilities.includes('local_db') ? (
+                    <div className={classes.root}>
+                      <AppBar
+                        position="fixed"
+                        open={drawerOpen}
+                        sx={{ bgcolor: '#3f51b5' }}
+                      >
+                        <Toolbar edge="start">
                           <IconButton
-                            sx={{ ml: 1 }}
-                            onClick={colorMode.toggleColorMode}
                             color="inherit"
+                            aria-label="open drawer"
+                            onClick={handleDrawerOpen}
+                            edge="start"
+                            sx={{
+                              mr: 2,
+                              ...(drawerOpen && { display: 'none' }),
+                            }}
                           >
-                            {mode === 'dark' ? <LightMode /> : <DarkMode />}
+                            <MenuIcon />
                           </IconButton>
-                        </Tooltip>
-                        <IconButton onClick={handleDrawerClose} size="large">
-                          {theme.direction === 'ltr' ? (
-                            <ChevronLeftIcon />
-                          ) : (
-                            <ChevronRightIcon />
-                          )}
-                        </IconButton>
-                      </DrawerHeader>
-                      <Sidebar releases={releases['releases']} />
-                    </Drawer>
+                          <Grid
+                            container
+                            justifyContent="space-between"
+                            alignItems="center"
+                          >
+                            <Typography variant="h6" className={classes.title}>
+                              Sippy
+                            </Typography>
+                            Last updated{' '}
+                            {lastUpdated !== null
+                              ? relativeTime(lastUpdated, startDate)
+                              : 'unknown'}
+                          </Grid>
+                        </Toolbar>
+                      </AppBar>
 
-                    <Main open={drawerOpen}>
-                      <DrawerHeader />
-                      {/* eslint-disable react/prop-types */}
-                      <Switch>
-                        <Route path="/about">
-                          <p>Hello, world!</p>
-                        </Route>
+                      <Drawer
+                        sx={{
+                          width: drawerWidth,
+                          flexShrink: 0,
+                          '& .MuiDrawer-paper': {
+                            width: drawerWidth,
+                            boxSizing: 'border-box',
+                          },
+                        }}
+                        variant="persistent"
+                        anchor="left"
+                        open={drawerOpen}
+                      >
+                        <DrawerHeader>
+                          <Tooltip
+                            title={
+                              mode === 'dark'
+                                ? 'Toggle light mode'
+                                : 'Toggle dark mode'
+                            }
+                          >
+                            <IconButton
+                              sx={{ ml: 1 }}
+                              onClick={colorMode.toggleColorMode}
+                              color="inherit"
+                            >
+                              {mode === 'dark' ? <LightMode /> : <DarkMode />}
+                            </IconButton>
+                          </Tooltip>
+                          <IconButton onClick={handleDrawerClose} size="large">
+                            {theme.direction === 'ltr' ? (
+                              <ChevronLeftIcon />
+                            ) : (
+                              <ChevronRightIcon />
+                            )}
+                          </IconButton>
+                        </DrawerHeader>
+                        <Sidebar releases={releases['releases']} />
+                      </Drawer>
 
-                        <Route
-                          path="/release/:release/tags/:tag"
-                          render={(props) => (
-                            <ReleasePayloadDetails
-                              key={
-                                'release-details-' + props.match.params.release
-                              }
-                              release={props.match.params.release}
-                              releaseTag={props.match.params.tag}
-                            />
-                          )}
-                        />
+                      <Main open={drawerOpen}>
+                        <DrawerHeader />
+                        {/* eslint-disable react/prop-types */}
+                        <Switch>
+                          <Route path="/about">
+                            <p>Hello, world!</p>
+                          </Route>
 
-                        <Route
-                          path="/release/:release/streams/:arch/:stream"
-                          render={(props) => (
-                            <PayloadStream
-                              release={props.match.params.release}
-                              arch={props.match.params.arch}
-                              stream={props.match.params.stream}
-                            />
-                          )}
-                        />
+                          <Route
+                            path="/release/:release/tags/:tag"
+                            render={(props) => (
+                              <ReleasePayloadDetails
+                                key={
+                                  'release-details-' +
+                                  props.match.params.release
+                                }
+                                release={props.match.params.release}
+                                releaseTag={props.match.params.tag}
+                              />
+                            )}
+                          />
 
-                        <Route
-                          path="/release/:release/streams"
-                          render={(props) => (
-                            <PayloadStreams
-                              key={
-                                'release-streams-' + props.match.params.release
-                              }
-                              release={props.match.params.release}
-                            />
-                          )}
-                        />
+                          <Route
+                            path="/release/:release/streams/:arch/:stream"
+                            render={(props) => (
+                              <PayloadStream
+                                release={props.match.params.release}
+                                arch={props.match.params.arch}
+                                stream={props.match.params.stream}
+                              />
+                            )}
+                          />
 
-                        <Route
-                          path="/release/:release/tags"
-                          render={(props) => (
-                            <ReleasePayloads
-                              key={'release-tags-' + props.match.params.release}
-                              release={props.match.params.release}
-                            />
-                          )}
-                        />
+                          <Route
+                            path="/release/:release/streams"
+                            render={(props) => (
+                              <PayloadStreams
+                                key={
+                                  'release-streams-' +
+                                  props.match.params.release
+                                }
+                                release={props.match.params.release}
+                              />
+                            )}
+                          />
 
-                        <Route
-                          path="/release/:release"
-                          render={(props) => (
-                            <ReleaseOverview
-                              key={
-                                'release-overview-' + props.match.params.release
-                              }
-                              release={props.match.params.release}
-                            />
-                          )}
-                        />
+                          <Route
+                            path="/release/:release/tags"
+                            render={(props) => (
+                              <ReleasePayloads
+                                key={
+                                  'release-tags-' + props.match.params.release
+                                }
+                                release={props.match.params.release}
+                              />
+                            )}
+                          />
 
-                        <Route
-                          path="/variants/:release/:variant"
-                          render={(props) => (
-                            <VariantStatus
-                              release={props.match.params.release}
-                              variant={props.match.params.variant}
-                            />
-                          )}
-                        />
+                          <Route
+                            path="/release/:release"
+                            render={(props) => (
+                              <ReleaseOverview
+                                key={
+                                  'release-overview-' +
+                                  props.match.params.release
+                                }
+                                release={props.match.params.release}
+                              />
+                            )}
+                          />
 
-                        <Route
-                          path="/jobs/:release/analysis"
-                          render={(props) => (
-                            <JobAnalysis release={props.match.params.release} />
-                          )}
-                        />
+                          <Route
+                            path="/variants/:release/:variant"
+                            render={(props) => (
+                              <VariantStatus
+                                release={props.match.params.release}
+                                variant={props.match.params.variant}
+                              />
+                            )}
+                          />
 
-                        <Route
-                          path="/jobs/:release"
-                          render={(props) => (
-                            <Jobs
-                              key={'jobs-' + props.match.params.release}
-                              title={
-                                'Job results for ' + props.match.params.release
-                              }
-                              release={props.match.params.release}
-                            />
-                          )}
-                        />
+                          <Route
+                            path="/jobs/:release/analysis"
+                            render={(props) => (
+                              <JobAnalysis
+                                release={props.match.params.release}
+                              />
+                            )}
+                          />
 
-                        <Route
-                          path="/tests/:release/analysis"
-                          render={(props) => (
-                            <TestAnalysis
-                              release={props.match.params.release}
-                            />
-                          )}
-                        />
+                          <Route
+                            path="/jobs/:release"
+                            render={(props) => (
+                              <Jobs
+                                key={'jobs-' + props.match.params.release}
+                                title={
+                                  'Job results for ' +
+                                  props.match.params.release
+                                }
+                                release={props.match.params.release}
+                              />
+                            )}
+                          />
 
-                        <Route
-                          path="/tests/:release"
-                          render={(props) => (
-                            <Tests
-                              key={'tests-' + props.match.params.release}
-                              release={props.match.params.release}
-                            />
-                          )}
-                        />
+                          <Route
+                            path="/tests/:release/analysis"
+                            render={(props) => (
+                              <TestAnalysis
+                                release={props.match.params.release}
+                              />
+                            )}
+                          />
 
-                        <Route
-                          path="/upgrade/:release"
-                          render={(props) => (
-                            <Upgrades
-                              key={'upgrades-' + props.match.params.release}
-                              release={props.match.params.release}
-                            />
-                          )}
-                        />
+                          <Route
+                            path="/tests/:release"
+                            render={(props) => (
+                              <Tests
+                                key={'tests-' + props.match.params.release}
+                                release={props.match.params.release}
+                              />
+                            )}
+                          />
 
-                        <Route
-                          path="/component_readiness"
-                          render={(props) => {
-                            return (
-                              <CompReadyVarsProvider>
-                                <ComponentReadiness
-                                  key={getUrlWithoutParams(['regressedModal'])}
-                                />
-                              </CompReadyVarsProvider>
-                            )
-                          }}
-                        />
+                          <Route
+                            path="/upgrade/:release"
+                            render={(props) => (
+                              <Upgrades
+                                key={'upgrades-' + props.match.params.release}
+                                release={props.match.params.release}
+                              />
+                            )}
+                          />
 
-                        <Route
-                          path="/install/:release"
-                          render={(props) => (
-                            <Install
-                              key={'install-' + props.match.params.release}
-                              release={props.match.params.release}
-                            />
-                          )}
-                        />
+                          <Route
+                            path="/component_readiness"
+                            render={(props) => {
+                              return (
+                                <CompReadyVarsProvider>
+                                  <ComponentReadiness
+                                    key={getUrlWithoutParams([
+                                      'regressedModal',
+                                    ])}
+                                  />
+                                </CompReadyVarsProvider>
+                              )
+                            }}
+                          />
 
-                        <Route
-                          path="/build_clusters/:cluster"
-                          render={(props) => (
-                            <BuildClusterDetails
-                              key={'cluster-' + props.match.params.cluster}
-                              cluster={props.match.params.cluster}
-                            />
-                          )}
-                        />
+                          <Route
+                            path="/install/:release"
+                            render={(props) => (
+                              <Install
+                                key={'install-' + props.match.params.release}
+                                release={props.match.params.release}
+                              />
+                            )}
+                          />
 
-                        <Route
-                          path="/build_clusters"
-                          render={() => <BuildClusterOverview />}
-                        />
+                          <Route
+                            path="/build_clusters/:cluster"
+                            render={(props) => (
+                              <BuildClusterDetails
+                                key={'cluster-' + props.match.params.cluster}
+                                cluster={props.match.params.cluster}
+                              />
+                            )}
+                          />
 
-                        <Route
-                          path="/repositories/:release/:org/:repo"
-                          render={(props) => (
-                            <RepositoryDetails
-                              release={props.match.params.release}
-                              org={props.match.params.org}
-                              repo={props.match.params.repo}
-                            />
-                          )}
-                        />
+                          <Route
+                            path="/build_clusters"
+                            render={() => <BuildClusterOverview />}
+                          />
 
-                        <Route
-                          path="/repositories/:release"
-                          render={(props) => (
-                            <Repositories
-                              release={props.match.params.release}
-                            />
-                          )}
-                        />
+                          <Route
+                            path="/repositories/:release/:org/:repo"
+                            render={(props) => (
+                              <RepositoryDetails
+                                release={props.match.params.release}
+                                org={props.match.params.org}
+                                repo={props.match.params.repo}
+                              />
+                            )}
+                          />
 
-                        <Route
-                          path="/pull_requests/:release"
-                          render={(props) => (
-                            <PullRequests
-                              key={'pr-' + props.match.params.release}
-                              release={props.match.params.release}
-                            />
-                          )}
-                        />
+                          <Route
+                            path="/repositories/:release"
+                            render={(props) => (
+                              <Repositories
+                                release={props.match.params.release}
+                              />
+                            )}
+                          />
 
-                        <Route
-                          path="/job_runs/:jobrunid/:jobname?/:repoinfo?/:pullnumber?/intervals"
-                          render={(props) => (
-                            <ProwJobRun
-                              jobRunID={props.match.params.jobrunid}
-                              jobName={props.match.params.jobname}
-                              repoInfo={props.match.params.repoinfo}
-                              pullNumber={props.match.params.pullnumber}
-                            />
-                          )}
-                        />
+                          <Route
+                            path="/pull_requests/:release"
+                            render={(props) => (
+                              <PullRequests
+                                key={'pr-' + props.match.params.release}
+                                release={props.match.params.release}
+                              />
+                            )}
+                          />
 
-                        <Route path="/">{landingPage}</Route>
-                      </Switch>
-                      {/* eslint-enable react/prop-types */}
-                    </Main>
-                  </div>
+                          <Route
+                            path="/job_runs/:jobrunid/:jobname?/:repoinfo?/:pullnumber?/intervals"
+                            render={(props) => (
+                              <ProwJobRun
+                                jobRunID={props.match.params.jobrunid}
+                                jobName={props.match.params.jobname}
+                                repoInfo={props.match.params.repoinfo}
+                                pullNumber={props.match.params.pullnumber}
+                              />
+                            )}
+                          />
+
+                          <Route path="/">{landingPage}</Route>
+                        </Switch>
+                        {/* eslint-enable react/prop-types */}
+                      </Main>
+                    </div>
+                  ) : (
+                    <Switch>
+                      <Redirect exact from="/" to="/component_readiness/main" />
+                      <Route
+                        path="/component_readiness"
+                        render={(props) => {
+                          return (
+                            <CompReadyVarsProvider>
+                              <ComponentReadiness
+                                key={getUrlWithoutParams(['regressedModal'])}
+                              />
+                            </CompReadyVarsProvider>
+                          )
+                        }}
+                      />
+                    </Switch>
+                  )}
                 </QueryParamProvider>
               </CapabilitiesContext.Provider>
             </ReportEndContext.Provider>

--- a/sippy-ng/src/components/Sidebar.js
+++ b/sippy-ng/src/components/Sidebar.js
@@ -173,233 +173,245 @@ export default function Sidebar(props) {
           }
         }}
       </CapabilitiesContext.Consumer>
-      <Divider />
-      <List
-        subheader={
-          <ListSubheader component="div" id="releases">
-            Releases
-          </ListSubheader>
-        }
-      >
-        {props.releases.map((release, index) => (
-          <Fragment key={'section-release-' + index}>
-            <ListItem
-              key={'item-release-' + index}
-              onClick={() => handleClick(index)}
-            >
-              <StyledListItemButton>
-                {open[index] ? <ExpandLess /> : <ExpandMore />}
-                <ListItemText primary={release} />
-              </StyledListItemButton>
-            </ListItem>
-            <Collapse in={open[index]} timeout="auto" unmountOnExit>
-              <List component="div" disablePadding>
-                <ListItem
-                  key={'release-overview-' + index}
-                  component={Link}
-                  to={'/release/' + release}
-                  className={classes.nested}
+
+      <CapabilitiesContext.Consumer>
+        {(value) => {
+          if (value.includes('local_db')) {
+            return (
+              <Fragment>
+                <Divider />
+                <List
+                  subheader={
+                    <ListSubheader component="div" id="releases">
+                      Releases
+                    </ListSubheader>
+                  }
                 >
-                  <StyledListItemButton>
-                    <ListItemIcon>
-                      <InfoIcon />
-                    </ListItemIcon>
-                    <ListItemText primary="Overview" />
-                  </StyledListItemButton>
-                </ListItem>
-                {release !== 'Presubmits' ? (
-                  <CapabilitiesContext.Consumer>
-                    {(value) => {
-                      if (value.includes('openshift_releases')) {
-                        return (
+                  {props.releases.map((release, index) => (
+                    <Fragment key={'section-release-' + index}>
+                      <ListItem
+                        key={'item-release-' + index}
+                        onClick={() => handleClick(index)}
+                      >
+                        <StyledListItemButton>
+                          {open[index] ? <ExpandLess /> : <ExpandMore />}
+                          <ListItemText primary={release} />
+                        </StyledListItemButton>
+                      </ListItem>
+                      <Collapse in={open[index]} timeout="auto" unmountOnExit>
+                        <List component="div" disablePadding>
                           <ListItem
-                            key={'release-tags-' + index}
+                            key={'release-overview-' + index}
                             component={Link}
-                            to={`/release/${release}/streams`}
+                            to={'/release/' + release}
                             className={classes.nested}
                           >
                             <StyledListItemButton>
                               <ListItemIcon>
-                                <FileCopyOutlined />
+                                <InfoIcon />
                               </ListItemIcon>
-                              <ListItemText primary="Payload Streams" />
+                              <ListItemText primary="Overview" />
                             </StyledListItemButton>
                           </ListItem>
-                        )
-                      }
-                    }}
-                  </CapabilitiesContext.Consumer>
-                ) : (
-                  ''
-                )}
-                <ListItem
-                  key={'release-jobs-' + index}
-                  component={Link}
-                  to={withSort(
-                    pathForJobsWithFilter(release, {
-                      items: [BOOKMARKS.RUN_7, ...withoutUnstable()],
-                    }),
-                    'net_improvement',
-                    'asc'
-                  )}
-                  className={classes.nested}
-                >
-                  <StyledListItemButton>
-                    <ListItemIcon>
-                      <ListIcon />
-                    </ListItemIcon>
-                    <ListItemText primary="Jobs" />
-                  </StyledListItemButton>
-                </ListItem>
+                          {release !== 'Presubmits' ? (
+                            <CapabilitiesContext.Consumer>
+                              {(value) => {
+                                if (value.includes('openshift_releases')) {
+                                  return (
+                                    <ListItem
+                                      key={'release-tags-' + index}
+                                      component={Link}
+                                      to={`/release/${release}/streams`}
+                                      className={classes.nested}
+                                    >
+                                      <StyledListItemButton>
+                                        <ListItemIcon>
+                                          <FileCopyOutlined />
+                                        </ListItemIcon>
+                                        <ListItemText primary="Payload Streams" />
+                                      </StyledListItemButton>
+                                    </ListItem>
+                                  )
+                                }
+                              }}
+                            </CapabilitiesContext.Consumer>
+                          ) : (
+                            ''
+                          )}
+                          <ListItem
+                            key={'release-jobs-' + index}
+                            component={Link}
+                            to={withSort(
+                              pathForJobsWithFilter(release, {
+                                items: [BOOKMARKS.RUN_7, ...withoutUnstable()],
+                              }),
+                              'net_improvement',
+                              'asc'
+                            )}
+                            className={classes.nested}
+                          >
+                            <StyledListItemButton>
+                              <ListItemIcon>
+                                <ListIcon />
+                              </ListItemIcon>
+                              <ListItemText primary="Jobs" />
+                            </StyledListItemButton>
+                          </ListItem>
 
-                {
-                  // FIXME: Base this on something like a per-release capabilities feature instead.
-                  release === 'Presubmits' ? (
-                    <Fragment>
-                      <ListItem
-                        key={'release-pull-requests-' + index}
-                        component={Link}
-                        to={`/pull_requests/${release}`}
-                        className={classes.nested}
-                      >
-                        <StyledListItemButton>
-                          <ListItemIcon>
-                            <GitHub />
-                          </ListItemIcon>
-                          <ListItemText primary="Pull Requests" />
-                        </StyledListItemButton>
-                      </ListItem>
-                      <ListItem
-                        key={'release-repositories-' + index}
-                        component={Link}
-                        to={`/repositories/${release}`}
-                        className={classes.nested}
-                      >
-                        <StyledListItemButton>
-                          <ListItemIcon>
-                            <Code />
-                          </ListItemIcon>
-                          <ListItemText primary="Repositories" />
-                        </StyledListItemButton>
-                      </ListItem>
+                          {
+                            // FIXME: Base this on something like a per-release capabilities feature instead.
+                            release === 'Presubmits' ? (
+                              <Fragment>
+                                <ListItem
+                                  key={'release-pull-requests-' + index}
+                                  component={Link}
+                                  to={`/pull_requests/${release}`}
+                                  className={classes.nested}
+                                >
+                                  <StyledListItemButton>
+                                    <ListItemIcon>
+                                      <GitHub />
+                                    </ListItemIcon>
+                                    <ListItemText primary="Pull Requests" />
+                                  </StyledListItemButton>
+                                </ListItem>
+                                <ListItem
+                                  key={'release-repositories-' + index}
+                                  component={Link}
+                                  to={`/repositories/${release}`}
+                                  className={classes.nested}
+                                >
+                                  <StyledListItemButton>
+                                    <ListItemIcon>
+                                      <Code />
+                                    </ListItemIcon>
+                                    <ListItemText primary="Repositories" />
+                                  </StyledListItemButton>
+                                </ListItem>
+                              </Fragment>
+                            ) : (
+                              ''
+                            )
+                          }
+
+                          <ListItem
+                            key={'release-tests-' + index}
+                            component={Link}
+                            to={withSort(
+                              pathForTestsWithFilter(release, {
+                                items: [
+                                  BOOKMARKS.RUN_7,
+                                  BOOKMARKS.NO_NEVER_STABLE,
+                                  BOOKMARKS.NO_AGGREGATED,
+                                  BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
+                                  BOOKMARKS.NO_STEP_GRAPH,
+                                  BOOKMARKS.NO_OPENSHIFT_TESTS_SHOULD_WORK,
+                                ],
+                                linkOperator: 'and',
+                              }),
+                              'current_working_percentage',
+                              'asc'
+                            )}
+                            className={classes.nested}
+                          >
+                            <StyledListItemButton>
+                              <ListItemIcon>
+                                <SearchIcon />
+                              </ListItemIcon>
+                              <ListItemText primary="Tests" />
+                            </StyledListItemButton>
+                          </ListItem>
+
+                          <CapabilitiesContext.Consumer>
+                            {(value) => {
+                              if (value.includes('openshift_releases')) {
+                                return (
+                                  <ListItem
+                                    key={'release-upgrade-' + index}
+                                    component={Link}
+                                    to={'/upgrade/' + release}
+                                    className={classes.nested}
+                                  >
+                                    <StyledListItemButton>
+                                      <ListItemIcon>
+                                        <ArrowUpwardIcon />
+                                      </ListItemIcon>
+                                      <ListItemText primary="Upgrade" />
+                                    </StyledListItemButton>
+                                  </ListItem>
+                                )
+                              }
+                            }}
+                          </CapabilitiesContext.Consumer>
+
+                          <CapabilitiesContext.Consumer>
+                            {(value) => {
+                              if (value.includes('openshift_releases')) {
+                                return (
+                                  <ListItem
+                                    key={'release-install-' + index}
+                                    component={Link}
+                                    to={'/install/' + release}
+                                    className={classes.nested}
+                                  >
+                                    <StyledListItemButton>
+                                      <ListItemIcon>
+                                        <ExitToAppIcon />
+                                      </ListItemIcon>
+                                      <ListItemText primary="Install" />
+                                    </StyledListItemButton>
+                                  </ListItem>
+                                )
+                              }
+                            }}
+                          </CapabilitiesContext.Consumer>
+
+                          <CapabilitiesContext.Consumer>
+                            {(value) => {
+                              if (value.includes('openshift_releases')) {
+                                let newInstall = useNewInstallTests(release)
+                                let link
+                                if (newInstall) {
+                                  link = pathForTestByVariant(
+                                    release,
+                                    'install should succeed: infrastructure'
+                                  )
+                                } else {
+                                  link = pathForTestByVariant(
+                                    release,
+                                    '[sig-sippy] infrastructure should work'
+                                  )
+                                }
+
+                                return (
+                                  <ListItem
+                                    key={'release-infrastructure-' + index}
+                                    component={Link}
+                                    to={link}
+                                    className={classes.nested}
+                                  >
+                                    <StyledListItemButton>
+                                      <ListItemIcon>
+                                        <ApartmentIcon />
+                                      </ListItemIcon>
+                                      <ListItemText primary="Infrastructure" />
+                                    </StyledListItemButton>
+                                  </ListItem>
+                                )
+                              }
+                            }}
+                          </CapabilitiesContext.Consumer>
+                        </List>
+                      </Collapse>
                     </Fragment>
-                  ) : (
-                    ''
-                  )
-                }
+                  ))}
+                </List>
+              </Fragment>
+            )
+          }
+        }}
+      </CapabilitiesContext.Consumer>
 
-                <ListItem
-                  key={'release-tests-' + index}
-                  component={Link}
-                  to={withSort(
-                    pathForTestsWithFilter(release, {
-                      items: [
-                        BOOKMARKS.RUN_7,
-                        BOOKMARKS.NO_NEVER_STABLE,
-                        BOOKMARKS.NO_AGGREGATED,
-                        BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
-                        BOOKMARKS.NO_STEP_GRAPH,
-                        BOOKMARKS.NO_OPENSHIFT_TESTS_SHOULD_WORK,
-                      ],
-                      linkOperator: 'and',
-                    }),
-                    'current_working_percentage',
-                    'asc'
-                  )}
-                  className={classes.nested}
-                >
-                  <StyledListItemButton>
-                    <ListItemIcon>
-                      <SearchIcon />
-                    </ListItemIcon>
-                    <ListItemText primary="Tests" />
-                  </StyledListItemButton>
-                </ListItem>
-
-                <CapabilitiesContext.Consumer>
-                  {(value) => {
-                    if (value.includes('openshift_releases')) {
-                      return (
-                        <ListItem
-                          key={'release-upgrade-' + index}
-                          component={Link}
-                          to={'/upgrade/' + release}
-                          className={classes.nested}
-                        >
-                          <StyledListItemButton>
-                            <ListItemIcon>
-                              <ArrowUpwardIcon />
-                            </ListItemIcon>
-                            <ListItemText primary="Upgrade" />
-                          </StyledListItemButton>
-                        </ListItem>
-                      )
-                    }
-                  }}
-                </CapabilitiesContext.Consumer>
-
-                <CapabilitiesContext.Consumer>
-                  {(value) => {
-                    if (value.includes('openshift_releases')) {
-                      return (
-                        <ListItem
-                          key={'release-install-' + index}
-                          component={Link}
-                          to={'/install/' + release}
-                          className={classes.nested}
-                        >
-                          <StyledListItemButton>
-                            <ListItemIcon>
-                              <ExitToAppIcon />
-                            </ListItemIcon>
-                            <ListItemText primary="Install" />
-                          </StyledListItemButton>
-                        </ListItem>
-                      )
-                    }
-                  }}
-                </CapabilitiesContext.Consumer>
-
-                <CapabilitiesContext.Consumer>
-                  {(value) => {
-                    if (value.includes('openshift_releases')) {
-                      let newInstall = useNewInstallTests(release)
-                      let link
-                      if (newInstall) {
-                        link = pathForTestByVariant(
-                          release,
-                          'install should succeed: infrastructure'
-                        )
-                      } else {
-                        link = pathForTestByVariant(
-                          release,
-                          '[sig-sippy] infrastructure should work'
-                        )
-                      }
-
-                      return (
-                        <ListItem
-                          key={'release-infrastructure-' + index}
-                          component={Link}
-                          to={link}
-                          className={classes.nested}
-                        >
-                          <StyledListItemButton>
-                            <ListItemIcon>
-                              <ApartmentIcon />
-                            </ListItemIcon>
-                            <ListItemText primary="Infrastructure" />
-                          </StyledListItemButton>
-                        </ListItem>
-                      )
-                    }
-                  }}
-                </CapabilitiesContext.Consumer>
-              </List>
-            </Collapse>
-          </Fragment>
-        ))}
-      </List>
       <Divider />
       <List
         subheader={


### PR DESCRIPTION
Allow launching only just component readiness. The other UI parts of Sippy don't load.

<img width="1339" alt="image" src="https://github.com/openshift/sippy/assets/429763/594c9f78-c4cb-459f-9034-863aa80f6fa7">


Example if you just want CR:
```
./sippy component-readiness
    --google-service-account-credential-file ~/google-service-account-credential-file.json
```

Bonus: /api now returns some very basic API docs.

TODO's:

- [x] Ken's PR to merge https://github.com/openshift/sippy/pull/1546
- [x] Fix UI sidebar weirdness with standalone