### PR TITLE
Normalize job names containing frequency

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -942,14 +943,22 @@ func previousRelease(release string) (string, error) {
 
 func (c *componentReportGenerator) normalizeProwJobName(prowName string) string {
 	name := prowName
-	name = strings.ReplaceAll(name, c.BaseRelease.Release, "X.X")
-	if prev, err := previousRelease(c.BaseRelease.Release); err == nil {
-		name = strings.ReplaceAll(name, prev, "X.X")
+	if c.BaseRelease.Release != "" {
+		name = strings.ReplaceAll(name, c.BaseRelease.Release, "X.X")
+		if prev, err := previousRelease(c.BaseRelease.Release); err == nil {
+			name = strings.ReplaceAll(name, prev, "X.X")
+		}
 	}
-	name = strings.ReplaceAll(name, c.SampleRelease.Release, "X.X")
-	if prev, err := previousRelease(c.SampleRelease.Release); err == nil {
-		name = strings.ReplaceAll(name, prev, "X.X")
+	if c.SampleRelease.Release != "" {
+		name = strings.ReplaceAll(name, c.SampleRelease.Release, "X.X")
+		if prev, err := previousRelease(c.SampleRelease.Release); err == nil {
+			name = strings.ReplaceAll(name, prev, "X.X")
+		}
 	}
+	// Some jobs encode frequency in their name, which can change
+	re := regexp.MustCompile(`-f\d+`)
+	name = re.ReplaceAllString(name, "-fXX")
+
 	return name
 }
 

--- a/pkg/api/component_report_test.go
+++ b/pkg/api/component_report_test.go
@@ -1208,3 +1208,44 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		})
 	}
 }
+
+func Test_componentReportGenerator_normalizeProwJobName(t *testing.T) {
+	tests := []struct {
+		name          string
+		sampleRelease string
+		baseRelease   string
+		jobName       string
+		want          string
+	}{
+		{
+			name:        "base release is removed",
+			baseRelease: "4.16",
+			jobName:     "periodic-ci-openshift-release-master-ci-4.16-e2e-azure-ovn-upgrade",
+			want:        "periodic-ci-openshift-release-master-ci-X.X-e2e-azure-ovn-upgrade",
+		},
+		{
+			name:          "sample release is removed",
+			sampleRelease: "4.16",
+			jobName:       "periodic-ci-openshift-release-master-ci-4.16-e2e-azure-ovn-upgrade",
+			want:          "periodic-ci-openshift-release-master-ci-X.X-e2e-azure-ovn-upgrade",
+		},
+		{
+			name:    "frequency is removed",
+			jobName: "periodic-ci-openshift-release-master-ci-test-job-f27",
+			want:    "periodic-ci-openshift-release-master-ci-test-job-fXX",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &componentReportGenerator{}
+			if tt.baseRelease != "" {
+				c.BaseRelease = apitype.ComponentReportRequestReleaseOptions{Release: tt.baseRelease}
+			}
+			if tt.sampleRelease != "" {
+				c.SampleRelease = apitype.ComponentReportRequestReleaseOptions{Release: tt.sampleRelease}
+			}
+
+			assert.Equalf(t, tt.want, c.normalizeProwJobName(tt.jobName), "normalizeProwJobName(%v)", tt.jobName)
+		})
+	}
+}


### PR DESCRIPTION
QE jobs contain a frequency element in the name (-f7, -f28, etc), we want to be able to normalize these job names.