### PR TITLE
UI update for variant cross-comparison

### DIFF
--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -413,15 +413,24 @@ func (c *componentReportGenerator) getCommonTestStatusQuery(allJobVariants crtyp
 		queryString += ` AND NOT 'Disruption' in UNNEST(capabilities)`
 	}
 
-	for k, vs := range c.IncludeVariants {
+	variantGroups := c.IncludeVariants
+	// potentially cross-compare variants for the sample
+	if isSample && len(c.VariantCrossCompare) > 0 {
+		variantGroups = c.CompareVariants
+	}
+	if variantGroups == nil { // server-side view definitions may omit a variants map
+		variantGroups = map[string][]string{}
+	}
+
+	for group, variants := range variantGroups {
 		queryString += " AND ("
 		first := true
-		for _, v := range vs {
+		for _, variant := range variants {
 			if first {
-				queryString += fmt.Sprintf(`jv_%s.variant_value = '%s'`, k, v)
+				queryString += fmt.Sprintf(`jv_%s.variant_value = '%s'`, group, variant)
 				first = false
 			} else {
-				queryString += fmt.Sprintf(` OR jv_%s.variant_value = '%s'`, k, v)
+				queryString += fmt.Sprintf(` OR jv_%s.variant_value = '%s'`, group, variant)
 			}
 		}
 		queryString += ")"
@@ -534,7 +543,10 @@ func (c *componentReportGenerator) getSampleQueryStatus(
 		ComponentReportGenerator: c,
 	}
 
-	componentReportTestStatus, errs := api.GetDataFromCacheOrGenerate[crtype.ReportTestStatus](c.client.Cache, c.cacheOption, api.GetPrefixedCacheKey("SampleTestStatus~", generator), generator.queryTestStatus, crtype.ReportTestStatus{})
+	componentReportTestStatus, errs := api.GetDataFromCacheOrGenerate[crtype.ReportTestStatus](
+		c.client.Cache, c.cacheOption,
+		api.GetPrefixedCacheKey("SampleTestStatus~", generator),
+		generator.queryTestStatus, crtype.ReportTestStatus{})
 
 	if len(errs) > 0 {
 		return nil, errs

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -1334,8 +1334,12 @@ func (c *componentReportGenerator) generateComponentTestReport(baseStatus map[st
 		if !ok {
 			testStats.ReportStatus = crtype.MissingSample
 		} else {
-			approvedRegression := regressionallowances.IntentionalRegressionFor(c.SampleRelease.Release, testID.ColumnIdentification, testID.TestID)
-			resolvedIssueCompensation, triagedIncidents = c.triagedIncidentsFor(testID)
+			var approvedRegression *regressionallowances.IntentionalRegression
+			if len(c.VariantCrossCompare) == 0 { // only really makes sense when not cross-comparing variants:
+				// look for corresponding regressions we can account for in the analysis
+				approvedRegression = regressionallowances.IntentionalRegressionFor(c.SampleRelease.Release, testID.ColumnIdentification, testID.TestID)
+				resolvedIssueCompensation, triagedIncidents = c.triagedIncidentsFor(testID)
+			}
 			requiredConfidence := c.getRequiredConfidence(testID.TestID, testID.Variants)
 			testStats = c.assessComponentStatus(requiredConfidence, sampleStats.TotalCount, sampleStats.SuccessCount,
 				sampleStats.FlakeCount, baseStats.TotalCount, baseStats.SuccessCount,

--- a/pkg/api/componentreadiness/queryparamparser_test.go
+++ b/pkg/api/componentreadiness/queryparamparser_test.go
@@ -25,7 +25,7 @@ var (
 func TestParseComponentReportRequest(t *testing.T) {
 
 	allJobVariants := crtype.JobVariants{Variants: map[string][]string{
-		"Architecture": {"amd64", "arm64", "heterogeneous"},
+		"Architecture": {"amd64", "arm64", "s390x", "ppc64le", "heterogeneous"},
 		"FeatureSet":   {"default", "techpreview"},
 		"Installer":    {"ipi", "upi"},
 		"Network":      {"ovn", "sdn"},
@@ -60,8 +60,29 @@ func TestParseComponentReportRequest(t *testing.T) {
 			IgnoreDisruption: true,
 		},
 	}
+	// would like to test with a view that does define cross-compare variants
+	view417cross := view417main
+	view417cross.Name = "4.17-cross"
+	view417cross.VariantOptions = crtype.RequestVariantOptions{
+		VariantCrossCompare: []string{"Topology"},
+		IncludeVariants: map[string][]string{
+			"Architecture": []string{"amd64"},
+			"Installer":    []string{"ipi", "upi"},
+			"Topology":     []string{"ha"},
+		},
+		CompareVariants: map[string][]string{
+			"Architecture": []string{"amd64"},
+			"Installer":    []string{"ipi", "upi"},
+			"Topology":     []string{"single"},
+		},
+		// also remove Topology from columnGroupBy and dbGroupBy
+		ColumnGroupBy: sets.NewString("Platform", "Architecture", "Network"),
+		DBGroupBy:     sets.NewString("Platform", "Architecture", "Network", "Suite", "FeatureSet", "Upgrade", "Installer"),
+	}
+
 	views := []crtype.View{
 		view417main,
+		view417cross,
 	}
 
 	now := time.Now().UTC()
@@ -92,7 +113,6 @@ func TestParseComponentReportRequest(t *testing.T) {
 				{"baseRelease", "4.15"},
 				{"baseStartTime", "2024-02-01T00:00:00Z"},
 				{"confidence", "95"},
-				{"groupBy", "cloud,arch,network"},
 				{"columnGroupBy", "Platform,Architecture,Network"},
 				{"dbGroupBy", "Platform,Architecture,Network,Topology,FeatureSet,Upgrade,Installer"},
 				{"ignoreDisruption", "true"},
@@ -146,7 +166,6 @@ func TestParseComponentReportRequest(t *testing.T) {
 				{"baseRelease", "4.15"},
 				{"baseStartTime", "ga-30d"},
 				{"confidence", "95"},
-				{"groupBy", "cloud,arch,network"},
 				{"columnGroupBy", "Platform,Architecture,Network"},
 				{"dbGroupBy", "Platform,Architecture,Network,Topology,FeatureSet,Upgrade,Installer"},
 				{"ignoreDisruption", "true"},
@@ -206,6 +225,7 @@ func TestParseComponentReportRequest(t *testing.T) {
 					"FeatureSet":   {"default", "techpreview"},
 					"Installer":    {"ipi", "upi"},
 				},
+				CompareVariants: nil, // the view is likely not to specify compare variants at all
 			},
 			baseRelease: crtype.RequestReleaseOptions{
 				Release: "4.16",
@@ -243,6 +263,111 @@ func TestParseComponentReportRequest(t *testing.T) {
 				{"includeVariant", "Topology:single"},
 			},
 			errMessage: "params cannot be combined with view",
+		},
+		{
+			name: "normal query params but with variant cross-compare",
+			queryParams: [][]string{
+				{"baseEndTime", "2024-02-28T23:59:59Z"},
+				{"baseRelease", "4.15"},
+				{"baseStartTime", "2024-02-01T00:00:00Z"},
+				{"columnGroupBy", "Platform,Network"},
+				{"dbGroupBy", "Platform,Network,FeatureSet,Upgrade,Installer"},
+				{"sampleEndTime", "2024-04-11T23:59:59Z"},
+				{"sampleRelease", "4.16"},
+				{"sampleStartTime", "2024-04-04T00:00:05Z"},
+				{"includeVariant", "Architecture:amd64"},
+				{"includeVariant", "Architecture:arm64"},
+				{"includeVariant", "Topology:ha"},
+				{"includeVariant", "FeatureSet:default"},
+				{"includeVariant", "Installer:ipi"},
+				{"includeVariant", "Installer:upi"},
+				{"variantCrossCompare", "Architecture"},
+				{"variantCrossCompare", "Topology"},
+				{"compareVariant", "Architecture:s390x"},
+				{"compareVariant", "Architecture:ppc64le"},
+				{"compareVariant", "Topology:single"},
+			},
+			variantOption: crtype.RequestVariantOptions{
+				ColumnGroupBy: sets.NewString("Platform", "Network"),
+				DBGroupBy:     sets.NewString("Platform", "Network", "FeatureSet", "Upgrade", "Installer"),
+				IncludeVariants: map[string][]string{
+					"Architecture": {"amd64", "arm64"},
+					"Topology":     {"ha"},
+					"FeatureSet":   {"default"},
+					"Installer":    {"ipi", "upi"},
+				},
+				CompareVariants: map[string][]string{
+					"Architecture": {"s390x", "ppc64le"},
+					"Topology":     {"single"},
+					"FeatureSet":   {"default"},
+					"Installer":    {"ipi", "upi"},
+				},
+				VariantCrossCompare: []string{"Architecture", "Topology"},
+				RequestedVariants:   map[string]string{},
+			},
+			baseRelease: crtype.RequestReleaseOptions{
+				Release: "4.15",
+				Start:   time.Date(2024, time.February, 1, 0, 0, 0, 0, time.UTC),
+				End:     time.Date(2024, time.February, 28, 23, 59, 59, 0, time.UTC),
+			},
+			sampleRelease: crtype.RequestReleaseOptions{
+				Release: "4.16",
+				Start:   time.Date(2024, time.April, 4, 0, 0, 5, 0, time.UTC),
+				End:     time.Date(2024, time.April, 11, 23, 59, 59, 0, time.UTC),
+			},
+			testIDOption: crtype.RequestTestIdentificationOptions{},
+			advancedOption: crtype.RequestAdvancedOptions{
+				MinimumFailure:   3,
+				Confidence:       95,
+				PityFactor:       5,
+				IgnoreMissing:    false,
+				IgnoreDisruption: true,
+			},
+			cacheOption: cache.RequestOptions{
+				ForceRefresh: false,
+			},
+		},
+		{
+			name: "cross-compare view",
+			queryParams: [][]string{
+				{"view", "4.17-cross"},
+			},
+			variantOption: crtype.RequestVariantOptions{
+				ColumnGroupBy: sets.NewString("Platform", "Architecture", "Network"),
+				DBGroupBy:     sets.NewString("Platform", "Architecture", "Network", "Suite", "FeatureSet", "Upgrade", "Installer"),
+				IncludeVariants: map[string][]string{
+					"Architecture": {"amd64"},
+					"Installer":    {"ipi", "upi"},
+					"Topology":     {"ha"},
+				},
+				VariantCrossCompare: []string{"Topology"},
+				CompareVariants: map[string][]string{
+					"Architecture": {"amd64"},
+					"Installer":    {"ipi", "upi"},
+					"Topology":     {"single"},
+				},
+			},
+			baseRelease: crtype.RequestReleaseOptions{
+				Release: "4.16",
+				Start:   time.Date(2024, time.May, 28, 0, 0, 0, 0, time.UTC),
+				End:     time.Date(2024, time.June, 27, 23, 59, 59, 0, time.UTC),
+			},
+			sampleRelease: crtype.RequestReleaseOptions{
+				Release: "4.17",
+				Start:   time.Date(nowMinus7Days.Year(), nowMinus7Days.Month(), nowMinus7Days.Day(), 0, 0, 0, 0, time.UTC),
+				End:     nowRoundUp,
+			},
+			testIDOption: crtype.RequestTestIdentificationOptions{},
+			advancedOption: crtype.RequestAdvancedOptions{
+				MinimumFailure:   3,
+				Confidence:       95,
+				PityFactor:       5,
+				IgnoreMissing:    false,
+				IgnoreDisruption: true,
+			},
+			cacheOption: cache.RequestOptions{
+				ForceRefresh: false,
+			},
 		},
 	}
 

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -139,6 +139,11 @@ func (c *componentReportGenerator) getTestDetailsQuery(allJobVariants crtype.Job
 	for group, variant := range c.RequestedVariants {
 		queryString += fmt.Sprintf(` AND jv_%s.variant_value = '%s'`, api.CleanseSQLName(group), api.CleanseSQLName(variant))
 	}
+	if isSample {
+		queryString += filterByCrossCompareVariants(c.VariantCrossCompare, c.CompareVariants, &commonParams)
+	} else {
+		queryString += filterByCrossCompareVariants(c.VariantCrossCompare, c.IncludeVariants, &commonParams)
+	}
 	return queryString, groupString, commonParams
 }
 

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -81,12 +81,6 @@ func (c *componentReportGenerator) GenerateJobRunTestReportStatus() (crtype.JobR
 // getTestDetailsQuery returns the report for a specific test + variant combo, including job run data.
 // This is for the bottom level most specific pages in component readiness.
 func (c *componentReportGenerator) getTestDetailsQuery(allJobVariants crtype.JobVariants, isSample bool) (string, string, []bigquery2.QueryParameter) {
-	joinVariants := ""
-	for v := range allJobVariants.Variants {
-		joinVariants += fmt.Sprintf("LEFT JOIN %s.job_variants jv_%s ON variant_registry_job_name = jv_%s.job_name AND jv_%s.variant_name = '%s'\n",
-			c.client.Dataset, v, v, v, v)
-	}
-
 	jobNameQueryPortion := normalJobNameCol
 	if c.SampleRelease.PullRequestOptions != nil && isSample {
 		jobNameQueryPortion = pullRequestDynamicJobNameCol
@@ -113,6 +107,12 @@ func (c *componentReportGenerator) getTestDetailsQuery(allJobVariants crtype.Job
 					INNER JOIN latest_component_mapping cm ON testsuite = cm.suite AND test_name = cm.name
 `, c.client.Dataset, c.client.Dataset, fmt.Sprintf(dedupedJunitTable, jobNameQueryPortion, c.client.Dataset, c.client.Dataset))
 
+	joinVariants := ""
+	for variant := range allJobVariants.Variants {
+		v := api.CleanseSQLName(variant)
+		joinVariants += fmt.Sprintf("LEFT JOIN %s.job_variants jv_%s ON variant_registry_job_name = jv_%s.job_name AND jv_%s.variant_name = '%s'\n",
+			c.client.Dataset, v, v, v, v)
+	}
 	queryString += joinVariants
 
 	groupString := `
@@ -136,10 +136,30 @@ func (c *componentReportGenerator) getTestDetailsQuery(allJobVariants crtype.Job
 			Value: c.TestID,
 		},
 	}
-	for k, v := range c.RequestedVariants {
-		queryString += fmt.Sprintf(` AND jv_%s.variant_value = '%s'`, k, v)
+	for group, variant := range c.RequestedVariants {
+		queryString += fmt.Sprintf(` AND jv_%s.variant_value = '%s'`, api.CleanseSQLName(group), api.CleanseSQLName(variant))
 	}
 	return queryString, groupString, commonParams
+}
+
+// filterByCrossCompareVariants adds the where clause for any variants being cross-compared (which are not included in RequiredVariants).
+// As a side effect, it also appends any necessary parameters for the clause.
+func filterByCrossCompareVariants(crossCompare []string, variantGroups map[string][]string, params *[]bigquery2.QueryParameter) (whereClause string) {
+	if len(variantGroups) == 0 {
+		return // avoid possible nil pointer dereference
+	}
+	for _, group := range crossCompare {
+		if variants := variantGroups[group]; len(variants) > 0 {
+			group = api.CleanseSQLName(group)
+			paramName := "CrossVariants" + group
+			whereClause += fmt.Sprintf(` AND jv_%s.variant_value IN UNNEST(@%s)`, group, paramName)
+			*params = append(*params, bigquery2.QueryParameter{
+				Name:  paramName,
+				Value: variants,
+			})
+		}
+	}
+	return
 }
 
 type baseJobRunTestStatusGenerator struct {
@@ -165,13 +185,17 @@ func (c *componentReportGenerator) getBaseJobRunTestStatus(commonQuery string,
 		ComponentReportGenerator: c,
 	}
 
-	componentReportTestStatus, errs := api.GetDataFromCacheOrGenerate[crtype.JobRunTestReportStatus](generator.ComponentReportGenerator.client.Cache, generator.cacheOption, api.GetPrefixedCacheKey("BaseJobRunTestStatus~", generator), generator.queryTestStatus, crtype.JobRunTestReportStatus{})
+	jobRunTestStatus, errs := api.GetDataFromCacheOrGenerate[crtype.JobRunTestReportStatus](
+		generator.ComponentReportGenerator.client.Cache, generator.cacheOption,
+		api.GetPrefixedCacheKey("BaseJobRunTestStatus~", generator),
+		generator.queryTestStatus,
+		crtype.JobRunTestReportStatus{})
 
 	if len(errs) > 0 {
 		return nil, errs
 	}
 
-	return componentReportTestStatus.BaseStatus, nil
+	return jobRunTestStatus.BaseStatus, nil
 }
 
 func (b *baseJobRunTestStatusGenerator) queryTestStatus() (crtype.JobRunTestReportStatus, []error) {
@@ -207,7 +231,8 @@ type sampleJobRunTestQueryGenerator struct {
 
 func (c *componentReportGenerator) getSampleJobRunTestStatus(commonQuery string,
 	groupByQuery string,
-	queryParameters []bigquery2.QueryParameter) (map[string][]crtype.JobRunTestStatusRow, []error) {
+	queryParameters []bigquery2.QueryParameter,
+) (map[string][]crtype.JobRunTestStatusRow, []error) {
 	generator := sampleJobRunTestQueryGenerator{
 		commonQuery:              commonQuery,
 		groupByQuery:             groupByQuery,
@@ -215,13 +240,17 @@ func (c *componentReportGenerator) getSampleJobRunTestStatus(commonQuery string,
 		ComponentReportGenerator: c,
 	}
 
-	componentReportTestStatus, errs := api.GetDataFromCacheOrGenerate[crtype.JobRunTestReportStatus](c.client.Cache, c.cacheOption, api.GetPrefixedCacheKey("SampleJobRunTestStatus~", generator), generator.queryTestStatus, crtype.JobRunTestReportStatus{})
+	jobRunTestStatus, errs := api.GetDataFromCacheOrGenerate[crtype.JobRunTestReportStatus](
+		c.client.Cache, c.cacheOption,
+		api.GetPrefixedCacheKey("SampleJobRunTestStatus~", generator),
+		generator.queryTestStatus,
+		crtype.JobRunTestReportStatus{})
 
 	if len(errs) > 0 {
 		return nil, errs
 	}
 
-	return componentReportTestStatus.SampleStatus, nil
+	return jobRunTestStatus.SampleStatus, nil
 }
 
 func (s *sampleJobRunTestQueryGenerator) queryTestStatus() (crtype.JobRunTestReportStatus, []error) {

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -178,3 +178,14 @@ func VariantListToMap(allJobVariants crtype.JobVariants, variants []string) (map
 	}
 	return variantsMap, err
 }
+
+// CleanseSQLName removes all non-alphanumeric characters from a string that could be used as a SQL name (table, column, etc)
+// This is useful for sanitizing dynamic queries built from user input.
+func CleanseSQLName(name string) string {
+	return strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			return r
+		}
+		return -1
+	}, name)
+}

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -149,32 +149,32 @@ func VariantsStringToSet(allJobVariants crtype.JobVariants, variantsString strin
 	return variantSet, nil
 }
 
-func IncludeVariantsToMap(allJobVariants crtype.JobVariants, includeVariants []string) (map[string][]string, error) {
-	includeVariantsMap := map[string][]string{}
+func VariantListToMap(allJobVariants crtype.JobVariants, variants []string) (map[string][]string, error) {
+	variantsMap := map[string][]string{}
 	var err error
-	for _, includeVariant := range includeVariants {
-		kv := strings.Split(includeVariant, ":")
+	for _, variant := range variants {
+		kv := strings.Split(variant, ":")
 		if len(kv) != 2 {
-			err = fmt.Errorf("invalid includeVariant %s", includeVariant)
-			return includeVariantsMap, err
+			err = fmt.Errorf("invalid variant %s in list", variant)
+			return variantsMap, err
 		}
 		values, ok := allJobVariants.Variants[kv[0]]
 		if !ok {
-			err = fmt.Errorf("invalid variant name from includeVariant %s", includeVariant)
-			return includeVariantsMap, err
+			err = fmt.Errorf("invalid name from list variant %s", variant)
+			return variantsMap, err
 		}
 		found := false
 		for _, v := range values {
 			if v == kv[1] {
-				includeVariantsMap[kv[0]] = append(includeVariantsMap[kv[0]], kv[1])
+				variantsMap[kv[0]] = append(variantsMap[kv[0]], kv[1])
 				found = true
 				break
 			}
 		}
 		if !found {
-			err = fmt.Errorf("invalid variant value from includeVariant %s", includeVariant)
-			return includeVariantsMap, err
+			err = fmt.Errorf("invalid value from list variant %s", variant)
+			return variantsMap, err
 		}
 	}
-	return includeVariantsMap, err
+	return variantsMap, err
 }

--- a/pkg/apis/api/componentreport/types.go
+++ b/pkg/apis/api/componentreport/types.go
@@ -42,10 +42,12 @@ type RequestTestIdentificationOptions struct {
 }
 
 type RequestVariantOptions struct {
-	ColumnGroupBy     sets.String         `json:"column_group_by" yaml:"column_group_by"`
-	DBGroupBy         sets.String         `json:"db_group_by" yaml:"db_group_by"`
-	IncludeVariants   map[string][]string `json:"include_variants" yaml:"include_variants"`
-	RequestedVariants map[string]string   `json:"requested_variants" yaml:"requested_variants"`
+	ColumnGroupBy       sets.String         `json:"column_group_by" yaml:"column_group_by"`
+	DBGroupBy           sets.String         `json:"db_group_by" yaml:"db_group_by"`
+	IncludeVariants     map[string][]string `json:"include_variants" yaml:"include_variants"`
+	CompareVariants     map[string][]string `json:"compare_variants" yaml:"compare_variants"`
+	VariantCrossCompare []string            `json:"variant_cross_compare" yaml:"variant_cross_compare"`
+	RequestedVariants   map[string]string   `json:"requested_variants" yaml:"requested_variants"`
 }
 
 // RequestOptions is a struct packaging all the options for a CR request.

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -311,7 +311,7 @@ func refreshComponentReadinessMetrics(client *bqclient.Client, prowURL, gcsBucke
 	if err != nil {
 		return err
 	}
-	includeVariantsMap, err := api.IncludeVariantsToMap(allJobVariants, componentreadiness.DefaultIncludeVariants)
+	includeVariantsMap, err := api.VariantListToMap(allJobVariants, componentreadiness.DefaultIncludeVariants)
 	if err != nil {
 		return err
 	}

--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -39,7 +39,7 @@ import PayloadStream from './releases/PayloadStream'
 import PayloadStreams from './releases/PayloadStreams'
 import ProwJobRun from './prow_job_runs/ProwJobRun'
 import PullRequests from './pull_requests/PullRequests'
-import React, { Fragment, useEffect } from 'react'
+import React, { Fragment, useEffect, useMemo } from 'react'
 import ReleaseOverview from './releases/ReleaseOverview'
 import ReleasePayloadDetails from './releases/ReleasePayloadDetails'
 import ReleasePayloads from './releases/ReleasePayloads'
@@ -105,6 +105,9 @@ export const ReleasesContext = React.createContext({})
 export const CapabilitiesContext = React.createContext([])
 export const ReportEndContext = React.createContext('')
 const ColorModeContext = React.createContext({ toggleColorMode: () => {} })
+
+// ReleaseGADates is an object that maps each 4.y release to its GA date (if any)
+export var ReleaseGADates = {}
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -188,7 +191,7 @@ export default function App(props) {
   const [lastUpdated, setLastUpdated] = React.useState(null)
   const [drawerOpen, setDrawerOpen] = React.useState(true)
   const [isLoaded, setLoaded] = React.useState(false)
-  const [releases, setReleases] = React.useState([])
+  const [releases, setReleases] = React.useState({ releases: [] })
   const [capabilities, setCapabilities] = React.useState([])
   const [reportDate, setReportDate] = React.useState([])
   const [fetchError, setFetchError] = React.useState('')
@@ -266,6 +269,19 @@ export default function App(props) {
   const handleDrawerClose = () => {
     setDrawerOpen(false)
   }
+
+  ReleaseGADates = useMemo(() => {
+    let gaDates = {}
+    releases.releases
+      .filter((aVersion) => {
+        // We won't process Presubmits or 3.11
+        return aVersion !== 'Presubmits' && aVersion != '3.11'
+      })
+      .forEach((r) => {
+        gaDates[r] = releases.ga_dates[r]
+      })
+    return gaDates
+  }, [releases])
 
   if (!isLoaded) {
     return <Typography>Loading...</Typography>

--- a/sippy-ng/src/component_readiness/CompReadyPageTitle.js
+++ b/sippy-ng/src/component_readiness/CompReadyPageTitle.js
@@ -1,18 +1,87 @@
-import { debugMode } from './CompReadyUtils'
+import { debugMode, getSummaryDate } from './CompReadyUtils'
+import { Fragment, useContext, useMemo } from 'react'
+import { Grid } from '@mui/material'
+import { ReleaseGADates } from '../App'
+import { VarsAtPageLoad } from './CompReadyVars'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-// CompReadyPageTitle is used to print the title of the pages and the accompanying
-// api call string for debugging.  This allows us to have consistent page titles
+// CompReadyPageTitle is used to print the title of the pages, important report parameters,
+// and (when debugging) the accompanying api call string. This allows us to have consistent page headers
 // and on page1, we can see the api call string change dynamically.
-// We can remove the part that prints the curl once debugging is no longer needed.
 export default function CompReadyPageTitle(props) {
-  const { pageTitle, apiCallStr } = props
+  const { pageTitle, pageNumber, apiCallStr } = props
   const callStr = `${apiCallStr}`
+
+  const pageHeader = (pageNumber, vars) => {
+    // console.log('inside pageHeader', vars.baseRelease, ReleaseGADates)
+    if (pageNumber === 5) {
+      // Page 5 is test details which already shows this info
+      return ''
+    }
+    let rows = []
+    rows.push(
+      <Fragment key="release">
+        <Grid item xs={6}>
+          {getSummaryDate(
+            vars.baseStartTime.toString(),
+            vars.baseEndTime.toString(),
+            vars.baseRelease,
+            ReleaseGADates
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          {getSummaryDate(
+            vars.sampleStartTime.toString(),
+            vars.sampleEndTime.toString(),
+            vars.sampleRelease,
+            ReleaseGADates
+          )}
+        </Grid>
+      </Fragment>
+    )
+    console.log('page title', vars)
+    if (vars.variantCrossCompare) {
+      let group
+      for (group of vars.variantCrossCompare) {
+        let basisVariants = vars.includeVariantsCheckedItems[group]
+        let sampleVariants = vars.compareVariantsCheckedItems[group]
+        rows.push(
+          <Fragment key={'variantCross_' + group}>
+            <Grid item xs={6}>
+              {group}:&nbsp;
+              <strong>
+                {basisVariants ? basisVariants.join(', ') : '(any)'}
+              </strong>
+            </Grid>
+            <Grid item xs={6}>
+              {group}:&nbsp;
+              <strong>
+                {sampleVariants ? sampleVariants.join(', ') : '(any)'}
+              </strong>
+            </Grid>
+          </Fragment>
+        )
+      }
+    }
+
+    return (
+      <Grid container spacing={2} style={{ marginBottom: '10px' }}>
+        <Grid item xs={6}>
+          <h3>Basis:</h3>
+        </Grid>
+        <Grid item xs={6}>
+          <h3>Sample:</h3>
+        </Grid>
+        {rows}
+      </Grid>
+    )
+  }
 
   return (
     <div>
       {pageTitle}
+      {pageHeader(pageNumber, VarsAtPageLoad)}
       {debugMode ? <p>curl -sk &apos;{callStr}&apos;</p> : null}
     </div>
   )
@@ -20,5 +89,6 @@ export default function CompReadyPageTitle(props) {
 
 CompReadyPageTitle.propTypes = {
   pageTitle: PropTypes.object.isRequired,
+  pageNumber: PropTypes.number, // .isRequired,
   apiCallStr: PropTypes.string.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -353,11 +353,9 @@ export function getUpdatedUrlParts(vars) {
   )
   Object.entries(vars.compareVariantsCheckedItems).forEach(
     ([group, variants]) => {
-      console.log(group, variants)
       // for UI purposes we may be holding compareVariants that aren't actually being compared, so they don't get wiped
       // out just by toggling the "Compare" button. But for the parameters we will filter these out.
       if (vars.variantCrossCompare.includes(group)) {
-        console.log('including', group, 'in compareVariants')
         variants.forEach((variant) => {
           queryParams.append('compareVariant', group + ':' + variant)
         })

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -328,7 +328,6 @@ export function getUpdatedUrlParts(vars) {
   const arraysMap = {
     columnGroupBy: filterOutVariantCC(vars.columnGroupByCheckedItems),
     dbGroupBy: filterOutVariantCC(vars.dbGroupByVariants),
-    variantCrossCompare: vars.variantCrossCompare,
   }
 
   const queryParams = new URLSearchParams()
@@ -362,6 +361,9 @@ export function getUpdatedUrlParts(vars) {
       }
     }
   )
+  vars.variantCrossCompare.forEach((item) => {
+    queryParams.append('variantCrossCompare', item)
+  })
 
   // Stringify and put the begin param character.
   queryParams.sort() // ensure they always stay in sorted order to prevent url history changes

--- a/sippy-ng/src/component_readiness/CompReadyVars.js
+++ b/sippy-ng/src/component_readiness/CompReadyVars.js
@@ -20,8 +20,21 @@ import { ReleasesContext } from '../App'
 import { safeEncodeURIComponent } from '../helpers'
 import CompReadyProgress from './CompReadyProgress'
 import PropTypes from 'prop-types'
-import React, { createContext, useContext, useEffect, useState } from 'react'
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+
+// shared state storage for the whole app
 export const CompReadyVarsContext = createContext()
+// Use VarsAtPageLoad for describing report contents.
+// This is built according to initial params at page load and frozen to keep the display
+// of "what am I looking at" from re-rendering as the user changes the controls,
+// until they trigger a new report loading in a new page.
+export var VarsAtPageLoad = {}
 
 export const CompReadyVarsProvider = ({ children }) => {
   const [allJobVariants, setAllJobVariants] = useState([])
@@ -63,6 +76,7 @@ export const CompReadyVarsProvider = ({ children }) => {
   const initialBaseEndTime =
     getReleaseDate(defaultBaseRelease).getTime() + 1 * days - 1 * seconds
 
+  /*
   console.log('defaultBaseRelease: ', defaultBaseRelease)
   console.log(
     'initialBaseStartTime: ',
@@ -72,6 +86,7 @@ export const CompReadyVarsProvider = ({ children }) => {
     'initialBaseEndTime: ',
     formatLongDate(initialBaseEndTime, dateEndFormat)
   )
+  */
 
   // Create the variables for the URL and set any initial values.
   const [baseReleaseParam = defaultBaseRelease, setBaseReleaseParam] =
@@ -379,6 +394,59 @@ export const CompReadyVarsProvider = ({ children }) => {
     console.log('Aborting /variant sippy API call')
   }
 
+  let vars = {
+    allJobVariants,
+    expandEnvironment,
+    baseRelease,
+    setBaseReleaseWithDates,
+    sampleRelease,
+    setSampleReleaseWithDates,
+    baseStartTime,
+    setBaseStartTime,
+    baseEndTime,
+    setBaseEndTime,
+    sampleStartTime,
+    setSampleStartTime,
+    sampleEndTime,
+    setSampleEndTime,
+    samplePROrg,
+    setSamplePROrg,
+    samplePRRepo,
+    setSamplePRRepo,
+    samplePRNumber,
+    setSamplePRNumber,
+    columnGroupByCheckedItems,
+    setColumnGroupByCheckedItems,
+    dbGroupByVariants,
+    includeVariantsCheckedItems,
+    replaceIncludeVariantsCheckedItems,
+    compareVariantsCheckedItems,
+    replaceCompareVariantsCheckedItems,
+    variantCrossCompare,
+    updateVariantCrossCompare,
+    confidence,
+    setConfidence,
+    pity,
+    setPity,
+    minFail,
+    setMinFail,
+    ignoreMissing,
+    setIgnoreMissing,
+    ignoreDisruption,
+    setIgnoreDisruption,
+    component,
+    setComponentParam,
+    capability,
+    setCapabilityParam,
+    environment,
+    setEnvironmentParam,
+    handleGenerateReport,
+  }
+  VarsAtPageLoad = useMemo(() => {
+    // console.log('inside useMemo', vars)
+    return Object.assign({}, vars)
+  }, [])
+
   if (fetchError != '') {
     return gotFetchError(fetchError)
   }
@@ -393,57 +461,9 @@ export const CompReadyVarsProvider = ({ children }) => {
       />
     )
   }
+
   return (
-    <CompReadyVarsContext.Provider
-      value={{
-        allJobVariants,
-        expandEnvironment,
-        baseRelease,
-        setBaseReleaseWithDates,
-        sampleRelease,
-        setSampleReleaseWithDates,
-        baseStartTime,
-        setBaseStartTime,
-        baseEndTime,
-        setBaseEndTime,
-        sampleStartTime,
-        setSampleStartTime,
-        sampleEndTime,
-        setSampleEndTime,
-        samplePROrg,
-        setSamplePROrg,
-        samplePRRepo,
-        setSamplePRRepo,
-        samplePRNumber,
-        setSamplePRNumber,
-        columnGroupByCheckedItems,
-        setColumnGroupByCheckedItems,
-        dbGroupByVariants,
-        includeVariantsCheckedItems,
-        replaceIncludeVariantsCheckedItems,
-        compareVariantsCheckedItems,
-        replaceCompareVariantsCheckedItems,
-        variantCrossCompare,
-        updateVariantCrossCompare,
-        confidence,
-        setConfidence,
-        pity,
-        setPity,
-        minFail,
-        setMinFail,
-        ignoreMissing,
-        setIgnoreMissing,
-        ignoreDisruption,
-        setIgnoreDisruption,
-        component,
-        setComponentParam,
-        capability,
-        setCapabilityParam,
-        environment,
-        setEnvironmentParam,
-        handleGenerateReport,
-      }}
-    >
+    <CompReadyVarsContext.Provider value={vars}>
       {children}
     </CompReadyVarsContext.Provider>
   )

--- a/sippy-ng/src/component_readiness/CompReadyVars.js
+++ b/sippy-ng/src/component_readiness/CompReadyVars.js
@@ -288,7 +288,7 @@ export const CompReadyVarsProvider = ({ children }) => {
   ]
 
   // This runs when someone pushes the "Generate Report" button.
-  // We form an api string and then call the api.
+  // It sets all parameters based on current state; this causes the URL to be updated and page to load with new params.
   const handleGenerateReport = (event) => {
     event.preventDefault()
     setBaseReleaseParam(baseRelease)

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -239,6 +239,13 @@ export default function ComponentReadiness(props) {
 
   const varsContext = useContext(CompReadyVarsContext)
 
+  // Use varsAtPageLoad for describing report contents.
+  // This backhand way of recording app state (built according to initial params at page load) keeps
+  // the display of "what am I looking at" from re-rendering as the user changes the controls,
+  // until they trigger a new report loading in a new page.
+  const [varsAtPageLoad, setVarsAtPageLoad] = React.useState({})
+  useEffect(() => setVarsAtPageLoad(varsContext), [])
+
   const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
   const [testNameParam, setTestNameParam] = useQueryParam('testName', String)
 
@@ -383,7 +390,7 @@ export default function ComponentReadiness(props) {
   }
 
   const pageTitle = makePageTitle(
-    `Component Readiness for ${varsContext.sampleRelease} vs. ${varsContext.baseRelease}`,
+    `Component Readiness`,
     `page 1`,
     `rows: ${data && data.rows ? data.rows.length : 0}, columns: ${
       data && data.rows && data.rows[0] && data.rows[0].columns
@@ -550,6 +557,7 @@ export default function ComponentReadiness(props) {
                       <Sidebar />
                       <CompReadyPageTitle
                         pageTitle={pageTitle}
+                        pageNumber={1}
                         apiCallStr={showValuesForReport()}
                       />
                       {data === initialPageTable ? (

--- a/sippy-ng/src/component_readiness/GeneratedAt.js
+++ b/sippy-ng/src/component_readiness/GeneratedAt.js
@@ -14,7 +14,7 @@ export default function GeneratedAt(props) {
     <Box align="right">
       <Typography variant="caption">
         <Tooltip title={props.time}>
-          Generated {relativeTime(d, new Date())}
+          <span>Generated {relativeTime(d, new Date())}</span>
         </Tooltip>
       </Typography>
     </Box>

--- a/sippy-ng/src/component_readiness/GroupByCheckboxList.js
+++ b/sippy-ng/src/component_readiness/GroupByCheckboxList.js
@@ -26,15 +26,14 @@ export default function GroupByCheckboxList(props) {
   }))
 
   const classes = useStyles()
-  const [checkedItems, setCheckedItems] = useState(props.checkedItems)
   const handleChange = (event) => {
     const item = event.target.name
     const isChecked = event.target.checked
     if (isChecked) {
-      setCheckedItems([...checkedItems, item])
+      props.setCheckedItems([...props.checkedItems, item])
     } else {
-      setCheckedItems(
-        checkedItems.filter((checkedItem) => checkedItem !== item)
+      props.setCheckedItems(
+        props.checkedItems.filter((checkedItem) => checkedItem !== item)
       )
     }
   }
@@ -72,7 +71,7 @@ export default function GroupByCheckboxList(props) {
                     disabled={isCompareMode}
                     control={
                       <Checkbox
-                        checked={checkedItems.includes(item)}
+                        checked={props.checkedItems.includes(item)}
                         disabled={isCompareMode}
                         onChange={handleChange}
                         name={item}

--- a/sippy-ng/src/component_readiness/IncludeVariantCheckboxList.js
+++ b/sippy-ng/src/component_readiness/IncludeVariantCheckboxList.js
@@ -123,6 +123,18 @@ export default function IncludeVariantCheckBoxList(props) {
           {isCompareMode
             ? CompareVariantGroup(params)
             : IncludeVariantGroup(params)}
+          <Tooltip
+            title={'Compare with different variants for sample and basis'}
+          >
+            <Button
+              variant="contained"
+              color="primary"
+              className={classes.control}
+              onClick={handleToggleCompare}
+            >
+              {isCompareMode ? 'Cancel Compare' : 'Compare'}
+            </Button>
+          </Tooltip>
         </AccordionDetails>
       </Accordion>
     </FormControl>


### PR DESCRIPTION
The final commit here adds on to https://github.com/openshift/sippy/pull/1937 trying to get a display of what you're looking at. I want to expand this to also reformat how it shows which component, capability, etc you're looking at, but at the moment I'm struggling to get it to match what the user requested. Sometimes the cross comparison variant seems to be dropped. Sometimes the dates don't get updated. I think my converting `useEffect` to `useMemo` and trying to consolidate in central components means the hooks are not running quite when I want them to, but it's really confusing.