### PR TITLE
TRT-1743: Remove flake from success count for test cases

### DIFF
--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -72,7 +72,11 @@ const (
 				CASE
 					WHEN flake_count > 0 THEN 0
 					ELSE success_val
-				END AS adjusted_success_val
+				END AS adjusted_success_val,
+				CASE
+					WHEN flake_count > 0 THEN 1
+					ELSE 0
+				END AS adjusted_flake_count
 			FROM
 				%s.junit
 			INNER JOIN %s.jobs  jobs ON 
@@ -436,7 +440,7 @@ func (c *componentReportGenerator) getTestDetailsQuery(allJobVariants apitype.Jo
 						COUNT(*) AS total_count,
 						ANY_VALUE(cm.capabilities) as capabilities,
 						SUM(adjusted_success_val) AS success_count,
-						SUM(flake_count) AS flake_count,
+						SUM(adjusted_flake_count) AS flake_count,
 					FROM (%s)
 					INNER JOIN latest_component_mapping cm ON testsuite = cm.suite AND test_name = cm.name
 `, c.client.Dataset, c.client.Dataset, fmt.Sprintf(dedupedJunitTable, jobNameQueryPortion, c.client.Dataset, c.client.Dataset))
@@ -664,7 +668,7 @@ func (c *componentReportGenerator) getCommonTestStatusQuery(allJobVariants apity
 						%s
 						COUNT(cm.id) AS total_count,
 						SUM(adjusted_success_val) AS success_count,
-						SUM(flake_count) AS flake_count,
+						SUM(adjusted_flake_count) AS flake_count,
 						ANY_VALUE(cm.component) AS component,
 						ANY_VALUE(cm.capabilities) AS capabilities,
 					FROM (%s)

--- a/pkg/api/component_report.go
+++ b/pkg/api/component_report.go
@@ -69,6 +69,10 @@ const (
 				jobs.repo,
 				jobs.pr_number,
 				jobs.pr_sha,
+				CASE
+					WHEN flake_count > 0 THEN 0
+					ELSE success_val
+				END AS adjusted_success_val
 			FROM
 				%s.junit
 			INNER JOIN %s.jobs  jobs ON 
@@ -431,7 +435,7 @@ func (c *componentReportGenerator) getTestDetailsQuery(allJobVariants apitype.Jo
 						ANY_VALUE(cm.jira_component_id) AS jira_component_id,
 						COUNT(*) AS total_count,
 						ANY_VALUE(cm.capabilities) as capabilities,
-						SUM(success_val) AS success_count,
+						SUM(adjusted_success_val) AS success_count,
 						SUM(flake_count) AS flake_count,
 					FROM (%s)
 					INNER JOIN latest_component_mapping cm ON testsuite = cm.suite AND test_name = cm.name
@@ -659,7 +663,7 @@ func (c *componentReportGenerator) getCommonTestStatusQuery(allJobVariants apity
 						cm.id as test_id,
 						%s
 						COUNT(cm.id) AS total_count,
-						SUM(success_val) AS success_count,
+						SUM(adjusted_success_val) AS success_count,
 						SUM(flake_count) AS flake_count,
 						ANY_VALUE(cm.component) AS component,
 						ANY_VALUE(cm.capabilities) AS capabilities,


### PR DESCRIPTION
In openshift-tests, we create two junits for the same test to indicate a flake, one success one failure. But depending on the order in which the two junits appear in the file, we get different entries to the junit BQ table. In one case the success count includes the flake while in the other it does not. This has caused math errors in some status calculation. 