### PR TITLE
NO-JIRA: update golangci-lint v1.57.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,22 +28,9 @@ linters-settings:
   gocritic:
     enabled-checks:
       # Diagnostic
-      - argOrder
-      - badCond
-      - caseOrder
-      - codegenComment
       - commentedOutCode
-      - deprecatedComment
-      - dupArg
-      - dupBranchBody
-      - dupCase
-      - dupSubExpr
-      - exitAfterDefer
-      - flagDeref
-      - flagName
       - nilValReturn
       - octalLiteral
-      - offBy1
       - sloppyReassign
       - weakCond
 
@@ -53,29 +40,14 @@ linters-settings:
       - rangeExprCopy
 
       # Style
-      - assignOp
       - boolExprSimplify
-      - captLocal
-      - commentFormatting
       - commentedOutImport
-      - defaultCaseOrder
       - docStub
-      - elseif
       - emptyFallthrough
       - hexLiteral
       - methodExprCall
-      - regexpMust
-      - singleCaseSwitch
-      - sloppyLen
-      - switchTrue
       - typeAssertChain
-      - typeSwitchVar
-      - underef
       - unlabelStmt
-      - unlambda
-      - unslice
-      - valSwap
-      - wrapperFunc
       - yodaStyleExpr
 
       # Opinionated

--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -4,7 +4,7 @@
 # [1] https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image
 #
 FROM registry.access.redhat.com/ubi9/ubi:latest
-ARG GOLANGCI_LINT_VERSION="1.54.2"
+ARG GOLANGCI_LINT_VERSION="1.57.2"
 RUN curl -Lso /tmp/golangci-lint.rpm \
           "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64.rpm" && \
       dnf module enable nodejs:18 -y && \

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -22,6 +22,6 @@ else
   $DOCKER run --rm \
     --volume "${PWD}:/go/src/github.com/openshift/sippy:z" \
     --workdir /go/src/github.com/openshift/sippy \
-    docker.io/golangci/golangci-lint:v1.54.2 \
+    docker.io/golangci/golangci-lint:v1.57.2 \
     golangci-lint "${@}"
 fi

--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -1453,8 +1453,8 @@ func (c *componentReportGenerator) generateComponentTestReport(baseStatus map[ap
 			goodRows = append(goodRows, reportRow)
 		}
 	}
-
-	report.Rows = append(regressionRows, goodRows...)
+	regressionRows = append(regressionRows, goodRows...)
+	report.Rows = regressionRows
 	return report
 }
 

