### PR TITLE
TRT-1619: cross-variant comparison UI

### DIFF
--- a/sippy-ng/src/component_readiness/CheckboxList.css
+++ b/sippy-ng/src/component_readiness/CheckboxList.css
@@ -5,3 +5,13 @@
   padding: 5px;
   margin-bottom: 10px;
 }
+.checkboxlist-headerName {
+  width: 220px;
+  padding: 0px;
+  margin: 0px;
+}
+.checkboxlist-summary {
+  background-color: rgb(0, 153, 255);
+  margin: 0px !important;
+  padding: 0px;
+}

--- a/sippy-ng/src/component_readiness/CompReadyMainInputs.js
+++ b/sippy-ng/src/component_readiness/CompReadyMainInputs.js
@@ -6,12 +6,10 @@ import {
   getUpdatedUrlParts,
 } from './CompReadyUtils'
 import { Fragment } from 'react'
-import { Link } from 'react-router-dom'
 import { makeStyles, useTheme } from '@mui/styles'
 import AdvancedOptions from './AdvancedOptions'
 import Button from '@mui/material/Button'
-import CheckBoxList from './CheckboxList'
-import CompReadyTestCell from './CompReadyTestCell'
+import GroupByCheckboxList from './GroupByCheckboxList'
 import IncludeVariantCheckBoxList from './IncludeVariantCheckboxList'
 import PropTypes from 'prop-types'
 import React, { useContext } from 'react'
