### PR TITLE
TRT-1748: WIP: Track more stats when opening/closing regression records in bigquery

### DIFF
--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -1142,6 +1142,15 @@ type ComponentReportTriageIncidentSummary struct {
 
 // TestRegression is used for rows in the test_regressions table and is used to track when we detect test
 // regressions opening and closing.
+//
+// It tracks the sample and base pass rate data at the time the regression was originally opened. If the
+// regression is re-opened within a few days (re-using the previous regression ID), this remains
+// the data from the original open.
+//
+// Similarly when the regression is closed, we also store the sample pass rate data at that time. (base
+// remaining unchanged is assumed as this is a fixed timeframe. If the regression reappears within
+// the timeframe we allow (couple days) and the regression is re-used, the closed sample pass rate data
+// will be cleared.
 type TestRegression struct {
 	Release      string                   `bigquery:"release" json:"release"`
 	TestID       string                   `bigquery:"test_id" json:"test_id"`
@@ -1150,6 +1159,21 @@ type TestRegression struct {
 	Opened       time.Time                `bigquery:"opened" json:"opened"`
 	Closed       bigquery.NullTimestamp   `bigquery:"closed" json:"closed"`
 	Variants     []ComponentReportVariant `bigquery:"variants" json:"variants"`
+
+	OpenedSampleSuccesses int     `bigquery:"opened_sample_successes" json:"opened_sample_successes"`
+	OpenedSampleFailures  int     `bigquery:"opened_sample_failures" json:"opened_sample_failures"`
+	OpenedSampleFlakes    int     `bigquery:"opened_sample_flakes" json:"opened_sample_flakes"`
+	OpenedSamplePassRate  float64 `bigquery:"opened_sample_pass_rate" json:"opened_sample_pass_rate"`
+
+	OpenedBaseSuccesses int     `bigquery:"opened_base_successes" json:"opened_base_successes"`
+	OpenedBaseFailures  int     `bigquery:"opened_base_failures" json:"opened_base_failures"`
+	OpenedBaseFlakes    int     `bigquery:"opened_base_flakes" json:"opened_base_flakes"`
+	OpenedBasePassRate  float64 `bigquery:"opened_base_pass_rate" json:"opened_base_pass_rate"`
+
+	ClosedSampleSuccesses int     `bigquery:"closed_sample_successes" json:"closed_sample_successes"`
+	ClosedSampleFailures  int     `bigquery:"closed_sample_failures" json:"closed_sample_failures"`
+	ClosedSampleFlakes    int     `bigquery:"closed_sample_flakes" json:"closed_sample_flakes"`
+	ClosedSamplePassRate  float64 `bigquery:"closed_sample_pass_rate" json:"closed_sample_pass_rate"`
 }
 
 type TriagedIncident struct {

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -1164,6 +1164,7 @@ type TestRegression struct {
 	OpenedSampleFailures  int     `bigquery:"opened_sample_failures" json:"opened_sample_failures"`
 	OpenedSampleFlakes    int     `bigquery:"opened_sample_flakes" json:"opened_sample_flakes"`
 	OpenedSamplePassRate  float64 `bigquery:"opened_sample_pass_rate" json:"opened_sample_pass_rate"`
+	OpenedFisherExact     float64 `bigquery:"opened_fisher_exact" json:"opened_fisher_exact"`
 
 	OpenedBaseSuccesses int     `bigquery:"opened_base_successes" json:"opened_base_successes"`
 	OpenedBaseFailures  int     `bigquery:"opened_base_failures" json:"opened_base_failures"`
@@ -1174,6 +1175,7 @@ type TestRegression struct {
 	ClosedSampleFailures  int     `bigquery:"closed_sample_failures" json:"closed_sample_failures"`
 	ClosedSampleFlakes    int     `bigquery:"closed_sample_flakes" json:"closed_sample_flakes"`
 	ClosedSamplePassRate  float64 `bigquery:"closed_sample_pass_rate" json:"closed_sample_pass_rate"`
+	ClosedFisherExact     float64 `bigquery:"closed_fisher_exact" json:"closed_fisher_exact"`
 }
 
 type TriagedIncident struct {

--- a/pkg/componentreadiness/tracker/tracker.go
+++ b/pkg/componentreadiness/tracker/tracker.go
@@ -133,7 +133,7 @@ UPDATE %s.%s SET
 	closed_sample_successes = %d, 
 	closed_sample_failures = %d, 
 	closed_sample_flakes = %d, 
-	closed_sample_pass_rate = %.2f 
+	closed_sample_pass_rate = %.2f,
 	closed_fisher_exact = %.2f 
 WHERE regression_id = '%s'`,
 		bq.client.Dataset,
@@ -219,8 +219,7 @@ func (rt *RegressionTracker) ReuseOrOpenRegression(
 				}
 			}
 		} else {
-			tLog.Infof("reusing already opened regression: %+v", openReg)
-
+			tLog.Debugf("reusing already opened regression: %+v", openReg)
 		}
 		return openReg, false, nil
 	}

--- a/pkg/componentreadiness/tracker/tracker.go
+++ b/pkg/componentreadiness/tracker/tracker.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	testRegressionsTable = "test_regressions"
+	// TODO: don't commit
+	testRegressionsTable = "test_regressions_dgoodwin_temp"
 )
 
 // RegressionStore is an underlying interface for where we store/load data on open test regressions.
@@ -81,11 +82,19 @@ func (bq *BigQueryRegressionStore) ListCurrentRegressions(release string) ([]api
 func (bq *BigQueryRegressionStore) OpenRegression(release string, newRegressedTest api.ComponentReportTestSummary) (*api.TestRegression, error) {
 	id := uuid.New()
 	newRegression := &api.TestRegression{
-		Release:      release,
-		TestID:       newRegressedTest.TestID,
-		TestName:     newRegressedTest.TestName,
-		RegressionID: id.String(),
-		Opened:       time.Now(),
+		Release:               release,
+		TestID:                newRegressedTest.TestID,
+		TestName:              newRegressedTest.TestName,
+		RegressionID:          id.String(),
+		Opened:                time.Now(),
+		OpenedSampleSuccesses: newRegressedTest.SampleStats.SuccessCount,
+		OpenedSampleFailures:  newRegressedTest.SampleStats.FailureCount,
+		OpenedSampleFlakes:    newRegressedTest.SampleStats.FlakeCount,
+		OpenedSamplePassRate:  newRegressedTest.SampleStats.SuccessRate,
+		OpenedBaseSuccesses:   newRegressedTest.BaseStats.SuccessCount,
+		OpenedBaseFailures:    newRegressedTest.BaseStats.FailureCount,
+		OpenedBaseFlakes:      newRegressedTest.BaseStats.FlakeCount,
+		OpenedBasePassRate:    newRegressedTest.BaseStats.SuccessRate,
 	}
 	for key, value := range newRegressedTest.Variants {
 		newRegression.Variants = append(newRegression.Variants, api.ComponentReportVariant{

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -331,7 +331,8 @@ func refreshComponentReadinessMetrics(client *bqclient.Client, prowURL, gcsBucke
 	}
 
 	// Get report
-	report, errs := api.GetComponentReportFromBigQuery(client, prowURL, gcsBucket, baseRelease, sampleRelease, testIDOption, variantOption, advancedOption, cacheOptions)
+	report, errs := api.GetComponentReportFromBigQuery(client, prowURL, gcsBucket, baseRelease,
+		sampleRelease, testIDOption, variantOption, advancedOption, cacheOptions, true)
 	if len(errs) > 0 {
 		var strErrors []string
 		for _, err := range errs {

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
-	"github.com/openshift/sippy/pkg/componentreadiness/tracker"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -371,11 +370,14 @@ func refreshComponentReadinessMetrics(client *bqclient.Client, prowURL, gcsBucke
 	}
 
 	// Maintain the test regressions table for anything new or now no longer appearing:
-	regressionTracker := tracker.NewRegressionTracker(tracker.NewBigQueryRegressionStore(client), !maintainRegressionTables)
-	err = regressionTracker.SyncComponentReport(sampleRelease.Release, &report)
-	if err != nil {
-		return errors.Wrap(err, "regression tracker reported an error")
-	}
+	/*
+		regressionTracker := tracker.NewRegressionTracker(tracker.NewBigQueryRegressionStore(client), !maintainRegressionTables)
+		err = regressionTracker.SyncComponentReport(sampleRelease.Release, &report)
+		if err != nil {
+			return errors.Wrap(err, "regression tracker reported an error")
+		}
+
+	*/
 
 	return nil
 }

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -331,7 +331,7 @@ func refreshComponentReadinessMetrics(client *bqclient.Client, prowURL, gcsBucke
 
 	// Get report
 	report, errs := api.GetComponentReportFromBigQuery(client, prowURL, gcsBucket, baseRelease,
-		sampleRelease, testIDOption, variantOption, advancedOption, cacheOptions, true)
+		sampleRelease, testIDOption, variantOption, advancedOption, cacheOptions, maintainRegressionTables)
 	if len(errs) > 0 {
 		var strErrors []string
 		for _, err := range errs {
@@ -368,16 +368,6 @@ func refreshComponentReadinessMetrics(client *bqclient.Client, prowURL, gcsBucke
 		componentReadinessTotalRegressionsMetric.WithLabelValues(row.Component).Set(float64(totalRegressedTestsByComponent))
 		componentReadinessUniqueRegressionsMetric.WithLabelValues(row.Component).Set(float64(uniqueRegressedTestsByComponent.Len()))
 	}
-
-	// Maintain the test regressions table for anything new or now no longer appearing:
-	/*
-		regressionTracker := tracker.NewRegressionTracker(tracker.NewBigQueryRegressionStore(client), !maintainRegressionTables)
-		err = regressionTracker.SyncComponentReport(sampleRelease.Release, &report)
-		if err != nil {
-			return errors.Wrap(err, "regression tracker reported an error")
-		}
-
-	*/
 
 	return nil
 }

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -671,6 +671,7 @@ func (s *Server) jsonComponentReportFromBigQuery(w http.ResponseWriter, req *htt
 		variantOption,
 		advancedOption,
 		cacheOption,
+		false,
 	)
 	if len(errs) > 0 {
 		log.Warningf("%d errors were encountered while querying component from big query:", len(errs))


### PR DESCRIPTION
This PR is the result of a shiftweek convo where Stephen and I discussed tracking more info in the test regression records so we can better understand how they're behaving. 

To do this, I needed stats for when we close the regression. The old implementation can't do this because it just generated a report and then closed out any open regressions no longer in the report. Obviously we don't have stats at that point. Instead I had to refactor the regression tracking straight into component_report.go. 

I'm not thrilled with the implementation and worry it's more complexity than it's worth. However in this state it's working, and you can see the results in test_regressions_dgoodwin_temp. Fisher value for closing doesn't seem to work yet, not sure if it always is coming out 0 or just in the cases I've seen so far. 

So questions for reviewer:
- is the data useful
- is the implementation contributing too much to the complexity in component_report
- would inserting a row into a table every time we scan the report and see a regressed test + open regression be better? this would allow charting the values over time until it disappears. we could go back to old implementation i think.
