### PR TITLE
trt-1788: Ensure IncludeVariants not otherwise referenced are part of test_details query

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -245,7 +245,7 @@ var (
 	// We're not sure what these aggregator jobs are but they exist as of right now:
 	aggregatorRegex = regexp.MustCompile(`(?i)aggregator-`)
 	alibabaRegex    = regexp.MustCompile(`(?i)-alibaba`)
-	arm64Regex      = regexp.MustCompile(`(?i)-arm64|-multi-a-a`)
+	arm64Regex      = regexp.MustCompile(`(?i)-arm64|-multi-a-a|-arm`)
 	assistedRegex   = regexp.MustCompile(`(?i)-assisted`)
 	awsRegex        = regexp.MustCompile(`(?i)-aws`)
 	azureRegex      = regexp.MustCompile(`(?i)-azure`)

--- a/pkg/variantregistry/ocp_test.go
+++ b/pkg/variantregistry/ocp_test.go
@@ -206,6 +206,31 @@ func TestVariantSyncer(t *testing.T) {
 			},
 		},
 		{
+			job: "periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.17-periodics-e2e-aws-arm",
+			variantsFile: map[string]string{
+				"Architecture": "amd64", // should be overruled by the job parsing.
+			},
+			expected: map[string]string{
+				VariantRelease:       "4.17",
+				VariantReleaseMajor:  "4",
+				VariantReleaseMinor:  "17",
+				VariantArch:          "arm64",
+				VariantInstaller:     "ipi",
+				VariantPlatform:      "aws",
+				VariantNetwork:       "ovn",
+				VariantNetworkStack:  "ipv4",
+				VariantOwner:         "eng",
+				VariantSuite:         "unknown",
+				VariantTopology:      "ha",
+				VariantUpgrade:       "none",
+				VariantAggregation:   "none",
+				VariantFeatureSet:    VariantDefaultValue,
+				VariantNetworkAccess: VariantDefaultValue,
+				VariantScheduler:     VariantDefaultValue,
+				VariantSecurityMode:  VariantDefaultValue,
+			},
+		},
+		{
 			job: "periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-e2e-ovn-powervs-capi-multi-p-p",
 			variantsFile: map[string]string{
 				"Architecture": "amd64", // should be overruled by the job parsing.


### PR DESCRIPTION
- Owner was not part of the TestDetails query and we were picking up non eng jobs.  
- Triage is based on TestDetails and perfscale job was added added to the triage job runs
- ComponentReadiness detected more triaged job runs than failures and skipped triage
- Fixed TD query to honor IncludeVariants not referenced elsewhere
- Found periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.17-periodics-e2e-aws-arm showing up as amd64, updated variant parsing