### PR TITLE
Remove bparees from approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,6 @@
 reviewers:
 approvers:
 - DennisPeriquet
-- bparees
 - deads2k
 - deepsm007
 - dgoodwin


### PR DESCRIPTION
Been a long time since it's made sense for me to be an approver here.  Sippy has been in good hands for quite a while.