### PR TITLE
TRT-1738: WIP: GROTESQUE HACK: compare ha vs single

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -30,7 +30,7 @@ import (
 const (
 	triagedIncidentsTableID = "triaged_incidents"
 
-	ignoredJobsRegexp = `-okd|-recovery|aggregator-|alibaba|-disruptive|-rollback|-out-of-change|-sno-fips-recert`
+	ignoredJobsRegexp = `-okd|-recovery|aggregator-|alibaba|-disruptive|-rollback|-out-of-change|-sno-fips-recert|-live-iso`
 
 	// This query de-dupes the test results. There are multiple issues present in
 	// our data set:


### PR DESCRIPTION
This is an insane hack to test if we can get meaningful data out of comparing ha jobs to single node jobs. It attempts to behind the scenes, in the bigquery queries, if we're asking for the sample, to hack in single instead of ha, but then report ha as the topology for the job, so all the subsequent comparisons work. This *seems* to be working. Test details obviously can't match jobs and I wouldn't expect it to, but it does seem to be performing the analysis across the two samples correctly.

best tested with:

```
go build -mod vendor ./cmd/sippy && ./sippy component-readiness \
  --log-level=info \
  --google-service-account-credential-file YOURSAJSON

and

npm start in sippy-ng
```

Then navigate to component readiness, select 4.17 for both sample and basis. Do *NOT* attempt changing anything for variants, this is assuming you're only asking for Topology:ha.

We appear to then get meaningful data, and drilling down into regressed tests seems to be showing ha jobs on left and single on right.