### PR TITLE
TRT-1667: Track component readiness test regression start/end dates

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -284,7 +284,7 @@ func (c *componentReportGenerator) GenerateReport() (apitype.ComponentReport, []
 	if len(errs) > 0 {
 		return apitype.ComponentReport{}, errs
 	}
-	bqs := tracker.NewBigQueryStorage(c.client.BQ)
+	bqs := tracker.NewBigQueryRegressionStore(c.client.BQ)
 	openRegressions, err := bqs.ListCurrentRegressions(c.SampleRelease.Release)
 	if err != nil {
 		errs = append(errs, err)

--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -1111,10 +1111,7 @@ func getNewCellStatus(testID apitype.ComponentReportTestIdentification,
 			release := openRegressions[0].Release
 			or := tracker.FindOpenRegression(release, rt, openRegressions)
 			if or != nil {
-				rt.RegressionStatus = apitype.ComponentReportRegressionStatus{
-					Status: reportStatus,
-					Opened: &or.Opened,
-				}
+				rt.Opened = &or.Opened
 			}
 		}
 		newCellStatus.regressedTests = append(newCellStatus.regressedTests, rt)
@@ -1129,10 +1126,7 @@ func getNewCellStatus(testID apitype.ComponentReportTestIdentification,
 			release := openRegressions[0].Release
 			or := tracker.FindOpenRegression(release, ti.ComponentReportTestSummary, openRegressions)
 			if or != nil {
-				ti.ComponentReportTestSummary.RegressionStatus = apitype.ComponentReportRegressionStatus{
-					Status: reportStatus,
-					Opened: &or.Opened,
-				}
+				ti.ComponentReportTestSummary.Opened = &or.Opened
 			}
 		}
 		newCellStatus.triagedIncidents = append(newCellStatus.triagedIncidents, ti)

--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -284,7 +284,7 @@ func (c *componentReportGenerator) GenerateReport() (apitype.ComponentReport, []
 	if len(errs) > 0 {
 		return apitype.ComponentReport{}, errs
 	}
-	bqs := tracker.NewBigQueryRegressionStore(c.client.BQ)
+	bqs := tracker.NewBigQueryRegressionStore(c.client)
 	openRegressions, err := bqs.ListCurrentRegressions(c.SampleRelease.Release)
 	if err != nil {
 		errs = append(errs, err)

--- a/pkg/api/component_report_test.go
+++ b/pkg/api/component_report_test.go
@@ -821,7 +821,7 @@ func TestGenerateComponentReport(t *testing.T) {
 	componentAndCapabilityGetter = fakeComponentAndCapabilityGetter
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			report := tc.generator.generateComponentTestReport(tc.baseStatus, tc.sampleStatus)
+			report := tc.generator.generateComponentTestReport(tc.baseStatus, tc.sampleStatus, []apitype.TestRegression{})
 			assert.Equal(t, tc.expectedReport, report, "expected report %+v, got %+v", tc.expectedReport, report)
 		})
 	}

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -915,12 +915,6 @@ type ComponentReportTestIdentification struct {
 
 type ComponentReportTestSummary struct {
 	ComponentReportTestIdentification
-	// Status is an integer status we're trying to get away from in favor of the regression status struct. (TODO)
-	Status           ComponentReportStatus           `json:"status"`
-	RegressionStatus ComponentReportRegressionStatus `json:"regression_status"`
-}
-
-type ComponentReportRegressionStatus struct {
 	// Status is an integer representing the severity of the regression.
 	Status ComponentReportStatus `json:"status"`
 
@@ -929,7 +923,7 @@ type ComponentReportRegressionStatus struct {
 	// the regression with it's *default view* query. However we always include it in the response (if that test
 	// is regressed per the query params used). Eventually we should only include these details if the default view
 	// is being used, without overriding the start/end dates.
-	Opened *time.Time `json:"regressed_since"`
+	Opened *time.Time `json:"opened"`
 }
 
 type ComponentReportTestDetails struct {

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -1107,7 +1107,7 @@ type ComponentReportTriageIncidentSummary struct {
 type TestRegression struct {
 	Release      string                 `bigquery:"release" json:"release"`
 	TestID       string                 `bigquery:"test_id" json:"test_id"`
-	TestName     string                 `bigquery:"test_name" json:"test_name"`
+	TestName     bigquery.NullString    `bigquery:"test_name" json:"test_name"`
 	RegressionID string                 `bigquery:"regression_id" json:"regression_id"`
 	Opened       time.Time              `bigquery:"opened" json:"opened"`
 	Closed       bigquery.NullTimestamp `bigquery:"closed" json:"closed"`

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -1102,9 +1102,22 @@ type ComponentReportTriageIncidentSummary struct {
 	TriagedIncidents []TriagedIncident `json:"incidents"`
 }
 
+// TestRegression is used for rows in the test_regressions table and is used to track when we detect test
+// regressions opening and closing.
+type TestRegression struct {
+	Release      string                 `bigquery:"release" json:"release"`
+	TestID       string                 `bigquery:"test_id" json:"test_id"`
+	TestName     string                 `bigquery:"test_name" json:"test_name"`
+	RegressionID string                 `bigquery:"regression_id" json:"regression_id"`
+	Opened       time.Time              `bigquery:"opened" json:"opened"`
+	Closed       bigquery.NullTimestamp `bigquery:"closed" json:"closed"`
+	Variants     []TriagedVariant       `bigquery:"variants" json:"variants"`
+}
+
 type TriagedIncident struct {
-	Release      string                       `bigquery:"release" json:"release"`
-	TestID       string                       `bigquery:"test_id" json:"test_id"`
+	Release string `bigquery:"release" json:"release"`
+	TestID  string `bigquery:"test_id" json:"test_id"`
+	// TODO: should this be joined in instead of recording? test_name can change for a given test_id
 	TestName     string                       `bigquery:"test_name" json:"test_name"`
 	IncidentID   string                       `bigquery:"incident_id" json:"incident_id"`
 	ModifiedTime time.Time                    `bigquery:"modified_time" json:"modified_time"`

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -1119,13 +1119,13 @@ type ComponentReportTriageIncidentSummary struct {
 // TestRegression is used for rows in the test_regressions table and is used to track when we detect test
 // regressions opening and closing.
 type TestRegression struct {
-	Release      string                 `bigquery:"release" json:"release"`
-	TestID       string                 `bigquery:"test_id" json:"test_id"`
-	TestName     bigquery.NullString    `bigquery:"test_name" json:"test_name"`
-	RegressionID string                 `bigquery:"regression_id" json:"regression_id"`
-	Opened       time.Time              `bigquery:"opened" json:"opened"`
-	Closed       bigquery.NullTimestamp `bigquery:"closed" json:"closed"`
-	Variants     []TriagedVariant       `bigquery:"variants" json:"variants"`
+	Release      string                   `bigquery:"release" json:"release"`
+	TestID       string                   `bigquery:"test_id" json:"test_id"`
+	TestName     string                   `bigquery:"test_name" json:"test_name"`
+	RegressionID string                   `bigquery:"regression_id" json:"regression_id"`
+	Opened       time.Time                `bigquery:"opened" json:"opened"`
+	Closed       bigquery.NullTimestamp   `bigquery:"closed" json:"closed"`
+	Variants     []ComponentReportVariant `bigquery:"variants" json:"variants"`
 }
 
 type TriagedIncident struct {
@@ -1135,7 +1135,7 @@ type TriagedIncident struct {
 	TestName     string                       `bigquery:"test_name" json:"test_name"`
 	IncidentID   string                       `bigquery:"incident_id" json:"incident_id"`
 	ModifiedTime time.Time                    `bigquery:"modified_time" json:"modified_time"`
-	Variants     []TriagedVariant             `bigquery:"variants" json:"variants"`
+	Variants     []ComponentReportVariant     `bigquery:"variants" json:"variants"`
 	Issue        TriagedIncidentIssue         `bigquery:"issue" json:"issue"`
 	JobRuns      []TriageJobRun               `bigquery:"job_runs" json:"job_runs"`
 	Attributions []TriagedIncidentAttribution `bigquery:"attributions" json:"attributions"`
@@ -1154,7 +1154,7 @@ type TriagedIncidentAttribution struct {
 	UpdateTime time.Time `bigquery:"update_time" json:"update_time"`
 }
 
-type TriagedVariant struct {
+type ComponentReportVariant struct {
 	Key   string `bigquery:"key" json:"key"`
 	Value string `bigquery:"value" json:"value"`
 }

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -915,7 +915,21 @@ type ComponentReportTestIdentification struct {
 
 type ComponentReportTestSummary struct {
 	ComponentReportTestIdentification
+	// Status is an integer status we're trying to get away from in favor of the regression status struct. (TODO)
+	Status           ComponentReportStatus           `json:"status"`
+	RegressionStatus ComponentReportRegressionStatus `json:"regression_status"`
+}
+
+type ComponentReportRegressionStatus struct {
+	// Status is an integer representing the severity of the regression.
 	Status ComponentReportStatus `json:"status"`
+
+	// Opened will be set to the time we first recorded this test went regressed.
+	// TODO: This is largely a hack right now, the sippy metrics loop sets this as soon as it notices
+	// the regression with it's *default view* query. However we always include it in the response (if that test
+	// is regressed per the query params used). Eventually we should only include these details if the default view
+	// is being used, without overriding the start/end dates.
+	Opened *time.Time `json:"regressed_since"`
 }
 
 type ComponentReportTestDetails struct {

--- a/pkg/componentreadiness/resolvedissues/types.go
+++ b/pkg/componentreadiness/resolvedissues/types.go
@@ -5,18 +5,16 @@ import (
 	"sort"
 
 	"github.com/openshift/sippy/pkg/util/sets"
+	"github.com/openshift/sippy/pkg/variantregistry"
 
 	"github.com/openshift/sippy/pkg/apis/api"
 )
 
-// sync with https://github.com/openshift/sippy/pull/1531/files#diff-3f72919066e1ec3ae4b037dfc91c09ef6d6eac0488762ef35c5a116f73ff1637R237 eventually
-const variantArchitecture = "Architecture"
-const variantNetwork = "Network"
-const variantPlatform = "Platform"
-const variantUpgrade = "Upgrade"
-const variantVariant = "Variant"
+// VariantVariant is a temporary holdover until we have full variant registry support
+// in component readiness.
+const VariantVariant = "Variant"
 
-var triageMatchVariants = buildTriageMatchVariants([]string{variantArchitecture, variantNetwork, variantPlatform, variantUpgrade, variantVariant})
+var triageMatchVariants = buildTriageMatchVariants([]string{variantregistry.VariantArch, variantregistry.VariantNetwork, variantregistry.VariantPlatform, variantregistry.VariantUpgrade, VariantVariant})
 
 func buildTriageMatchVariants(in []string) sets.String {
 	if in == nil || len(in) < 1 {
@@ -34,19 +32,19 @@ func buildTriageMatchVariants(in []string) sets.String {
 func TransformVariant(variant api.ComponentReportColumnIdentification) []api.TriagedVariant {
 
 	return []api.TriagedVariant{{
-		Key:   variantArchitecture,
+		Key:   variantregistry.VariantArch,
 		Value: variant.Arch,
 	}, {
-		Key:   variantNetwork,
+		Key:   variantregistry.VariantNetwork,
 		Value: variant.Network,
 	}, {
-		Key:   variantPlatform,
+		Key:   variantregistry.VariantPlatform,
 		Value: variant.Platform,
 	}, {
-		Key:   variantUpgrade,
+		Key:   variantregistry.VariantUpgrade,
 		Value: variant.Upgrade,
 	}, {
-		Key:   variantVariant,
+		Key:   VariantVariant,
 		Value: variant.Variant,
 	}}
 }

--- a/pkg/componentreadiness/resolvedissues/types.go
+++ b/pkg/componentreadiness/resolvedissues/types.go
@@ -29,9 +29,9 @@ func buildTriageMatchVariants(in []string) sets.String {
 
 	return set
 }
-func TransformVariant(variant api.ComponentReportColumnIdentification) []api.TriagedVariant {
+func TransformVariant(variant api.ComponentReportColumnIdentification) []api.ComponentReportVariant {
 
-	return []api.TriagedVariant{{
+	return []api.ComponentReportVariant{{
 		Key:   variantregistry.VariantArch,
 		Value: variant.Arch,
 	}, {
@@ -48,9 +48,9 @@ func TransformVariant(variant api.ComponentReportColumnIdentification) []api.Tri
 		Value: variant.Variant,
 	}}
 }
-func KeyForTriagedIssue(testID string, variants []api.TriagedVariant) TriagedIssueKey {
+func KeyForTriagedIssue(testID string, variants []api.ComponentReportVariant) TriagedIssueKey {
 
-	matchVariants := make([]api.TriagedVariant, 0)
+	matchVariants := make([]api.ComponentReportVariant, 0)
 	for _, v := range variants {
 		// currently we ignore variants that aren't in api.ComponentReportColumnIdentification
 		if triageMatchVariants.Has(v.Key) {

--- a/pkg/componentreadiness/tracker/tracker.go
+++ b/pkg/componentreadiness/tracker/tracker.go
@@ -202,6 +202,7 @@ func (rt *RegressionTracker) SyncComponentReport(release string, report *api.Com
 				openReg.Closed = bigquery.NullTimestamp{}
 			}
 			matchedOpenRegressions = append(matchedOpenRegressions, *openReg)
+			rLog.Infof("re-opened existing regression: %+v", openReg)
 		} else {
 			// Open a new regression:
 			newReg, err := rt.backend.OpenRegression(release, regTest)

--- a/pkg/componentreadiness/tracker/tracker.go
+++ b/pkg/componentreadiness/tracker/tracker.go
@@ -197,7 +197,6 @@ func (rt *RegressionTracker) SyncComponentReport(release string, report *api.Com
 					return errors.Wrapf(err, "error re-opening regression: %v", openReg)
 				}
 				rLog.Infof("re-opened existing regression: %+v", openReg)
-				//openReg.Closed = bigquery.NullTimestamp{}
 			} else {
 				rLog.WithFields(log.Fields{
 					"test": regTest.TestName,
@@ -226,7 +225,8 @@ func (rt *RegressionTracker) SyncComponentReport(release string, report *api.Com
 				break
 			}
 		}
-		if !matched {
+		// If we didn't match to an active test regression, and this record isn't already closed, close it.
+		if !matched && !regression.Closed.Valid {
 			rLog.Infof("found a regression no longer appearing in the report which should be closed: %v", regression)
 			err := rt.backend.CloseRegression(regression.RegressionID, now)
 			if err != nil {

--- a/pkg/componentreadiness/tracker/tracker.go
+++ b/pkg/componentreadiness/tracker/tracker.go
@@ -85,10 +85,10 @@ func (bq *BigQueryRegressionStore) OpenRegression(release string, newRegressedTe
 	newRegression := &api.TestRegression{
 		Release:      release,
 		TestID:       newRegressedTest.TestID,
-		TestName:     bigquery.NullString{StringVal: newRegressedTest.TestName, Valid: true},
+		TestName:     newRegressedTest.TestName,
 		RegressionID: id.String(),
 		Opened:       time.Now(),
-		Variants: []api.TriagedVariant{
+		Variants: []api.ComponentReportVariant{
 			{
 				Key:   variantregistry.VariantNetwork,
 				Value: newRegressedTest.Network,

--- a/pkg/componentreadiness/tracker/tracker.go
+++ b/pkg/componentreadiness/tracker/tracker.go
@@ -1,0 +1,255 @@
+package tracker
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/google/uuid"
+	"github.com/openshift/sippy/pkg/apis/api"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/api/iterator"
+)
+
+const (
+	testRegressionsDataSet = "ci_analysis_us"
+	testRegressionsTable   = "test_regressions"
+)
+
+type Storage interface {
+	ListCurrentRegressions(release string) ([]api.TestRegression, error)
+	OpenRegression(release string, newRegressedTest api.ComponentReportTestSummary) (*api.TestRegression, error)
+	CloseRegression(regressionID string, closedAt time.Time) error
+}
+
+// InMemoryRegressionTracker is purely for testing purposes.
+type InMemoryStorage struct{}
+
+// BigQueryStorage is the primary implementation for real world usage, tracking when we detect test
+// regressions opening/closing in the Bigquery test_regressions table.
+type BigQueryStorage struct {
+	client *bigquery.Client
+}
+
+func NewBigQueryStorage(client *bigquery.Client) Storage {
+	return &BigQueryStorage{client: client}
+}
+
+func (bqs *BigQueryStorage) ListCurrentRegressions(release string) ([]api.TestRegression, error) {
+	// TODO: list only open regressions, or possibly in future also those closed within last few days to
+	// detect churn. For now we'll keep it simple and only list open.
+	queryString := fmt.Sprintf("SELECT * FROM %s.%s WHERE release = @SampleRelease AND closed IS NULL",
+		testRegressionsDataSet, testRegressionsTable)
+
+	params := make([]bigquery.QueryParameter, 0)
+	params = append(params, []bigquery.QueryParameter{
+		{
+			Name:  "SampleRelease",
+			Value: release,
+		},
+	}...)
+
+	sampleQuery := bqs.client.Query(queryString)
+	sampleQuery.Parameters = append(sampleQuery.Parameters, params...)
+
+	regressions := make([]api.TestRegression, 0)
+	log.Infof("Fetching current test regressions with:\n%s\nParameters:\n%+v\n",
+		sampleQuery.Q, sampleQuery.Parameters)
+
+	it, err := sampleQuery.Read(context.TODO())
+	if err != nil {
+		log.WithError(err).Error("error querying triaged incidents from bigquery")
+		return regressions, err
+	}
+
+	for {
+		var regression api.TestRegression
+		err := it.Next(&regression)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.WithError(err).Error("error parsing triaged incident from bigquery")
+			return nil, errors.Wrap(err, "error parsing triaged incident from bigquery")
+		}
+		regressions = append(regressions, regression)
+	}
+	return regressions, nil
+
+}
+func (bqs *BigQueryStorage) OpenRegression(release string, newRegressedTest api.ComponentReportTestSummary) (*api.TestRegression, error) {
+	id := uuid.New()
+	newRegression := &api.TestRegression{
+		Release:      release,
+		TestID:       newRegressedTest.TestID,
+		TestName:     newRegressedTest.TestName,
+		RegressionID: id.String(),
+		Opened:       time.Now(),
+		Variants: []api.TriagedVariant{
+			{
+				Key:   "Network",
+				Value: newRegressedTest.Network,
+			},
+			{
+				Key:   "Upgrade",
+				Value: newRegressedTest.Upgrade,
+			},
+			{
+				Key:   "Platform",
+				Value: newRegressedTest.Platform,
+			},
+			{
+				Key:   "Architecture",
+				Value: newRegressedTest.Arch,
+			},
+			{
+				Key:   "Variant",
+				Value: newRegressedTest.Variant,
+			},
+		},
+	}
+	inserter := bqs.client.Dataset(testRegressionsDataSet).Table(testRegressionsTable).Inserter()
+	items := []*api.TestRegression{
+		newRegression,
+	}
+	if err := inserter.Put(context.TODO(), items); err != nil {
+		return nil, err
+	}
+	return newRegression, nil
+
+}
+func (bqs *BigQueryStorage) CloseRegression(regressionID string, closedAt time.Time) error {
+	queryString := fmt.Sprintf("UPDATE %s.%s SET closed = '%s' WHERE regression_id = '%s'",
+		testRegressionsDataSet, testRegressionsTable, closedAt.Format("2006-01-02 15:04:05.999999"), regressionID)
+
+	query := bqs.client.Query(queryString)
+
+	// Execute the query
+	job, err := query.Run(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	// Wait for the query to complete and retrieve the job status
+	status, err := job.Wait(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	if err := status.Err(); err != nil {
+		return err
+	}
+	return nil
+
+}
+
+func NewRegressionTracker(storage Storage) *RegressionTracker {
+	return &RegressionTracker{
+		storage: storage,
+	}
+}
+
+// RegressionTracker is the primary object for managing regression tracking logic.
+type RegressionTracker struct {
+	storage Storage
+}
+
+func (rt *RegressionTracker) SyncComponentReport(release string, report *api.ComponentReport) error {
+	regressions, err := rt.storage.ListCurrentRegressions(release)
+	if err != nil {
+		return err
+	}
+	rLog := log.WithField("func", "SyncComponentReport")
+	rLog.Infof("loaded %d regressions from db", len(regressions))
+
+	matchedOpenRegressions := []api.TestRegression{} // all the matches we found, used to determine what had no match
+	for _, row := range report.Rows {
+		for _, col := range row.Columns {
+			for _, regTest := range col.RegressedTests {
+				if openReg := findOpenRegression(release, regTest, regressions); openReg != nil {
+					rLog.WithFields(log.Fields{
+						"test": regTest.TestName,
+					}).Infof("found open regression: %+v", openReg)
+					//matchedOpenRegressions = append(matchedOpenRegressions, *openReg)
+				} else {
+					// Open a new regression:
+					newReg, err := rt.storage.OpenRegression(release, regTest)
+					if err != nil {
+						rLog.WithError(err).Errorf("error opening new regression for: %+v", regTest)
+						return errors.Wrapf(err, "error opening new regression: %+v", regTest)
+					}
+					rLog.Infof("opened new regression: %+v", newReg)
+				}
+			}
+		}
+	}
+
+	// Now we want to close any open regressions that are not appearing in the latest report:
+	now := time.Now()
+	for _, regression := range regressions {
+		var matched bool
+		for _, m := range matchedOpenRegressions {
+			if reflect.DeepEqual(m, regression) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			rLog.Infof("found a regression no longer appearing in the report which should be closed: %+v", regression)
+			err := rt.storage.CloseRegression(regression.RegressionID, now)
+			if err != nil {
+				rLog.WithError(err).Errorf("error closing regression: %+v", regression)
+				return errors.Wrap(err, "error closing regression")
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func findOpenRegression(release string,
+	regTest api.ComponentReportTestSummary,
+	regressions []api.TestRegression) *api.TestRegression {
+
+	for _, tr := range regressions {
+		if tr.Release != release {
+			continue
+		}
+		// We compare test ID not name, as names can change.
+		if tr.TestID != regTest.TestID {
+			continue
+		}
+		// TODO: needs updating when we're ready for dynamic variants
+		if regTest.Network != findVariant("Network", tr) {
+			continue
+		}
+		if regTest.Upgrade != findVariant("Upgrade", tr) {
+			continue
+		}
+		if regTest.Platform != findVariant("Platform", tr) {
+			continue
+		}
+		if regTest.Variant != findVariant("Variant", tr) {
+			continue
+		}
+		if regTest.Arch != findVariant("Architecture", tr) {
+			continue
+		}
+		// If we made it this far, this appears to be a match:
+		return &tr
+	}
+	return nil
+}
+
+func findVariant(variantName string, testReg api.TestRegression) string {
+	for _, v := range testReg.Variants {
+		if v.Key == variantName {
+			return v.Value
+		}
+	}
+	return ""
+}

--- a/pkg/componentreadiness/tracker/tracker.go
+++ b/pkg/componentreadiness/tracker/tracker.go
@@ -10,6 +10,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/openshift/sippy/pkg/apis/api"
 	sippybigquery "github.com/openshift/sippy/pkg/bigquery"
+	"github.com/openshift/sippy/pkg/componentreadiness/resolvedissues"
+	"github.com/openshift/sippy/pkg/variantregistry"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
@@ -88,23 +90,23 @@ func (bq *BigQueryRegressionStore) OpenRegression(release string, newRegressedTe
 		Opened:       time.Now(),
 		Variants: []api.TriagedVariant{
 			{
-				Key:   "Network",
+				Key:   variantregistry.VariantNetwork,
 				Value: newRegressedTest.Network,
 			},
 			{
-				Key:   "Upgrade",
+				Key:   variantregistry.VariantUpgrade,
 				Value: newRegressedTest.Upgrade,
 			},
 			{
-				Key:   "Platform",
+				Key:   variantregistry.VariantPlatform,
 				Value: newRegressedTest.Platform,
 			},
 			{
-				Key:   "Architecture",
+				Key:   variantregistry.VariantArch,
 				Value: newRegressedTest.Arch,
 			},
 			{
-				Key:   "Variant",
+				Key:   resolvedissues.VariantVariant,
 				Value: newRegressedTest.Variant,
 			},
 		},
@@ -249,19 +251,19 @@ func FindOpenRegression(release string,
 			continue
 		}
 		// TODO: needs updating when we're ready for dynamic variants
-		if regTest.Network != findVariant("Network", tr) {
+		if regTest.Network != findVariant(variantregistry.VariantNetwork, tr) {
 			continue
 		}
-		if regTest.Upgrade != findVariant("Upgrade", tr) {
+		if regTest.Upgrade != findVariant(variantregistry.VariantUpgrade, tr) {
 			continue
 		}
-		if regTest.Platform != findVariant("Platform", tr) {
+		if regTest.Platform != findVariant(variantregistry.VariantPlatform, tr) {
 			continue
 		}
-		if regTest.Variant != findVariant("Variant", tr) {
+		if regTest.Variant != findVariant(resolvedissues.VariantVariant, tr) {
 			continue
 		}
-		if regTest.Arch != findVariant("Architecture", tr) {
+		if regTest.Arch != findVariant(variantregistry.VariantArch, tr) {
 			continue
 		}
 		// If we made it this far, this appears to be a match:

--- a/pkg/componentreadiness/tracker/tracker.go
+++ b/pkg/componentreadiness/tracker/tracker.go
@@ -145,10 +145,8 @@ func (bqs *BigQueryStorage) updateClosed(regressionID, closed string) error {
 		return err
 	}
 
-	if err := status.Err(); err != nil {
-		return err
-	}
-	return nil
+	err = status.Err()
+	return err
 }
 
 func NewRegressionTracker(storage Storage) *RegressionTracker {
@@ -174,9 +172,7 @@ func (rt *RegressionTracker) SyncComponentReport(release string, report *api.Com
 	allRegressedTests := []api.ComponentReportTestSummary{}
 	for _, row := range report.Rows {
 		for _, col := range row.Columns {
-			for _, regTest := range col.RegressedTests {
-				allRegressedTests = append(allRegressedTests, regTest)
-			}
+			allRegressedTests = append(allRegressedTests, col.RegressedTests...)
 			// Once triaged, regressions move to this list, we want to still consider them an open regression until
 			// the report says they're cleared and they disappear fully. Triaged does not imply fixed or no longer
 			// a regression.

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -339,7 +339,7 @@ func refreshComponentReadinessMetrics(client *bqclient.Client, prowURL, gcsBucke
 	// Maintain the test regressions table for anything new or now no longer appearing:
 	// TODO: do we need to protect this somehow so it doesn't run on multiple developer machines? They should all
 	// be trying to apply the same updates resulting just in more rapid feedback in the table.
-	regressionTracker := tracker.NewRegressionTracker(tracker.NewBigQueryRegressionStore(client.BQ))
+	regressionTracker := tracker.NewRegressionTracker(tracker.NewBigQueryRegressionStore(client))
 	err = regressionTracker.SyncComponentReport(sampleRelease.Release, &report)
 	if err != nil {
 		return errors.Wrap(err, "regression tracker reported an error")

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -339,7 +339,7 @@ func refreshComponentReadinessMetrics(client *bqclient.Client, prowURL, gcsBucke
 	// Maintain the test regressions table for anything new or now no longer appearing:
 	// TODO: do we need to protect this somehow so it doesn't run on multiple developer machines? They should all
 	// be trying to apply the same updates resulting just in more rapid feedback in the table.
-	regressionTracker := tracker.NewRegressionTracker(tracker.NewBigQueryStorage(client.BQ))
+	regressionTracker := tracker.NewRegressionTracker(tracker.NewBigQueryRegressionStore(client.BQ))
 	err = regressionTracker.SyncComponentReport(sampleRelease.Release, &report)
 	if err != nil {
 		return errors.Wrap(err, "regression tracker reported an error")

--- a/sippy-ng/src/component_readiness/ComponentReadiness.css
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.css
@@ -1,7 +1,7 @@
 .cr-report-button {
-    display: flex;
-    justify-content: center;
-    margin-bottom: 20px;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
 }
 
 .cr-table-wrapper {
@@ -22,7 +22,7 @@
 .cr-comp-read-table {
   width: auto !important;
   margin-top: 0.5em;
-  border: 1px solid #EEE;
+  border: 1px solid #eee;
   table-layout: fixed;
 }
 

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -135,7 +135,6 @@ export default function RegressedTestsModal(props) {
       field: 'opened',
       headerName: 'Regressed Since',
       flex: 15,
-      valueGetter: (params) => params.row.regression_status.regressed_since,
       valueGetter: (params) => {
         const regressedSinceDate = new Date(
           params.row.regression_status.regressed_since

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -137,13 +137,11 @@ export default function RegressedTestsModal(props) {
       headerName: 'Regressed Since',
       flex: 15,
       valueGetter: (params) => {
-        if (!params.row.regression_status.regressed_since) {
+        if (!params.row.opened) {
           // For a regression we haven't yet detected:
           return ''
         }
-        const regressedSinceDate = new Date(
-          params.row.regression_status.regressed_since
-        )
+        const regressedSinceDate = new Date(params.row.opened)
         return relativeTime(regressedSinceDate, new Date())
       },
       renderCell: (param) => (

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -4,6 +4,7 @@ import { DataGrid, GridToolbar } from '@mui/x-data-grid'
 import { FileCopy } from '@mui/icons-material'
 import { formColumnName, sortQueryParams } from './CompReadyUtils'
 import { Link } from 'react-router-dom'
+import { relativeTime } from '../helpers'
 import { safeEncodeURIComponent } from '../helpers'
 import CompSeverityIcon from './CompSeverityIcon'
 import Dialog from '@mui/material/Dialog'
@@ -136,21 +137,14 @@ export default function RegressedTestsModal(props) {
       headerName: 'Regressed Since',
       flex: 15,
       valueGetter: (params) => {
+        if (!params.row.regression_status.regressed_since) {
+          // For a regression we haven't yet detected:
+          return ''
+        }
         const regressedSinceDate = new Date(
           params.row.regression_status.regressed_since
         )
-        const formattedRegressedSince = regressedSinceDate.toLocaleString(
-          'en-US',
-          {
-            year: 'numeric',
-            month: '2-digit',
-            day: '2-digit',
-            hour: '2-digit',
-            minute: '2-digit',
-          }
-        )
-
-        return formattedRegressedSince
+        return relativeTime(regressedSinceDate, new Date())
       },
       renderCell: (param) => (
         <Tooltip title="WARNING: This is the first time we detected this test regressed in the default query. This value is not relevant if you've altered query parameters from the default.">

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -132,6 +132,34 @@ export default function RegressedTestsModal(props) {
       renderCell: (param) => <div className="test-name">{param.value}</div>,
     },
     {
+      field: 'opened',
+      headerName: 'Regressed Since',
+      flex: 15,
+      valueGetter: (params) => params.row.regression_status.regressed_since,
+      valueGetter: (params) => {
+        const regressedSinceDate = new Date(
+          params.row.regression_status.regressed_since
+        )
+        const formattedRegressedSince = regressedSinceDate.toLocaleString(
+          'en-US',
+          {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+          }
+        )
+
+        return formattedRegressedSince
+      },
+      renderCell: (param) => (
+        <Tooltip title="WARNING: This is the first time we detected this test regressed in the default query. This value is not relevant if you've altered query parameters from the default.">
+          <div className="regressed-since">{param.value}</div>
+        </Tooltip>
+      ),
+    },
+    {
       field: 'test_id',
       flex: 5,
       headerName: 'ID',
@@ -186,7 +214,7 @@ export default function RegressedTestsModal(props) {
     <Fragment>
       <Dialog
         fullWidth={true}
-        maxWidth="xl"
+        maxWidth={false}
         open={props.isOpen}
         onClose={props.close}
       >

--- a/sippy-ng/src/index.css
+++ b/sippy-ng/src/index.css
@@ -2,7 +2,10 @@ a {
   text-decoration: none;
 }
 
-a:link, a:active, a:hover, a:visited {
+a:link,
+a:active,
+a:hover,
+a:visited {
   color: inherit;
 }
 

--- a/sippy-ng/src/pull_requests/PullRequestsTable.css
+++ b/sippy-ng/src/pull_requests/PullRequestsTable.css
@@ -1,12 +1,11 @@
 .pr-title {
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 4;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
 
-    line-height: normal;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: break-spaces;
-    word-wrap: break-word;
+  line-height: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: break-spaces;
+  word-wrap: break-word;
 }
-

--- a/sippy-ng/src/releases/PayloadTestFailures.css
+++ b/sippy-ng/src/releases/PayloadTestFailures.css
@@ -1,11 +1,11 @@
 .clamped {
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 20;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 20;
 
-    line-height: normal;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: break-spaces;
-    word-wrap: break-word;
+  line-height: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: break-spaces;
+  word-wrap: break-word;
 }


### PR DESCRIPTION
Sippy's metrics loop which queries the default component readiness report already, now uses this data to maintain a new test_regressions table in bigquery tracking when a test first went regressed, and when it resolved. The opened date is now returned in a new sub-struct on the test summary for regressed/triaged tests, and displayed in the test modal.

Because params can change, the goal here is to specifically track when a test regressed *in the default report*. For simplicity now however, regardless of your parameters, we'll include that opened date in the response provided the test was still regressed in that report. In future, we may only include this value if you're using the "default" server side view.

The code attempts to re-use recent regressions, within the last two days, to limit flapping on regressions that are appearing/disappearing depending on borderline results available.

The opened/closed dates are approximate, depending on when the metrics loop runs and picks up the newest data.
