### PR TITLE
trt-1740: use valueGetter for variants column

### DIFF
--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -90,11 +90,10 @@ export default function RegressedTestsModal(props) {
       field: 'variants',
       headerName: 'Variants',
       flex: 30,
-      renderCell: (param) => (
-        <div className="test-name">
-          {formColumnName({ variants: param.value })}
-        </div>
-      ),
+      valueGetter: (params) => {
+        return formColumnName({ variants: params.row.variants })
+      },
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
     },
     {
       field: 'opened',


### PR DESCRIPTION
Use valueGetter for variants formColumnName  call as noted in the [doc](https://mui.com/x/react-data-grid/filtering/customization/).