### PR TITLE
trt-1712: Update triage for new variants

### DIFF
--- a/hack/requirements.txt
+++ b/hack/requirements.txt
@@ -1,3 +1,4 @@
 requests
 google-cloud-bigquery
-urllib
+google-cloud
+urllib3

--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -1419,12 +1419,14 @@ func triagedIssuesFor(releaseIncidents *resolvedissues.TriagedIncidentsForReleas
 			}
 			impactedJobRuns.Insert(impactedJobRun.URL)
 
-			if impactedJobRun.StartTime.After(startTime) && impactedJobRun.StartTime.Before(endTime) {
-				numJobRunsToSuppress++
-			} else if startTime.Sub(impactedJobRun.StartTime) < (6 * time.Hour) {
-				// query uses modified time, we track start time
-				// could also consider tracking EndTime which would be closer to modified time
-				// but more work
+			compareTime := impactedJobRun.StartTime
+			// preference is to compare to CompletedTime as it will more closely match jobrun modified time
+			// but, it is optional so default to StartTime and set to CompletedTime when present
+			if impactedJobRun.CompletedTime.Valid {
+				compareTime = impactedJobRun.CompletedTime.Timestamp
+			}
+
+			if compareTime.After(startTime) && compareTime.Before(endTime) {
 				numJobRunsToSuppress++
 			}
 		}

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -1136,13 +1136,14 @@ type TriagedIncident struct {
 	Release string `bigquery:"release" json:"release"`
 	TestID  string `bigquery:"test_id" json:"test_id"`
 	// TODO: should this be joined in instead of recording? test_name can change for a given test_id
-	TestName     string                       `bigquery:"test_name" json:"test_name"`
-	IncidentID   string                       `bigquery:"incident_id" json:"incident_id"`
-	ModifiedTime time.Time                    `bigquery:"modified_time" json:"modified_time"`
-	Variants     []ComponentReportVariant     `bigquery:"variants" json:"variants"`
-	Issue        TriagedIncidentIssue         `bigquery:"issue" json:"issue"`
-	JobRuns      []TriageJobRun               `bigquery:"job_runs" json:"job_runs"`
-	Attributions []TriagedIncidentAttribution `bigquery:"attributions" json:"attributions"`
+	TestName        string                       `bigquery:"test_name" json:"test_name"`
+	IncidentID      string                       `bigquery:"incident_id" json:"incident_id"`
+	IncidentGroupID string                       `bigquery:"incident_group_id" json:"incident_group_id"`
+	ModifiedTime    time.Time                    `bigquery:"modified_time" json:"modified_time"`
+	Variants        []ComponentReportVariant     `bigquery:"variants" json:"variants"`
+	Issue           TriagedIncidentIssue         `bigquery:"issue" json:"issue"`
+	JobRuns         []TriageJobRun               `bigquery:"job_runs" json:"job_runs"`
+	Attributions    []TriagedIncidentAttribution `bigquery:"attributions" json:"attributions"`
 }
 
 type TriagedIncidentIssue struct {
@@ -1164,6 +1165,7 @@ type ComponentReportVariant struct {
 }
 
 type TriageJobRun struct {
-	URL       string    `bigquery:"url" json:"url"`
-	StartTime time.Time `bigquery:"start_time" json:"start_time"`
+	URL           string                 `bigquery:"url" json:"url"`
+	StartTime     time.Time              `bigquery:"start_time" json:"start_time"`
+	CompletedTime bigquery.NullTimestamp `bigquery:"completed_time" json:"completed_time"`
 }

--- a/pkg/componentreadiness/resolvedissues/types.go
+++ b/pkg/componentreadiness/resolvedissues/types.go
@@ -10,7 +10,9 @@ import (
 	"github.com/openshift/sippy/pkg/apis/api"
 )
 
-var triageMatchVariants = buildTriageMatchVariants([]string{variantregistry.VariantArch, variantregistry.VariantNetwork, variantregistry.VariantPlatform, variantregistry.VariantUpgrade})
+var triageMatchVariants = buildTriageMatchVariants([]string{variantregistry.VariantPlatform, variantregistry.VariantArch, variantregistry.VariantNetwork,
+	variantregistry.VariantTopology, variantregistry.VariantFeatureSet, variantregistry.VariantUpgrade,
+	variantregistry.VariantSuite, variantregistry.VariantInstaller})
 
 func buildTriageMatchVariants(in []string) sets.String {
 	if in == nil || len(in) < 1 {
@@ -37,12 +39,63 @@ func TransformVariant(variant api.ComponentReportColumnIdentification) []api.Com
 }
 func KeyForTriagedIssue(testID string, variants []api.ComponentReportVariant) TriagedIssueKey {
 
-	matchVariants := make([]api.ComponentReportVariant, 0)
+	triagedVariants := make(map[string]string)
+	// initialize missing defaults
+	triagedVariants[variantregistry.VariantSuite] = "unknown"
+	triagedVariants[variantregistry.VariantTopology] = "ha"
+	triagedVariants[variantregistry.VariantFeatureSet] = "default"
+	triagedVariants[variantregistry.VariantInstaller] = "ipi"
+
 	for _, v := range variants {
 		// currently we ignore variants that aren't in api.ComponentReportColumnIdentification
 		if triageMatchVariants.Has(v.Key) {
-			matchVariants = append(matchVariants, v)
+			newValue := v.Value
+			switch v.Key {
+			case "Upgrade":
+				switch v.Value {
+				case "upgrade-minor":
+					newValue = "minor"
+				case "upgrade-micro":
+					newValue = "micro"
+				case "no-upgrade":
+					newValue = "none"
+				}
+			case "Platform":
+				switch v.Value {
+				case "metal-ipi":
+					newValue = "metal"
+				}
+			}
+			triagedVariants[v.Key] = newValue
+		} else if v.Key == "Variant" {
+			// inspect the value and create a new key for it to match up with the new variants
+			// if the key is part of our triageMatchVariants then add it
+			newKey := ""
+			newValue := v.Value
+			// We have some variant=standard triage records but the discussion was that was just a default value for 'nothing' and isn't needed to
+			// be mapped to the new variant standard
+
+			switch v.Value {
+			case "proxy":
+				newKey = variantregistry.VariantNetworkAccess
+			case "fips":
+				newKey = variantregistry.VariantSecurityMode
+			case "rt":
+				newKey = variantregistry.VariantScheduler
+				newValue = "realtime"
+			case "serial":
+				newKey = variantregistry.VariantSuite
+			}
+
+			if triageMatchVariants.Has(newKey) {
+				triagedVariants[newKey] = newValue
+			}
 		}
+	}
+
+	matchVariants := make([]api.ComponentReportVariant, 0)
+	for key, value := range triagedVariants {
+		matchVariants = append(matchVariants, api.ComponentReportVariant{Key: key, Value: value})
 	}
 
 	sort.Slice(matchVariants,


### PR DESCRIPTION
- Convert existing triage key/value to new variants when read.  
- Use new variants for new triage records.
- Record job run CompletedTime when available
- Use CompletedTime over StartTime for triage job run window when available