### PR TITLE
Fix mixed case on NetworkStack variant in registry

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -153,6 +153,10 @@ func (v *OCPVariantLoader) CalculateVariantsForJob(jLog logrus.FieldLogger, jobN
 	// containing a map. Some properties will be ignored as they are job RUN specific, not job specific.
 	// Others we need to carefully decide who wins in the event is a mismatch.
 	for k, v := range variantFile {
+		if k == VariantNetworkStack {
+			// Use ipv6 / ipv4 for consistency with a lot of pre-existing code.
+			v = strings.ToLower(v)
+		}
 		if fileVariantsToIgnore[k] {
 			continue
 		}


### PR DESCRIPTION
Caused by jobname analysis using lowercase, and cluster-data file using mixed case. Sticking with lower as I don't know what might be out there this could break.
