### PR TITLE
Allow affects version to be nil

### DIFF
--- a/sippy-ng/src/bugs/BugTable.js
+++ b/sippy-ng/src/bugs/BugTable.js
@@ -79,8 +79,12 @@ export default function BugTable(props) {
                 <a href={bug.url}>{bug.summary}</a>
               </TableCell>
               <TableCell>{bug.status}</TableCell>
-              <TableCell>{bug.components.join(',')}</TableCell>
-              <TableCell>{bug.affects_versions.join(',')}</TableCell>
+              <TableCell>
+                {bug.components ? bug.components.join(',') : ''}
+              </TableCell>
+              <TableCell>
+                {bug.affects_versions ? bug.affects_versions.join(',') : ''}
+              </TableCell>
               <TableCell>
                 {relativeTime(new Date(bug.last_change_time), new Date())}
               </TableCell>


### PR DESCRIPTION
This page errors
https://sippy.dptools.openshift.org/sippy-ng/tests/4.16/analysis?test=%5Bbz-networking%5D%5Binvariant%5D%20alert%2FOVNKubernetesResourceRetryFailure%20should%20not%20be%20at%20or%20above%20info&filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bbz-networking%5D%5Binvariant%5D%20alert%2FOVNKubernetesResourceRetryFailure%20should%20not%20be%20at%20or%20above%20info%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D