### PR TITLE
trt-1555: Support keeping only common job runs for all test ids

### DIFF
--- a/hack/.gitignore
+++ b/hack/.gitignore
@@ -1,0 +1,2 @@
+*.json
+gen-resolved-issue

--- a/hack/gen-resolved-issue.md
+++ b/hack/gen-resolved-issue.md
@@ -13,6 +13,56 @@ Install dependencies:
 pip3 install -r requirements.txt
 ```
 
+
+# Overview
+
+## Group Incident ID
+--assign-incident-group-id: Assign the specified incident-group-id common among records.  Used when updating an existing incident-group-id and you want to add to the existing group.  When omitted a new incident-group-id will automatically be created.
+
+## Issue description, type and URL
+--issue-description: A short description of the regression
+
+--issue-type: The type of regression ['Infrastructure', 'Product']   
+
+--issue-url: The URL (JIRA / PR) associated with the regression
+
+## If there is a specific time window to consider for JobRunStartTimes specify the min and max and any runs outside that window will be ignored
+--job-run-start-time-max: The latest date time to consider a failed job run for an incident
+
+--job-run-start-time-min: The latest date time to consider a failed job run for an incident
+
+## If the JSON file specified in --input-file is complete and you don't need to use the --test-report-url to look up JobRuns, etc. set this flag to true
+--load-incidents-from-file: Skip test report lookup and persist incidents from the specified input file, only valid with output-type DB ['True', 'False'], default=False
+
+## If you expect an existing incident to exist but it hasn't been updated within the last two weeks you can specify a target modified time for the match incident search range to use
+--target-modified-time: The target date to query for existing record (range: target-2weeks - target)
+
+## Specify the single test id to match, or use an input file for multiple tests
+--test-id: The internal id of the test
+
+## The release this incident is against
+--test-release: "The release the test is running against.
+
+## The api url from component readiness dev tools network console that contains regression results for the test(s) specified 
+--test-report-url: The component readiness api url for the test regression.
+
+## Match All Job Runs
+--match-all-job-runs: Only the job runs common to all of the test ids will be preserved.  If there is a test id / variant match that does not contain common runs then all results will be dropped.  Only valid with output-type == JSON. ['True' 'False'], default=False
+
+## A JSON structured file, potentially output by this tool, to be used as input for matching tests creating records
+--input-file: JSON input file containing test criteria for creating incidents.
+
+## The output file to write JSON output too    
+--output-file: Write JSON output to the specified file instead of DB.
+
+## Write JSON output or persist to DB    
+--output-type: Write the incident record(s) as JSON or as DB record ['JSON', 'DB'], default='JSON'
+When the output type is DB 'GOOGLE_APPLICATION_CREDENTIALS' environment variable must be specified.
+
+## Capture just the test information for output
+--output-test-info-only: When the incident record is JSON you can record only the test info and not job_runs, must be specified on the command line ['True', 'False'] default=False
+
+
 # Examples
 
 ## Example Input file with a list of TestIds to match
@@ -37,7 +87,7 @@ pip3 install -r requirements.txt
         { "TestId": "openshift-tests-upgrade:44e2e0e6106443fef746afb65a3aaa9f"},
         { "TestId": "openshift-tests-upgrade:fbe6ebd6d5f577a21de3de9504ca242a"},
         { "TestId": "openshift-tests-upgrade:a7bca0ce3787e8bd213b32795d81bb50"},
-        { "TestId": "openshift-tests-upgrade:c2f88e80fa2064a98711768d5a679735"}
+        { "TestId": "openshift-tests-upgrade:c2f88e80fa2064a98711768d5a679735"} 
     ]
 }
 ```
@@ -48,9 +98,9 @@ pip3 install -r requirements.txt
 
 Review `test_cno_pods_output.json`, remove the OutputType or change it to DB
 
