### PR TITLE
trt-1668: Add triage start time buffer

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -1329,6 +1329,11 @@ func triagedIssuesFor(releaseIncidents *resolvedissues.TriagedIncidentsForReleas
 
 			if impactedJobRun.StartTime.After(startTime) && impactedJobRun.StartTime.Before(endTime) {
 				numJobRunsToSuppress++
+			} else if startTime.Sub(impactedJobRun.StartTime) < (6 * time.Hour) {
+				// query uses modified time, we track start time
+				// could also consider tracking EndTime which would be closer to modified time
+				// but more work
+				numJobRunsToSuppress++
 			}
 		}
 	}


### PR DESCRIPTION
Sample query uses modified time.  Triage job runs track start time.  Short term fix is to add a 6 hour buffer for triage job runs that are about to fall off but we still want to consider.