### PR TITLE
TRT-1582: Support capability filtering in the API

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -533,6 +533,13 @@ func (c *componentReportGenerator) getCommonTestStatusQuery() (string, string, [
 			Value: c.Arch,
 		})
 	}
+	if c.Capability != "" {
+		queryString += " AND @Capability in UNNEST(capabilities)"
+		commonParams = append(commonParams, bigquery.QueryParameter{
+			Name:  "Capability",
+			Value: c.Capability,
+		})
+	}
 	if c.Network != "" {
 		queryString += ` AND network = @Network`
 		commonParams = append(commonParams, bigquery.QueryParameter{


### PR DESCRIPTION
Smaller alternative to https://github.com/openshift/sippy/pull/1604

This is a small change to allow filtering by capability, I have the UI parts in another branch but it's probably not ready before I go on PTO, and I know David may want this if Sippy's regular test API isn't sufficient somehow.

Just append `&capability=Other` to the API call to filter the results, e.g.
  http://localhost:8080/api/component_readiness?baseEndTime=2024-02-28T23:59:59Z&baseRelease=4.15&baseStartTime=2024-02-01T00:00:00Z&confidence=95&excludeArches=arm64,heterogeneous,ppc64le,s390x&excludeClouds=openstack,ibmcloud,libvirt,ovirt,unknown&excludeVariants=hypershift,osd,microshift,techpreview,single-node,assisted,compact&groupBy=cloud,arch,network&ignoreDisruption=true&ignoreMissing=false&minFail=3&pity=5&sampleEndTime=2024-04-08T23:59:59Z&sampleRelease=4.16&sampleStartTime=2024-04-02T00:00:00Z&capability=Other