### PR TITLE
Revert "TRT-1484: Migrate bugloader to use bigquery data sources"

### DIFF
--- a/cmd/sippy/load.go
+++ b/cmd/sippy/load.go
@@ -141,12 +141,7 @@ func NewLoadCommand() *cobra.Command {
 
 				// Bug Loader
 				if l == "bugs" {
-					// Get a bigquery client
-					bqc, err := f.BigQueryFlags.GetBigQueryClient(context.Background(), nil, f.GoogleCloudFlags.ServiceAccountCredentialFile)
-					if err != nil {
-						return errors.WithMessage(err, "could not get bigquery client: %+v")
-					}
-					loaders = append(loaders, bugloader.New(dbc, bqc))
+					loaders = append(loaders, bugloader.New(dbc))
 				}
 			}
 

--- a/pkg/dataloader/bugloader/bugloader.go
+++ b/pkg/dataloader/bugloader/bugloader.go
@@ -1,62 +1,36 @@
 package bugloader
 
 import (
-	"context"
 	"fmt"
+	"regexp"
+	"sort"
 	"strconv"
+	"strings"
+	"time"
 
+	"github.com/andygrunwald/go-jira"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"google.golang.org/api/iterator"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
-	"github.com/openshift/sippy/pkg/bigquery"
 	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/loader"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/testidentification"
+	"github.com/openshift/sippy/pkg/util/sets"
 )
 
-const (
-	// Unfortunate cross-project join
-	ComponentMappingProject = "openshift-gce-devel"
-	ComponentMappingDataset = "ci_analysis_us"
-	ComponentMappingTable   = "component_mapping_latest"
-
-	TicketDataQuery = `WITH TicketData AS (
-  SELECT
-    t.*,
-    c.message AS comment
-  FROM
-    openshift-ci-data-analysis.jira_data.tickets_dedup t
-  LEFT JOIN UNNEST(t.comments) AS c
-  WHERE t.summary IS NOT NULL
-)
-SELECT
-  t.issue.key as key,
-  t.issue.id AS jira_id,
-  t.summary as summary,
-  j.name AS link_name,
-  t.last_changed_time as last_change_time,
-  t.status.name as status,
-  ARRAY(SELECT name FROM UNNEST(affects_versions)) as affects_versions,
-  ARRAY(SELECT name FROM UNNEST(fix_versions)) as fix_versions,
-  ARRAY(SELECT name FROM UNNEST(components)) as components,
-  t.labels as labels
-FROM
-  TicketData t`
-)
+var FindIssuesForVariants = loader.FindIssuesForVariants
 
 type BugLoader struct {
 	dbc    *db.DB
-	bqc    *bigquery.Client
 	errors []error
 }
 
