### PR TITLE
Improve bug handling in component readiness

### DIFF
--- a/sippy-ng/src/bugs/BugButton.js
+++ b/sippy-ng/src/bugs/BugButton.js
@@ -6,7 +6,6 @@ import React, { useState } from 'react'
 
 const useStyles = makeStyles((theme) => ({
   alignedButton: {
-    marginTop: 25,
     float: 'left',
   },
 }))
@@ -36,25 +35,30 @@ Additional context here:
       url += `&components=${props.jiraComponentID}`
     }
 
+    if (Array.isArray(props.labels) && props.labels.length > 0) {
+      props.labels.forEach((label) => {
+        url += `&labels=${safeEncodeURIComponent(label)}`
+      })
+    }
+
     window.open(url, '_blank')
   }
 
   return (
-    <>
-      <Button
-        variant="contained"
-        color="primary"
-        className={classes.alignedButton}
-        onClick={handleClick}
-      >
-        File a new bug
-      </Button>
-    </>
+    <Button
+      variant="contained"
+      color="primary"
+      className={classes.alignedButton}
+      onClick={handleClick}
+    >
+      File a new bug
+    </Button>
   )
 }
 
 BugButton.propTypes = {
-  jiraComponentID: PropTypes.number,
+  jiraComponentID: PropTypes.string,
   context: PropTypes.string,
+  labels: PropTypes.array,
   testName: PropTypes.string.isRequired,
 }

--- a/sippy-ng/src/bugs/BugTable.js
+++ b/sippy-ng/src/bugs/BugTable.js
@@ -8,7 +8,7 @@ import {
   TableRow,
   Typography,
 } from '@mui/material'
-import { safeEncodeURIComponent } from '../helpers'
+import { relativeTime, safeEncodeURIComponent } from '../helpers'
 import Alert from '@mui/material/Alert'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
@@ -66,7 +66,7 @@ export default function BugTable(props) {
             <TableCell>Status</TableCell>
             <TableCell>Component</TableCell>
             <TableCell>Affects Versions</TableCell>
-            <TableCell>Fix Versions</TableCell>
+            <TableCell>Last Modified</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -81,7 +81,9 @@ export default function BugTable(props) {
               <TableCell>{bug.status}</TableCell>
               <TableCell>{bug.components.join(',')}</TableCell>
               <TableCell>{bug.affects_versions.join(',')}</TableCell>
-              <TableCell>{bug.fix_versions.join(',')}</TableCell>
+              <TableCell>
+                {relativeTime(new Date(bug.last_change_time), new Date())}
+              </TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -1,5 +1,12 @@
 import './ComponentReadiness.css'
-import { Box, Grid, Paper, TableContainer, Typography } from '@mui/material'
+import {
+  Box,
+  Button,
+  Grid,
+  Paper,
+  TableContainer,
+  Typography,
+} from '@mui/material'
 import {
   cancelledDataTable,
   getColumns,
@@ -327,12 +334,21 @@ Flakes: ${stats.flake_count}`
       </div>
       <Grid container>
         <Grid md={12}>
-          <h2>Known Bugs</h2>
+          <h2>Linked Bugs</h2>
           <BugTable testName={testName} />
-          <BugButton
-            testName={testName}
-            jiraComponentID={data.jira_component_id}
-            context={`Component Readiness has found a potential regression in ${testName}.
+          <Box
+            sx={{
+              display: 'flex',
+              marginTop: 2,
+              alignItems: 'center',
+              gap: 2,
+            }}
+          >
+            <BugButton
+              testName={testName}
+              jiraComponentID={data.jira_component_id}
+              labels={['component-regression']}
+              context={`Component Readiness has found a potential regression in ${testName}.
  
 ${probabilityStr(statusStr, data.fisher_exact)}
 ${printStatsText(
@@ -350,7 +366,15 @@ ${printStatsText(
 
 View the test details report at ${document.location.href}
             `}
-          />
+            />
+            <Button
+              variant="contained"
+              color="secondary"
+              href="https://issues.redhat.com/issues/?filter=12432468"
+            >
+              View other open regressions
+            </Button>
+          </Box>
         </Grid>
       </Grid>
 

--- a/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
+++ b/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
@@ -9,6 +9,7 @@ import {
 } from '@mui/material'
 import { BooleanParam, useQueryParam } from 'use-query-params'
 import {
+  BugReport,
   Clear,
   GridView,
   HelpCenter,
@@ -24,6 +25,7 @@ import {
   SearchIconWrapper,
   StyledInputBase,
 } from './CompReadyUtils'
+import BugButton from '../bugs/BugButton'
 import ComponentReadinessHelp from './ComponentReadinessHelp'
 import IconButton from '@mui/material/IconButton'
 import PropTypes from 'prop-types'
@@ -187,6 +189,19 @@ export default function ComponentReadinessToolBar(props) {
             ) : (
               <></>
             )}
+            <Box sx={{ display: { md: 'flex' } }}>
+              <IconButton
+                size="large"
+                aria-label="Show open bugs"
+                color="inherit"
+                href="https://issues.redhat.com/issues/?filter=12432468"
+              >
+                <Tooltip title="Show open bugs">
+                  <BugReport />
+                </Tooltip>
+              </IconButton>
+            </Box>
+
             <Box sx={{ display: { md: 'flex' } }}>
               <IconButton
                 size="large"

--- a/sippy-ng/src/tests/TestAnalysis.js
+++ b/sippy-ng/src/tests/TestAnalysis.js
@@ -256,10 +256,17 @@ export function TestAnalysis(props) {
                 </Tooltip>
               </Typography>
               <BugTable testName={testName} />
-              <BugButton
-                jiraComponentID={test.jira_component_id}
-                testName={testName}
-              />
+              <Box
+                sx={{
+                  display: 'flex',
+                  marginTop: 2,
+                }}
+              >
+                <BugButton
+                  jiraComponentID={test.jira_component_id}
+                  testName={testName}
+                />
+              </Box>
             </Card>
           </Grid>
 


### PR DESCRIPTION
- Link directly to jira on component readiness and test detail pages
- Add `component-regression` label automatically when filing from CR
- Show last modified in the bug table

<img width="1098" alt="image" src="https://github.com/openshift/sippy/assets/429763/cea9d212-de7d-4df3-afc2-52a666f9d8ea">

<img width="1109" alt="image" src="https://github.com/openshift/sippy/assets/429763/fff3d1fa-f41b-4c16-b4ca-8880b00fbf7b">
