### PR TITLE
Trt 1594 regression icons

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -610,7 +610,6 @@ func (c *componentReportGenerator) getCommonTestStatusQuery() (string, string, [
 type baseQueryGenerator struct {
 	client                   *bqcachedclient.Client
 	cacheOption              cache.RequestOptions
-	BaseRelease              apitype.ComponentReportRequestReleaseOptions
 	commonQuery              string
 	groupByQuery             string
 	queryParameters          []bigquery.QueryParameter
@@ -627,7 +626,6 @@ func (c *componentReportGenerator) getBaseQueryStatus(commonQuery string,
 			// increase the time that base query is cached for since it shouldn't be changing?
 			CRTimeRoundingFactor: c.cacheOption.CRTimeRoundingFactor,
 		},
-		BaseRelease:              c.BaseRelease,
 		commonQuery:              commonQuery,
 		groupByQuery:             groupByQuery,
 		queryParameters:          queryParameters,
@@ -653,15 +651,15 @@ func (b *baseQueryGenerator) queryTestStatus() (apitype.ComponentReportTestStatu
 	baseQuery.Parameters = append(baseQuery.Parameters, []bigquery.QueryParameter{
 		{
 			Name:  "From",
-			Value: b.BaseRelease.Start,
+			Value: b.ComponentReportGenerator.BaseRelease.Start,
 		},
 		{
 			Name:  "To",
-			Value: b.BaseRelease.End,
+			Value: b.ComponentReportGenerator.BaseRelease.End,
 		},
 		{
 			Name:  "BaseRelease",
-			Value: b.BaseRelease.Release,
+			Value: b.ComponentReportGenerator.BaseRelease.Release,
 		},
 	}...)
 
@@ -678,7 +676,6 @@ func (b *baseQueryGenerator) queryTestStatus() (apitype.ComponentReportTestStatu
 
 type sampleQueryGenerator struct {
 	client                   *bqcachedclient.Client
-	SampleRelease            apitype.ComponentReportRequestReleaseOptions
 	commonQuery              string
 	groupByQuery             string
 	queryParameters          []bigquery.QueryParameter
@@ -691,7 +688,6 @@ func (c *componentReportGenerator) getSampleQueryStatus(
 	queryParameters []bigquery.QueryParameter) (map[apitype.ComponentTestIdentification]apitype.ComponentTestStatus, []error) {
 	generator := sampleQueryGenerator{
 		client:                   c.client,
-		SampleRelease:            c.SampleRelease,
 		commonQuery:              commonQuery,
 		groupByQuery:             groupByQuery,
 		queryParameters:          queryParameters,
@@ -716,15 +712,15 @@ func (s *sampleQueryGenerator) queryTestStatus() (apitype.ComponentReportTestSta
 	sampleQuery.Parameters = append(sampleQuery.Parameters, []bigquery.QueryParameter{
 		{
 			Name:  "From",
-			Value: s.SampleRelease.Start,
+			Value: s.ComponentReportGenerator.SampleRelease.Start,
 		},
 		{
 			Name:  "To",
-			Value: s.SampleRelease.End,
+			Value: s.ComponentReportGenerator.SampleRelease.End,
 		},
 		{
 			Name:  "SampleRelease",
-			Value: s.SampleRelease.Release,
+			Value: s.ComponentReportGenerator.SampleRelease.Release,
 		},
 	}...)
 

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -997,9 +997,13 @@ type ComponentJobRunTestReportStatus struct {
 
 const (
 	// ExtremeRegression shows regression with >15% pass rate change
-	ExtremeRegression ComponentReportStatus = -3
+	ExtremeRegression ComponentReportStatus = -5
 	// SignificantRegression shows significant regression
-	SignificantRegression ComponentReportStatus = -2
+	SignificantRegression ComponentReportStatus = -4
+	// ExtremeTriagedRegression shows an ExtremeRegression that clears when Triaged incidents are factored in
+	ExtremeTriagedRegression ComponentReportStatus = -3
+	// SignificantTriagedRegression shows a SignificantRegression that clears when Triaged incidents are factored in
+	SignificantTriagedRegression ComponentReportStatus = -2
 	// MissingSample indicates sample data missing
 	MissingSample ComponentReportStatus = -1
 	// NotSignificant indicates no significant difference

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -15,6 +15,8 @@ import heart from './improved.svg'
 import React from 'react'
 import red from './regressed.svg'
 import red_3d from './extreme.svg'
+import red_3d_triaged from './extreme-triaged.svg'
+import red_triaged from './regressed-triaged.svg'
 
 // Set to true for debug mode
 export const debugMode = false
@@ -168,11 +170,32 @@ export function getStatusAndIcon(status, grayFactor = 0) {
       />
     )
   } else if (status == -2) {
+    statusStr = statusStr + 'SignificantTriagedRegression detected'
+    icon = (
+      <img
+        width="15px"
+        height="15px"
+        src={red_triaged}
+        alt="SignificantTriagedRegression"
+      />
+    )
+  } else if (status == -3) {
+    statusStr =
+      statusStr + 'ExtremeTriagedRegression detected ( >15% pass rate change)'
+    icon = (
+      <img
+        width="15px"
+        height="15px"
+        src={red_3d_triaged}
+        alt="ExtremeTriagedRegression >15%"
+      />
+    )
+  } else if (status == -4) {
     statusStr = statusStr + 'SignificantRegression detected'
     icon = (
       <img width="15px" height="15px" src={red} alt="SignificantRegression" />
     )
-  } else if (status <= -3) {
+  } else if (status <= -5) {
     statusStr =
       statusStr + 'ExtremeRegression detected ( >15% pass rate change)'
     icon = (

--- a/sippy-ng/src/component_readiness/extreme-triaged.svg
+++ b/sippy-ng/src/component_readiness/extreme-triaged.svg
@@ -4,33 +4,9 @@
    viewBox="0 0 64 64"
    version="1.1"
    id="svg697"
-   sodipodi:docname="extreme-triaged.svg"
-   inkscape:version="1.2 (dc2aeda, 2022-05-15)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
+   xmlns="http://www.w3.org/2000/svg">
   <defs
      id="defs701" />
-  <sodipodi:namedview
-     id="namedview699"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     showgrid="false"
-     inkscape:zoom="13.484375"
-     inkscape:cx="32"
-     inkscape:cy="32"
-     inkscape:window-width="1390"
-     inkscape:window-height="1041"
-     inkscape:window-x="0"
-     inkscape:window-y="25"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg697" />
   <path
      d="M0 0h63.91v63.91H0z"
      style="fill:#e31017"

--- a/sippy-ng/src/component_readiness/regressed-triaged.svg
+++ b/sippy-ng/src/component_readiness/regressed-triaged.svg
@@ -4,33 +4,9 @@
    viewBox="0 0 64 64"
    version="1.1"
    id="svg1290"
-   sodipodi:docname="regressed-triaged.svg"
-   inkscape:version="1.2 (dc2aeda, 2022-05-15)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
+   xmlns="http://www.w3.org/2000/svg">
   <defs
      id="defs1294" />
-  <sodipodi:namedview
-     id="namedview1292"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     showgrid="false"
-     inkscape:zoom="13.921875"
-     inkscape:cx="32.071829"
-     inkscape:cy="32.071829"
-     inkscape:window-width="1390"
-     inkscape:window-height="1041"
-     inkscape:window-x="0"
-     inkscape:window-y="25"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg1290" />
   <path
      d="M-.03-.03H64V64H-.03z"
      style="fill:#e31017;fill-opacity:1"


### PR DESCRIPTION
Shows 'triaged' icons for regressions that are cleared via triaged incidents.

Screenshot showing the watch count triaged regression under Unknown

![image](https://github.com/openshift/sippy/assets/36795216/790021ce-2edd-4cd3-a15e-08a949e76f58)


Small amount of cleanup for sampleQueryGenerator and baseQueryGenerator since we pulled in ComponentReportGenerator for cache key making the separate storage of SampleRelease and BaseRelease redundant. 