### PR TITLE
NO-JIRA: update linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ run:
 linters:
   disable-all: true
   enable:
-    - depguard
     - errcheck
     - exportloopref
     - goconst

--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -4,7 +4,7 @@
 # [1] https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image
 #
 FROM registry.access.redhat.com/ubi9/ubi:latest
-ARG GOLANGCI_LINT_VERSION="1.51.2"
+ARG GOLANGCI_LINT_VERSION="1.54.2"
 RUN curl -Lso /tmp/golangci-lint.rpm \
           "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64.rpm" && \
       dnf module enable nodejs:18 -y && \

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -22,6 +22,6 @@ else
   $DOCKER run --rm \
     --volume "${PWD}:/go/src/github.com/openshift/sippy:z" \
     --workdir /go/src/github.com/openshift/sippy \
-    docker.io/golangci/golangci-lint:v1.51.2 \
+    docker.io/golangci/golangci-lint:v1.54.2 \
     golangci-lint "${@}"
 fi


### PR DESCRIPTION
Choice # 1 - bump up to 1.54.2 and remove depguard

Doesn't look like we have configuration for it so it would be blacklist with not blacklisting.

Configs have changes and we now have failures.  Will work on alternate config changes allowing all / specific failure list depending on the size.

Latest golangci-lint version appears to be 1.57.2.  There are a couple more issues flagged by gocritic that we could work through now if we want.