### PR TITLE
Revert "TRT-1588: Avoid NULL for prowjob_start_ts"

### DIFF
--- a/pkg/apis/prow/prow.go
+++ b/pkg/apis/prow/prow.go
@@ -67,7 +67,7 @@ type ProwJobSpec struct {
 }
 
 type ProwJobStatus struct {
-	StartTime        *time.Time              `json:"startTime,omitempty"`
+	StartTime        time.Time               `json:"startTime,omitempty"`
 	PendingTime      *time.Time              `json:"pendingTime,omitempty"`
 	CompletionTime   *time.Time              `json:"completionTime,omitempty"`
 	State            ProwJobState            `json:"state,omitempty"`

--- a/pkg/dataloader/prowloader/bigqueryjobs.go
+++ b/pkg/dataloader/prowloader/bigqueryjobs.go
@@ -52,7 +52,6 @@ func (pl *ProwLoader) fetchProwJobsFromOpenShiftBigQuery() ([]prow.ProwJob, []er
 		"FROM `ci_analysis_us.jobs` " +
 		`WHERE TIMESTAMP(prowjob_completion) > @queryFrom
 	       AND prowjob_url IS NOT NULL
-	       AND prowjob_start_ts IS NOT NULL
 	       ORDER BY prowjob_start_ts`)
 	query.Parameters = []bigquery.QueryParameter{
 		{
@@ -106,7 +105,7 @@ func (pl *ProwLoader) fetchProwJobsFromOpenShiftBigQuery() ([]prow.ProwJob, []er
 			},
 			Status: prow.ProwJobStatus{
 				StartTime:      bqjr.StartTime,
-				CompletionTime: bqjr.CompletionTime,
+				CompletionTime: &bqjr.CompletionTime,
 				State:          prow.ProwJobState(bqjr.State),
 				URL:            bqjr.URL,
 				BuildID:        bqjr.BuildID,
@@ -132,8 +131,8 @@ type bigqueryProwJobRun struct {
 	BuildID        string              `bigquery:"prowjob_build_id"`
 	Type           string              `bigquery:"prowjob_type"`
 	Cluster        string              `bigquery:"prowjob_cluster"`
-	StartTime      *time.Time          `bigquery:"prowjob_start_ts"`
-	CompletionTime *time.Time          `bigquery:"prowjob_completion_ts"`
+	StartTime      time.Time           `bigquery:"prowjob_start_ts"`
+	CompletionTime time.Time           `bigquery:"prowjob_completion_ts"`
 	URL            string              `bigquery:"prowjob_url"`
 	PRSha          bigquery.NullString `bigquery:"pr_sha"`
 	PRAuthor       bigquery.NullString `bigquery:"pr_author"`

--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -599,7 +599,7 @@ func (pl *ProwLoader) prowJobToJobRun(ctx context.Context, pj *prow.ProwJob, rel
 
 		var duration time.Duration
 		if pj.Status.CompletionTime != nil {
-			duration = pj.Status.CompletionTime.Sub(*pj.Status.StartTime)
+			duration = pj.Status.CompletionTime.Sub(pj.Status.StartTime)
 		}
 
 		err = pl.dbc.DB.WithContext(ctx).Create(&models.ProwJobRun{
@@ -611,7 +611,7 @@ func (pl *ProwLoader) prowJobToJobRun(ctx context.Context, pj *prow.ProwJob, rel
 			ProwJob:       *dbProwJob,
 			ProwJobID:     dbProwJob.ID,
 			URL:           pj.Status.URL,
-			Timestamp:     *pj.Status.StartTime,
+			Timestamp:     pj.Status.StartTime,
 			OverallResult: overallResult,
 			PullRequests:  pulls,
 			TestFailures:  failures,

--- a/pkg/sippyserver/pr_commenting_processor.go
+++ b/pkg/sippyserver/pr_commenting_processor.go
@@ -782,7 +782,7 @@ func (aw *AnalysisWorker) buildProwJobMap(prJobRoot string) (map[time.Time]prow.
 		}
 
 		if pj.Status.StartTime.After(mostRecentStartTime) {
-			mostRecentStartTime = *pj.Status.StartTime
+			mostRecentStartTime = pj.Status.StartTime
 		}
 	}
 


### PR DESCRIPTION
Reverts openshift/sippy#1581

Sippy not syncing:

```
time="2024-04-03T19:28:20.509Z" level=error msg="loader \"prow\" returned error: googleapi: Error 400: Unrecognized name: prowjob_start_ts; Did you mean prowjob_start? at [16:20], invalidQuery"
971
Error: errors were encountered while loading database, see logs for details
```