### PR TITLE
Add regressions for 4.17

### DIFF
--- a/pkg/regressionallowances/intentional_regressions.go
+++ b/pkg/regressionallowances/intentional_regressions.go
@@ -1,6 +1,7 @@
 package regressionallowances
 
 import (
+	_ "embed"
 	"encoding/json"
 	"fmt"
 )
@@ -62,13 +63,19 @@ import (
 // }
 // ]
 
+//go:embed regressions_4.17.json
+var regressions4_17 []byte
+
 var (
 	release415 release = "4.15"
+	release417 release = "4.17"
 )
 
 //nolint:all
 func init() {
 	// importIntentionalRegressions(release415, regressions4_15)
+	importIntentionalRegressions(release417, regressions4_17)
+
 }
 
 func importIntentionalRegressions(releaseTarget release, jsonRegressions []byte) {

--- a/pkg/regressionallowances/regressions_4.17.json
+++ b/pkg/regressionallowances/regressions_4.17.json
@@ -29,7 +29,7 @@
     "TestID": "openshift-tests:d6b41cee7afca1c2a0b52f9e6975425f",
     "TestName": "[bz-kube-apiserver][invariant] alert/KubeAPIErrorBudgetBurn should not be at or above info",
     "JiraBug": "https://issues.redhat.com/browse/OCPBUGS-42083",
-    "ReasonToAllowInsteadOfFix": "TBD Reason",
+    "ReasonToAllowInsteadOfFix": "Degraded near the end of stabilization.  Investigation indicated not a release blocker.",
     "variant": {
       "variants": {
         "Network": "ovn",

--- a/pkg/regressionallowances/regressions_4.17.json
+++ b/pkg/regressionallowances/regressions_4.17.json
@@ -20,7 +20,32 @@
     "PreviousSuccesses": 66,
     "PreviousFailures": 0,
     "PreviousFlakes": 1,
-    "RegressedSuccesses": 27,
+    "RegressedSuccesses": 25,
+    "RegressedFailures": 3,
+    "RegressedFlakes": 0
+  },
+  {
+    "JiraComponent": "Management Console",
+    "TestID": "openshift-tests:f9552d2b4b817d19bdcd666a7b8d1ece",
+    "TestName": "[bz-Management Console] clusteroperator/console should not change condition/Available",
+    "JiraBug": "https://issues.redhat.com/browse/OCPBUGS-39580",
+    "ReasonToAllowInsteadOfFix": "Test flaked in 4.16, became more strict in 4.17",
+    "variant": {
+      "variants": {
+        "Network": "ovn",
+        "Upgrade": "none",
+        "Architecture": "amd64",
+        "Platform": "vsphere",
+        "FeatureSet": "default",
+        "Suite": "unknown",
+        "Topology": "ha",
+        "Installer": "upi"
+      }
+    },
+    "PreviousSuccesses": 72,
+    "PreviousFailures": 0,
+    "PreviousFlakes": 1,
+    "RegressedSuccesses": 35,
     "RegressedFailures": 4,
     "RegressedFlakes": 0
   },
@@ -45,8 +70,33 @@
     "PreviousSuccesses": 74,
     "PreviousFailures": 0,
     "PreviousFlakes": 0,
-    "RegressedSuccesses": 24,
+    "RegressedSuccesses": 20,
     "RegressedFailures": 3,
+    "RegressedFlakes": 0
+  },
+  {
+    "JiraComponent": "kube-apiserver",
+    "TestID": "openshift-tests-upgrade:d6b41cee7afca1c2a0b52f9e6975425f",
+    "TestName": "[bz-kube-apiserver][invariant] alert/KubeAPIErrorBudgetBurn should not be at or above info",
+    "JiraBug": "https://issues.redhat.com/browse/OCPBUGS-42083",
+    "ReasonToAllowInsteadOfFix": "Degraded near the end of stabilization.  Investigation indicated not a release blocker.",
+    "variant": {
+      "variants": {
+        "Network": "ovn",
+        "Upgrade": "micro",
+        "Architecture": "amd64",
+        "Platform": "azure",
+        "FeatureSet": "default",
+        "Suite": "unknown",
+        "Topology": "ha",
+        "Installer": "ipi"
+      }
+    },
+    "PreviousSuccesses": 735,
+    "PreviousFailures": 3,
+    "PreviousFlakes": 0,
+    "RegressedSuccesses": 211,
+    "RegressedFailures": 16,
     "RegressedFlakes": 0
   }
 ]

--- a/pkg/regressionallowances/regressions_4.17.json
+++ b/pkg/regressionallowances/regressions_4.17.json
@@ -4,7 +4,7 @@
     "TestID": "openshift-tests:f9552d2b4b817d19bdcd666a7b8d1ece",
     "TestName": "[bz-Management Console] clusteroperator/console should not change condition/Available",
     "JiraBug": "https://issues.redhat.com/browse/OCPBUGS-39580",
-    "ReasonToAllowInsteadOfFix": "TBD Reason",
+    "ReasonToAllowInsteadOfFix": "Test flaked in 4.16, became more strict in 4.17",
     "variant": {
       "variants": {
         "Network": "ovn",
@@ -29,7 +29,7 @@
     "TestID": "openshift-tests:f9552d2b4b817d19bdcd666a7b8d1ece",
     "TestName": "[bz-Management Console] clusteroperator/console should not change condition/Available",
     "JiraBug": "https://issues.redhat.com/browse/OCPBUGS-39580",
-    "ReasonToAllowInsteadOfFix": "TBD Reason",
+    "ReasonToAllowInsteadOfFix": "Test flaked in 4.16, became more strict in 4.17",
     "variant": {
       "variants": {
         "Network": "ovn",

--- a/pkg/regressionallowances/regressions_4.17.json
+++ b/pkg/regressionallowances/regressions_4.17.json
@@ -1,0 +1,77 @@
+[
+  {
+    "JiraComponent": "Management Console",
+    "TestID": "openshift-tests:f9552d2b4b817d19bdcd666a7b8d1ece",
+    "TestName": "[bz-Management Console] clusteroperator/console should not change condition/Available",
+    "JiraBug": "https://issues.redhat.com/browse/OCPBUGS-39580",
+    "ReasonToAllowInsteadOfFix": "TBD Reason",
+    "variant": {
+      "variants": {
+        "Network": "ovn",
+        "Upgrade": "none",
+        "Architecture": "amd64",
+        "Platform": "vsphere",
+        "FeatureSet": "default",
+        "Suite": "serial",
+        "Topology": "ha",
+        "Installer": "upi"
+      }
+    },
+    "PreviousSuccesses": 61,
+    "PreviousFailures": 0,
+    "PreviousFlakes": 1,
+    "RegressedSuccesses": 18,
+    "RegressedFailures": 3,
+    "RegressedFlakes": 0
+  },
+  {
+    "JiraComponent": "Management Console",
+    "TestID": "openshift-tests:f9552d2b4b817d19bdcd666a7b8d1ece",
+    "TestName": "[bz-Management Console] clusteroperator/console should not change condition/Available",
+    "JiraBug": "https://issues.redhat.com/browse/OCPBUGS-39580",
+    "ReasonToAllowInsteadOfFix": "TBD Reason",
+    "variant": {
+      "variants": {
+        "Network": "ovn",
+        "Upgrade": "none",
+        "Architecture": "amd64",
+        "Platform": "vsphere",
+        "FeatureSet": "default",
+        "Suite": "unknown",
+        "Topology": "ha",
+        "Installer": "upi"
+      }
+    },
+    "PreviousSuccesses": 68,
+    "PreviousFailures": 0,
+    "PreviousFlakes": 1,
+    "RegressedSuccesses": 27,
+    "RegressedFailures": 3,
+    "RegressedFlakes": 0
+  },
+  {
+    "JiraComponent": "openshift-apiserver",
+    "TestID": "openshift-tests:e7f70b89f489bfa8d1e923c9832cdeff",
+    "TestName": "[bz-openshift-apiserver] clusteroperator/openshift-apiserver should not change condition/Available",
+    "JiraBug": "https://issues.redhat.com/browse/OCPBUGS-23746",
+    "ReasonToAllowInsteadOfFix": "TBD Reason",
+    "variant": {
+      "variants": {
+        "Network": "ovn",
+        "Upgrade": "none",
+        "Architecture": "amd64",
+        "Platform": "vsphere",
+        "FeatureSet": "default",
+        "Suite": "unknown",
+        "Topology": "ha",
+        "Installer": "ipi"
+      }
+    },
+    "PreviousSuccesses": 139,
+    "PreviousFailures": 0,
+    "PreviousFlakes": 1,
+    "RegressedSuccesses": 71,
+    "RegressedFailures": 4,
+    "RegressedFlakes": 0
+  }
+]

--- a/pkg/regressionallowances/regressions_4.17.json
+++ b/pkg/regressionallowances/regressions_4.17.json
@@ -17,61 +17,36 @@
         "Installer": "upi"
       }
     },
-    "PreviousSuccesses": 61,
-    "PreviousFailures": 0,
-    "PreviousFlakes": 1,
-    "RegressedSuccesses": 18,
-    "RegressedFailures": 3,
-    "RegressedFlakes": 0
-  },
-  {
-    "JiraComponent": "Management Console",
-    "TestID": "openshift-tests:f9552d2b4b817d19bdcd666a7b8d1ece",
-    "TestName": "[bz-Management Console] clusteroperator/console should not change condition/Available",
-    "JiraBug": "https://issues.redhat.com/browse/OCPBUGS-39580",
-    "ReasonToAllowInsteadOfFix": "Test flaked in 4.16, became more strict in 4.17",
-    "variant": {
-      "variants": {
-        "Network": "ovn",
-        "Upgrade": "none",
-        "Architecture": "amd64",
-        "Platform": "vsphere",
-        "FeatureSet": "default",
-        "Suite": "unknown",
-        "Topology": "ha",
-        "Installer": "upi"
-      }
-    },
-    "PreviousSuccesses": 68,
+    "PreviousSuccesses": 66,
     "PreviousFailures": 0,
     "PreviousFlakes": 1,
     "RegressedSuccesses": 27,
-    "RegressedFailures": 3,
+    "RegressedFailures": 4,
     "RegressedFlakes": 0
   },
   {
-    "JiraComponent": "openshift-apiserver",
-    "TestID": "openshift-tests:e7f70b89f489bfa8d1e923c9832cdeff",
-    "TestName": "[bz-openshift-apiserver] clusteroperator/openshift-apiserver should not change condition/Available",
-    "JiraBug": "https://issues.redhat.com/browse/OCPBUGS-23746",
+    "JiraComponent": "kube-apiserver",
+    "TestID": "openshift-tests:d6b41cee7afca1c2a0b52f9e6975425f",
+    "TestName": "[bz-kube-apiserver][invariant] alert/KubeAPIErrorBudgetBurn should not be at or above info",
+    "JiraBug": "https://issues.redhat.com/browse/OCPBUGS-42083",
     "ReasonToAllowInsteadOfFix": "TBD Reason",
     "variant": {
       "variants": {
         "Network": "ovn",
         "Upgrade": "none",
         "Architecture": "amd64",
-        "Platform": "vsphere",
+        "Platform": "azure",
         "FeatureSet": "default",
-        "Suite": "unknown",
+        "Suite": "serial",
         "Topology": "ha",
         "Installer": "ipi"
       }
     },
-    "PreviousSuccesses": 139,
+    "PreviousSuccesses": 74,
     "PreviousFailures": 0,
-    "PreviousFlakes": 1,
-    "RegressedSuccesses": 71,
-    "RegressedFailures": 4,
+    "PreviousFlakes": 0,
+    "RegressedSuccesses": 24,
+    "RegressedFailures": 3,
     "RegressedFlakes": 0
   }
 ]


### PR DESCRIPTION
Add regression to clear the regression signal and preserve the previous releases baseline

- Add JSON file
- Embed the JSON in intentional_regressions.go
- Import the regressions
- If the file exists and regressions are already being imported new regressions can be added to the existing release specific regressions file



```
//go:embed regressions_4.17.json
var regressions4_17 []byte

func init() {
importIntentionalRegressions(release417, regressions4_17)
}
```