-func New(dbc *db.DB, bqc *bigquery.Client) *BugLoader {
+func New(dbc *db.DB) *BugLoader {
 	return &BugLoader{
 		dbc: dbc,
-		bqc: bqc,
 	}
 }
 
@@ -68,45 +42,100 @@ func (bl *BugLoader) Errors() []error {
 	return bl.errors
 }
 
+// LoadBugs does a bulk query of all our tests and jobs, 50 at a time, to search.ci and then syncs the associations to the db.
 func (bl *BugLoader) Load() {
-	dbExpectedBugs := make([]*models.Bug, 0)
-
-	// Fetch bugs<->test mapping from bigquery
 	testCache, err := loadTestCache(bl.dbc, []string{})
 	if err != nil {
 		bl.errors = append(bl.errors, err)
 		return
 	}
-	testBugs, err := bl.getTestBugMappings(context.TODO(), testCache)
-	if err != nil {
-		panic(err)
-	}
 
-	// Fetch bugs<->job mapping from bigquery
 	jobCache, err := loadProwJobCache(bl.dbc)
 	if err != nil {
 		bl.errors = append(bl.errors, err)
 		return
 	}
-	jobBugs, err := bl.getJobBugMappings(context.TODO(), jobCache)
+
+	log.Info("querying search.ci for test/job associations")
+	testIssues, err := loader.FindIssuesForTests(sets.StringKeySet(testCache).List()...)
 	if err != nil {
-		panic(err)
+		log.WithError(err).Warning("Issue Lookup Error: an error was encountered looking up existing bugs for failing tests, some test failures may have associated bugs that are not listed below.")
+		err = errors.Wrap(err, "error querying bugs for tests")
+		bl.errors = append(bl.errors, err)
 	}
 
-	// Merge all the bugs together
-	allBugs := testBugs
-	for _, b := range jobBugs {
-		if _, ok := allBugs[b.ID]; ok {
-			allBugs[b.ID].Jobs = b.Jobs
-			continue
+	jobIssues, err := loader.FindIssuesForJobs(sets.StringKeySet(jobCache).List()...)
+	if err != nil {
+		log.WithError(err).Warning("Issue Lookup Error: an error was encountered looking up existing bugs for failing jobs, some job failures may have associated bugs that are not listed below.")
+		err = errors.Wrap(err, "error querying bugs for jobs")
+		bl.errors = append(bl.errors, err)
+	}
+
+	err = appendJobIssuesFromVariants(jobCache, jobIssues)
+	if err != nil {
+		log.WithError(err).Warning("Issue Lookup Error: an error was encountered looking up existing bugs by jobs by variants.")
+		err = errors.Wrap(err, "error querying bugs for variants")
+		bl.errors = append(bl.errors, err)
+	}
+
+	log.Info("syncing issue test/job associations to db")
+
+	// Merge the test/job bugs into one list, associated with each failing test or job, mapped to our db model for the bug.
+	dbExpectedBugs := map[int64]*models.Bug{}
+
+	for testName, apiBugArr := range testIssues {
+		for _, apiBug := range apiBugArr {
+			issueID, err := strconv.ParseInt(apiBug.ID, 10, 64)
+			if err != nil {
+				log.WithError(err).Errorf("error parsing issue ID: %+v", apiBug)
+				err = errors.Wrap(err, "error parsing issue ID")
+				bl.errors = append(bl.errors, err)
+				continue
+			}
+			if _, ok := dbExpectedBugs[issueID]; !ok {
+				log.Debugf("converting issue: %+v", apiBug)
+				newBug := convertAPIIssueToDBIssue(issueID, apiBug)
+				dbExpectedBugs[issueID] = newBug
+			}
+			if _, ok := testCache[testName]; !ok {
+				// Shouldn't be possible, if it is we want to know.
+				err := fmt.Errorf("test name was in bug cache but not in database?: %s", testName)
+				log.WithError(err).Error("unexpected error getting test from cache")
+				bl.errors = append(bl.errors, err)
+				continue
+			}
+			dbExpectedBugs[issueID].Tests = append(dbExpectedBugs[issueID].Tests, *testCache[testName])
 		}
-		allBugs[b.ID] = b
-	}
-	for _, b := range allBugs {
-		dbExpectedBugs = append(dbExpectedBugs, b)
 	}
 
-	// Find or create new bugs and mappings
+	log.WithField("jobIssues", len(jobIssues)).Info("found job issues")
+	for jobSearchStr, apiBugArr := range jobIssues {
+		for _, apiBug := range apiBugArr {
+			issueID, err := strconv.ParseInt(apiBug.ID, 10, 64)
+			if err != nil {
+				log.WithError(err).Errorf("error parsing issue ID: %+v", apiBug)
+				err = errors.Wrap(err, "error parsing issue ID")
+				bl.errors = append(bl.errors, err)
+				continue
+			}
+			if _, ok := dbExpectedBugs[issueID]; !ok {
+				newBug := convertAPIIssueToDBIssue(issueID, apiBug)
+				dbExpectedBugs[issueID] = newBug
+			}
+			// We search for job=[jobname]=all, need to extract the raw job name from that search string
+			// which is what appears in our jobIssues map.
+			jobName := jobSearchStr[4 : len(jobSearchStr)-4]
+			if _, ok := jobCache[jobName]; !ok {
+				// Shouldn't be possible, if it is we want to know.
+				err := fmt.Errorf("job name was in bug cache but not in database?: %s", jobName)
+				log.WithError(err).Error("unexpected error getting job from cache")
+				bl.errors = append(bl.errors, err)
+				continue
+			}
+			dbExpectedBugs[issueID].Jobs = append(dbExpectedBugs[issueID].Jobs, *jobCache[jobName])
+		}
+	}
+
 	expectedBugIDs := make([]uint, 0, len(dbExpectedBugs))
 	for _, bug := range dbExpectedBugs {
 		expectedBugIDs = append(expectedBugIDs, bug.ID)
@@ -135,9 +164,9 @@ func (bl *BugLoader) Load() {
 			continue
 		}
 	}
-	log.Infof("created or updated %d bugs", len(expectedBugIDs))
 
-	// Remove old unseen bugs
+	// Delete all stale referenced bugs that are no longer in our expected bugs.
+	// Unscoped deletes the rows from the db, rather than soft delete.
 	res := bl.dbc.DB.Where("id not in ?", expectedBugIDs).Unscoped().Delete(&models.Bug{})
 	if res.Error != nil {
 		err := errors.Wrap(res.Error, "error deleting stale bugs")
@@ -149,128 +178,49 @@ func (bl *BugLoader) Load() {
 	if err := updateWatchlist(bl.dbc); err != nil {
 		bl.errors = append(bl.errors, err...)
 	}
+
 }
 
-// getTestBugMappings looks for jira cards that contain a test name from the ci-test-mapping database in bigquery.  We
-// search the Jira comments, description and summary for the test name.
-func (bl *BugLoader) getTestBugMappings(ctx context.Context, testCache map[string]*models.Test) (map[uint]*models.Bug, error) {
-	bugs := make(map[uint]*models.Bug)
-
-	// `WHERE j.name != upgrade` is because there's a test named just `upgrade` in some junits, which querying
-	// Jira for produces thousands of tickets
-	querySQL := fmt.Sprintf(
-		`%s CROSS JOIN %s.%s.%s j WHERE j.name != "upgrade" AND (STRPOS(t.summary, j.name) > 0 OR STRPOS(t.description, j.name) > 0 OR STRPOS(t.comment, j.name) > 0)`,
-		TicketDataQuery, ComponentMappingProject, ComponentMappingDataset, ComponentMappingTable)
-	log.Debugf(querySQL)
-	query := bl.bqc.BQ.Query(querySQL)
-
-	it, err := query.Read(ctx)
-	if err != nil {
-		return nil, errors.WithMessage(err, "failed to execute query")
+func convertAPIIssueToDBIssue(issueID int64, apiIssue jira.Issue) *models.Bug {
+	newBug := &models.Bug{
+		ID:             uint(issueID),
+		Key:            apiIssue.Key,
+		Status:         apiIssue.Fields.Status.Name,
+		LastChangeTime: time.Time(apiIssue.Fields.Updated),
+		Summary:        apiIssue.Fields.Summary,
+		URL:            fmt.Sprintf("https://issues.redhat.com/browse/%s", apiIssue.Key),
+		Tests:          []models.Test{},
 	}
 
-	type bugWithTest struct {
-		models.Bug
-		JiraID   string `bigquery:"jira_id"`
-		TestName string `bigquery:"link_name"`
+	// The version and components fields may typically or always be just one value, but we're told it
+	// may not be possible to actually prevent someone adding multiple, so we'll be ready for the possibility.
+	components := []string{}
+	for _, c := range apiIssue.Fields.Components {
+		components = append(components, c.Name)
 	}
-	for {
-		var bwt bugWithTest
-		err := it.Next(&bwt)
-		if errors.Is(err, iterator.Done) {
-			break
-		}
-		if err != nil {
-			return nil, errors.WithMessage(err, "failed to iterate over bug results")
-		}
+	sort.Strings(components)
+	newBug.Components = components
 
-		// Make sure data in BQ is sane
-		if bwt.JiraID == "" || bwt.TestName == "" {
-			continue
-		}
-
-		intID, err := strconv.Atoi(bwt.JiraID)
-		if err != nil {
-			bl.errors = append(bl.errors, errors.WithMessagef(err, "failed to convert jira id %s", bwt.JiraID))
-			continue
-
-		}
-		bwt.ID = uint(intID)
-
-		if _, ok := testCache[bwt.TestName]; !ok {
-			// This is probably common since we're using ci-test-mapping test names, and sippy may not know all of them
-			log.Debugf("test name was in jira issue but not known by sippy: %s", bwt.TestName)
-			continue
-		}
-
-		if _, ok := bugs[bwt.ID]; !ok {
-			bugs[bwt.ID] = &bwt.Bug
-		}
-
-		bugs[bwt.ID].Tests = append(bugs[bwt.ID].Tests, *testCache[bwt.TestName])
+	affectsVersions := []string{}
+	for _, av := range apiIssue.Fields.AffectsVersions {
+		affectsVersions = append(affectsVersions, av.Name)
 	}
+	sort.Strings(affectsVersions)
+	newBug.AffectsVersions = affectsVersions
 
-	return bugs, nil
-}
-
-// getJobBugMappings looks for jira cards that contain a job name from the jobs table in bigquery.  We
-// search the Jira comments, description and summary for the job name.
-func (bl *BugLoader) getJobBugMappings(ctx context.Context, jobCache map[string]*models.ProwJob) (map[uint]*models.Bug, error) {
-	bugs := make(map[uint]*models.Bug)
-
-	querySQL := fmt.Sprintf(
-		`%s CROSS JOIN (SELECT DISTINCT prowjob_job_name AS name FROM openshift-gce-devel.ci_analysis_us.jobs WHERE prowjob_job_name IS NOT NULL AND prowjob_job_name != "") j WHERE (STRPOS(t.summary, j.name) > 0 OR STRPOS(t.description, j.name) > 0 OR STRPOS(t.comment, j.name) > 0)`,
-		TicketDataQuery)
-	log.Debugf(querySQL)
-	query := bl.bqc.BQ.Query(querySQL)
-
-	it, err := query.Read(ctx)
-	if err != nil {
-		return nil, errors.WithMessage(err, "failed to execute query")
+	fixVersions := []string{}
+	for _, fv := range apiIssue.Fields.FixVersions {
+		fixVersions = append(fixVersions, fv.Name)
 	}
+	sort.Strings(fixVersions)
+	newBug.FixVersions = fixVersions
 
-	type bugWithJob struct {
-		models.Bug
-		JiraID  string `bigquery:"jira_id"`
-		JobName string `bigquery:"link_name"`
-	}
-	for {
-		var bwj bugWithJob
-		err := it.Next(&bwj)
-		if errors.Is(err, iterator.Done) {
-			break
-		}
-		if err != nil {
-			return nil, errors.WithMessage(err, "failed to iterate over bug results")
-		}
+	labels := apiIssue.Fields.Labels
+	labels = append(labels, apiIssue.Fields.Labels...)
+	sort.Strings(labels)
+	newBug.Labels = labels
 
-		// Make sure data in BQ is sane
-		if bwj.JiraID == "" || bwj.JobName == "" {
-			continue
-		}
-
-		intID, err := strconv.Atoi(bwj.JiraID)
-		if err != nil {
-			bl.errors = append(bl.errors, errors.WithMessagef(err, "failed to convert jira id %s", bwj.JiraID))
-			continue
-
-		}
-		bwj.ID = uint(intID)
-
-		if _, ok := jobCache[bwj.JobName]; !ok {
-			// This is probably common because sippy probably doesn't know about *all* jobs like the BQ table does
-			log.Debugf("job name was in jira issue but not known by sippy: %s", bwj.JobName)
-			continue
-		}
-
-		if _, ok := bugs[bwj.ID]; !ok {
-			bugs[bwj.ID] = &bwj.Bug
-		}
-
-		bugs[bwj.ID].Jobs = append(bugs[bwj.ID].Jobs, *jobCache[bwj.JobName])
-	}
-
-	return bugs, nil
+	return newBug
 }
 
 func loadTestCache(dbc *db.DB, preloads []string) (map[string]*models.Test, error) {
@@ -314,6 +264,81 @@ func loadProwJobCache(dbc *db.DB) (map[string]*models.ProwJob, error) {
 	}
 	log.Infof("job cache created with %d entries from database", len(prowJobCache))
 	return prowJobCache, nil
+}
+
+func variantsKey(variants []string) string {
+	v := make([]string, len(variants))
+	copy(v, variants)
+	sort.Strings(v)
+	return strings.Join(v, ",")
+}
+
+func appendJobIssuesFromVariants(jobCache map[string]*models.ProwJob, jobIssues map[string][]jira.Issue) error {
+	// variantSetMap maps a sorted names of variants to a set of the variants for easy comparison
+	variantsSetMap := map[string]sets.String{}
+	// variantsIssuesMap maps a sorted names of variants to a slice of issues
+	variantsIssuesMap := map[string][]jira.Issue{}
+
+	variantIssues, err := FindIssuesForVariants()
+	if err != nil {
+		log.Warningf("Issue Lookup Error: an error was encountered looking up existing bugs for variants, some test failures may have associated bugs that are not listed below.  Lookup error: %v", err.Error())
+		return err
+	}
+
+	variantMatches := regexp.MustCompile(loader.VariantSearchRegex)
+	for key, issues := range variantIssues {
+		subMatches := variantMatches.FindStringSubmatch(key)
+		if len(subMatches) == 2 {
+			// Update the variantsSetMap
+			variants := strings.Split(subMatches[1], ",")
+			variantsKey := variantsKey(variants)
+			if _, ok := variantsSetMap[variantsKey]; !ok {
+				variantsSetMap[variantsKey] = sets.NewString(variants...)
+			}
+
+			// Update the variantsIssuesMap
+			if _, ok := variantsIssuesMap[variantsKey]; !ok {
+				variantsIssuesMap[variantsKey] = []jira.Issue{}
+			}
+			variantsIssuesMap[variantsKey] = append(variantsIssuesMap[variantsKey], issues...)
+		}
+	}
+	// Now go through all jobs to append issues
+	for _, job := range jobCache {
+		if len(job.Variants) > 0 {
+			variantsKey := variantsKey(job.Variants)
+
+			// Cache in the map for subsequent jobs
+			if _, ok := variantsSetMap[variantsKey]; !ok {
+				variantsSetMap[variantsKey] = sets.NewString(job.Variants...)
+			}
+
+			for key, issues := range variantsIssuesMap {
+				if !variantsSetMap[variantsKey].IsSuperset(variantsSetMap[key]) {
+					continue
+				}
+				candidates := []jira.Issue{}
+				for _, issue := range issues {
+					if issue.Fields == nil {
+						continue
+					}
+					for _, version := range issue.Fields.AffectsVersions {
+						if job.Release == version.Name || strings.HasPrefix(version.Name, job.Release+".") {
+							candidates = append(candidates, issue)
+							break
+						}
+					}
+				}
+				jobSearchStrings := fmt.Sprintf("job=%s=all", job.Name)
+				if _, ok := jobIssues[jobSearchStrings]; !ok {
+					jobIssues[jobSearchStrings] = []jira.Issue{}
+				}
+				jobIssues[jobSearchStrings] = append(jobIssues[jobSearchStrings], candidates...)
+			}
+		}
+	}
+
+	return nil
 }
 
 func updateWatchlist(dbc *db.DB) []error {

--- a/pkg/dataloader/bugloader/bugloader_test.go
+++ b/pkg/dataloader/bugloader/bugloader_test.go
@@ -1,0 +1,213 @@
+package bugloader
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/andygrunwald/go-jira"
+
+	"github.com/openshift/sippy/pkg/db/models"
+)
+
+func findIssuesForVariants() (map[string][]jira.Issue, error) {
+	result := map[string][]jira.Issue{
+		"sippy-link=[variants=azure,ovn]": []jira.Issue{
+			{
+				ID: "1",
+				Fields: &jira.IssueFields{
+					AffectsVersions: []*jira.AffectsVersion{
+						{Name: "4.12.z"},
+					},
+				},
+			},
+		},
+		"sippy-link=[variants=ovn]": []jira.Issue{
+			{
+				ID: "2",
+				Fields: &jira.IssueFields{
+					AffectsVersions: []*jira.AffectsVersion{
+						{Name: "4.11"},
+						{Name: "4.12"},
+					},
+				},
+			},
+		},
+	}
+	return result, nil
+}
+
+func errorFindIssuesForVariants() (map[string][]jira.Issue, error) {
+	return map[string][]jira.Issue{}, fmt.Errorf("error finding variant issues")
+}
+
+func TestAppendJobIssuesFromVariants(t *testing.T) {
+	tests := []struct {
+		name           string
+		jobCache       map[string]*models.ProwJob
+		jobIssues      map[string][]jira.Issue
+		expectedResult map[string][]jira.Issue
+		expectErr      bool
+		findIssuesFunc func() (map[string][]jira.Issue, error)
+	}{
+		{
+			name: "find issues by variants with no errors",
+			jobCache: map[string]*models.ProwJob{
+				"1": &models.ProwJob{Name: "periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-csi",
+					Release: "4.11", Variants: []string{"azure", "amd64", "ovn", "ha"},
+				},
+				"2": &models.ProwJob{Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-azure-csi",
+					Release: "4.12", Variants: []string{"azure", "amd64", "ovn", "ha"},
+				},
+				"3": &models.ProwJob{Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere-sdn-upi-serial",
+					Release: "4.12", Variants: []string{"vsphere-ipi", "amd64", "sdn", "ha", "serial"},
+				},
+			},
+			jobIssues:      map[string][]jira.Issue{},
+			expectErr:      false,
+			findIssuesFunc: findIssuesForVariants,
+			expectedResult: map[string][]jira.Issue{
+				"job=periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-csi=all": []jira.Issue{
+					{
+						ID: "2",
+						Fields: &jira.IssueFields{
+							AffectsVersions: []*jira.AffectsVersion{
+								{Name: "4.11"},
+								{Name: "4.12"},
+							},
+						},
+					},
+				},
+				"job=periodic-ci-openshift-release-master-nightly-4.12-e2e-azure-csi=all": []jira.Issue{
+					{
+						ID: "1",
+						Fields: &jira.IssueFields{
+							AffectsVersions: []*jira.AffectsVersion{
+								{Name: "4.12.z"},
+							},
+						},
+					},
+					{
+						ID: "2",
+						Fields: &jira.IssueFields{
+							AffectsVersions: []*jira.AffectsVersion{
+								{Name: "4.11"},
+								{Name: "4.12"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "append issues by variants with no errors",
+			jobCache: map[string]*models.ProwJob{
+				"1": &models.ProwJob{Name: "periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-csi",
+					Release: "4.11", Variants: []string{"azure", "amd64", "ovn", "ha"},
+				},
+				"2": &models.ProwJob{Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-azure-csi",
+					Release: "4.12", Variants: []string{"azure", "amd64", "ovn", "ha"},
+				},
+				"3": &models.ProwJob{Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere-sdn-upi-serial",
+					Release: "4.12", Variants: []string{"vsphere-ipi", "amd64", "sdn", "ha", "serial"},
+				},
+			},
+			jobIssues: map[string][]jira.Issue{
+				"job=periodic-ci-openshift-release-master-nightly-4.12-e2e-azure-csi=all": []jira.Issue{
+					{
+						ID: "3",
+						Fields: &jira.IssueFields{
+							AffectsVersions: []*jira.AffectsVersion{
+								{Name: "4.12"},
+							},
+						},
+					},
+				},
+			},
+			expectErr:      false,
+			findIssuesFunc: findIssuesForVariants,
+			expectedResult: map[string][]jira.Issue{
+				"job=periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-csi=all": []jira.Issue{
+					{
+						ID: "2",
+						Fields: &jira.IssueFields{
+							AffectsVersions: []*jira.AffectsVersion{
+								{Name: "4.11"},
+								{Name: "4.12"},
+							},
+						},
+					},
+				},
+				"job=periodic-ci-openshift-release-master-nightly-4.12-e2e-azure-csi=all": []jira.Issue{
+					{
+						ID: "1",
+						Fields: &jira.IssueFields{
+							AffectsVersions: []*jira.AffectsVersion{
+								{Name: "4.12.z"},
+							},
+						},
+					},
+					{
+						ID: "2",
+						Fields: &jira.IssueFields{
+							AffectsVersions: []*jira.AffectsVersion{
+								{Name: "4.11"},
+								{Name: "4.12"},
+							},
+						},
+					},
+					{
+						ID: "3",
+						Fields: &jira.IssueFields{
+							AffectsVersions: []*jira.AffectsVersion{
+								{Name: "4.12"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "find issues by variants with errors",
+			jobCache: map[string]*models.ProwJob{
+				"1": &models.ProwJob{Name: "periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-csi",
+					Release: "4.11", Variants: []string{"azure", "amd64", "ovn", "ha"},
+				},
+				"2": &models.ProwJob{Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-azure-csi",
+					Release: "4.12", Variants: []string{"azure", "amd64", "ovn", "ha"},
+				},
+				"3": &models.ProwJob{Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere-sdn-upi-serial",
+					Release: "4.12", Variants: []string{"vsphere-ipi", "amd64", "sdn", "ha", "serial"},
+				},
+			},
+			jobIssues:      map[string][]jira.Issue{},
+			expectErr:      true,
+			findIssuesFunc: errorFindIssuesForVariants,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			origFindIssuesFunc := FindIssuesForVariants
+			FindIssuesForVariants = tc.findIssuesFunc
+			err := appendJobIssuesFromVariants(tc.jobCache, tc.jobIssues)
+			if tc.expectErr && err == nil {
+				t.Errorf("Expect test error but get nil")
+			} else if !tc.expectErr && err != nil {
+				t.Errorf("Expect no test error but get %v", err)
+			} else if !tc.expectErr {
+				for _, jobIssue := range tc.jobIssues {
+					sort.Slice(jobIssue, func(i, j int) bool {
+						return jobIssue[i].ID < jobIssue[j].ID
+					})
+				}
+				eq := reflect.DeepEqual(tc.jobIssues, tc.expectedResult)
+				if !eq {
+					t.Errorf("Final job issues:\n %+v do not match expected:\n %+v", tc.jobIssues, tc.expectedResult)
+				}
+			}
+			FindIssuesForVariants = origFindIssuesFunc
+		})
+	}
+}


### PR DESCRIPTION
Reverts openshift/sippy#1540

Affects versions and last changed are coming up blank in sippy production even though the table has the values.  They were populated when I tested locally.   Maybe I broke something on a late change to the PR.  Go back to the old bug loader while I sort this out.
