### PR TITLE
TRT-1574: Server Side Views

### DIFF
--- a/cmd/sippy/serve.go
+++ b/cmd/sippy/serve.go
@@ -2,18 +2,11 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
 	"net/http"
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
 	resources "github.com/openshift/sippy"
 	"github.com/openshift/sippy/pkg/apis/cache"
 	"github.com/openshift/sippy/pkg/bigquery"
@@ -23,34 +16,35 @@ import (
 	"github.com/openshift/sippy/pkg/sippyserver"
 	"github.com/openshift/sippy/pkg/sippyserver/metrics"
 	"github.com/openshift/sippy/pkg/util"
-)
-
-var (
-	defaultCRTimeRoundingFactor = 4 * time.Hour
-	maxCRTimeRoundingFactor     = 12 * time.Hour
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type ServerFlags struct {
-	BigQueryFlags    *flags.BigQueryFlags
-	CacheFlags       *flags.CacheFlags
-	DBFlags          *flags.PostgresFlags
-	GoogleCloudFlags *flags.GoogleCloudFlags
-	ModeFlags        *flags.ModeFlags
+	BigQueryFlags           *flags.BigQueryFlags
+	CacheFlags              *flags.CacheFlags
+	DBFlags                 *flags.PostgresFlags
+	GoogleCloudFlags        *flags.GoogleCloudFlags
+	ModeFlags               *flags.ModeFlags
+	ComponentReadinessFlags *flags.ComponentReadinessFlags
 
-	ListenAddr           string
-	MetricsAddr          string
-	CRTimeRoundingFactor time.Duration
+	ListenAddr  string
+	MetricsAddr string
 }
 
 func NewServerFlags() *ServerFlags {
 	return &ServerFlags{
-		BigQueryFlags:    flags.NewBigQueryFlags(),
-		CacheFlags:       flags.NewCacheFlags(),
-		DBFlags:          flags.NewPostgresDatabaseFlags(),
-		GoogleCloudFlags: flags.NewGoogleCloudFlags(),
-		ModeFlags:        flags.NewModeFlags(),
-		ListenAddr:       ":8080",
-		MetricsAddr:      ":2112",
+		BigQueryFlags:           flags.NewBigQueryFlags(),
+		CacheFlags:              flags.NewCacheFlags(),
+		DBFlags:                 flags.NewPostgresDatabaseFlags(),
+		GoogleCloudFlags:        flags.NewGoogleCloudFlags(),
+		ModeFlags:               flags.NewModeFlags(),
+		ComponentReadinessFlags: flags.NewComponentReadinessFlags(),
+		ListenAddr:              ":8080",
+		MetricsAddr:             ":2112",
 	}
 }
 
@@ -60,12 +54,10 @@ func (f *ServerFlags) BindFlags(flagSet *pflag.FlagSet) {
 	f.DBFlags.BindFlags(flagSet)
 	f.GoogleCloudFlags.BindFlags(flagSet)
 	f.ModeFlags.BindFlags(flagSet)
+	f.ComponentReadinessFlags.BindFlags(flagSet)
 
 	flagSet.StringVar(&f.ListenAddr, "listen", f.ListenAddr, "The address to serve analysis reports on (default :8080)")
 	flagSet.StringVar(&f.MetricsAddr, "listen-metrics", f.MetricsAddr, "The address to serve prometheus metrics on (default :2112)")
-	factorUsage := fmt.Sprintf("Set the rounding factor for component readiness release time. The time will be rounded down to the nearest multiple of the factor. Maximum value is %v", maxCRTimeRoundingFactor)
-	flagSet.DurationVar(&f.CRTimeRoundingFactor, "component-readiness-time-rounding-factor", defaultCRTimeRoundingFactor, factorUsage)
-
 }
 
 func NewServeCommand() *cobra.Command {
@@ -130,12 +122,13 @@ func NewServeCommand() *cobra.Command {
 				bigQueryClient,
 				pinnedDateTime,
 				cacheClient,
-				f.CRTimeRoundingFactor,
+				f.ComponentReadinessFlags.CRTimeRoundingFactor,
+				f.ComponentReadinessFlags.ParseViewsFile(),
 			)
 
 			if f.MetricsAddr != "" {
 				// Do an immediate metrics update
-				err = metrics.RefreshMetricsDB(dbc, bigQueryClient, f.GoogleCloudFlags.StorageBucket, f.ModeFlags.GetVariantManager(), util.GetReportEnd(pinnedDateTime), cache.RequestOptions{CRTimeRoundingFactor: f.CRTimeRoundingFactor})
+				err = metrics.RefreshMetricsDB(dbc, bigQueryClient, f.GoogleCloudFlags.StorageBucket, f.ModeFlags.GetVariantManager(), util.GetReportEnd(pinnedDateTime), cache.RequestOptions{CRTimeRoundingFactor: f.ComponentReadinessFlags.CRTimeRoundingFactor})
 				if err != nil {
 					log.WithError(err).Error("error refreshing metrics")
 				}
@@ -148,7 +141,7 @@ func NewServeCommand() *cobra.Command {
 						select {
 						case <-ticker.C:
 							log.Info("tick")
-							err := metrics.RefreshMetricsDB(dbc, bigQueryClient, f.GoogleCloudFlags.StorageBucket, f.ModeFlags.GetVariantManager(), util.GetReportEnd(pinnedDateTime), cache.RequestOptions{CRTimeRoundingFactor: f.CRTimeRoundingFactor})
+							err := metrics.RefreshMetricsDB(dbc, bigQueryClient, f.GoogleCloudFlags.StorageBucket, f.ModeFlags.GetVariantManager(), util.GetReportEnd(pinnedDateTime), cache.RequestOptions{CRTimeRoundingFactor: f.ComponentReadinessFlags.CRTimeRoundingFactor})
 							if err != nil {
 								log.WithError(err).Error("error refreshing metrics")
 							}

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -795,28 +795,37 @@ type ComponentReportRequestTestIdentificationOptions struct {
 // ComponentReportRequestExcludeOptions group all the exclude options passed in the request.
 // Each of the variable is a comma separated string.
 type ComponentReportRequestExcludeOptions struct {
-	ExcludePlatforms string
-	ExcludeArches    string
-	ExcludeNetworks  string
-	ExcludeUpgrades  string
-	ExcludeVariants  string
+	ExcludePlatforms string `json:"exclude_platforms"`
+	ExcludeArches    string `json:"exclude_arches"`
+	ExcludeNetworks  string `json:"exclude_networks"`
+	ExcludeUpgrades  string `json:"exclude_upgrades"`
+	ExcludeVariants  string `json:"exclude_variants"`
+}
+
+// ComponentReportView is a server side construct representing a predefined view over the data.
+// Useful for defining the primary view of what we deem required for considering the release ready.
+type ComponentReportView struct {
+	Name            string                                `json:"name"`
+	VariantOptions  ComponentReportRequestVariantOptions  `json:"variant_options"`
+	ExcludeOptions  ComponentReportRequestExcludeOptions  `json:"exclude_options"`
+	AdvancedOptions ComponentReportRequestAdvancedOptions `json:"advance_options"`
 }
 
 type ComponentReportRequestVariantOptions struct {
-	GroupBy  string
-	Platform string
-	Upgrade  string
-	Arch     string
-	Network  string
-	Variant  string
+	GroupBy  string `json:"group_by"`
+	Platform string `json:"platform"`
+	Upgrade  string `json:"upgrade"`
+	Arch     string `json:"arch"`
+	Network  string `json:"network"`
+	Variant  string `json:"variant"`
 }
 
 type ComponentReportRequestAdvancedOptions struct {
-	MinimumFailure   int
-	Confidence       int
-	PityFactor       int
-	IgnoreMissing    bool
-	IgnoreDisruption bool
+	MinimumFailure   int  `json:"minimum_failure"`
+	Confidence       int  `json:"confidence"`
+	PityFactor       int  `json:"pity_factor"`
+	IgnoreMissing    bool `json:"ignore_missing"`
+	IgnoreDisruption bool `json:"ignore_disruption"`
 }
 
 type ComponentTestStatus struct {

--- a/pkg/flags/cache.go
+++ b/pkg/flags/cache.go
@@ -9,8 +9,7 @@ import (
 	"github.com/openshift/sippy/pkg/cache/redis"
 )
 
-// CacheFlags holds caching configuration information for Sippy such as the location
-// of its configuration file.
+// CacheFlags holds caching configuration information for Sippy.
 type CacheFlags struct {
 	RedisURL string
 }

--- a/pkg/flags/component_readiness.go
+++ b/pkg/flags/component_readiness.go
@@ -1,0 +1,49 @@
+package flags
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	apitype "github.com/openshift/sippy/pkg/apis/api"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	defaultCRTimeRoundingFactor = 4 * time.Hour
+	maxCRTimeRoundingFactor     = 12 * time.Hour
+)
+
+// ComponentReadinessFlags holds configuration information for serving ComponentReadiness.
+type ComponentReadinessFlags struct {
+	ComponentReadinessViewsFile string
+	CRTimeRoundingFactor        time.Duration
+}
+
+func NewComponentReadinessFlags() *ComponentReadinessFlags {
+	return &ComponentReadinessFlags{}
+}
+
+func (f *ComponentReadinessFlags) BindFlags(fs *pflag.FlagSet) {
+	factorUsage := fmt.Sprintf("Set the rounding factor for component readiness release time. The time will be rounded down to the nearest multiple of the factor. Maximum value is %v", maxCRTimeRoundingFactor)
+	fs.StringVar(&f.ComponentReadinessViewsFile, "component-readiness-views", "", "Optional yaml file for server side predefined Component Readiness views")
+	fs.DurationVar(&f.CRTimeRoundingFactor, "component-readiness-time-rounding-factor", defaultCRTimeRoundingFactor, factorUsage)
+}
+
+func (f *ComponentReadinessFlags) ParseViewsFile() []apitype.ComponentReportView {
+	crViews := []apitype.ComponentReportView{}
+	if f.ComponentReadinessViewsFile != "" {
+		yamlFile, err := os.ReadFile(f.ComponentReadinessViewsFile)
+		if err != nil {
+			log.WithError(err).Fatalf("unable to read component readiness views from %s", f.ComponentReadinessViewsFile)
+		}
+		err = yaml.Unmarshal(yamlFile, &crViews)
+		if err != nil {
+			log.WithError(err).Fatalf("unable to parse component readiness views from %s", f.ComponentReadinessViewsFile)
+		}
+		log.Infof("parsed views: %+v", crViews)
+	}
+	return crViews
+}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -800,7 +800,6 @@ func parseComponentReportRequest(views []apitype.ComponentReportView, req *http.
 			err = pErr
 			return
 		}
-		// TODO: set params from view
 		variantOption = view.VariantOptions
 		excludeOption = view.ExcludeOptions
 		advancedOption = view.AdvancedOptions

--- a/pkg/sippyserver/server_test.go
+++ b/pkg/sippyserver/server_test.go
@@ -2,11 +2,17 @@ package sippyserver
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
+	"github.com/openshift/sippy/pkg/apis/cache"
 	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateProwJobRun(t *testing.T) {
@@ -119,4 +125,112 @@ func TestEncodeDefaultHighRisk(t *testing.T) {
 	if analysis.OverallRisk.Level.Level != apitype.FailureRiskLevelHigh.Level {
 		t.Fatal("Invalid overall risk analysis after decoding")
 	}
+}
+
+func TestParseComponentReportRequest(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		// inputs
+		views       []apitype.ComponentReportView
+		queryParams map[string]string
+
+		// expected outputs
+		baseRelease    apitype.ComponentReportRequestReleaseOptions
+		sampleRelease  apitype.ComponentReportRequestReleaseOptions
+		testIDOption   apitype.ComponentReportRequestTestIdentificationOptions
+		variantOption  apitype.ComponentReportRequestVariantOptions
+		excludeOption  apitype.ComponentReportRequestExcludeOptions
+		advancedOption apitype.ComponentReportRequestAdvancedOptions
+		cacheOption    cache.RequestOptions
+		errMessage     string
+	}{
+		{
+			name: "normal query params",
+			queryParams: map[string]string{
+				"baseEndTime":      "2024-02-28T23:59:59Z",
+				"baseRelease":      "4.15",
+				"baseStartTime":    "2024-02-01T00:00:00Z",
+				"confidence":       "95",
+				"excludeArches":    "arm64,heterogeneous,ppc64le,s390x",
+				"excludeClouds":    "openstack,ibmcloud,libvirt,ovirt,unknown",
+				"excludeVariants":  "hypershift,osd,microshift,techpreview,single-node,assisted,compact",
+				"groupBy":          "cloud,arch,network",
+				"ignoreDisruption": "true",
+				"ignoreMissing":    "false",
+				"minFail":          "3",
+				"pity":             "5",
+				"sampleEndTime":    "2024-04-11T23:59:59Z",
+				"sampleRelease":    "4.16",
+				"sampleStartTime":  "2024-04-04T00:00:05Z",
+			},
+
+			baseRelease: apitype.ComponentReportRequestReleaseOptions{
+				Release: "4.15",
+				Start:   time.Date(2024, time.February, 1, 0, 0, 0, 0, time.UTC),
+				End:     time.Date(2024, time.February, 28, 23, 59, 59, 0, time.UTC),
+			},
+			sampleRelease: apitype.ComponentReportRequestReleaseOptions{
+				Release: "4.16",
+				Start:   time.Date(2024, time.April, 4, 0, 0, 5, 0, time.UTC),
+				End:     time.Date(2024, time.April, 11, 23, 59, 59, 0, time.UTC),
+			},
+			testIDOption: apitype.ComponentReportRequestTestIdentificationOptions{},
+			variantOption: apitype.ComponentReportRequestVariantOptions{
+				GroupBy:  "cloud,arch,network",
+				Platform: "",
+				Upgrade:  "",
+				Arch:     "",
+				Network:  "",
+				Variant:  "",
+			},
+			excludeOption: apitype.ComponentReportRequestExcludeOptions{
+				ExcludePlatforms: "openstack,ibmcloud,libvirt,ovirt,unknown",
+				ExcludeArches:    "arm64,heterogeneous,ppc64le,s390x",
+				ExcludeNetworks:  "",
+				ExcludeUpgrades:  "",
+				ExcludeVariants:  "hypershift,osd,microshift,techpreview,single-node,assisted,compact",
+			},
+			advancedOption: apitype.ComponentReportRequestAdvancedOptions{
+				MinimumFailure:   3,
+				Confidence:       95,
+				PityFactor:       5,
+				IgnoreMissing:    false,
+				IgnoreDisruption: true,
+			},
+			cacheOption: cache.RequestOptions{
+				ForceRefresh:         false,
+				CRTimeRoundingFactor: 4 * time.Hour,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			params := url.Values{}
+			for k, v := range tc.queryParams {
+				params.Set(k, v)
+			}
+
+			// path/body are irrelevant at this point in time, we only parse query params in the func being tested
+			req, err := http.NewRequest("GET", "https://example.com/path?"+params.Encode(), nil)
+			require.NoError(t, err)
+			baseRelease, sampleRelease, testIDOption, variantOption, excludeOption, advancedOption, cacheOption, err :=
+				parseComponentReportRequest(req, 4*time.Hour)
+			assert.Equal(t, tc.baseRelease, baseRelease)
+			assert.Equal(t, tc.sampleRelease, sampleRelease)
+			assert.Equal(t, tc.testIDOption, testIDOption)
+			assert.Equal(t, tc.variantOption, variantOption)
+			assert.Equal(t, tc.excludeOption, excludeOption)
+			assert.Equal(t, tc.advancedOption, advancedOption)
+			assert.Equal(t, tc.cacheOption, cacheOption)
+			if tc.errMessage != "" {
+				assert.Error(t, err)
+				assert.True(t, strings.Contains(err.Error(), tc.errMessage))
+			}
+			assert.Equal(t, tc.baseRelease, baseRelease)
+		})
+	}
+
 }

--- a/pkg/sippyserver/server_test.go
+++ b/pkg/sippyserver/server_test.go
@@ -310,6 +310,21 @@ func TestParseComponentReportRequest(t *testing.T) {
 
 			errMessage: "params cannot be combined with view",
 		},
+		{
+			name: "view does not exist",
+			queryParams: map[string]string{
+				"baseEndTime":     "2024-02-28T23:59:59Z",
+				"baseRelease":     "4.15",
+				"baseStartTime":   "2024-02-01T00:00:00Z",
+				"sampleEndTime":   "2024-04-11T23:59:59Z",
+				"sampleRelease":   "4.16",
+				"sampleStartTime": "2024-04-04T00:00:05Z",
+				"view":            "no such view",
+			},
+
+			errMessage: "unknown view",
+		},
+		// TODO: omit base release, assume based on sample release and whether or not it's GA
 	}
 
 	for _, tc := range tests {
@@ -327,7 +342,7 @@ func TestParseComponentReportRequest(t *testing.T) {
 
 			if tc.errMessage != "" {
 				require.Error(t, err)
-				require.True(t, strings.Contains(err.Error(), tc.errMessage))
+				require.Contains(t, err.Error(), tc.errMessage)
 			} else {
 				assert.Equal(t, tc.baseRelease, baseRelease)
 				assert.Equal(t, tc.sampleRelease, sampleRelease)


### PR DESCRIPTION
Server now accepts a CLI param for `--component-readiness-views views.yaml`.

```yaml
---
- name: main
  variant_options:
    group_by: ''
    platform: ''
    upgrade: ''
    arch: ''
    network: ''
    variant: ''
  exclude_options:
    exclude_platforms: ''
    exclude_arches: ''
    exclude_networks: ''
    exclude_upgrades: ''
    exclude_variants: ''
  advance_options:
    minimum_failure: 0
    confidence: 0
    pity_factor: 0
    ignore_missing: false
    ignore_disruption: false
```

Adds a new /api/component_readiness/views API call to list these views, and their params. This is intended for future use in the UI to list params, and allow a user to stop using the view but tweak it's settings to get their own custom URL.

/api/component_readiness now accepts a ?view=main param. If specified, all the params above should conflict with the fact you specified a view. 

Thus far, start/end times are not part of the view, this will be up for discussion with the team. base and sample release are both still required, we may make base optional and assume to use sample-1 if sample is not GA yet, or sampleGA if it is.