### PR TITLE
WIP: Dynamic variants in Component Readiness

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -498,7 +498,7 @@ func (c *componentReportGenerator) getCommonTestStatusQuery() (string, string, [
 	log.Infof("selectVariants:\n%s", selectVariants)
 	log.Infof("groupByVariants:\n%s", groupByVariants)
 
-	// WARNING: returning additional columns from this query will require explicit parsing in DeserializeRowToTestStatus
+	// WARNING: returning additional columns from this query will require explicit parsing in deserializeRowToTestStatus
 	// TODO: jira_component and jira_comopnent_id appear to not be used? Could save bigquery costs if we remove them.
 	queryString := fmt.Sprintf(`WITH latest_component_mapping AS (
 						SELECT *
@@ -825,12 +825,12 @@ func testToComponentAndCapability(test apitype.ComponentTestIdentification, stat
 
 // getRowColumnIdentifications defines the rows and columns since they are variable. For rows, different pages have different row titles (component, capability etc)
 // Columns titles depends on the groupBy parameter user requests. A particular test can belong to multiple rows of different capabilities.
-func (c *componentReportGenerator) getRowColumnIdentifications(testIDStr string, stats apitype.ComponentTestStatus) ([]apitype.ComponentReportRowIdentification, []apitype.ComponentReportColumnIdentification, error) {
+func (c *componentReportGenerator) getRowColumnIdentifications(testIDStr string, stats apitype.ComponentTestStatus) ([]apitype.ComponentReportRowIdentification, []apitype.ColumnID, error) {
 	var test apitype.ComponentTestIdentification
 	// TODO: is this too slow?
 	err := json.Unmarshal([]byte(testIDStr), &test)
 	if err != nil {
-		return []apitype.ComponentReportRowIdentification{}, []apitype.ComponentReportColumnIdentification{}, err
+		return []apitype.ComponentReportRowIdentification{}, []apitype.ColumnID{}, err
 	}
 
 	component, capabilities := componentAndCapabilityGetter(test, stats)
@@ -872,7 +872,7 @@ func (c *componentReportGenerator) getRowColumnIdentifications(testIDStr string,
 			}
 		}
 	}
-	columns := []apitype.ComponentReportColumnIdentification{}
+	columns := []apitype.ColumnID{}
 	if c.TestID != "" {
 		// When testID is specified, ignore groupBy to disambiguate the test
 		column := apitype.ComponentReportColumnIdentification{}
@@ -881,7 +881,12 @@ func (c *componentReportGenerator) getRowColumnIdentifications(testIDStr string,
 		column.Arch = test.Arch
 		column.Upgrade = test.Upgrade
 		column.Variant = test.FlatVariants
-		columns = append(columns, column)
+		column.Variants = test.Variants
+		columnKeyBytes, err := json.Marshal(column)
+		if err != nil {
+			return []apitype.ComponentReportRowIdentification{}, []apitype.ColumnID{}, err
+		}
+		columns = append(columns, apitype.ColumnID(columnKeyBytes))
 	} else {
 		groups := sets.NewString(strings.Split(c.GroupBy, ",")...)
 		column := apitype.ComponentReportColumnIdentification{}
@@ -900,7 +905,11 @@ func (c *componentReportGenerator) getRowColumnIdentifications(testIDStr string,
 		if groups.Has("variants") {
 			column.Variant = test.FlatVariants
 		}
-		columns = append(columns, column)
+		columnKeyBytes, err := json.Marshal(column)
+		if err != nil {
+			return []apitype.ComponentReportRowIdentification{}, []apitype.ColumnID{}, err
+		}
+		columns = append(columns, apitype.ColumnID(columnKeyBytes))
 	}
 
 	return rows, columns, nil
@@ -933,7 +942,7 @@ func fetchTestStatus(query *bigquery.Query) (map[string]apitype.ComponentTestSta
 			errs = append(errs, errors.Wrap(err, "error parsing prowjob from bigquery"))
 			continue
 		}
-		testIDStr, testStatus, err := DeserializeRowToTestStatus(row, schema)
+		testIDStr, testStatus, err := deserializeRowToTestStatus(row, schema)
 		if err != nil {
 			err2 := errors.Wrap(err, "error deserializing row from bigquery")
 			log.Error(err2.Error())
@@ -946,10 +955,10 @@ func fetchTestStatus(query *bigquery.Query) (map[string]apitype.ComponentTestSta
 	return status, errs
 }
 
-// DeserializeRowToTestStatus deserializes a single row into a testID string and matching status.
+// deserializeRowToTestStatus deserializes a single row into a testID string and matching status.
 // This is where we handle the dynamic variant_ columns, parsing these into a map on the test identification.
 // Other fixed columns we expect are serialized directly to their appropriate columns.
-func DeserializeRowToTestStatus(row []bigquery.Value, schema bigquery.Schema) (string, apitype.ComponentTestStatus, error) {
+func deserializeRowToTestStatus(row []bigquery.Value, schema bigquery.Schema) (string, apitype.ComponentTestStatus, error) {
 	if len(row) != len(schema) {
 		return "", apitype.ComponentTestStatus{}, fmt.Errorf("number of values in row doesn't match schema length")
 	}
@@ -988,20 +997,26 @@ func DeserializeRowToTestStatus(row []bigquery.Value, schema bigquery.Schema) (s
 		case col == "test_suite":
 			cts.TestSuite = row[i].(string)
 		case col == "total_count":
-			cts.TotalCount = row[i].(int)
+			cts.TotalCount = int(row[i].(int64))
 		case col == "success_count":
-			cts.SuccessCount = row[i].(int)
+			cts.SuccessCount = int(row[i].(int64))
 		case col == "flake_count":
-			cts.FlakeCount = row[i].(int)
+			cts.FlakeCount = int(row[i].(int64))
 		case col == "component":
 			cts.Component = row[i].(string)
 		case col == "capabilities":
-			cts.Capabilities = row[i].([]string)
+			capArr := row[i].([]bigquery.Value)
+			cts.Capabilities = make([]string, len(capArr))
+			for i := range capArr {
+				cts.Capabilities[i] = capArr[i].(string)
+			}
 		case strings.HasPrefix(col, "variant_"):
 			variantName := col[len("variant_"):]
-			tid.Variants[variantName] = row[i].(string)
+			if row[i] != nil {
+				tid.Variants[variantName] = row[i].(string)
+			}
 		default:
-			log.Warn("ignoring column in query: %s", col)
+			log.Warnf("ignoring column in query: %s", col)
 		}
 
 		/*
@@ -1151,12 +1166,12 @@ func getNewCellStatus(testID apitype.ComponentReportTestIdentification,
 }
 
 func updateCellStatus(rowIdentifications []apitype.ComponentReportRowIdentification,
-	columnIdentifications []apitype.ComponentReportColumnIdentification,
+	columnIdentifications []apitype.ColumnID,
 	testID apitype.ComponentReportTestIdentification,
 	reportStatus apitype.ComponentReportStatus,
-	status map[apitype.ComponentReportRowIdentification]map[apitype.ComponentReportColumnIdentification]cellStatus,
+	status map[apitype.ComponentReportRowIdentification]map[apitype.ColumnID]cellStatus,
 	allRows map[apitype.ComponentReportRowIdentification]struct{},
-	allColumns map[apitype.ComponentReportColumnIdentification]struct{}) {
+	allColumns map[apitype.ColumnID]struct{}) {
 	for _, columnIdentification := range columnIdentifications {
 		if _, ok := allColumns[columnIdentification]; !ok {
 			allColumns[columnIdentification] = struct{}{}
@@ -1174,7 +1189,7 @@ func updateCellStatus(rowIdentifications []apitype.ComponentReportRowIdentificat
 		}
 		row, ok := status[rowIdentification]
 		if !ok {
-			row = map[apitype.ComponentReportColumnIdentification]cellStatus{}
+			row = map[apitype.ColumnID]cellStatus{}
 			for _, columnIdentification := range columnIdentifications {
 				row[columnIdentification] = getNewCellStatus(testID, reportStatus, nil)
 				status[rowIdentification] = row
@@ -1460,10 +1475,10 @@ func (c *componentReportGenerator) generateComponentTestReport(baseStatus map[st
 		Rows: []apitype.ComponentReportRow{},
 	}
 	// aggregatedStatus is the aggregated status based on the requested rows and columns
-	aggregatedStatus := map[apitype.ComponentReportRowIdentification]map[apitype.ComponentReportColumnIdentification]cellStatus{}
+	aggregatedStatus := map[apitype.ComponentReportRowIdentification]map[apitype.ColumnID]cellStatus{}
 	// allRows and allColumns are used to make sure rows are ordered and all rows have the same columns in the same order
 	allRows := map[apitype.ComponentReportRowIdentification]struct{}{}
-	allColumns := map[apitype.ComponentReportColumnIdentification]struct{}{}
+	allColumns := map[apitype.ColumnID]struct{}{}
 	// testID is used to identify the most regressed test. With this, we can
 	// create a shortcut link from any page to go straight to the most regressed test page.
 	for testIdentification, baseStats := range baseStatus {
@@ -1519,25 +1534,30 @@ func (c *componentReportGenerator) generateComponentTestReport(baseStatus map[st
 	})
 
 	// Sort the column identifications
-	sortedColumns := []apitype.ComponentReportColumnIdentification{}
+	sortedColumns := []apitype.ColumnID{}
 	for columnID := range allColumns {
 		sortedColumns = append(sortedColumns, columnID)
 	}
 	sort.Slice(sortedColumns, func(i, j int) bool {
-		less := sortedColumns[i].Platform < sortedColumns[j].Platform
-		if sortedColumns[i].Platform == sortedColumns[j].Platform {
-			less = sortedColumns[i].Arch < sortedColumns[j].Arch
-			if sortedColumns[i].Arch == sortedColumns[j].Arch {
-				less = sortedColumns[i].Network < sortedColumns[j].Network
-				if sortedColumns[i].Network == sortedColumns[j].Network {
-					less = sortedColumns[i].Upgrade < sortedColumns[j].Upgrade
-					if sortedColumns[i].Upgrade == sortedColumns[j].Upgrade {
-						less = sortedColumns[i].Variant < sortedColumns[j].Variant
+		// TODO: is sorting based on the json string keys ok?
+		return sortedColumns[i] < sortedColumns[j]
+		/*
+			less := sortedColumns[i].Platform < sortedColumns[j].Platform
+			if sortedColumns[i].Platform == sortedColumns[j].Platform {
+				less = sortedColumns[i].Arch < sortedColumns[j].Arch
+				if sortedColumns[i].Arch == sortedColumns[j].Arch {
+					less = sortedColumns[i].Network < sortedColumns[j].Network
+					if sortedColumns[i].Network == sortedColumns[j].Network {
+						less = sortedColumns[i].Upgrade < sortedColumns[j].Upgrade
+						if sortedColumns[i].Upgrade == sortedColumns[j].Upgrade {
+							less = sortedColumns[i].Variant < sortedColumns[j].Variant
+						}
 					}
 				}
 			}
-		}
-		return less
+			return less
+
+		*/
 	})
 
 	// Now build the report
@@ -1553,7 +1573,12 @@ func (c *componentReportGenerator) generateComponentTestReport(baseStatus map[st
 			if reportRow.Columns == nil {
 				reportRow.Columns = []apitype.ComponentReportColumn{}
 			}
-			reportColumn := apitype.ComponentReportColumn{ComponentReportColumnIdentification: columnID}
+			var colIDStruct apitype.ComponentReportColumnIdentification
+			err := json.Unmarshal([]byte(columnID), &colIDStruct)
+			if err != nil {
+				return apitype.ComponentReport{}, err
+			}
+			reportColumn := apitype.ComponentReportColumn{ComponentReportColumnIdentification: colIDStruct}
 			status, ok := columns[columnID]
 			if !ok {
 				reportColumn.Status = apitype.MissingBasisAndSample

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -831,11 +831,17 @@ type ComponentTestStatus struct {
 }
 
 type ComponentReportTestStatus struct {
-	BaseStatus   map[ComponentTestIdentification]ComponentTestStatus `json:"base_status"`
-	SampleStatus map[ComponentTestIdentification]ComponentTestStatus `json:"sample_status"`
-	GeneratedAt  *time.Time                                          `json:"generated_at"`
+	// BaseStatus represents the stable basis for the comparison. Maps ComponentTestIdentification serialized as a string, to test status.
+	BaseStatus map[string]ComponentTestStatus `json:"base_status"`
+
+	// SampleSatus represents the sample for the comparison. Maps ComponentTestIdentification serialized as a string, to test status.
+	SampleStatus map[string]ComponentTestStatus `json:"sample_status"`
+	GeneratedAt  *time.Time                     `json:"generated_at"`
 }
 
+// ComponentTestIdentification TODO: we need to get Network/Upgrade/Arch/Platform/FlatVariants off this struct as the actual variants will be dynamic.
+// However making it a map will likely break anything using this struct as a map key.
+// We may need to serialize it to a predictable string? Serialize as JSON string perhaps? Will fields be predictably ordered? Seems like go maps are always alphabetical.
 type ComponentTestIdentification struct {
 	TestID       string `json:"test_id"`
 	Network      string `json:"network"`
@@ -843,9 +849,13 @@ type ComponentTestIdentification struct {
 	Arch         string `json:"arch"`
 	Platform     string `json:"platform"`
 	FlatVariants string `json:"flat_variants"`
+
+	// Proposed
+	Variants map[string]string `json:"variants"`
+	// Then serialize to a string for use as a map key?
 }
 
-// implement encoding.TextMarshaler for json map key marshalling support
+// MarshalText implements encoding.TextMarshaler for json map key marshalling support
 func (s ComponentTestIdentification) MarshalText() (text []byte, err error) {
 	type t ComponentTestIdentification
 	return json.Marshal(t(s))

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -850,15 +850,14 @@ type ComponentTestIdentification struct {
 	Platform     string `json:"platform"`
 	FlatVariants string `json:"flat_variants"`
 
-	// Proposed
+	// Proposed, need to serialize to use as map key
 	Variants map[string]string `json:"variants"`
-	// Then serialize to a string for use as a map key?
 }
 
 // MarshalText implements encoding.TextMarshaler for json map key marshalling support
-func (s ComponentTestIdentification) MarshalText() (text []byte, err error) {
+func (s *ComponentTestIdentification) MarshalText() (text []byte, err error) {
 	type t ComponentTestIdentification
-	return json.Marshal(t(s))
+	return json.Marshal((*t)(s))
 }
 
 func (s *ComponentTestIdentification) UnmarshalText(text []byte) error {
@@ -866,6 +865,9 @@ func (s *ComponentTestIdentification) UnmarshalText(text []byte) error {
 	return json.Unmarshal(text, (*t)(s))
 }
 
+// TODO: obsoleted by bigquery dynamic parsing
+
+/*
 type ComponentTestStatusRow struct {
 	TestName     string   `bigquery:"test_name"`
 	TestSuite    string   `bigquery:"test_suite"`
@@ -882,6 +884,8 @@ type ComponentTestStatusRow struct {
 	Component    string   `bigquery:"component"`
 	Capabilities []string `bigquery:"capabilities"`
 }
+
+*/
 
 type ComponentReport struct {
 	Rows        []ComponentReportRow `json:"rows,omitempty"`
@@ -907,12 +911,15 @@ type ComponentReportColumn struct {
 	RegressedTests []ComponentReportTestSummary `json:"regressed_tests,omitempty"`
 }
 
+type ColumnID string
+
 type ComponentReportColumnIdentification struct {
-	Network  string `json:"network,omitempty"`
-	Upgrade  string `json:"upgrade,omitempty"`
-	Arch     string `json:"arch,omitempty"`
-	Platform string `json:"platform,omitempty"`
-	Variant  string `json:"variant,omitempty"`
+	Network  string            `json:"network,omitempty"`
+	Upgrade  string            `json:"upgrade,omitempty"`
+	Arch     string            `json:"arch,omitempty"`
+	Platform string            `json:"platform,omitempty"`
+	Variant  string            `json:"variant,omitempty"`
+	Variants map[string]string `json:"variants"`
 }
 
 type ComponentReportStatus int


### PR DESCRIPTION
This is a PoC to explore how we could get component readiness working with dynamic variants instead of a fixed set as we do today.

The general approach outlined thus far:
- we control the query for component readiness in code, so programatically inject columns for each variant requested in the API call into the select, join, and group by portions of the query. No view is required for this, chatgpt revealed a way to do it with standard joins.
- switch to a more dynamic method of reading the column values back out of the bigquery results, as we don't have fixed columns anymore that will map to a static go struct.
- variants move to a map[string]string on the ComponentTestIdentification.
- because we use ComponentTestIdentification as a map key, and structs containing map fields cannot be used as map keys, switch to using a string representation (json serialized right now). Will need to watch computation cost but the implication of doing a few thousand serializations/deserializations of small json structs is likely insignificant.