### PR TITLE
trt-1604: handled undefined tests bugs query

### DIFF
--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"gorm.io/gorm"
+
 	"cloud.google.com/go/storage"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -513,6 +515,10 @@ func (s *Server) jsonTestBugsFromDB(w http.ResponseWriter, req *http.Request) {
 
 	bugs, err := query.LoadBugsForTest(s.db, testName, false)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			api.RespondWithJSON(http.StatusOK, w, []models.Bug{})
+			return
+		}
 		log.WithError(err).Error("error querying test bugs from db")
 		api.RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{
 			"code":    http.StatusInternalServerError,


### PR DESCRIPTION
Attempts to fix error for [Issues](https://sippy.dptools.openshift.org/sippy-ng/jobs/4.16/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-master-nightly-4.16-metal-ovn-single-node-recert-cluster-rename%22%7D%5D%7D) not loading on Job Analysis page

```
time="2024-05-02T11:18:12.51Z" level=error msg="error querying test bugs from db" error="record not found"
time="2024-05-02T11:18:12.51Z" level=info msg="responded to request" elapsed=25.86793ms method=GET uri="/api/tests/bugs?test=undefined"
```