-Run the command to persist the entries to DB
+Run the command to persist the entries to DB (make sure GOOGLE_APPLICATION_CREDENTIALS is defined)
 ```
-./gen-resolved-issue.py --input-file=test_cno_pods_output.json --output-type=DB --load-incidents-from-file
+./gen-resolved-issue.py --input-file=test_cno_pods_output.json --output-type=DB --load-incidents-from-file=True
 ```
 
 
@@ -77,7 +127,6 @@ Start with a wildcard for the TestId and a minimal list of Variants
                     "value": "metal-ipi"
                 }
             ]
-
         }
     ]
 }

--- a/hack/gen-resolved-issue.md
+++ b/hack/gen-resolved-issue.md
@@ -1,3 +1,18 @@
+# Installation
+
+Optional virtual environment:
+
+```
+$ virtualenv gen-resolved-issue
+$ source gen-resolved-issue/bin/activate
+```
+
+Install dependencies:
+
+```
+pip3 install -r requirements.txt
+```
+
 # Examples
 
 ## Example Input file with a list of TestIds to match
@@ -22,7 +37,7 @@
         { "TestId": "openshift-tests-upgrade:44e2e0e6106443fef746afb65a3aaa9f"},
         { "TestId": "openshift-tests-upgrade:fbe6ebd6d5f577a21de3de9504ca242a"},
         { "TestId": "openshift-tests-upgrade:a7bca0ce3787e8bd213b32795d81bb50"},
