### PR TITLE
trt-1668: Add support for issue-resolution-date

### DIFF
--- a/hack/gen-resolved-issue.md
+++ b/hack/gen-resolved-issue.md
@@ -26,6 +26,8 @@ pip3 install -r requirements.txt
 
 --issue-url: The URL (JIRA / PR) associated with the regression
 
+--issue-resolution-date: The date when the issue was fixed and no longer causing test regressions, this will clear the triaged regression icon if it is within the sample range
+
 ## If there is a specific time window to consider for JobRunStartTimes specify the min and max and any runs outside that window will be ignored
 --job-run-start-time-max: The latest date time to consider a failed job run for an incident
 

--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -1477,13 +1477,11 @@ func (c *componentReportGenerator) generateComponentTestReport(baseStatus map[ap
 				canClearReportStatus := true
 				for _, ti := range triagedIncidents {
 					if ti.Issue.Type != string(resolvedissues.TriageIssueTypeInfrastructure) {
-						// TODO: add check for missing ti.Issue.ResolutionDate
-						// once we stop setting ResolutionDate automatically
-						// we don't have to clear this flag for non Infrastructure types
-						// that have a ResolutionDate
-						// if !ti.Issue.ResolutionDate.Valid {
-						canClearReportStatus = false
-						// }
+						// if a non Infrastructure regression isn't marked resolved or the resolution date is after the end of our sample query
+						// then we won't clear it.  Otherwise, we can.
+						if !ti.Issue.ResolutionDate.Valid || ti.Issue.ResolutionDate.Timestamp.After(c.SampleRelease.End) {
+							canClearReportStatus = false
+						}
 					}
 				}
 


### PR DESCRIPTION
Adds support for --issue-resolution-date, when a resolution date is set and it is within the sample window the triage icon will be replaced with the NotSignificant icon.

The triage script has been updated to not automatically set a resolution date.  If not specified the incident will be left open and the triage icon will be shown.