### PR TITLE
Stop selecting override display flag by default on intervals charts

### DIFF
--- a/sippy-ng/src/prow_job_runs/ProwJobRun.js
+++ b/sippy-ng/src/prow_job_runs/ProwJobRun.js
@@ -551,7 +551,7 @@ ProwJobRun.defaultProps = {
     'NodeState',
   ],
   intervalFile: '',
-  overrideDisplayFlag: true,
+  overrideDisplayFlag: false,
 }
 
 ProwJobRun.propTypes = {


### PR DESCRIPTION
This was because important intervals did not have the display flag
correctly set until 4.17. Now that we're primarily focused on 4.17+,
this can be unselected by default. If working with old releases and you
see too little data, just check the box.
