### PR TITLE
TRT-1661: Add link to title pages to help triage

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilities.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilities.js
@@ -20,6 +20,7 @@ import ComponentReadinessToolBar from './ComponentReadinessToolBar'
 import CompReadyCancelled from './CompReadyCancelled'
 import CompReadyPageTitle from './CompReadyPageTitle'
 import CompReadyProgress from './CompReadyProgress'
+import CopyPageURL from './CopyPageURL'
 import GeneratedAt from './GeneratedAt'
 import PropTypes from 'prop-types'
 import React, { Fragment, useContext, useEffect, useState } from 'react'
@@ -288,6 +289,7 @@ export default function CompReadyEnvCapabilities(props) {
         </Table>
       </TableContainer>
       <GeneratedAt time={data.generated_at} />
+      <CopyPageURL apiCallStr={apiCallStr} />
     </Fragment>
   )
 }

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapability.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapability.js
@@ -20,6 +20,7 @@ import CompReadyCancelled from './CompReadyCancelled'
 import CompReadyPageTitle from './CompReadyPageTitle'
 import CompReadyProgress from './CompReadyProgress'
 import CompTestRow from './CompTestRow'
+import CopyPageURL from './CopyPageURL'
 import GeneratedAt from './GeneratedAt'
 import PropTypes from 'prop-types'
 import React, { Fragment, useContext, useEffect, useState } from 'react'
@@ -291,6 +292,7 @@ export default function CompReadyEnvCapability(props) {
         </Table>
       </TableContainer>
       <GeneratedAt time={data.generated_at} />
+      <CopyPageURL apiCallStr={apiCallStr} />
     </Fragment>
   )
 }

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
@@ -19,6 +19,7 @@ import ComponentReadinessToolBar from './ComponentReadinessToolBar'
 import CompReadyCancelled from './CompReadyCancelled'
 import CompReadyPageTitle from './CompReadyPageTitle'
 import CompReadyProgress from './CompReadyProgress'
+import CopyPageURL from './CopyPageURL'
 import GeneratedAt from './GeneratedAt'
 import PropTypes from 'prop-types'
 import React, { Fragment, useContext, useEffect, useState } from 'react'
@@ -259,6 +260,7 @@ export default function CompReadyEnvCapabilityTest(props) {
         </Table>
       </TableContainer>
       <GeneratedAt time={data.generated_at} />
+      <CopyPageURL apiCallStr={apiCallStr} />
     </Fragment>
   )
 }

--- a/sippy-ng/src/component_readiness/CompReadyPageTitle.js
+++ b/sippy-ng/src/component_readiness/CompReadyPageTitle.js
@@ -12,7 +12,8 @@ export default function CompReadyPageTitle(props) {
 
   return (
     <div>
-      <a href={callStr}>{pageTitle}</a>
+      {pageTitle}
+      {debugMode ? <p>curl -sk &apos;{callStr}&apos;</p> : null}
     </div>
   )
 }

--- a/sippy-ng/src/component_readiness/CompReadyPageTitle.js
+++ b/sippy-ng/src/component_readiness/CompReadyPageTitle.js
@@ -12,8 +12,7 @@ export default function CompReadyPageTitle(props) {
 
   return (
     <div>
-      {pageTitle}
-      {debugMode ? <p>curl -sk &apos;{callStr}&apos;</p> : null}
+      <a href={callStr}>{pageTitle}</a>
     </div>
   )
 }

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -31,6 +31,7 @@ import CompReadyCancelled from './CompReadyCancelled'
 import CompReadyPageTitle from './CompReadyPageTitle'
 import CompReadyProgress from './CompReadyProgress'
 import CompReadyTestDetailRow from './CompReadyTestDetailRow'
+import CopyPageURL from './CopyPageURL'
 import GeneratedAt from './GeneratedAt'
 import IconButton from '@mui/material/IconButton'
 import InfoIcon from '@mui/icons-material/Info'
@@ -553,6 +554,7 @@ View the test details report at ${document.location.href}
         ID copied!
       </Popover>
       <GeneratedAt time={data.generated_at} />
+      <CopyPageURL apiCallStr={apiCallStr} />
     </Fragment>
   )
 }

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -67,6 +67,7 @@ import CompReadyPageTitle from './CompReadyPageTitle'
 import CompReadyProgress from './CompReadyProgress'
 import CompReadyRow from './CompReadyRow'
 import CompReadyTestReport from './CompReadyTestReport'
+import CopyPageURL from './CopyPageURL'
 import GeneratedAt from './GeneratedAt'
 import IconButton from '@mui/material/IconButton'
 import MenuIcon from '@mui/icons-material/Menu'
@@ -840,6 +841,7 @@ export default function ComponentReadiness(props) {
                             </Table>
                           </TableContainer>
                           <GeneratedAt time={data.generated_at} />
+                          <CopyPageURL apiCallStr={showValuesForReport()} />
                         </div>
                       )}
                     </div>

--- a/sippy-ng/src/component_readiness/CopyPageURL.js
+++ b/sippy-ng/src/component_readiness/CopyPageURL.js
@@ -1,19 +1,18 @@
 import { Box, Button, Tooltip, Typography } from '@mui/material'
+import Link from '@mui/material/Link'
 import PropTypes from 'prop-types'
 import React from 'react'
 
 // This is used as a convenient way to capture the page URL for use with
 // the triaging workflow.
 export default function CopyPageURL(props) {
-  const handleCopyClick = () => {
-    navigator.clipboard.writeText(props.apiCallStr)
-  }
-
   return (
     <Box align="right">
       <Typography variant="caption">
         <Tooltip title={props.apiCallStr}>
-          <Button onClick={handleCopyClick}>copy page URL</Button>
+          <Link href={props.apiCallStr} target="_blank">
+            API URL
+          </Link>
         </Tooltip>
       </Typography>
     </Box>

--- a/sippy-ng/src/component_readiness/CopyPageURL.js
+++ b/sippy-ng/src/component_readiness/CopyPageURL.js
@@ -1,0 +1,25 @@
+import { Box, Button, Tooltip, Typography } from '@mui/material'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+// This is used as a convenient way to capture the page URL for use with
+// the triaging workflow.
+export default function CopyPageURL(props) {
+  const handleCopyClick = () => {
+    navigator.clipboard.writeText(props.apiCallStr)
+  }
+
+  return (
+    <Box align="left">
+      <Typography variant="caption">
+        <Tooltip title={props.apiCallStr}>
+          <Button onClick={handleCopyClick}>copy page URL</Button>
+        </Tooltip>
+      </Typography>
+    </Box>
+  )
+}
+
+CopyPageURL.propTypes = {
+  apiCallStr: PropTypes.string,
+}

--- a/sippy-ng/src/component_readiness/CopyPageURL.js
+++ b/sippy-ng/src/component_readiness/CopyPageURL.js
@@ -10,7 +10,7 @@ export default function CopyPageURL(props) {
   }
 
   return (
-    <Box align="left">
+    <Box align="right">
       <Typography variant="caption">
         <Tooltip title={props.apiCallStr}>
           <Button onClick={handleCopyClick}>copy page URL</Button>


### PR DESCRIPTION
This will adds a link in the lower right page to page API URL. This will (hopefully) obviate the need to use the debugging tools to retrieve the link used for the triage workflow.