--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -47,7 +47,8 @@ func useNewInstallTest(release string) bool {
 func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release string, reportEnd time.Time) {
 	excludedVariants := testidentification.DefaultExcludedVariants
 	// Minor upgrades install a previous version and should not be counted against the current version's install stat.
-	excludedInstallVariants := append(testidentification.DefaultExcludedVariants, "upgrade-minor")
+	excludedInstallVariants := testidentification.DefaultExcludedVariants
+	excludedInstallVariants = append(excludedInstallVariants, "upgrade-minor")
 
 	indicators := make(map[string]apitype.Test)
 

--- a/pkg/api/install.go
+++ b/pkg/api/install.go
@@ -17,7 +17,8 @@ import (
 
 // PrintInstallJSONReportFromDB renders a report showing the success/fail rates of operator installation.
 func PrintInstallJSONReportFromDB(w http.ResponseWriter, dbc *db.DB, release string) {
-	excludedVariants := append(testidentification.DefaultExcludedVariants, "upgrade-minor")
+	excludedVariants := testidentification.DefaultExcludedVariants
+	excludedVariants = append(excludedVariants, "upgrade-minor")
 	exactTestNames := sets.NewString()
 	testPrefixes := sets.NewString(testidentification.OperatorInstallPrefix)
 	if useNewInstallTest(release) {

--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -183,14 +183,14 @@ func findReleaseMatchJobNames(dbc *db.DB, jobRun *models.ProwJobRun, compareRele
 					gosort.Strings(job.Variants)
 					if stringSlicesEqual(variants, job.Variants) {
 
-						jobIds, err := query.ProwJobRunIds(dbc, job.ID)
+						jobIDs, err := query.ProwJobRunIDs(dbc, job.ID)
 
 						if err != nil {
 							logger.WithError(err).Errorf("Failed to query job run ids for %d", job.ID)
 							continue
 						}
 
-						totalJobRunsCount += len(jobIds)
+						totalJobRunsCount += len(jobIDs)
 						allJobNames = append(allJobNames, "'"+job.Name+"'")
 					}
 				}

--- a/pkg/api/jobs.go
+++ b/pkg/api/jobs.go
@@ -66,16 +66,17 @@ func PrintVariantReportFromDB(w http.ResponseWriter, req *http.Request,
 	var err error
 
 	startParam := req.URL.Query().Get("start")
-	if startParam != "" {
+	switch {
+	case startParam != "":
 		start, err = time.Parse("2006-01-02", startParam)
 		if err != nil {
 			RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": fmt.Sprintf("Error decoding start param: %s", err.Error())})
 			return
 		}
-	} else if req.URL.Query().Get("period") == periodTwoDay {
+	case req.URL.Query().Get("period") == periodTwoDay:
 		// twoDay report period starts 9 days ago, (comparing last 2 days vs previous 7)
 		start = reportEnd.Add(-9 * 24 * time.Hour)
-	} else {
+	default:
 		// Default start to 14 days ago
 		start = reportEnd.Add(-14 * 24 * time.Hour)
 	}
@@ -83,18 +84,18 @@ func PrintVariantReportFromDB(w http.ResponseWriter, req *http.Request,
 	// TODO: currently we're assuming dates use the 00:00:00, is it more logical to add 23:23 for boundary and end? or
 	// for callers to know to specify one day beyond.
 	boundaryParam := req.URL.Query().Get("boundary")
-	if boundaryParam != "" {
+	switch {
+	case boundaryParam != "":
 		boundary, err = time.Parse("2006-01-02", boundaryParam)
 		if err != nil {
 			RespondWithJSON(http.StatusBadRequest, w, map[string]interface{}{"code": http.StatusBadRequest, "message": fmt.Sprintf("Error decoding boundary param: %s", err.Error())})
 			return
 		}
-	} else if req.URL.Query().Get("period") == periodTwoDay {
+	case req.URL.Query().Get("period") == periodTwoDay:
 		boundary = reportEnd.Add(-2 * 24 * time.Hour)
-	} else {
+	default:
 		// Default boundary to 7 days ago
 		boundary = reportEnd.Add(-7 * 24 * time.Hour)
-
 	}
 
 	endParam := req.URL.Query().Get("end")
@@ -241,12 +242,12 @@ type jobDetailAPIResult struct {
 }
 
 func (jobs jobDetailAPIResult) limit(req *http.Request) jobDetailAPIResult {
+	newJobs := jobs
 	limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
-	if limit > 0 && len(jobs.Jobs) >= limit {
-		jobs.Jobs = jobs.Jobs[:limit]
+	if limit > 0 && len(newJobs.Jobs) >= limit {
+		newJobs.Jobs = newJobs.Jobs[:limit]
 	}
-
-	return jobs
+	return newJobs
 }
 
 // PrintJobDetailsReportFromDB renders the detailed list of runs for matching jobs.

--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -262,10 +262,11 @@ type testsDetailAPIResult struct {
 }
 
 func (tests testsDetailAPIResult) limit(req *http.Request) testsDetailAPIResult {
+	newTests := tests
 	limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
-	if limit > 0 && len(tests.Tests) >= limit {
-		tests.Tests = tests.Tests[:limit]
+	if limit > 0 && len(newTests.Tests) >= limit {
+		newTests.Tests = newTests.Tests[:limit]
 	}
 
-	return tests
+	return newTests
 }

--- a/pkg/dataloader/prowloader/bigqueryjobs.go
+++ b/pkg/dataloader/prowloader/bigqueryjobs.go
@@ -90,7 +90,8 @@ func (pl *ProwLoader) fetchProwJobsFromOpenShiftBigQuery() ([]prow.ProwJob, []er
 				refs = &prow.Refs{Org: bqjr.PROrg.StringVal, Repo: bqjr.PRRepo.StringVal}
 				pulls := make([]prow.Pull, 0)
 				pull := prow.Pull{Number: prNumber, SHA: bqjr.PRSha.StringVal, Author: bqjr.PRAuthor.StringVal}
-				refs.Pulls = append(pulls, pull)
+				pulls = append(pulls, pull)
+				refs.Pulls = pulls
 			}
 		} else if bqjr.Type == "presubmit" {
 			log.Warningf("Presubmit job found without matching PR data for: %s", bqjr.JobName)

--- a/pkg/dataloader/prowloader/github/github_test.go
+++ b/pkg/dataloader/prowloader/github/github_test.go
@@ -31,7 +31,8 @@ func TestClient_GetPRSHAMerged(t *testing.T) {
 
 	prFetch := func(org, repo string, number int) (*gh.PullRequest, error) {
 		prFetchCalls++
-		if org == openshift && repo == kubernetes && number == 1 {
+		switch {
+		case org == openshift && repo == kubernetes && number == 1:
 			return &gh.PullRequest{
 				MergedAt: &now,
 				Head: &gh.PullRequestBranch{
@@ -40,9 +41,9 @@ func TestClient_GetPRSHAMerged(t *testing.T) {
 				Title:   &pr1Title,
 				HTMLURL: &pr1URL,
 			}, nil
-		} else if org == openshift && repo == kubernetes && number == 2 {
+		case org == openshift && repo == kubernetes && number == 2:
 			return &gh.PullRequest{}, nil
-		} else if org == openshift && repo == "not-exist" {
+		case org == openshift && repo == "not-exist":
 			return nil, &gh.ErrorResponse{
 				Response: &http.Response{
 					StatusCode: 404,

--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -868,11 +868,12 @@ func (pl *ProwLoader) extractTestCases(suite *junit.TestSuite, suiteID *uint, te
 	for _, tc := range suite.TestCases {
 		status := sippyprocessingv1.TestStatusFailure
 		var failureOutput *models.ProwJobRunTestOutput
-		if tc.SkipMessage != nil {
+		switch {
+		case tc.SkipMessage != nil:
 			continue
-		} else if tc.FailureOutput == nil {
+		case tc.FailureOutput == nil:
 			status = sippyprocessingv1.TestStatusSuccess
-		} else {
+		default:
 			failureOutput = &models.ProwJobRunTestOutput{
 				Output: tc.FailureOutput.Output,
 			}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -182,7 +182,8 @@ func syncSchema(db *gorm.DB, hashType SchemaHashType, name, desiredSchema, dropS
 	}
 
 	var updateRequired bool
-	if currSchemaHash.ID == 0 {
+	switch {
+	case currSchemaHash.ID == 0:
 		vlog.Debug("no current schema hash in db, creating")
 		updateRequired = true
 		currSchemaHash = models.SchemaHash{
@@ -190,11 +191,11 @@ func syncSchema(db *gorm.DB, hashType SchemaHashType, name, desiredSchema, dropS
 			Name: name,
 			Hash: hashStr,
 		}
-	} else if currSchemaHash.Hash != hashStr {
+	case currSchemaHash.Hash != hashStr:
 		vlog.WithField("oldHash", currSchemaHash.Hash).Debug("schema hash has changed, recreating")
 		currSchemaHash.Hash = hashStr
 		updateRequired = true
-	} else if forceUpdate {
+	case forceUpdate:
 		vlog.Debug("schema hash has not changed but a force update was requested, recreating")
 		updateRequired = true
 	}

--- a/pkg/db/query/job_queries.go
+++ b/pkg/db/query/job_queries.go
@@ -44,16 +44,16 @@ func ProwJobSimilarName(dbc *db.DB, rootName, release string) ([]models.ProwJob,
 	return jobs, nil
 }
 
-func ProwJobRunIds(dbc *db.DB, prowJobID uint) ([]uint, error) {
-	jobIds := make([]uint, 0)
+func ProwJobRunIDs(dbc *db.DB, prowJobID uint) ([]uint, error) {
+	jobIDs := make([]uint, 0)
 	q := dbc.DB.Raw(`SELECT id 
 	FROM prow_job_runs WHERE prow_job_id = ?`, prowJobID)
 	if q.Error != nil {
 		return nil, q.Error
 	}
-	q.Scan(&jobIds)
+	q.Scan(&jobIDs)
 
-	return jobIds, nil
+	return jobIDs, nil
 }
 
 func ProwJobHistoricalTestCounts(dbc *db.DB, prowJobID uint) (int, error) {

--- a/pkg/sippyserver/parameters.go
+++ b/pkg/sippyserver/parameters.go
@@ -123,7 +123,9 @@ func splitJobAndJobRunFilters(fil *filter.Filter) (*filter.Filter, *filter.Filte
 		LinkOperator: fil.LinkOperator,
 	}
 	for _, f := range fil.Items {
-		if f.Field == "timestamp" {
+		switch {
+
+		case f.Field == "timestamp":
 			ms, err := strconv.ParseInt(f.Value, 0, 64)
 			if err != nil {
 				return nil, nil, err
@@ -131,9 +133,9 @@ func splitJobAndJobRunFilters(fil *filter.Filter) (*filter.Filter, *filter.Filte
 
 			f.Value = time.Unix(0, ms*int64(time.Millisecond)).Format("2006-01-02T15:04:05-0700")
 			jobRunsFilter.Items = append(jobRunsFilter.Items, f)
-		} else if f.Field == "cluster" {
+		case f.Field == "cluster":
 			jobRunsFilter.Items = append(jobRunsFilter.Items, f)
-		} else {
+		default:
 			jobFilter.Items = append(jobFilter.Items, f)
 		}
 	}

--- a/pkg/testidentification/ocp_variants.go
+++ b/pkg/testidentification/ocp_variants.go
@@ -283,31 +283,43 @@ func determinePlatform(jobName string) string {
 	// Platforms
 	if alibabaRegex.MatchString(jobName) {
 		return "alibaba"
-	} else if awsRegex.MatchString(jobName) {
+	}
+	if awsRegex.MatchString(jobName) {
 		return "aws"
-	} else if azureRegex.MatchString(jobName) {
+	}
+	if azureRegex.MatchString(jobName) {
 		return "azure"
-	} else if gcpRegex.MatchString(jobName) {
+	}
+	if gcpRegex.MatchString(jobName) {
 		return "gcp"
-	} else if libvirtRegex.MatchString(jobName) {
+	}
+	if libvirtRegex.MatchString(jobName) {
 		return "libvirt"
-	} else if metalAssistedRegex.MatchString(jobName) || (metalRegex.MatchString(jobName) && singleNodeRegex.MatchString(jobName)) {
+	}
+	if metalAssistedRegex.MatchString(jobName) || (metalRegex.MatchString(jobName) && singleNodeRegex.MatchString(jobName)) {
 		// Without support for negative lookbacks in the native
 		// regexp library, it's easiest to differentiate these
 		// three by seeing if it's metal-assisted or metal-ipi, and then fall through
 		// to check if it's UPI metal.
 		return "metal-assisted"
-	} else if metalIPIRegex.MatchString(jobName) {
+	}
+
+	if metalIPIRegex.MatchString(jobName) {
 		return "metal-ipi"
-	} else if metalRegex.MatchString(jobName) {
+	}
+	if metalRegex.MatchString(jobName) {
 		return "metal-upi"
-	} else if openstackRegex.MatchString(jobName) {
+	}
+	if openstackRegex.MatchString(jobName) {
 		return "openstack"
-	} else if ovirtRegex.MatchString(jobName) {
+	}
+	if ovirtRegex.MatchString(jobName) {
 		return "ovirt"
-	} else if vsphereUPIRegex.MatchString(jobName) {
+	}
+	if vsphereUPIRegex.MatchString(jobName) {
 		return "vsphere-upi"
-	} else if vsphereRegex.MatchString(jobName) {
+	}
+	if vsphereRegex.MatchString(jobName) {
 		return "vsphere-ipi"
 	}
 
@@ -317,35 +329,40 @@ func determinePlatform(jobName string) string {
 func determineArchitecture(jobName string) string {
 	if arm64Regex.MatchString(jobName) {
 		return "arm64"
-	} else if ppc64leRegex.MatchString(jobName) {
-		return "ppc64le"
-	} else if s390xRegex.MatchString(jobName) {
-		return "s390x"
-	} else if multiRegex.MatchString(jobName) {
-		return "heterogeneous"
-	} else {
-		return "amd64"
 	}
+	if ppc64leRegex.MatchString(jobName) {
+		return "ppc64le"
+	}
+	if s390xRegex.MatchString(jobName) {
+		return "s390x"
+	}
+	if multiRegex.MatchString(jobName) {
+		return "heterogeneous"
+	}
+
+	return "amd64"
 }
 
 func determineNetwork(jobName, release string) string {
 	if ovnRegex.MatchString(jobName) {
 		return "ovn"
-	} else if sdnRegex.MatchString(jobName) {
-		return "sdn"
-	} else {
-		// If no explicit version, guess based on release
-		ovnBecomesDefault, _ := version.NewVersion("4.12")
-		releaseVersion, err := version.NewVersion(release)
-		if err != nil {
-			log.Warningf("could not determine network type for %q", jobName)
-			return ""
-		} else if releaseVersion.GreaterThanOrEqual(ovnBecomesDefault) {
-			return "ovn"
-		} else {
-			return "sdn"
-		}
 	}
+	if sdnRegex.MatchString(jobName) {
+		return "sdn"
+	}
+
+	// If no explicit version, guess based on release
+	ovnBecomesDefault, _ := version.NewVersion("4.12")
+	releaseVersion, err := version.NewVersion(release)
+	if err != nil {
+		log.Warningf("could not determine network type for %q", jobName)
+		return ""
+	}
+	if releaseVersion.GreaterThanOrEqual(ovnBecomesDefault) {
+		return "ovn"
+	}
+
+	return "sdn"
 }
 
 func (openshiftVariants) IsJobNeverStable(jobName string) bool {


### PR DESCRIPTION
Mostly gocritic ifelse -> switch changes as well as removing explicit check enablement for defaults.

```
level=warning msg="[linters_context] gocritic: no need to enable check \"argOrder\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"badCond\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"caseOrder\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"codegenComment\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"deprecatedComment\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"dupArg\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"dupBranchBody\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"dupCase\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"dupSubExpr\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"exitAfterDefer\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"flagDeref\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"flagName\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"offBy1\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"assignOp\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"captLocal\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"commentFormatting\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"defaultCaseOrder\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"elseif\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"regexpMust\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"singleCaseSwitch\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"sloppyLen\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"switchTrue\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"typeSwitchVar\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"underef\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"unlambda\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"unslice\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"valSwap\": it's already enabled"
level=warning msg="[linters_context] gocritic: no need to enable check \"wrapperFunc\": it's already enabled"
```