### PR TITLE
ignore no display disruption intervals

### DIFF
--- a/sippy-ng/src/prow_job_runs/ProwJobRun.js
+++ b/sippy-ng/src/prow_job_runs/ProwJobRun.js
@@ -551,7 +551,7 @@ ProwJobRun.defaultProps = {
     'NodeState',
   ],
   intervalFile: '',
-  overrideDisplayFlag: false,
+  overrideDisplayFlag: true,
 }
 
 ProwJobRun.propTypes = {

--- a/sippy-ng/src/prow_job_runs/ProwJobRun.js
+++ b/sippy-ng/src/prow_job_runs/ProwJobRun.js
@@ -584,6 +584,11 @@ function filterIntervals(
     if (!overrideDisplayFlag && !eventInterval.display) {
       return shouldInclude
     }
+    // Hack for Disruption intervals, we don't ever want to show those without the display flag, they should have been
+    // separated on source.
+    if (eventInterval.source === 'Disruption' && !eventInterval.display) {
+      return shouldInclude
+    }
     if (re) {
       if (
         re.test(eventInterval.displayMessage) ||


### PR DESCRIPTION
    Ignore disruption intervals without the display flag.
    
    Small hack to work around problems moving towards a UI that only shows
    intervals if the code generating them said they were meant for user
    display, which is not presently in all releases we're using. As such,
    overriding the display flag right now is very useful for 4.16, but this
    includes some disruption intervals we should never be showing. I should
    have separated them on Source, but again, hard to get that to all active
    releases.
    
    For now, have the UI never display those so the "override display flag"
    works well on 4.16.
