### PR TITLE
TRT-1649: Exclude bugs in resolved state from open count

### DIFF
--- a/pkg/db/functions.go
+++ b/pkg/db/functions.go
@@ -116,7 +116,7 @@ results AS (
                                 AND prow_jobs.release = $1
                 AND timestamp BETWEEN $2 AND $4
    		LEFT JOIN bug_jobs on prow_jobs.id = bug_jobs.prow_job_id
-        LEFT JOIN bugs on bugs.id = bug_jobs.bug_id AND lower(bugs.status) != 'closed'
+        LEFT JOIN bugs on bugs.id = bug_jobs.bug_id AND lower(bugs.status) NOT IN ('verified', 'modified', 'closed', 'on_qa')
         group by prow_jobs.name, prow_jobs.variants
 ),
 last_pass AS (


### PR DESCRIPTION
We consider Verified, ON_QA, MODIFIED, and Closed to be terminal states from TRT's perspective.  Once a fix is merged we don't want to silence alerts anymore, or consider that bug in the open count.