### PR TITLE
upkeep: updated table grid view

### DIFF
--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -57,6 +57,7 @@ const drawerWidth = 240
 const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
   ({ theme, open }) => ({
     flexGrow: 1,
+    width: `100vw`,
     padding: theme.spacing(3),
     transition: theme.transitions.create('margin', {
       easing: theme.transitions.easing.sharp,
@@ -64,6 +65,7 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
     }),
     marginLeft: `-${drawerWidth}px`,
     ...(open && {
+      width: `calc(100% - ${drawerWidth}px)`,
       transition: theme.transitions.create('margin', {
         easing: theme.transitions.easing.easeOut,
         duration: theme.transitions.duration.enteringScreen,

--- a/sippy-ng/src/releases/Install.js
+++ b/sippy-ng/src/releases/Install.js
@@ -66,7 +66,7 @@ export default function Install(props) {
   return (
     <Fragment>
       <SimpleBreadcrumbs release={props.release} currentPage="Install" />
-      <Grid width="100vw">
+      <Grid>
         <Typography variant="h4" style={{ margin: 10 }} align="center">
           Install health for {props.release}
         </Typography>
@@ -75,14 +75,14 @@ export default function Install(props) {
         path="/"
         render={({ location }) => (
           <Fragment>
-            <Grid container spacing={3} width="100vw">
+            <Grid container justifyContent="center" spacing={3}>
               <TopLevelIndicators
                 release={props.release}
                 indicators={health.indicators}
               />
             </Grid>
 
-            <Grid container spacing={2} alignItems="stretch">
+            <Grid>
               <Switch>
                 <Route path={path + '/operators'}>
                   <TestByVariantTable

--- a/sippy-ng/src/releases/Upgrades.js
+++ b/sippy-ng/src/releases/Upgrades.js
@@ -54,7 +54,7 @@ export default function Upgrades(props) {
   return (
     <Fragment>
       <SimpleBreadcrumbs release={props.release} currentPage="Upgrades" />
-      <Grid width="100vw">
+      <Grid>
         <Typography variant="h4" style={{ margin: 10 }} align="center">
           Upgrade health for {props.release}
         </Typography>

--- a/sippy-ng/src/tests/TestByVariantTable.js
+++ b/sippy-ng/src/tests/TestByVariantTable.js
@@ -1,5 +1,7 @@
 import './TestByVariantTable.css'
+import { grey } from '@mui/material/colors'
 import { Link } from 'react-router-dom'
+import { makeStyles } from '@mui/styles'
 import { parseVariantName, pathForExactTestAnalysis } from '../helpers'
 import { scale } from 'chroma-js'
 import { TableContainer, Tooltip, Typography } from '@mui/material'
@@ -8,6 +10,7 @@ import { useTheme } from '@mui/material/styles'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import FormGroup from '@mui/material/FormGroup'
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
+import Paper from '@mui/material/Paper'
 import PassRateIcon from '../components/PassRateIcon'
 import PropTypes from 'prop-types'
 import React, { Fragment } from 'react'
@@ -17,6 +20,30 @@ import TableBody from '@mui/material/TableBody'
 import TableCell from '@mui/material/TableCell'
 import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
+
+const useStyles = makeStyles((theme) => ({
+  tableContainer: {
+    maxHeight: 800,
+    [theme.breakpoints.down('sm')]: {
+      maxHeight: 500,
+    },
+    [theme.breakpoints.down('md')]: {
+      maxHeight: 600,
+    },
+    [theme.breakpoints.down('lg')]: {
+      maxHeight: 700,
+    },
+  },
+  stickyCellName: {
+    position: 'sticky',
+    left: 0,
+    background: theme.palette.mode === 'dark' ? grey[800] : 'white',
+    borderRight: '2px solid black',
+    lineHeight: 'normal',
+    whiteSpace: 'break-spaces',
+    wordWrap: 'break-word',
+  },
+}))
 
 function PassRateCompare(props) {
   const { previous, current } = props
@@ -130,9 +157,9 @@ Cell.propTypes = {
 
 function Row(props) {
   const { columnNames, testName, results } = props
-
+  const classes = useStyles()
   const nameColumn = (
-    <TableCell className={'cell-name'} key={testName}>
+    <TableCell className={classes.stickyCellName} key={testName}>
       <Tooltip title={testName}>
         <Typography className="cell-name">
           <Link
@@ -185,7 +212,7 @@ export default function TestByVariantTable(props) {
   const cookie =
     cookies['testDetailShowFull'] || cookies['testDetailShowFull'] === 'true'
   const [showFull, setShowFull] = React.useState(props.showFull || cookie)
-
+  const classes = useStyles()
   if (props.data === undefined || props.data.tests.length === 0) {
     return <p>No data.</p>
   }
@@ -198,11 +225,13 @@ export default function TestByVariantTable(props) {
     setShowFull(e.target.checked)
   }
 
-  const pageTitle = (
-    <Typography variant="h4" style={{ margin: 20, textAlign: 'center' }}>
-      {props.title}
-    </Typography>
-  )
+  const pageTitle = () => {
+    props.title ? (
+      <Typography variant="h4" style={{ margin: 20, textAlign: 'center' }}>
+        {props.title}
+      </Typography>
+    ) : null
+  }
 
   if (props.data.tests && Object.keys(props.data.tests).length === 0) {
     return (
@@ -222,7 +251,10 @@ export default function TestByVariantTable(props) {
   }
 
   const nameColumn = (
-    <TableCell className={`col-name ${props.briefTable ? 'col-hide' : ''}`}>
+    <TableCell
+      className={`col-name ${props.briefTable ? 'col-hide' : ''}`}
+      sx={{ zIndex: 1099 }}
+    >
       <FormGroup row>
         <FormControlLabel
           control={
@@ -239,10 +271,10 @@ export default function TestByVariantTable(props) {
   )
 
   return (
-    <div className="view" width="100%">
+    <Paper variant="outlined" elevation={3} sx={{ margin: '20px' }}>
       {pageTitle}
-      <TableContainer component="div" className="wrapper">
-        <Table className="test-variant-table">
+      <TableContainer className={classes.tableContainer}>
+        <Table stickyHeader>
           <TableHead>
             <TableRow>
               {props.briefTable ? '' : nameColumn}
@@ -279,7 +311,7 @@ export default function TestByVariantTable(props) {
           </TableBody>
         </Table>
       </TableContainer>
-    </div>
+    </Paper>
   )
 }
 


### PR DESCRIPTION
updated view tree so that main sets the max width of the container and the children fit inside, this should keep things from moving out of bounds when the side panel is opened 

added sticky header and columns with a bounded table width to make navigation a little easier

/assign @stbenjam 

Can you try this one locally first, I tried to test as much as I could with the web dev tools, but view tree changes like this have ways of surprising me.

Ex:
![sippy](https://github.com/openshift/sippy/assets/11326541/73f542e4-3ea0-4511-aa51-110032c725d9)

