### PR TITLE
Revert "Update filtering to allow for owners"

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyMainInputs.js
+++ b/sippy-ng/src/component_readiness/CompReadyMainInputs.js
@@ -43,6 +43,7 @@ export default function CompReadyMainInputs(props) {
     'FromReleaseMinor',
     'NetworkAccess',
     'NetworkStack',
+    'Owner',
     'Release',
     'ReleaseMajor',
     'ReleaseMinor',

--- a/sippy-ng/src/component_readiness/CompReadyVars.js
+++ b/sippy-ng/src/component_readiness/CompReadyVars.js
@@ -103,7 +103,6 @@ export const CompReadyVarsProvider = ({ children }) => {
       'Installer:ipi',
       'Installer:upi',
       'Owner:eng',
-      'Owner:qe',
       'Platform:aws',
       'Platform:azure',
       'Platform:gcp',


### PR DESCRIPTION
Reverts openshift/sippy#1898

Getting error `invalid variant value from includeVariant Owner:qe`