### PR TITLE
Add regression for metal dualstack

### DIFF
--- a/pkg/regressionallowances/intentional_regressions.go
+++ b/pkg/regressionallowances/intentional_regressions.go
@@ -1,6 +1,7 @@
 package regressionallowances
 
 import (
+	_ "embed"
 	"encoding/json"
 	"fmt"
 )
@@ -62,13 +63,19 @@ import (
 // }
 // ]
 
+//go:embed metal_dualstack_4.17_regression.json
+var metal_dualstack_regressions4_17 []byte
+
 var (
 	release415 release = "4.15"
+	release417 release = "4.17"
 )
 
 //nolint:all
 func init() {
 	// importIntentionalRegressions(release415, regressions4_15)
+	importIntentionalRegressions(release417, metal_dualstack_regressions4_17)
+
 }
 
 func importIntentionalRegressions(releaseTarget release, jsonRegressions []byte) {

--- a/pkg/regressionallowances/metal_dualstack_4.17_regression.json
+++ b/pkg/regressionallowances/metal_dualstack_4.17_regression.json
@@ -1,0 +1,27 @@
+[
+  {
+    "JiraComponent": "Networking / cluster-network-operator",
+    "TestID": "Operator results:4b5f6af893ad5577904fbaec3254506d",
+    "TestName": "operator conditions network",
+    "JiraBug": "https://issues.redhat.com/browse/OCPBUGS-41811",
+    "ReasonToAllowInsteadOfFix": "TBD Reason - Explain why we can't address the issue before GA",
+    "variant": {
+      "variants": {
+        "Network": "ovn",
+        "Upgrade": "none",
+        "Architecture": "amd64",
+        "Platform": "metal",
+        "FeatureSet": "default",
+        "Suite": "parallel",
+        "Topology": "ha",
+        "Installer": "ipi"
+      }
+    },
+    "PreviousSuccesses": 22,
+    "PreviousFailures": 0,
+    "PreviousFlakes": 0,
+    "RegressedSuccesses": 6,
+    "RegressedFailures": 4,
+    "RegressedFlakes": 0
+  }
+]


### PR DESCRIPTION
Add regression to clear the regression signal and preserve the previous releases baseline

- Add JSON file
- Embed the JSON in intentional_regressions.go
- Import the regressions



```
//go:embed metal_dualstack_4.17_regression.json
var metal_dualstack_regressions4_17 []byte

func init() {
importIntentionalRegressions(release417, metal_dualstack_regressions4_17)
}
```