### PR TITLE
trt-1792: Add all regressions view to RegressedTestsModal.js

### DIFF
--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -32,7 +32,6 @@ import {
   initialPageTable,
   makePageTitle,
   makeRFC3339Time,
-  mergeRegressedTests,
   noDataTable,
   Search,
   SearchIconWrapper,

--- a/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
+++ b/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
@@ -20,14 +20,11 @@ import {
 } from '@mui/icons-material'
 import { Link } from 'react-router-dom'
 import {
-  mergeRegressedTests,
-  mergeTriagedIncidents,
+  mergeRegressionData,
   Search,
   SearchIconWrapper,
   StyledInputBase,
 } from './CompReadyUtils'
-import BugButton from '../bugs/BugButton'
-import ComponentReadinessHelp from './ComponentReadinessHelp'
 import IconButton from '@mui/material/IconButton'
 import PropTypes from 'prop-types'
 import React, { Fragment } from 'react'
@@ -48,8 +45,11 @@ export default function ComponentReadinessToolBar(props) {
     filterVals,
   } = props
 
-  const regressedTests = mergeRegressedTests(data)
-  const triagedIncidents = mergeTriagedIncidents(data)
+  let regressionData = mergeRegressionData(data)
+
+  const regressedTests = regressionData.length > 0 ? regressionData[0] : null
+  const allRegressedTests = regressionData.length > 1 ? regressionData[1] : null
+  const triagedIncidents = regressionData.length > 2 ? regressionData[2] : null
 
   const linkToReport = () => {
     const currentUrl = new URL(window.location.href)
@@ -253,6 +253,7 @@ export default function ComponentReadinessToolBar(props) {
       </Popover>
       <RegressedTestsModal
         regressedTests={regressedTests}
+        allRegressedTests={allRegressedTests}
         triagedIncidents={triagedIncidents}
         filterVals={filterVals}
         isOpen={regressedTestDialog}

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -1,59 +1,9 @@
-import {
-  Box,
-  Button,
-  Grid,
-  Popover,
-  Tab,
-  Tabs,
-  Tooltip,
-  Typography,
-} from '@mui/material'
-import { CompReadyVarsContext } from './CompReadyVars'
-import { DataGrid, GridToolbar } from '@mui/x-data-grid'
-import { FileCopy } from '@mui/icons-material'
-import { formColumnName, sortQueryParams } from './CompReadyUtils'
-import { Link } from 'react-router-dom'
-import { relativeTime } from '../helpers'
-import { safeEncodeURIComponent } from '../helpers'
-import CompSeverityIcon from './CompSeverityIcon'
+import { Box, Button, Grid, Tab, Tabs, Typography } from '@mui/material'
 import Dialog from '@mui/material/Dialog'
-import IconButton from '@mui/material/IconButton'
 import PropTypes from 'prop-types'
 import React, { Fragment, useContext } from 'react'
+import RegressedTestsPanel from './RegressedTestsPanel'
 import TriagedIncidentsPanel from './TriagedIncidentsPanel'
-
-// Construct a URL with all existing filters plus testId, environment, and testName.
-// This is the url used when you click inside a TableCell on page4 on the right.
-// We pass these arguments to the component that generates the test details report.
-function generateTestReport(
-  testId,
-  variants,
-  filterVals,
-  componentName,
-  capabilityName,
-  testName
-) {
-  const environmentVal = formColumnName({ variants: variants })
-  const { expandEnvironment } = useContext(CompReadyVarsContext)
-  const safeComponentName = safeEncodeURIComponent(componentName)
-  const safeTestId = safeEncodeURIComponent(testId)
-  const safeTestName = safeEncodeURIComponent(testName)
-  let variantsUrl = ''
-  Object.entries(variants).forEach(([key, value]) => {
-    variantsUrl += '&' + key + '=' + safeEncodeURIComponent(value)
-  })
-  const retUrl =
-    '/component_readiness/test_details' +
-    filterVals +
-    `&testId=${safeTestId}` +
-    expandEnvironment(environmentVal) +
-    `&component=${safeComponentName}` +
-    `&capability=${capabilityName}` +
-    variantsUrl +
-    `&testName=${safeTestName}`
-
-  return sortQueryParams(retUrl)
-}
 
 function tabProps(index) {
   return {
@@ -95,149 +45,6 @@ export default function RegressedTestsModal(props) {
     setActiveTabIndex(newValue)
   }
 
-  const [sortModel, setSortModel] = React.useState([
-    { field: 'component', sort: 'asc' },
-  ])
-
-  // Helpers for copying the test ID to clipboard
-  const [copyPopoverEl, setCopyPopoverEl] = React.useState(null)
-  const copyPopoverOpen = Boolean(copyPopoverEl)
-  const copyTestID = (event, testId) => {
-    event.preventDefault()
-    navigator.clipboard.writeText(testId)
-    setCopyPopoverEl(event.currentTarget)
-    setTimeout(() => setCopyPopoverEl(null), 2000)
-  }
-
-  // define table columns
-  const columns = [
-    {
-      field: 'component',
-      headerName: 'Component',
-      flex: 20,
-      renderCell: (param) => <div className="test-name">{param.value}</div>,
-    },
-    {
-      field: 'capability',
-      headerName: 'Capability',
-      flex: 12,
-      renderCell: (param) => <div className="test-name">{param.value}</div>,
-    },
-    {
-      field: 'test_name',
-      headerName: 'Test Name',
-      flex: 40,
-      renderCell: (param) => <div className="test-name">{param.value}</div>,
-    },
-    {
-      field: 'test_suite',
-      headerName: 'Test Suite',
-      flex: 15,
-      renderCell: (param) => <div className="test-name">{param.value}</div>,
-    },
-    {
-      field: 'variants',
-      headerName: 'Variants',
-      flex: 30,
-      valueGetter: (params) => {
-        return formColumnName({ variants: params.row.variants })
-      },
-      renderCell: (param) => <div className="test-name">{param.value}</div>,
-    },
-    {
-      field: 'opened',
-      headerName: 'Regressed Since',
-      flex: 12,
-      valueGetter: (params) => {
-        if (!params.row.opened) {
-          // For a regression we haven't yet detected:
-          return ''
-        }
-        const regressedSinceDate = new Date(params.row.opened)
-        return relativeTime(regressedSinceDate, new Date())
-      },
-      renderCell: (param) => (
-        <Tooltip title="WARNING: This is the first time we detected this test regressed in the default query. This value is not relevant if you've altered query parameters from the default.">
-          <div className="regressed-since">{param.value}</div>
-        </Tooltip>
-      ),
-    },
-    {
-      field: 'fisher_exact',
-      headerName: 'Certainty',
-      flex: 8,
-      valueGetter: (params) => {
-        if (!params.row.fisher_exact) {
-          return ''
-        }
-        return (100 - params.row.fisher_exact * 100).toFixed(1)
-      },
-      renderCell: (param) => (
-        <div className="fishers-exact">{param.value}%</div>
-      ),
-    },
-    {
-      field: 'pass_rate_delta',
-      headerName: 'Pass Rate Delta',
-      flex: 8,
-      valueGetter: (params) => {
-        if (!params.row.sample_stats || !params.row.base_stats) {
-          return ''
-        }
-        return (
-          (params.row.sample_stats.success_rate * 100).toFixed(0) -
-          (params.row.base_stats.success_rate * 100).toFixed(0)
-        )
-      },
-      renderCell: (param) => <div className="pass-rate">{param.value}%</div>,
-    },
-    {
-      field: 'test_id',
-      flex: 5,
-      headerName: 'ID',
-      renderCell: (params) => {
-        return (
-          <IconButton
-            onClick={(event) => copyTestID(event, params.value)}
-            size="small"
-            aria-label="Copy test ID"
-            color="inherit"
-            sx={{ marginBottom: 1 }}
-          >
-            <Tooltip title="Copy test ID">
-              <FileCopy color="primary" />
-            </Tooltip>
-          </IconButton>
-        )
-      },
-    },
-    {
-      field: 'status',
-      headerName: 'Status',
-      renderCell: (params) => (
-        <div
-          style={{
-            textAlign: 'center',
-          }}
-          className="status"
-        >
-          <Link
-            to={generateTestReport(
-              params.row.test_id,
-              params.row.variants,
-              props.filterVals,
-              params.row.component,
-              params.row.capability,
-              params.row.test_name
-            )}
-          >
-            <CompSeverityIcon status={params.value} />
-          </Link>
-        </div>
-      ),
-      flex: 6,
-    },
-  ]
   return (
     <Fragment>
       <Dialog
@@ -252,41 +59,24 @@ export default function RegressedTestsModal(props) {
             onChange={handleTabChange}
             aria-label="Regressed Tests Tabs"
           >
-            <Tab label="Regressed Tests" {...tabProps(0)} />
-            <Tab label="Triaged Incidents" {...tabProps(1)} />
+            <Tab label="Untriaged Regressions" {...tabProps(0)} />
+            <Tab label="Regressed Tests" {...tabProps(1)} />
+            <Tab label="Triaged Incidents" {...tabProps(2)} />
           </Tabs>
           <RegressedTestsTabPanel activeIndex={activeTabIndex} index={0}>
-            <DataGrid
-              sortModel={sortModel}
-              onSortModelChange={setSortModel}
-              components={{ Toolbar: GridToolbar }}
-              rows={props.regressedTests}
-              columns={columns}
-              getRowId={(row) =>
-                row.test_id +
-                row.component +
-                row.capability +
-                Object.keys(row.variants)
-                  .map((key) => row.variants[key])
-                  .join(' ')
-              }
-              pageSize={10}
-              rowHeight={60}
-              autoHeight={true}
-              checkboxSelection={false}
-              componentsProps={{
-                toolbar: {
-                  columns: columns,
-                  showQuickFilter: true,
-                },
-              }}
+            <RegressedTestsPanel
+              regressedTests={props.regressedTests}
+              filterVals={props.filterVals}
             />
           </RegressedTestsTabPanel>
           <RegressedTestsTabPanel activeIndex={activeTabIndex} index={1}>
-            <TriagedIncidentsPanel
-              regressedTests={props.regressedTests}
-              triagedIncidents={props.triagedIncidents}
+            <RegressedTestsPanel
+              regressedTests={props.allRegressedTests}
+              filterVals={props.filterVals}
             />
+          </RegressedTestsTabPanel>
+          <RegressedTestsTabPanel activeIndex={activeTabIndex} index={2}>
+            <TriagedIncidentsPanel triagedIncidents={props.triagedIncidents} />
           </RegressedTestsTabPanel>
           <Button
             style={{ marginTop: 20, marginBottom: 20, marginLeft: 20 }}
@@ -297,22 +87,6 @@ export default function RegressedTestsModal(props) {
             CLOSE
           </Button>
         </Grid>
-        <Popover
-          id="copyPopover"
-          open={copyPopoverOpen}
-          anchorEl={copyPopoverEl}
-          onClose={() => setCopyPopoverEl(null)}
-          anchorOrigin={{
-            vertical: 'bottom',
-            horizontal: 'center',
-          }}
-          transformOrigin={{
-            vertical: 'top',
-            horizontal: 'center',
-          }}
-        >
-          ID copied!
-        </Popover>
       </Dialog>
     </Fragment>
   )
@@ -320,6 +94,7 @@ export default function RegressedTestsModal(props) {
 
 RegressedTestsModal.propTypes = {
   regressedTests: PropTypes.array,
+  allRegressedTests: PropTypes.array,
   triagedIncidents: PropTypes.array,
   filterVals: PropTypes.string.isRequired,
   isOpen: PropTypes.bool,

--- a/sippy-ng/src/component_readiness/RegressedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsPanel.js
@@ -1,0 +1,241 @@
+import { CompReadyVarsContext } from './CompReadyVars'
+import { DataGrid, GridToolbar } from '@mui/x-data-grid'
+import { FileCopy } from '@mui/icons-material'
+import { formColumnName, sortQueryParams } from './CompReadyUtils'
+import { Link } from 'react-router-dom'
+import { Popover, Tooltip } from '@mui/material'
+import { relativeTime, safeEncodeURIComponent } from '../helpers'
+import CompSeverityIcon from './CompSeverityIcon'
+import IconButton from '@mui/material/IconButton'
+import PropTypes from 'prop-types'
+import React, { Fragment, useContext } from 'react'
+
+// Construct a URL with all existing filters plus testId, environment, and testName.
+// This is the url used when you click inside a TableCell on page4 on the right.
+// We pass these arguments to the component that generates the test details report.
+function generateTestReport(
+  testId,
+  variants,
+  filterVals,
+  componentName,
+  capabilityName,
+  testName
+) {
+  const environmentVal = formColumnName({ variants: variants })
+  const { expandEnvironment } = useContext(CompReadyVarsContext)
+  const safeComponentName = safeEncodeURIComponent(componentName)
+  const safeTestId = safeEncodeURIComponent(testId)
+  const safeTestName = safeEncodeURIComponent(testName)
+  let variantsUrl = ''
+  Object.entries(variants).forEach(([key, value]) => {
+    variantsUrl += '&' + key + '=' + safeEncodeURIComponent(value)
+  })
+  const retUrl =
+    '/component_readiness/test_details' +
+    filterVals +
+    `&testId=${safeTestId}` +
+    expandEnvironment(environmentVal) +
+    `&component=${safeComponentName}` +
+    `&capability=${capabilityName}` +
+    variantsUrl +
+    `&testName=${safeTestName}`
+
+  return sortQueryParams(retUrl)
+}
+
+export default function RegressedTestsPanel(props) {
+  const [sortModel, setSortModel] = React.useState([
+    { field: 'component', sort: 'asc' },
+  ])
+
+  // Helpers for copying the test ID to clipboard
+  const [copyPopoverEl, setCopyPopoverEl] = React.useState(null)
+  const copyPopoverOpen = Boolean(copyPopoverEl)
+  const copyTestID = (event, testId) => {
+    event.preventDefault()
+    navigator.clipboard.writeText(testId)
+    setCopyPopoverEl(event.currentTarget)
+    setTimeout(() => setCopyPopoverEl(null), 2000)
+  }
+
+  // define table columns
+  const columns = [
+    {
+      field: 'component',
+      headerName: 'Component',
+      flex: 20,
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'capability',
+      headerName: 'Capability',
+      flex: 12,
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'test_name',
+      headerName: 'Test Name',
+      flex: 40,
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'test_suite',
+      headerName: 'Test Suite',
+      flex: 15,
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'variants',
+      headerName: 'Variants',
+      flex: 30,
+      valueGetter: (params) => {
+        return formColumnName({ variants: params.row.variants })
+      },
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'opened',
+      headerName: 'Regressed Since',
+      flex: 12,
+      valueGetter: (params) => {
+        if (!params.row.opened) {
+          // For a regression we haven't yet detected:
+          return ''
+        }
+        const regressedSinceDate = new Date(params.row.opened)
+        return relativeTime(regressedSinceDate, new Date())
+      },
+      renderCell: (param) => (
+        <Tooltip title="WARNING: This is the first time we detected this test regressed in the default query. This value is not relevant if you've altered query parameters from the default.">
+          <div className="regressed-since">{param.value}</div>
+        </Tooltip>
+      ),
+    },
+    {
+      field: 'fisher_exact',
+      headerName: 'Certainty',
+      flex: 8,
+      valueGetter: (params) => {
+        if (!params.row.fisher_exact) {
+          return ''
+        }
+        return (100 - params.row.fisher_exact * 100).toFixed(1)
+      },
+      renderCell: (param) => (
+        <div className="fishers-exact">{param.value}%</div>
+      ),
+    },
+    {
+      field: 'pass_rate_delta',
+      headerName: 'Pass Rate Delta',
+      flex: 8,
+      valueGetter: (params) => {
+        if (!params.row.sample_stats || !params.row.base_stats) {
+          return ''
+        }
+        return (
+          (params.row.sample_stats.success_rate * 100).toFixed(0) -
+          (params.row.base_stats.success_rate * 100).toFixed(0)
+        )
+      },
+      renderCell: (param) => <div className="pass-rate">{param.value}%</div>,
+    },
+    {
+      field: 'test_id',
+      flex: 5,
+      headerName: 'ID',
+      renderCell: (params) => {
+        return (
+          <IconButton
+            onClick={(event) => copyTestID(event, params.value)}
+            size="small"
+            aria-label="Copy test ID"
+            color="inherit"
+            sx={{ marginBottom: 1 }}
+          >
+            <Tooltip title="Copy test ID">
+              <FileCopy color="primary" />
+            </Tooltip>
+          </IconButton>
+        )
+      },
+    },
+    {
+      field: 'status',
+      headerName: 'Status',
+      renderCell: (params) => (
+        <div
+          style={{
+            textAlign: 'center',
+          }}
+          className="status"
+        >
+          <Link
+            to={generateTestReport(
+              params.row.test_id,
+              params.row.variants,
+              props.filterVals,
+              params.row.component,
+              params.row.capability,
+              params.row.test_name
+            )}
+          >
+            <CompSeverityIcon status={params.value} />
+          </Link>
+        </div>
+      ),
+      flex: 6,
+    },
+  ]
+
+  return (
+    <Fragment>
+      <DataGrid
+        sortModel={sortModel}
+        onSortModelChange={setSortModel}
+        components={{ Toolbar: GridToolbar }}
+        rows={props.regressedTests}
+        columns={columns}
+        getRowId={(row) =>
+          row.test_id +
+          row.component +
+          row.capability +
+          Object.keys(row.variants)
+            .map((key) => row.variants[key])
+            .join(' ')
+        }
+        pageSize={10}
+        rowHeight={60}
+        autoHeight={true}
+        checkboxSelection={false}
+        componentsProps={{
+          toolbar: {
+            columns: columns,
+            showQuickFilter: true,
+          },
+        }}
+      />
+      <Popover
+        id="copyPopover"
+        open={copyPopoverOpen}
+        anchorEl={copyPopoverEl}
+        onClose={() => setCopyPopoverEl(null)}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+      >
+        ID copied!
+      </Popover>
+    </Fragment>
+  )
+}
+
+RegressedTestsPanel.propTypes = {
+  regressedTests: PropTypes.array,
+  filterVals: PropTypes.string.isRequired,
+}

--- a/sippy-ng/src/component_readiness/TriagedIncidentGroups.js
+++ b/sippy-ng/src/component_readiness/TriagedIncidentGroups.js
@@ -69,6 +69,5 @@ export default function TriagedIncidentGroups(props) {
 
 TriagedIncidentGroups.propTypes = {
   eventEmitter: PropTypes.object,
-  regressedTests: PropTypes.array,
   triagedIncidents: PropTypes.array,
 }

--- a/sippy-ng/src/component_readiness/TriagedIncidentsPanel.js
+++ b/sippy-ng/src/component_readiness/TriagedIncidentsPanel.js
@@ -14,7 +14,6 @@ export default function TriagedIncidentsPanel(props) {
       <Grid>
         <TriagedIncidentGroups
           eventEmitter={eventEmitter}
-          regressedTests={props.regressedTests}
           triagedIncidents={props.triagedIncidents}
         />
         <TriagedVariants eventEmitter={eventEmitter} />
@@ -25,8 +24,5 @@ export default function TriagedIncidentsPanel(props) {
 }
 
 TriagedIncidentsPanel.propTypes = {
-  /* regressedTests is currently a placeholder
-  for future work adding / updating incidents */
-  regressedTests: PropTypes.array,
   triagedIncidents: PropTypes.array,
 }

--- a/sippy-ng/src/component_readiness/TriagedVariants.js
+++ b/sippy-ng/src/component_readiness/TriagedVariants.js
@@ -1,5 +1,7 @@
 import { DataGrid, GridToolbar } from '@mui/x-data-grid'
-import { Typography } from '@mui/material'
+import { formColumnName } from './CompReadyUtils'
+import { relativeTime } from '../helpers'
+import { Tooltip, Typography } from '@mui/material'
 import PropTypes from 'prop-types'
 import React, { Fragment } from 'react'
 
@@ -38,98 +40,67 @@ export default function TriagedVariants(props) {
   // define table columns
   const columns = [
     {
+      field: 'component',
+      headerName: 'Component',
+      flex: 20,
+      valueGetter: (params) => {
+        return params.row.details.component
+      },
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'capability',
+      headerName: 'Capability',
+      flex: 12,
+      valueGetter: (params) => {
+        return params.row.details.capability
+      },
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
       field: 'test_name',
-      valueGetter: (value) => {
-        return value.row.test_name
+      headerName: 'Test Name',
+      flex: 40,
+      valueGetter: (params) => {
+        return params.row.details.test_name
       },
-      headerName: 'Test',
-      flex: 20,
       renderCell: (param) => <div className="test-name">{param.value}</div>,
     },
     {
-      field: 'architecture',
-      valueGetter: (value) => {
-        let showValue = 'Missing'
-        value.row.variants.forEach((variant) => {
-          if ('key' in variant && variant['key'] === 'Architecture') {
-            if ('value' in variant) {
-              showValue = variant['value']
-            }
-          }
-        })
-        return showValue
+      field: 'test_suite',
+      headerName: 'Test Suite',
+      flex: 15,
+      valueGetter: (params) => {
+        return params.row.details.test_suite
       },
-      headerName: 'Architecture',
-      flex: 20,
       renderCell: (param) => <div className="test-name">{param.value}</div>,
     },
     {
-      field: 'network',
-      valueGetter: (value) => {
-        let showValue = 'Missing'
-        value.row.variants.forEach((variant) => {
-          if ('key' in variant && variant['key'] === 'Network') {
-            if ('value' in variant) {
-              showValue = variant['value']
-            }
-          }
-        })
-        return showValue
+      field: 'variants',
+      headerName: 'Variants',
+      flex: 30,
+      valueGetter: (params) => {
+        return formColumnName({ variants: params.row.details.variants })
       },
-      headerName: 'Network',
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'opened',
+      headerName: 'Regressed Since',
       flex: 12,
-      renderCell: (param) => <div className="test-name">{param.value}</div>,
-    },
-    {
-      field: 'platform',
-      valueGetter: (value) => {
-        let showValue = 'Missing'
-        value.row.variants.forEach((variant) => {
-          if ('key' in variant && variant['key'] === 'Platform') {
-            if ('value' in variant) {
-              showValue = variant['value']
-            }
-          }
-        })
-        return showValue
+      valueGetter: (params) => {
+        if (!params.row.details.opened) {
+          // For a regression we haven't yet detected:
+          return ''
+        }
+        const regressedSinceDate = new Date(params.row.details.opened)
+        return relativeTime(regressedSinceDate, new Date())
       },
-      headerName: 'Platform',
-      flex: 12,
-      renderCell: (param) => <div className="test-name">{param.value}</div>,
-    },
-    {
-      field: 'upgrade',
-      valueGetter: (value) => {
-        let showValue = 'Missing'
-        value.row.variants.forEach((variant) => {
-          if ('key' in variant && variant['key'] === 'Upgrade') {
-            if ('value' in variant) {
-              showValue = variant['value']
-            }
-          }
-        })
-        return showValue
-      },
-      headerName: 'Upgrade',
-      flex: 12,
-      renderCell: (param) => <div className="test-name">{param.value}</div>,
-    },
-    {
-      field: 'variant', // gets replaced with pantfusi
-      valueGetter: (value) => {
-        let showValue = 'Missing'
-        value.row.variants.forEach((variant) => {
-          if ('key' in variant && variant['key'] === 'Variant') {
-            if ('value' in variant) {
-              showValue = variant['value']
-            }
-          }
-        })
-        return showValue
-      },
-      headerName: 'Variant',
-      flex: 12,
-      renderCell: (param) => <div className="test-name">{param.value}</div>,
+      renderCell: (param) => (
+        <Tooltip title="WARNING: This is the first time we detected this test regressed in the default query. This value is not relevant if you've altered query parameters from the default.">
+          <div className="regressed-since">{param.value}</div>
+        </Tooltip>
+      ),
     },
   ]
 


### PR DESCRIPTION
- Moved RegressedTests to its own panel
- Consolidated code creating regression data arrays
- Added new tab with all regressed tests
- Refactored Triaged Incidents Test Failures columns to better align with Regressed Tests



![image](https://github.com/user-attachments/assets/711f82ba-a7f2-43ed-aa93-37103e5012ce)

![image](https://github.com/user-attachments/assets/53c0258e-06f1-4beb-ab78-d088290b5373)
