### PR TITLE
Include and display regressed test pass rates

### DIFF
--- a/pkg/api/component_report_test.go
+++ b/pkg/api/component_report_test.go
@@ -474,8 +474,26 @@ func TestGenerateComponentReport(t *testing.T) {
 												Variants: awsAMD64OVNTest.Variants,
 											},
 										},
-										Status:      apitype.ExtremeRegression,
-										FisherExact: 1.8251046156331867e-21,
+										ComponentReportTestStats: apitype.ComponentReportTestStats{
+											ReportStatus: apitype.ExtremeRegression,
+											FisherExact:  1.8251046156331867e-21,
+											SampleStats: apitype.ComponentReportTestDetailsReleaseStats{
+												ComponentReportTestDetailsTestStats: apitype.ComponentReportTestDetailsTestStats{
+													SuccessRate:  0.51,
+													SuccessCount: 50,
+													FailureCount: 49,
+													FlakeCount:   1,
+												},
+											},
+											BaseStats: apitype.ComponentReportTestDetailsReleaseStats{
+												ComponentReportTestDetailsTestStats: apitype.ComponentReportTestDetailsTestStats{
+													SuccessRate:  0.91,
+													SuccessCount: 900,
+													FailureCount: 90,
+													FlakeCount:   10,
+												},
+											},
+										},
 									},
 									{
 										ComponentReportTestIdentification: apitype.ComponentReportTestIdentification{
@@ -487,8 +505,26 @@ func TestGenerateComponentReport(t *testing.T) {
 												Variants: awsAMD64OVN2Test.Variants,
 											},
 										},
-										Status:      apitype.SignificantRegression,
-										FisherExact: 0.002621948654892275,
+										ComponentReportTestStats: apitype.ComponentReportTestStats{
+											ReportStatus: apitype.SignificantRegression,
+											FisherExact:  0.002621948654892275,
+											SampleStats: apitype.ComponentReportTestDetailsReleaseStats{
+												ComponentReportTestDetailsTestStats: apitype.ComponentReportTestDetailsTestStats{
+													SuccessRate:  0.81,
+													SuccessCount: 80,
+													FailureCount: 19,
+													FlakeCount:   1,
+												},
+											},
+											BaseStats: apitype.ComponentReportTestDetailsReleaseStats{
+												ComponentReportTestDetailsTestStats: apitype.ComponentReportTestDetailsTestStats{
+													SuccessRate:  0.91,
+													SuccessCount: 900,
+													FailureCount: 90,
+													FlakeCount:   10,
+												},
+											},
+										},
 									},
 								},
 							},
@@ -754,8 +790,26 @@ func TestGenerateComponentReport(t *testing.T) {
 												Variants: awsAMD64OVNTest.Variants,
 											},
 										},
-										Status:      apitype.SignificantRegression,
-										FisherExact: 0.07837082801914011,
+										ComponentReportTestStats: apitype.ComponentReportTestStats{
+											ReportStatus: apitype.SignificantRegression,
+											FisherExact:  0.07837082801914011,
+											SampleStats: apitype.ComponentReportTestDetailsReleaseStats{
+												ComponentReportTestDetailsTestStats: apitype.ComponentReportTestDetailsTestStats{
+													SuccessRate:  0.86,
+													SuccessCount: 85,
+													FailureCount: 14,
+													FlakeCount:   1,
+												},
+											},
+											BaseStats: apitype.ComponentReportTestDetailsReleaseStats{
+												ComponentReportTestDetailsTestStats: apitype.ComponentReportTestDetailsTestStats{
+													SuccessRate:  0.91,
+													SuccessCount: 900,
+													FailureCount: 90,
+													FlakeCount:   10,
+												},
+											},
+										},
 									},
 								},
 							},
@@ -1079,10 +1133,12 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 					ComponentReportRowIdentification:    testDetailsRowIdentification,
 					ComponentReportColumnIdentification: testDetailsColumnIdentification,
 				},