-        { "TestId": "openshift-tests-upgrade:c2f88e80fa2064a98711768d5a679735"}        
+        { "TestId": "openshift-tests-upgrade:c2f88e80fa2064a98711768d5a679735"}
     ]
 }
 ```
@@ -62,7 +77,7 @@ Start with a wildcard for the TestId and a minimal list of Variants
                     "value": "metal-ipi"
                 }
             ]
-               
+
         }
     ]
 }

--- a/hack/requirements.txt
+++ b/hack/requirements.txt
@@ -1,0 +1,2 @@
+requests
+google-cloud-bigquery

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -4,6 +4,7 @@ import {
   Button,
   Grid,
   Paper,
+  Popover,
   TableContainer,
   Typography,
 } from '@mui/material'
@@ -19,7 +20,7 @@ import {
 } from './CompReadyUtils'
 import { ComponentReadinessStyleContext } from './ComponentReadiness'
 import { CompReadyVarsContext } from './CompReadyVars'
-import { Help } from '@mui/icons-material'
+import { FileCopy, Help, InsertLink } from '@mui/icons-material'
 import { Link } from 'react-router-dom'
 import { ReleasesContext } from '../App'
 import { safeEncodeURIComponent } from '../helpers'
@@ -73,6 +74,27 @@ export default function CompReadyTestReport(props) {
   const safeTestId = safeEncodeURIComponent(testId)
 
   const { expandEnvironment } = useContext(CompReadyVarsContext)
+
+  // Helpers for copying the test ID to clipboard
+  const [copyPopoverEl, setCopyPopoverEl] = React.useState(null)
+  const copyPopoverOpen = Boolean(copyPopoverEl)
+  const copyTestID = (event) => {
+    event.preventDefault()
+    navigator.clipboard.writeText(testId)
+    setCopyPopoverEl(event.currentTarget)
+    setTimeout(() => setCopyPopoverEl(null), 2000)
+  }
+
+  const handleCopy = async (event) => {
+    try {
+      await navigator.clipboard.writeText(testId)
+      setAnchorEl(event.currentTarget)
+      setTimeout(() => setAnchorEl(null), 1500) // Close popover after 1.5 seconds
+    } catch (err) {
+      setAnchorEl(event.currentTarget)
+      setTimeout(() => setAnchorEl(null), 1500) // Close popover after 1.5 seconds
+    }
+  }
 
   const apiCallStr =
     getTestDetailsAPIUrl() +
@@ -403,7 +425,18 @@ View the test details report at ${document.location.href}
         <TableBody>
           <TableRow>
             <TableCell>Test ID:</TableCell>
-            <TableCell>{testId}</TableCell>
+            <TableCell>
+              {testId}
+              <IconButton
+                aria-label="Copy test ID"
+                color="inherit"
+                onClick={copyTestID}
+              >
+                <Tooltip title="Copy test ID">
+                  <FileCopy />
+                </Tooltip>
+              </IconButton>
+            </TableCell>
           </TableRow>
           <TableRow>
             <TableCell>Environment:</TableCell>
@@ -503,6 +536,22 @@ View the test details report at ${document.location.href}
           </TableBody>
         </Table>
       </TableContainer>
+      <Popover
+        id="copyPopover"
+        open={copyPopoverOpen}
+        anchorEl={copyPopoverEl}
+        onClose={() => setCopyPopoverEl(null)}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+      >
+        ID copied!
+      </Popover>
       <GeneratedAt time={data.generated_at} />
     </Fragment>
   )

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -1,11 +1,13 @@
-import { Button, Grid, Tooltip, Typography } from '@mui/material'
+import { Button, Grid, Popover, Tooltip, Typography } from '@mui/material'
 import { CompReadyVarsContext } from './CompReadyVars'
 import { DataGrid, GridToolbar } from '@mui/x-data-grid'
+import { FileCopy } from '@mui/icons-material'
 import { formColumnName, sortQueryParams } from './CompReadyUtils'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
 import CompSeverityIcon from './CompSeverityIcon'
 import Dialog from '@mui/material/Dialog'
+import IconButton from '@mui/material/IconButton'
 import PropTypes from 'prop-types'
 import React, { Fragment, useContext } from 'react'
 
@@ -63,6 +65,16 @@ export default function RegressedTestsModal(props) {
     { field: 'component', sort: 'asc' },
   ])
 
+  // Helpers for copying the test ID to clipboard
+  const [copyPopoverEl, setCopyPopoverEl] = React.useState(null)
+  const copyPopoverOpen = Boolean(copyPopoverEl)
+  const copyTestID = (event, testId) => {
+    event.preventDefault()
+    navigator.clipboard.writeText(testId)
+    setCopyPopoverEl(event.currentTarget)
+    setTimeout(() => setCopyPopoverEl(null), 2000)
+  }
+
   // define table columns
   const columns = [
     {
@@ -118,6 +130,26 @@ export default function RegressedTestsModal(props) {
       headerName: 'Variant',
       flex: 10,
       renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'test_id',
+      flex: 5,
+      headerName: 'ID',
+      renderCell: (params) => {
+        return (
+          <IconButton
+            onClick={(event) => copyTestID(event, params.value)}
+            size="small"
+            aria-label="Copy test ID"
+            color="inherit"
+            sx={{ marginBottom: 1 }}
+          >
+            <Tooltip title="Copy test ID">
+              <FileCopy color="primary" />
+            </Tooltip>
+          </IconButton>
+        )
+      },
     },
     {
       field: 'status',
@@ -202,6 +234,22 @@ export default function RegressedTestsModal(props) {
             CLOSE
           </Button>
         </Grid>
+        <Popover
+          id="copyPopover"
+          open={copyPopoverOpen}
+          anchorEl={copyPopoverEl}
+          onClose={() => setCopyPopoverEl(null)}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'center',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
+          }}
+        >
+          ID copied!
+        </Popover>
       </Dialog>
     </Fragment>
   )


### PR DESCRIPTION
* Removes 'OutputType' from JSON output since JSON is the default and persisting it requires manual step to remove when writing to DB.
* Updates [gen-resolved-issue.md](https://github.com/neisw/sippy/blob/0231b877cdd42b4165390e838785dcdf256bb8ed/hack/gen-resolved-issue.md) to document the input argument options
* Adds --match-all-job-runs to drop job runs from the incident records that don't contain all of the  specified test ids
** Likely needs more work to not drop everything when a testid / variant doesn't have any common job runs which will currently drop all job runs.