### PR TITLE
DO NOT MERGE: Just test e2e

### DIFF
--- a/e2e-scripts/sippy-e2e-sippy-e2e-test-commands.sh
+++ b/e2e-scripts/sippy-e2e-sippy-e2e-test-commands.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# test
 set -x
 
 function cleanup() {


### PR DESCRIPTION
The `technical-release-team/sippy-bigquery-job-importer` credential was modified to use the same one as the friday disruption data PR (which is read-only).