### PR TITLE
updated to handle new information in variant names

### DIFF
--- a/sippy-ng/src/components/MiniCard.js
+++ b/sippy-ng/src/components/MiniCard.js
@@ -2,12 +2,13 @@ import {
   Box,
   Card,
   CardContent,
+  CardHeader,
   Grid,
   Tooltip,
-  Typography,
 } from '@mui/material'
 import { Link } from 'react-router-dom'
 import { makeStyles, useTheme } from '@mui/styles'
+import { parseVariantName } from '../helpers'
 import { scale } from 'chroma-js'
 import PassRateIcon from './PassRateIcon'
 import PropTypes from 'prop-types'
@@ -41,6 +42,8 @@ export default function MiniCard(props) {
     bgColor = theme.palette.text.disabled
   }
 
+  let variantInfo = parseVariantName(props.name)
+
   const summary = (
     <Fragment>
       <div align="center">
@@ -57,11 +60,11 @@ export default function MiniCard(props) {
       className={`${classes.miniCard}`}
       sx={{ backgroundColor: bgColor }}
     >
+      <CardHeader title={variantInfo.name} subheader={variantInfo.variant} />
       <CardContent
         className={`${classes.cardContent}`}
         sx={{ textAlign: 'center' }}
       >
-        <Typography variant="h6">{props.name}</Typography>
         <Grid
           container
           direction="row"

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -322,3 +322,16 @@ export function getUrlWithoutParams(params) {
   params.forEach((param) => url.searchParams.delete(param))
   return url.href
 }
+
+export function parseVariantName(variantName) {
+  let name = variantName
+  let variant = ''
+  if (variantName.split(':').length > 1) {
+    name = variantName.split(':')[1]
+    variant = variantName.split(':')[0]
+  }
+  return {
+    name,
+    variant,
+  }
+}

--- a/sippy-ng/src/tests/TestByVariantTable.css
+++ b/sippy-ng/src/tests/TestByVariantTable.css
@@ -38,9 +38,11 @@
   opacity: 1;
   border-left: 1px solid black;
   border-right: 1px solid black;
-  width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100vh;
   min-width: 100px;
-  max-width: 100px;
+  max-width: 170px;
 }
 
 .col-result-full {

--- a/sippy-ng/src/tests/TestByVariantTable.js
+++ b/sippy-ng/src/tests/TestByVariantTable.js
@@ -1,6 +1,6 @@
 import './TestByVariantTable.css'
 import { Link } from 'react-router-dom'
-import { pathForExactTestAnalysis } from '../helpers'
+import { parseVariantName, pathForExactTestAnalysis } from '../helpers'
 import { scale } from 'chroma-js'
 import { TableContainer, Tooltip, Typography } from '@mui/material'
 import { useCookies } from 'react-cookie'
@@ -246,14 +246,20 @@ export default function TestByVariantTable(props) {
           <TableHead>
             <TableRow>
               {props.briefTable ? '' : nameColumn}
-              {props.data.column_names.map((column, idx) => (
-                <TableCell
-                  className={'col-result' + (showFull ? '-full' : '')}
-                  key={'column' + '-' + idx}
-                >
-                  {column}
-                </TableCell>
-              ))}
+              {props.data.column_names.map((column, idx) => {
+                const variantInfo = parseVariantName(column)
+                return (
+                  <TableCell
+                    className={'col-result' + (showFull ? '-full' : '')}
+                    key={'column' + '-' + idx}
+                  >
+                    <Typography variant="h6">{variantInfo.name}</Typography>
+                    <Typography variant="caption">
+                      {variantInfo.variant}
+                    </Typography>
+                  </TableCell>
+                )
+              })}
             </TableRow>
           </TableHead>
           <TableBody>


### PR DESCRIPTION
Updated display to split up the variant name to make it easier to see for overview grid and test grid

/assign @stbenjam 

Ex:
<img width="1136" alt="image" src="https://github.com/openshift/sippy/assets/11326541/f82ffa10-1e86-4bfc-8c99-0964bd6cb731">

<img width="1365" alt="image" src="https://github.com/openshift/sippy/assets/11326541/ca4868b7-4fc4-4e37-abd4-a4275a683c7d">


