### PR TITLE
Remove qe from defaults

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyVars.js
+++ b/sippy-ng/src/component_readiness/CompReadyVars.js
@@ -103,7 +103,6 @@ export const CompReadyVarsProvider = ({ children }) => {
       'Installer:ipi',
       'Installer:upi',
       'Owner:eng',
-      'Owner:qe',
       'Platform:aws',
       'Platform:azure',
       'Platform:gcp',


### PR DESCRIPTION
Partial revert.  Ken added a dummy qe job to get CR working again, but it'll be removed by this code eventually https://github.com/openshift/sippy/blob/master/pkg/variantregistry/loader.go#L103