-				SampleStats:  sampleReleaseStatsOneHigh,
-				BaseStats:    baseReleaseStatsOneHigh,
-				FisherExact:  0.4807457902463764,
-				ReportStatus: apitype.NotSignificant,
+				ComponentReportTestStats: apitype.ComponentReportTestStats{
+					SampleStats:  sampleReleaseStatsOneHigh,
+					BaseStats:    baseReleaseStatsOneHigh,
+					FisherExact:  0.4807457902463764,
+					ReportStatus: apitype.NotSignificant,
+				},
 				JobStats: []apitype.ComponentReportTestDetailsJobStats{
 					{
 						JobName:     prowJob1,
@@ -1119,10 +1175,12 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 					ComponentReportRowIdentification:    testDetailsRowIdentification,
 					ComponentReportColumnIdentification: testDetailsColumnIdentification,
 				},
-				SampleStats:  sampleReleaseStatsOneLow,
-				BaseStats:    baseReleaseStatsOneHigh,
-				FisherExact:  8.209711662216515e-28,
-				ReportStatus: apitype.ExtremeRegression,
+				ComponentReportTestStats: apitype.ComponentReportTestStats{
+					SampleStats:  sampleReleaseStatsOneLow,
+					BaseStats:    baseReleaseStatsOneHigh,
+					FisherExact:  8.209711662216515e-28,
+					ReportStatus: apitype.ExtremeRegression,
+				},
 				JobStats: []apitype.ComponentReportTestDetailsJobStats{
 					{
 						JobName:     prowJob1,
@@ -1159,10 +1217,12 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 					ComponentReportRowIdentification:    testDetailsRowIdentification,
 					ComponentReportColumnIdentification: testDetailsColumnIdentification,
 				},
-				SampleStats:  sampleReleaseStatsOneHigh,
-				BaseStats:    baseReleaseStatsOneLow,
-				FisherExact:  4.911246201592593e-22,
-				ReportStatus: apitype.SignificantImprovement,
+				ComponentReportTestStats: apitype.ComponentReportTestStats{
+					SampleStats:  sampleReleaseStatsOneHigh,
+					BaseStats:    baseReleaseStatsOneLow,
+					FisherExact:  4.911246201592593e-22,
+					ReportStatus: apitype.SignificantImprovement,
+				},
 				JobStats: []apitype.ComponentReportTestDetailsJobStats{
 					{
 						JobName:     prowJob1,
@@ -1207,10 +1267,12 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 					ComponentReportRowIdentification:    testDetailsRowIdentification,
 					ComponentReportColumnIdentification: testDetailsColumnIdentification,
 				},
-				SampleStats:  sampleReleaseStatsTwoHigh,
-				BaseStats:    baseReleaseStatsTwoHigh,
-				FisherExact:  0.4119831376606586,
-				ReportStatus: apitype.NotSignificant,
+				ComponentReportTestStats: apitype.ComponentReportTestStats{
+					SampleStats:  sampleReleaseStatsTwoHigh,
+					BaseStats:    baseReleaseStatsTwoHigh,
+					FisherExact:  0.4119831376606586,
+					ReportStatus: apitype.NotSignificant,
+				},
 				JobStats: []apitype.ComponentReportTestDetailsJobStats{
 					{
 						JobName:     prowJob1,
@@ -1455,9 +1517,9 @@ func Test_componentReportGenerator_assessComponentStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &componentReportGenerator{}
 
-			status, fischers := c.assessComponentStatus(0, tt.sampleTotal, tt.sampleSuccess, tt.sampleFlake, tt.baseTotal, tt.baseSuccess, tt.baseFlake, nil, tt.numberOfIgnoredSamples)
-			assert.Equalf(t, tt.expectedStatus, status, "assessComponentStatus expected status not equal")
-			assert.Equalf(t, tt.expectedFischers, fischers, "assessComponentStatus expected fischers value not equal")
+			testStats := c.assessComponentStatus(0, tt.sampleTotal, tt.sampleSuccess, tt.sampleFlake, tt.baseTotal, tt.baseSuccess, tt.baseFlake, nil, tt.numberOfIgnoredSamples)
+			assert.Equalf(t, tt.expectedStatus, testStats.ReportStatus, "assessComponentStatus expected status not equal")
+			assert.Equalf(t, tt.expectedFischers, testStats.FisherExact, "assessComponentStatus expected fischers value not equal")
 		})
 	}
 }

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -938,8 +938,6 @@ type ComponentReportTestIdentification struct {
 
 type ComponentReportTestSummary struct {
 	ComponentReportTestIdentification
-	// Status is an integer representing the severity of the regression.
-	Status ComponentReportStatus `json:"status"`
 
 	// Opened will be set to the time we first recorded this test went regressed.
 	// TODO: This is largely a hack right now, the sippy metrics loop sets this as soon as it notices
@@ -948,19 +946,26 @@ type ComponentReportTestSummary struct {
 	// is being used, without overriding the start/end dates.
 	Opened *time.Time `json:"opened"`
 
-	FisherExact float64 `json:"fisher_exact"`
+	ComponentReportTestStats
+}
+
+// ComponentReportTestStats is an overview struct for a particular regressed test's stats.
+// (basis passes and pass rate, sample passes and pass rate, and fishers exact confidence)
+type ComponentReportTestStats struct {
+	// Status is an integer representing the severity of the regression.
+	ReportStatus ComponentReportStatus                  `json:"status"`
+	FisherExact  float64                                `json:"fisher_exact"`
+	SampleStats  ComponentReportTestDetailsReleaseStats `json:"sample_stats"`
+	BaseStats    ComponentReportTestDetailsReleaseStats `json:"base_stats"`
 }
 
 type ComponentReportTestDetails struct {
 	ComponentReportTestIdentification
-	JiraComponent   string                                 `json:"jira_component"`
-	JiraComponentID *big.Rat                               `json:"jira_component_id"`
-	SampleStats     ComponentReportTestDetailsReleaseStats `json:"sample_stats"`
-	BaseStats       ComponentReportTestDetailsReleaseStats `json:"base_stats"`
-	FisherExact     float64                                `json:"fisher_exact"`
-	ReportStatus    ComponentReportStatus                  `json:"report_status"`
-	JobStats        []ComponentReportTestDetailsJobStats   `json:"job_stats,omitempty"`
-	GeneratedAt     *time.Time                             `json:"generated_at"`
+	ComponentReportTestStats
+	JiraComponent   string                               `json:"jira_component"`
+	JiraComponentID *big.Rat                             `json:"jira_component_id"`
+	JobStats        []ComponentReportTestDetailsJobStats `json:"job_stats,omitempty"`
+	GeneratedAt     *time.Time                           `json:"generated_at"`
 }
 
 type ComponentReportTestDetailsReleaseStats struct {

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -232,7 +232,7 @@ export default function CompReadyTestReport(props) {
     }
   }
 
-  const [statusStr, assessmentIcon] = getStatusAndIcon(data.report_status)
+  const [statusStr, assessmentIcon] = getStatusAndIcon(data.status)
   const significanceTitle = `Test results for individual Prow Jobs may not be statistically
   significant, but when taken in aggregate, there may be a statistically
   significant difference compared to the historical basis
@@ -401,7 +401,7 @@ Flakes: ${stats.flake_count}`
               context={`Component Readiness has found a potential regression in the following test:
 
 {code}${testName}{code}
- 
+
 ${probabilityStr(statusStr, data.fisher_exact)}
 ${printStatsText(
   'Sample (being evaluated)',

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -122,9 +122,11 @@ export default function RegressedTestsModal(props) {
         if (!params.row.fisher_exact) {
           return ''
         }
-        return (100 - params.row.fisher_exact * 100).toFixed(1) + '%'
+        return (100 - params.row.fisher_exact * 100).toFixed(1)
       },
-      renderCell: (param) => <div className="fishers-exact">{param.value}</div>,
+      renderCell: (param) => (
+        <div className="fishers-exact">{param.value}%</div>
+      ),
     },
     {
       field: 'pass_rate_delta',

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -127,6 +127,21 @@ export default function RegressedTestsModal(props) {
       renderCell: (param) => <div className="fishers-exact">{param.value}</div>,
     },
     {
+      field: 'pass_rate_delta',
+      headerName: 'Pass Rate Delta',
+      flex: 8,
+      valueGetter: (params) => {
+        if (!params.row.sample_stats || !params.row.base_stats) {
+          return ''
+        }
+        return (
+          (params.row.sample_stats.success_rate * 100).toFixed(0) -
+          (params.row.base_stats.success_rate * 100).toFixed(0)
+        )
+      },
+      renderCell: (param) => <div className="pass-rate">{param.value}%</div>,
+    },
+    {
       field: 'test_id',
       flex: 5,
       headerName: 'ID',


### PR DESCRIPTION
- **Include pass rates in regressed tests API struct**
- **Show the change in pass rate in regressed tests modal**
- **Make regression certainty col sortable**
- **Return stats even for non-regressed tests in assessComponentStatus**

These changes are working towards tracking pass rates when we open/close regressions, but wanted to put up for review in isolation to make things easier.
