### PR TITLE
Update filtering to allow for owners

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyMainInputs.js
+++ b/sippy-ng/src/component_readiness/CompReadyMainInputs.js
@@ -43,7 +43,6 @@ export default function CompReadyMainInputs(props) {
     'FromReleaseMinor',
     'NetworkAccess',
     'NetworkStack',
-    'Owner',
     'Release',
     'ReleaseMajor',
     'ReleaseMinor',

--- a/sippy-ng/src/component_readiness/CompReadyVars.js
+++ b/sippy-ng/src/component_readiness/CompReadyVars.js
@@ -103,6 +103,7 @@ export const CompReadyVarsProvider = ({ children }) => {
       'Installer:ipi',
       'Installer:upi',
       'Owner:eng',
+      'Owner:qe',
       'Platform:aws',
       'Platform:azure',
       'Platform:gcp',


### PR DESCRIPTION
This updates the side bar to allow filtering by owner and adds qe and as defaults so the QE instance correctly shows their jobs. This should have no effect on the engineering instance as there's no `qe` owned jobs in our tables.