### PR TITLE
trt-1668: Clear triage status for Infrastructure

### DIFF
--- a/hack/gen-resolved-issue.py
+++ b/hack/gen-resolved-issue.py
@@ -187,6 +187,7 @@ def write_incident_record (triaged_incident, modified_time, target_modified_time
     variants = triaged_incident["Variants"]
 
     issue_type  = triaged_incident["Issue"]["Type"]
+    issue_url = ""
 
     if "URL" in triaged_incident["Issue"]:
         issue_url   = triaged_incident["Issue"]["URL"]

--- a/pkg/componentreadiness/resolvedissues/types.go
+++ b/pkg/componentreadiness/resolvedissues/types.go
@@ -79,6 +79,10 @@ func KeyForTriagedIssue(testID string, variants []api.TriagedVariant) TriagedIss
 	}
 }
 
+type TriageIssueType string
+
+const TriageIssueTypeInfrastructure TriageIssueType = "Infrastructure"
+
 type Release string
 
 type TriagedIssueKey struct {


### PR DESCRIPTION
Clears triage regression status for Infrastructure issue types.
Lays groundwork to clear issues with resolved date.
Fixes bug in triage script when issue url is not provided.

![image](https://github.com/openshift/sippy/assets/36795216/615feeb1-3f3b-496b-9dc4-28d75739edac)

->

![image](https://github.com/openshift/sippy/assets/36795216/6673dace-e0fa-4fd5-8322-19a6284b8336)


