### PR TITLE
Fix concurrent map write bug in Sippy

### DIFF
--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -920,8 +921,10 @@ func (s *Server) jsonTestDetailsReportFromDB(w http.ResponseWriter, req *http.Re
 }
 
 func (s *Server) jsonReleasesReportFromDB(w http.ResponseWriter, _ *http.Request) {
+	gaDateMap := make(map[string]time.Time)
+	maps.Copy(gaDateMap, releaseloader.GADateMap)
 	response := apitype.Releases{
-		GADates: releaseloader.GADateMap,
+		GADates: gaDateMap,
 	}
 	releases, err := api.GetReleases(s.db, s.bigQueryClient)
 	if err != nil {


### PR DESCRIPTION
Sippy in some cases can panic when the /api/releases API is called more than once before it's cached.  This is because the API response's GA dates is a global.  The API should make a copy of it before modifying it.

```
fatal error: concurrent map writes

goroutine 191 [running]:
github.com/openshift/sippy/pkg/sippyserver.(*Server).jsonReleasesReportFromDB(0x140001420e0, {0x102abbf38, 0x140006440e0}, 0x140004d78f8?)
	/Users/stbenjam/go/src/github.com/openshift/sippy/pkg/sippyserver/server.go:939 +0x28c
net/http.HandlerFunc.ServeHTTP(0x140004d7938?, {0x102abbf38?, 0x140006440e0?}, 0x11f91d150?)
	/opt/homebrew/Cellar/go/1.21.4/libexec/src/net/http/server.go:2136 +0x38
[...]
```

You can pretty reliably force the panic by doing something like this on a local Sippy instance *without* Redis:

```bash
$ for i in {1..100}; do curl http://localhost:8080/api/releases & done; wait
```

After this fix it won't panic anymore.