@@ -53,7 +51,7 @@ export default function CompReadyMainInputs(props) {
   const varsContext = useContext(CompReadyVarsContext)
   const compReadyEnvOptions = (
     <div>
-      <CheckBoxList
+      <GroupByCheckboxList
         headerName="Group By"
         displayList={varsContext.dbGroupByVariants}
         checkedItems={varsContext.columnGroupByCheckedItems}
@@ -61,8 +59,11 @@ export default function CompReadyMainInputs(props) {
       />
       {Object.keys(varsContext.allJobVariants)
         .filter((key) => !checkBoxHiddenIncludeVariants.has(key))
-        .map((variant, i) => (
-          <IncludeVariantCheckBoxList key={variant} variantName={variant} />
+        .map((variant) => (
+          <IncludeVariantCheckBoxList
+            key={variant}
+            variantGroupName={variant}
+          />
         ))}
       <AdvancedOptions
         headerName="Advanced"
@@ -86,28 +87,7 @@ export default function CompReadyMainInputs(props) {
           size="large"
           variant="contained"
           color="primary"
-          to={
-            '/component_readiness/main' +
-            getUpdatedUrlParts(
-              varsContext.baseRelease,
-              varsContext.baseStartTime,
-              varsContext.baseEndTime,
-              varsContext.sampleRelease,
-              varsContext.sampleStartTime,
-              varsContext.sampleEndTime,
-              varsContext.samplePROrg,
-              varsContext.samplePRRepo,
-              varsContext.samplePRNumber,
-              varsContext.columnGroupByCheckedItems,
-              varsContext.includeVariantsCheckedItems,
-              varsContext.dbGroupByVariants,
-              varsContext.confidence,
-              varsContext.pity,
-              varsContext.minFail,
-              varsContext.ignoreDisruption,
-              varsContext.ignoreMissing
-            )
-          }
+          to={'/component_readiness/main' + getUpdatedUrlParts(varsContext)}
           onClick={varsContext.handleGenerateReport}
         >
           <Tooltip
@@ -123,7 +103,8 @@ export default function CompReadyMainInputs(props) {
 
       <div className={classes.crRelease}>
         <ReleaseSelector
-          label="Release to Evaluate"
+          label="Sample Release"
+          tooltip="Release and dates to compare for regression against the basis (historical) release"
           version={varsContext.sampleRelease}
           onChange={varsContext.setSampleReleaseWithDates}
           startTime={formatLongDate(varsContext.sampleStartTime, dateFormat)}
@@ -142,7 +123,8 @@ export default function CompReadyMainInputs(props) {
       <div className={classes.crRelease}>
         <ReleaseSelector
           version={varsContext.baseRelease}
-          label="Historical Release"
+          label="Basis Release"
+          tooltip="Release and dates to specify a historical record of how tests have performed"
           onChange={varsContext.setBaseReleaseWithDates}
           startTime={formatLongDate(varsContext.baseStartTime, dateFormat)}
           setStartTime={varsContext.setBaseStartTime}

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -1,10 +1,4 @@
-import {
-  alpha,
-  Checkbox,
-  FormControl,
-  InputBase,
-  Typography,
-} from '@mui/material'
+import { alpha, InputBase, Typography } from '@mui/material'
 import { format } from 'date-fns'
 import { styled } from '@mui/styles'
 import Alert from '@mui/material/Alert'
@@ -117,6 +111,7 @@ export function getStatusAndIcon(status, grayFactor = 0) {
       statusStr + 'SignificantImprovement detected (improved sample rate)'
     icon = (
       <img
+        alt="SignificantImprovement"
         src={heart}
         width="15px"
         height="15px"
@@ -296,60 +291,44 @@ export function formatLongDate(aLongDate, aDateFormat) {
     console.log('Error: unknown date format: ', typeof aLongDate)
     dateObj = new Date(aLongDate)
   }
-  const ret = format(dateObj, aDateFormat)
-  return ret
+  return format(dateObj, aDateFormat)
 }
 
 // These next set of variables are used for CompReadyMainInputs
 
 // Take the values needed to make an api call and return a string that can be used to
 // make that call.
-// TODO: pass varsContext entirely, instead of nearly every field on it in multiple places positionally
-export function getUpdatedUrlParts(
-  baseRelease,
-  baseStartTime,
-  baseEndTime,
-  sampleRelease,
-  sampleStartTime,
-  sampleEndTime,
-  samplePROrg,
-  samplePRRepo,
-  samplePRNumber,
-  columnGroupByCheckedItems,
-  includeVariantsCheckedItems,
-  dbGroupByVariants,
-  confidence,
-  pity,
-  minFail,
-  ignoreDisruption,
-  ignoreMissing
-) {
+export function getUpdatedUrlParts(vars) {
   const valuesMap = {
-    baseRelease: baseRelease,
-    baseStartTime: formatLongDate(baseStartTime, dateFormat),
-    baseEndTime: formatLongDate(baseEndTime, dateEndFormat),
-    sampleRelease: sampleRelease,
-    sampleStartTime: formatLongDate(sampleStartTime, dateFormat),
-    sampleEndTime: formatLongDate(sampleEndTime, dateEndFormat),
-    confidence: confidence,
-    pity: pity,
-    minFail: minFail,
-    ignoreDisruption: ignoreDisruption,
-    ignoreMissing: ignoreMissing,
-    //component: component,
+    baseRelease: vars.baseRelease,
+    baseStartTime: formatLongDate(vars.baseStartTime, dateFormat),
+    baseEndTime: formatLongDate(vars.baseEndTime, dateEndFormat),
+    sampleRelease: vars.sampleRelease,
+    sampleStartTime: formatLongDate(vars.sampleStartTime, dateFormat),
+    sampleEndTime: formatLongDate(vars.sampleEndTime, dateEndFormat),
+    confidence: vars.confidence,
+    pity: vars.pity,
+    minFail: vars.minFail,
+    ignoreDisruption: vars.ignoreDisruption,
+    ignoreMissing: vars.ignoreMissing,
+    //component: vars.component,
   }
 
-  if (samplePROrg && samplePRRepo && samplePRNumber) {
-    valuesMap.samplePROrg = samplePROrg
-    valuesMap.samplePRRepo = samplePRRepo
-    valuesMap.samplePRNumber = samplePRNumber
+  if (vars.samplePROrg && vars.samplePRRepo && vars.samplePRNumber) {
+    valuesMap.samplePROrg = vars.samplePROrg
+    valuesMap.samplePRRepo = vars.samplePRRepo
+    valuesMap.samplePRNumber = vars.samplePRNumber
   }
 
   // TODO: inject the PR vars into query params
 
+  function filterOutVariantCC(values) {
+    return values.filter((value) => !vars.variantCrossCompare.includes(value))
+  }
   const arraysMap = {
-    columnGroupBy: columnGroupByCheckedItems,
-    dbGroupBy: dbGroupByVariants,
+    columnGroupBy: filterOutVariantCC(vars.columnGroupByCheckedItems),
+    dbGroupBy: filterOutVariantCC(vars.dbGroupByVariants),
+    variantCrossCompare: vars.variantCrossCompare,
   }
 
   const queryParams = new URLSearchParams()
@@ -366,22 +345,34 @@ export function getUpdatedUrlParts(
     }
   })
 
-  // Render includeVariantsCheckedItems
-  Object.entries(includeVariantsCheckedItems).forEach(([key, values]) => {
-    values.forEach((value) => {
-      queryParams.append('includeVariant', key + ':' + value)
-    })
-  })
+  // Render selected variants
+  convertVariantItemsToParam(vars.includeVariantsCheckedItems).forEach(
+    (item) => {
+      queryParams.append('includeVariant', item)
+    }
+  )
+  Object.entries(vars.compareVariantsCheckedItems).forEach(
+    ([group, variants]) => {
+      console.log(group, variants)
+      // for UI purposes we may be holding compareVariants that aren't actually being compared, so they don't get wiped
+      // out just by toggling the "Compare" button. But for the parameters we will filter these out.
+      if (vars.variantCrossCompare.includes(group)) {
+        console.log('including', group, 'in compareVariants')
+        variants.forEach((variant) => {
+          queryParams.append('compareVariant', group + ':' + variant)
+        })
+      }
+    }
+  )
 
   // Stringify and put the begin param character.
   queryParams.sort() // ensure they always stay in sorted order to prevent url history changes
 
   // When using URLSearchParams to construct a query string, it follows the application/x-www-form-urlencoded format,
   // which uses + to represent space characters. The rest of Sippy uses the URI encoding tools in JS, which relies on
-  // %20 for spaces. This makes URL's change, which creates additional history entries, and breaks the back button.
+  // %20 for spaces. This makes URLs change, which creates additional history entries, and breaks the back button.
   const queryString = queryParams.toString().replace(/\+/g, '%20')
-  const retVal = `?${queryString}`
-  return retVal
+  return '?' + queryString
 }
 
 // sortQueryParams sorts a query parameters order so we don't screw up the history when they change
@@ -524,3 +515,30 @@ export const StyledInputBase = styled(InputBase)(({ theme }) => ({
     },
   },
 }))
+
+/** some functions for managing the variant parameters **/
+export const convertParamToVariantItems = (variantItemsParam) => {
+  let groupedVariants = {}
+  variantItemsParam.forEach((variant) => {
+    // each variant here should look like e.g. "Platform:aws"
+    let kv = variant.split(':')
+    if (kv.length === 2) {
+      if (kv[0] in groupedVariants) {
+        groupedVariants[kv[0]].push(kv[1])
+      } else {
+        groupedVariants[kv[0]] = [kv[1]]
+      }
+    }
+  })
+  return groupedVariants
+  // which now looks like {Platform: ["aws", "azure"], ...}
+}
+export const convertVariantItemsToParam = (groupedVariants) => {
+  let param = []
+  Object.keys(groupedVariants).forEach((group) => {
+    groupedVariants[group].forEach((variant) => {
+      param.push(group + ':' + variant)
+    })
+  })
+  return param
+}

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -303,27 +303,7 @@ export default function ComponentReadiness(props) {
   // Show the current state of the filter variables and the url.
   // Create API call string and return it.
   const showValuesForReport = () => {
-    const apiCallStr =
-      getAPIUrl() +
-      getUpdatedUrlParts(
-        varsContext.baseRelease,
-        varsContext.baseStartTime,
-        varsContext.baseEndTime,
-        varsContext.sampleRelease,
-        varsContext.sampleStartTime,
-        varsContext.sampleEndTime,
-        varsContext.samplePROrg,
-        varsContext.samplePRRepo,
-        varsContext.samplePRNumber,
-        varsContext.columnGroupByCheckedItems,
-        varsContext.includeVariantsCheckedItems,
-        varsContext.dbGroupByVariants,
-        varsContext.confidence,
-        varsContext.pity,
-        varsContext.minFail,
-        varsContext.ignoreDisruption,
-        varsContext.ignoreMissing
-      )
+    const apiCallStr = getAPIUrl() + getUpdatedUrlParts(varsContext)
     const formattedApiCallStr = makeRFC3339Time(apiCallStr)
     return formattedApiCallStr
   }
@@ -436,25 +416,7 @@ export default function ComponentReadiness(props) {
                 path="/component_readiness/test_details"
                 render={(props) => {
                   // We need to pass the testId and testName
-                  const filterVals = getUpdatedUrlParts(
-                    varsContext.baseRelease,
-                    varsContext.baseStartTime,
-                    varsContext.baseEndTime,
-                    varsContext.sampleRelease,
-                    varsContext.sampleStartTime,
-                    varsContext.sampleEndTime,
-                    varsContext.samplePROrg,
-                    varsContext.samplePRRepo,
-                    varsContext.samplePRNumber,
-                    varsContext.columnGroupByCheckedItems,
-                    varsContext.includeVariantsCheckedItems,
-                    varsContext.dbGroupByVariants,
-                    varsContext.confidence,
-                    varsContext.pity,
-                    varsContext.minFail,
-                    varsContext.ignoreDisruption,
-                    varsContext.ignoreMissing
-                  )
+                  const filterVals = getUpdatedUrlParts(varsContext)
                   varsContext.setComponentParam(varsContext.component)
                   varsContext.setCapabilityParam(varsContext.capability)
                   setTestIdParam(testId)
@@ -477,25 +439,7 @@ export default function ComponentReadiness(props) {
                 path="/component_readiness/test"
                 render={(props) => {
                   // We need to pass the testId
-                  const filterVals = getUpdatedUrlParts(
-                    varsContext.baseRelease,
-                    varsContext.baseStartTime,
-                    varsContext.baseEndTime,
-                    varsContext.sampleRelease,
-                    varsContext.sampleStartTime,
-                    varsContext.sampleEndTime,
-                    varsContext.samplePROrg,
-                    varsContext.samplePRRepo,
-                    varsContext.samplePRNumber,
-                    varsContext.columnGroupByCheckedItems,
-                    varsContext.includeVariantsCheckedItems,
-                    varsContext.dbGroupByVariants,
-                    varsContext.confidence,
-                    varsContext.pity,
-                    varsContext.minFail,
-                    varsContext.ignoreDisruption,
-                    varsContext.ignoreMissing
-                  )
+                  const filterVals = getUpdatedUrlParts(varsContext)
                   varsContext.setComponentParam(varsContext.component)
                   varsContext.setCapabilityParam(varsContext.capability)
                   setTestIdParam(testId)
@@ -514,25 +458,7 @@ export default function ComponentReadiness(props) {
                 path="/component_readiness/env_test"
                 render={(props) => {
                   // We need to pass the environment and testId
-                  const filterVals = getUpdatedUrlParts(
-                    varsContext.baseRelease,
-                    varsContext.baseStartTime,
-                    varsContext.baseEndTime,
-                    varsContext.sampleRelease,
-                    varsContext.sampleStartTime,
-                    varsContext.sampleEndTime,
-                    varsContext.samplePROrg,
-                    varsContext.samplePRRepo,
-                    varsContext.samplePRNumber,
-                    varsContext.columnGroupByCheckedItems,
-                    varsContext.includeVariantsCheckedItems,
-                    varsContext.dbGroupByVariants,
-                    varsContext.confidence,
-                    varsContext.pity,
-                    varsContext.minFail,
-                    varsContext.ignoreDisruption,
-                    varsContext.ignoreMissing
-                  )
+                  const filterVals = getUpdatedUrlParts(varsContext)
                   varsContext.setComponentParam(varsContext.component)
                   varsContext.setCapabilityParam(varsContext.capability)
                   varsContext.setEnvironmentParam(varsContext.environment)
@@ -554,25 +480,7 @@ export default function ComponentReadiness(props) {
                 path="/component_readiness/capability"
                 render={(props) => {
                   // We need the component and capability from url
-                  const filterVals = getUpdatedUrlParts(
-                    varsContext.baseRelease,
-                    varsContext.baseStartTime,
-                    varsContext.baseEndTime,
-                    varsContext.sampleRelease,
-                    varsContext.sampleStartTime,
-                    varsContext.sampleEndTime,
-                    varsContext.samplePROrg,
-                    varsContext.samplePRRepo,
-                    varsContext.samplePRNumber,
-                    varsContext.columnGroupByCheckedItems,
-                    varsContext.includeVariantsCheckedItems,
-                    varsContext.dbGroupByVariants,
-                    varsContext.confidence,
-                    varsContext.pity,
-                    varsContext.minFail,
-                    varsContext.ignoreDisruption,
-                    varsContext.ignoreMissing
-                  )
+                  const filterVals = getUpdatedUrlParts(varsContext)
                   varsContext.setComponentParam(varsContext.component)
                   varsContext.setCapabilityParam(varsContext.capability)
                   return (
@@ -590,25 +498,7 @@ export default function ComponentReadiness(props) {
                 path="/component_readiness/env_capability"
                 render={(props) => {
                   // We need the component and capability and environment from url
-                  const filterVals = getUpdatedUrlParts(
-                    varsContext.baseRelease,
-                    varsContext.baseStartTime,
-                    varsContext.baseEndTime,
-                    varsContext.sampleRelease,
-                    varsContext.sampleStartTime,
-                    varsContext.sampleEndTime,
-                    varsContext.samplePROrg,
-                    varsContext.samplePRRepo,
-                    varsContext.samplePRNumber,
-                    varsContext.columnGroupByCheckedItems,
-                    varsContext.includeVariantsCheckedItems,
-                    varsContext.dbGroupByVariants,
-                    varsContext.confidence,
-                    varsContext.pity,
-                    varsContext.minFail,
-                    varsContext.ignoreDisruption,
-                    varsContext.ignoreMissing
-                  )
+                  const filterVals = getUpdatedUrlParts(varsContext)
                   return (
                     <CompReadyEnvCapability
                       key="capabilities"
@@ -624,25 +514,7 @@ export default function ComponentReadiness(props) {
               <Route
                 path="/component_readiness/capabilities"
                 render={(props) => {
-                  const filterVals = getUpdatedUrlParts(
-                    varsContext.baseRelease,
-                    varsContext.baseStartTime,
-                    varsContext.baseEndTime,
-                    varsContext.sampleRelease,
-                    varsContext.sampleStartTime,
-                    varsContext.sampleEndTime,
-                    varsContext.samplePROrg,
-                    varsContext.samplePRRepo,
-                    varsContext.samplePRNumber,
-                    varsContext.columnGroupByCheckedItems,
-                    varsContext.includeVariantsCheckedItems,
-                    varsContext.dbGroupByVariants,
-                    varsContext.confidence,
-                    varsContext.pity,
-                    varsContext.minFail,
-                    varsContext.ignoreDisruption,
-                    varsContext.ignoreMissing
-                  )
+                  const filterVals = getUpdatedUrlParts(varsContext)
                   return (
                     <CompReadyEnvCapabilities
                       filterVals={filterVals}
@@ -655,25 +527,7 @@ export default function ComponentReadiness(props) {
               <Route
                 path="/component_readiness/env_capabilities"
                 render={(props) => {
-                  const filterVals = getUpdatedUrlParts(
-                    varsContext.baseRelease,
-                    varsContext.baseStartTime,
-                    varsContext.baseEndTime,
-                    varsContext.sampleRelease,
-                    varsContext.sampleStartTime,
-                    varsContext.sampleEndTime,
-                    varsContext.samplePROrg,
-                    varsContext.samplePRRepo,
-                    varsContext.samplePRNumber,
-                    varsContext.columnGroupByCheckedItems,
-                    varsContext.includeVariantsCheckedItems,
-                    varsContext.dbGroupByVariants,
-                    varsContext.confidence,
-                    varsContext.pity,
-                    varsContext.minFail,
-                    varsContext.ignoreDisruption,
-                    varsContext.ignoreMissing
-                  )
+                  const filterVals = getUpdatedUrlParts(varsContext)
                   varsContext.setComponentParam(varsContext.component)
                   varsContext.setEnvironmentParam(varsContext.environment)
                   // We normally would get the environment and pass it but it doesn't work
@@ -690,25 +544,7 @@ export default function ComponentReadiness(props) {
               <Route
                 path={'/component_readiness/main'}
                 render={(props) => {
-                  const filterVals = getUpdatedUrlParts(
-                    varsContext.baseRelease,
-                    varsContext.baseStartTime,
-                    varsContext.baseEndTime,
-                    varsContext.sampleRelease,
-                    varsContext.sampleStartTime,
-                    varsContext.sampleEndTime,
-                    varsContext.samplePROrg,
-                    varsContext.samplePRRepo,
-                    varsContext.samplePRNumber,
-                    varsContext.columnGroupByCheckedItems,
-                    varsContext.includeVariantsCheckedItems,
-                    varsContext.dbGroupByVariants,
-                    varsContext.confidence,
-                    varsContext.pity,
-                    varsContext.minFail,
-                    varsContext.ignoreDisruption,
-                    varsContext.ignoreMissing
-                  )
+                  const filterVals = getUpdatedUrlParts(varsContext)
                   return (
                     <div className="cr-view">
                       <Sidebar />

--- a/sippy-ng/src/component_readiness/GroupByCheckboxList.js
+++ b/sippy-ng/src/component_readiness/GroupByCheckboxList.js
@@ -7,37 +7,26 @@ import {
   FormControl,
   FormControlLabel,
   FormGroup,
+  Tooltip,
 } from '@mui/material'
+import { CompReadyVarsContext } from './CompReadyVars'
 import { ExpandMore } from '@mui/icons-material'
 import { makeStyles } from '@mui/styles'
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
 import Typography from '@mui/material/Typography'
 
-export default function CheckBoxList(props) {
+export default function GroupByCheckboxList(props) {
+  const varsContext = useContext(CompReadyVarsContext)
   const useStyles = makeStyles((theme) => ({
     formControl: {
       margin: theme.spacing(1),
       minWidth: '20px',
     },
-    selectEmpty: {
-      marginTop: theme.spacing(2),
-    },
-    headerName: {
-      width: '220px',
-      padding: '0px',
-      margin: '0px',
-    },
-    summary: {
-      backgroundColor: 'rgb(0, 153, 255)',
-      margin: '0px !important',
-      padding: '0px',
-    },
   }))
 
   const classes = useStyles()
-  const checkedItems = props.checkedItems
-  const setCheckedItems = props.setCheckedItems
+  const [checkedItems, setCheckedItems] = useState(props.checkedItems)
   const handleChange = (event) => {
     const item = event.target.name
     const isChecked = event.target.checked
@@ -56,9 +45,9 @@ export default function CheckBoxList(props) {
       className={classes.formControl}
       component="fieldset"
     >
-      <Accordion className={classes.headerName}>
+      <Accordion className="checkboxlist-headerName">
         <AccordionSummary
-          className={classes.summary}
+          className="checkboxlist-summary"
           expandIcon={<ExpandMore />}
         >
           <Typography className="checkboxlist-label">
@@ -67,19 +56,33 @@ export default function CheckBoxList(props) {
         </AccordionSummary>
         <AccordionDetails>
           <FormGroup>
-            {props.displayList.map((item) => (
-              <FormControlLabel
-                key={item}
-                control={
-                  <Checkbox
-                    checked={checkedItems.includes(item)}
-                    onChange={handleChange}
-                    name={item}
+            {props.displayList.map((item) => {
+              let isCompareMode = varsContext.variantCrossCompare.includes(item)
+              return (
+                <Tooltip
+                  key={item}
+                  title={
+                    isCompareMode
+                      ? 'Column grouping is disabled for this variant while selected for cross-comparison'
+                      : 'Separate columns by variants in group ' + item
+                  }
+                >
+                  <FormControlLabel
+                    key={item}
+                    disabled={isCompareMode}
+                    control={
+                      <Checkbox
+                        checked={checkedItems.includes(item)}
+                        disabled={isCompareMode}
+                        onChange={handleChange}
+                        name={item}
+                      />
+                    }
+                    label={item}
                   />
-                }
-                label={item}
-              />
-            ))}
+                </Tooltip>
+              )
+            })}
           </FormGroup>
         </AccordionDetails>
       </Accordion>
@@ -87,7 +90,7 @@ export default function CheckBoxList(props) {
   )
 }
 
-CheckBoxList.propTypes = {
+GroupByCheckboxList.propTypes = {
   headerName: PropTypes.string,
   displayList: PropTypes.array,
   checkedItems: PropTypes.array,

--- a/sippy-ng/src/component_readiness/IncludeVariantCheckboxList.js
+++ b/sippy-ng/src/component_readiness/IncludeVariantCheckboxList.js
@@ -1,31 +1,202 @@
+import './CheckboxList.css'
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Button,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  Grid,
+  Tooltip,
+} from '@mui/material'
 import { CompReadyVarsContext } from './CompReadyVars'
-import CheckBoxList from './CheckboxList'
+import { ExpandMore } from '@mui/icons-material'
+import { makeStyles } from '@mui/styles'
 import PropTypes from 'prop-types'
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
+import Typography from '@mui/material/Typography'
 
 export default function IncludeVariantCheckBoxList(props) {
-  const variantName = props.variantName
+  const variantGroupName = props.variantGroupName
   const varsContext = useContext(CompReadyVarsContext)
-  const [checkedItems, setCheckedItems] = React.useState(
-    variantName in varsContext.includeVariantsCheckedItems
-      ? varsContext.includeVariantsCheckedItems[variantName]
+  const [includeItems, setIncludeItems] = React.useState(
+    variantGroupName in varsContext.includeVariantsCheckedItems
+      ? varsContext.includeVariantsCheckedItems[variantGroupName]
       : []
   )
-
-  const updateCheckedItems = (newCheckedItems) => {
-    varsContext.replaceIncludeVariantsCheckedItems(variantName, newCheckedItems)
-    setCheckedItems(newCheckedItems)
+  const updateIncludeItems = (newItems) => {
+    varsContext.replaceIncludeVariantsCheckedItems(variantGroupName, newItems)
+    setIncludeItems(newItems)
   }
+
+  const [compareItems, setCompareItems] = React.useState(
+    variantGroupName in varsContext.compareVariantsCheckedItems
+      ? varsContext.compareVariantsCheckedItems[variantGroupName]
+      : []
+  )
+  const updateCompareItems = (newItems) => {
+    varsContext.replaceCompareVariantsCheckedItems(variantGroupName, newItems)
+    setCompareItems(newItems)
+  }
+
+  const handleVariantSelection = (
+    event,
+    checkedItems,
+    setCheckedItems,
+    updateCheckedItems
+  ) => {
+    const item = event.target.name
+    const newItems = event.target.checked
+      ? [...checkedItems, item]
+      : checkedItems.filter((checkedItem) => checkedItem !== item)
+    setCheckedItems(newItems)
+    updateCheckedItems(newItems)
+  }
+  const handleIncludeVariantSelection = (event) => {
+    handleVariantSelection(
+      event,
+      includeItems,
+      setIncludeItems,
+      updateIncludeItems
+    )
+  }
+  const handleCompareVariantSelection = (event) => {
+    handleVariantSelection(
+      event,
+      compareItems,
+      setCompareItems,
+      updateCompareItems
+    )
+  }
+
+  const [isCompareMode, setIsCompareMode] = useState(
+    varsContext.variantCrossCompare.includes(variantGroupName)
+  )
+  const handleToggleCompare = (event) => {
+    varsContext.updateVariantCrossCompare(variantGroupName, !isCompareMode)
+    setIsCompareMode(!isCompareMode)
+  }
+
+  const classes = makeStyles((theme) => ({
+    formControl: {
+      margin: theme.spacing(1),
+      minWidth: '20px',
+    },
+    gridCenter: {
+      marginTop: theme.spacing(1),
+      textAlign: 'center',
+    },
+    gridRight: {
+      justifyContent: 'flex-end',
+      display: 'flex',
+    },
+  }))()
+
+  let params = {
+    variantGroupName,
+    classes,
+    displayList: varsContext.allJobVariants[variantGroupName],
+    includeItems,
+    handleIncludeVariantSelection,
+    compareItems,
+    handleCompareVariantSelection,
+  }
+
   return (
-    <CheckBoxList
-      headerName={'Include ' + variantName}
-      displayList={varsContext.allJobVariants[variantName]}
-      checkedItems={checkedItems}
-      setCheckedItems={updateCheckedItems}
-    />
+    <FormControl
+      variant="standard"
+      className={classes.formControl}
+      component="fieldset"
+    >
+      <Accordion className="checkboxlist-headerName">
+        <AccordionSummary
+          className="checkboxlist-summary"
+          expandIcon={<ExpandMore />}
+        >
+          <Typography className="checkboxlist-label">
+            Include {variantGroupName}
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          {isCompareMode
+            ? CompareVariantGroup(params)
+            : IncludeVariantGroup(params)}
+          <Tooltip
+            title={'Compare with different variants for sample and basis'}
+          >
+            <Button
+              variant="contained"
+              color="primary"
+              className={classes.control}
+              onClick={handleToggleCompare}
+            >
+              {isCompareMode ? 'Cancel Compare' : 'Compare'}
+            </Button>
+          </Tooltip>
+        </AccordionDetails>
+      </Accordion>
+    </FormControl>
+  )
+}
+
+function IncludeVariantGroup(params) {
+  return (
+    <FormGroup>
+      {params.displayList.map((item) => (
+        <FormControlLabel
+          key={item}
+          control={
+            <Checkbox
+              checked={params.includeItems.includes(item)}
+              onChange={params.handleIncludeVariantSelection}
+              name={item}
+            />
+          }
+          label={item}
+        />
+      ))}
+    </FormGroup>
+  )
+}
+
+function CompareVariantGroup(params) {
+  return (
+    <FormGroup>
+      <Grid container spacing={2}>
+        <Grid item xs={6}>
+          Basis
+        </Grid>
+        <Grid item xs={6} className={params.classes.gridRight}>
+          Sample
+        </Grid>
+      </Grid>
+      {params.displayList.map((item) => (
+        <Grid container spacing={2} key={item}>
+          <Grid item xs={2}>
+            <Checkbox
+              checked={params.includeItems.includes(item)}
+              onChange={params.handleIncludeVariantSelection}
+              name={item}
+            />
+          </Grid>
+          <Grid item xs={8} className={params.classes.gridCenter}>
+            {item}
+          </Grid>
+          <Grid item xs={2}>
+            <Checkbox
+              checked={params.compareItems.includes(item)}
+              onChange={params.handleCompareVariantSelection}
+              name={item}
+            />
+          </Grid>
+        </Grid>
+      ))}
+    </FormGroup>
   )
 }
 
 IncludeVariantCheckBoxList.propTypes = {
-  variantName: PropTypes.string,
+  variantGroupName: PropTypes.string.isRequired,
 }

--- a/sippy-ng/src/component_readiness/IncludeVariantCheckboxList.js
+++ b/sippy-ng/src/component_readiness/IncludeVariantCheckboxList.js
@@ -123,18 +123,6 @@ export default function IncludeVariantCheckBoxList(props) {
           {isCompareMode
             ? CompareVariantGroup(params)
             : IncludeVariantGroup(params)}
-          <Tooltip
-            title={'Compare with different variants for sample and basis'}
-          >
-            <Button
-              variant="contained"
-              color="primary"
-              className={classes.control}
-              onClick={handleToggleCompare}
-            >
-              {isCompareMode ? 'Cancel Compare' : 'Compare'}
-            </Button>
-          </Tooltip>
         </AccordionDetails>
       </Accordion>
     </FormControl>

--- a/sippy-ng/src/component_readiness/ReleaseSelector.js
+++ b/sippy-ng/src/component_readiness/ReleaseSelector.js
@@ -157,7 +157,9 @@ function ReleaseSelector(props) {
       <Grid container justifyContent="center" alignItems="center">
         <Grid item md={12}>
           <FormControl variant="standard" className={classes.formControl}>
-            <InputLabel className={classes.label}>{label}</InputLabel>
+            <Tooltip title={props.tooltip}>
+              <InputLabel className={classes.label}>{label}</InputLabel>
+            </Tooltip>
             <Select variant="standard" value={version} onChange={onChange}>
               {Object.keys(versions).map((v) => (
                 <MenuItem key={v} value={v}>
@@ -277,6 +279,7 @@ ReleaseSelector.propTypes = {
   endTime: PropTypes.string,
   setEndTime: PropTypes.func,
   label: PropTypes.string,
+  tooltip: PropTypes.string,
   version: PropTypes.string,
   onChange: PropTypes.func,
   pullRequestSupport: PropTypes.bool,


### PR DESCRIPTION
# step 1: UI inputs

Enable the UI for specifying variants for cross-comparison, both in the
UI parameters and API parameters. This introduces the "Compare" button  
in the variant selection sidebar, and plumbs the results through. This  
adds parameters for "variantCrossCompare" and "compareVariant" which    
specify (respectively) the variant groups that should query for 
different values in sample vs basis, and what those actual values should
be.

There was also a fair amount of refactoring and renaming along the way.
I tried to distinguish variantGroup ("Architecture") from individual    
variants ("Architecture:amd64"). Hopefully the result is clearer.

# step 2: API support

Since this could take a while, I added a second commit that removes the "Compare" button in the UI so that if we want, we can merge this PR without exposing the functionality.