### PR TITLE
TRT-1615: Create api to use the new variant registry

### DIFF
--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -1026,6 +1026,17 @@ type ComponentReportTestVariants struct {
 	Variant  []string `json:"variant,omitempty"`
 }
 
+// JobVariant defines a variant and the possible values
+type JobVariant struct {
+	VariantName   string   `bigquery:"variant_name"`
+	VariantValues []string `bigquery:"variant_values"`
+}
+
+// JobVariants contains all variants supported in the system.
+type JobVariants struct {
+	Variants map[string][]string `json:"variants,omitempty"`
+}
+
 var FailureRiskLevelNone = RiskLevel{Name: "None", Level: 0}
 var FailureRiskLevelLow = RiskLevel{Name: "Low", Level: 1}
 var FailureRiskLevelUnknown = RiskLevel{Name: "Unknown", Level: 25}


### PR DESCRIPTION
New API "/api/jobs/variants".

Example output:
```
{
  "variants": {
    "Aggregation": [
      "aggregated",
      "none"
    ],
    "Architecture": [
      "amd64",
      "arm64",
      "heterogeneous",
      "ppc64le",
      "s390x"
    ],
    "FeatureSet": [
      "default",
      "techpreview"
    ],
    "FromRelease": [
      "0.0",
      "0.1",
      "0.2",
      "0.22",
      "0.23",
      "0.24",
      "0.25",
      "0.26",
      "1.0",
      "1.1",
      "1.2",
      "1.3",
      "1.4",
      "1.5",
      "1.6",
      "1.7",
      "1.8",
      "1.9",
      "1.10",
      "1.11",
      "1.12",
      "1.13",
      "1.14",
      "1.15",
      "1.16",
      "1.17",
      "1.18",
      "1.19",
      "1.20",
      "1.21",
      "1.22",
      "1.23",
      "1.24",
      "1.25",
      "1.26",
      "1.27",
      "1.28",
      "1.29",
      "1.30",
      "1.31",
      "1.32",
      "1.52",
      "1.54",
      "1.55",
      "1.58",
      "1.64",
      "1.70",
      "2.2",
      "2.3",
      "2.4",
      "2.5",
      "2.6",
      "2.7",
      "2.8",
      "2.9",
      "2.10",
      "3.11",
      "4.1",
      "4.2",
      "4.3",
      "4.4",
      "4.5",
      "4.6",
      "4.7",
      "4.8",
      "4.9",
      "4.10",
      "4.11",
      "4.12",
      "4.13",
      "4.14",
      "4.15",
      "4.16",
      "4.17",
      "5.0",
      "5.1",
      "5.2",
      "5.3",
      "5.4",
      "5.5",
      "5.6",
      "5.7",
      "5.8",
      "5.9"
    ],
    "FromReleaseMajor": [
      "0",
      "1",
      "2",
      "3",
      "4",
      "5"
    ],
    "FromReleaseMinor": [
      "0",
      "1",
      "2",
      "3",
      "4",
      "5",
      "6",
      "7",
      "8",
      "9",
      "10",
      "11",
      "12",
      "13",
      "14",
      "15",
      "16",
      "17",
      "18",
      "19",
      "20",
      "21",
      "22",
      "23",
      "24",
      "25",
      "26",
      "27",
      "28",
      "29",
      "30",
      "31",
      "32",
      "52",
      "54",
      "55",
      "58",
      "64",
      "70"
    ],
    "Installer": [
      "assisted",
      "hypershift",
      "ipi",
      "upi"
    ],
    "Network": [
      "ovn",
      "sdn"
    ],
    "NetworkAccess": [
      "default",
      "proxy"
    ],
    "NetworkStack": [
      "IPv4",
      "IPv6",
      "dual",
      "ipv4",
      "ipv6"
    ],
    "Owner": [
      "eng",
      "osd"
    ],
    "Platform": [
      "alibaba",
      "aws",
      "azure",
      "gcp",
      "libvirt",
      "metal",
      "openstack",
      "ovirt",
      "vsphere"
    ],
    "Release": [
      "0.0",
      "0.1",
      "0.2",
      "0.22",
      "0.23",
      "0.24",
      "0.25",
      "0.26",
      "1.0",
      "1.1",
      "1.2",
      "1.3",
      "1.4",
      "1.5",
      "1.6",
      "1.7",
      "1.8",
      "1.9",
      "1.10",
      "1.11",
      "1.12",
      "1.13",
      "1.14",
      "1.19",
      "1.20",
      "1.21",
      "1.22",
      "1.23",
      "1.24",
      "1.25",
      "1.26",
      "1.27",
      "1.28",
      "1.29",
      "1.30",
      "1.31",
      "1.32",
      "1.52",
      "1.54",
      "1.55",
      "1.58",
      "1.64",
      "1.70",
      "2.2",
      "2.3",
      "2.4",
      "2.5",
      "2.6",
      "2.7",
      "2.8",
      "2.9",
      "2.10",
      "3.11",
      "4.1",
      "4.2",
      "4.3",
      "4.4",
      "4.5",
      "4.6",
      "4.7",
      "4.8",
      "4.9",
      "4.10",
      "4.11",
      "4.12",
      "4.13",
      "4.14",
      "4.15",
      "4.16",
      "4.17",
      "5.0",
      "5.1",
      "5.2",
      "5.3",
      "5.4",
      "5.5",
      "5.6",
      "5.7",
      "5.8",
      "5.9"
    ],
    "ReleaseMajor": [
      "0",
      "1",
      "2",
      "3",
      "4",
      "5"
    ],
    "ReleaseMinor": [
      "0",
      "1",
      "2",
      "3",
      "4",
      "5",
      "6",
      "7",
      "8",
      "9",
      "10",
      "11",
      "12",
      "13",
      "14",
      "15",
      "16",
      "17",
      "19",
      "20",
      "21",
      "22",
      "23",
      "24",
      "25",
      "26",
      "27",
      "28",
      "29",
      "30",
      "31",
      "32",
      "52",
      "54",
      "55",
      "58",
      "64",
      "70"
    ],
    "Scheduler": [
      "default",
      "realtime"
    ],
    "SecurityMode": [
      "default",
      "fips"
    ],
    "Suite": [
      "etcd-scaling",
      "serial",
      "unknown"
    ],
    "Topology": [
      "compact",
      "external",
      "ha",
      "microshift",
      "single"
    ],
    "Upgrade": [
      "micro",
      "minor",
      "none"
    ]
  }
}
```