### PR TITLE
Honor job name over cluster-data.json for Topology

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -220,6 +220,10 @@ func (v *OCPVariantLoader) CalculateVariantsForJob(jLog logrus.FieldLogger, jobN
 				// amd64 as it's read from a single node.
 				jLog.Infof("variant mismatch: using %s from job name", k)
 				continue
+			case VariantTopology:
+				// Topology mismatches on Compact as the job cluster data reports ha.
+				jLog.Infof("variant mismatch: using %s from job name", k)
+				continue
 			default:
 				jLog.Infof("variant mismatch: using %s from job run variants file", k)
 				variants[k] = v


### PR DESCRIPTION
Compact jobs were among the few mismatching here, as in-cluster they report ha which was skewing our data. The remaining mismatches don't look particularly critical to address but we can still examine logs if someone wants to go hunting.
