### PR TITLE
TRT-1811: fallback queries

### DIFF
--- a/cmd/sippy/component_readiness.go
+++ b/cmd/sippy/component_readiness.go
@@ -151,6 +151,15 @@ func (f *ComponentReadinessFlags) runServerMode() error {
 		if err != nil {
 			log.WithError(err).Warn("unable to create GCS client, some APIs may not work")
 		}
+
+		if bigQueryClient != nil {
+			persistentCacheClient, err := f.CacheFlags.GetPersistentCacheClient(bigQueryClient)
+			if err != nil {
+				log.WithError(err).Warn("couldn't get persistent cache client")
+			} else {
+				bigQueryClient.PersistentCache = persistentCacheClient
+			}
+		}
 	}
 
 	views, err := f.ComponentReadinessFlags.ParseViewsFile()
@@ -206,7 +215,7 @@ func (f *ComponentReadinessFlags) runServerMode() error {
 		// Serve our metrics endpoint for prometheus to scrape
 		go func() {
 			http.Handle("/metrics", promhttp.Handler())
-			err := http.ListenAndServe(f.MetricsAddr, nil) //nolint
+			err := http.ListenAndServe(f.MetricsAddr, nil) // nolint
 			if err != nil {
 				panic(err)
 			}

--- a/cmd/sippy/component_readiness.go
+++ b/cmd/sippy/component_readiness.go
@@ -152,13 +152,8 @@ func (f *ComponentReadinessFlags) runServerMode() error {
 			log.WithError(err).Warn("unable to create GCS client, some APIs may not work")
 		}
 
-		if bigQueryClient != nil {
-			persistentCacheClient, err := f.CacheFlags.GetPersistentCacheClient(bigQueryClient)
-			if err != nil {
-				log.WithError(err).Warn("couldn't get persistent cache client")
-			} else {
-				bigQueryClient.PersistentCache = persistentCacheClient
-			}
+		if bigQueryClient != nil && f.CacheFlags.EnablePersistentCaching {
+			bigQueryClient = f.CacheFlags.DecorateBiqQueryClientWithPersistentCache(bigQueryClient)
 		}
 	}
 

--- a/cmd/sippy/serve.go
+++ b/cmd/sippy/serve.go
@@ -99,13 +99,8 @@ func NewServeCommand() *cobra.Command {
 					return errors.WithMessage(err, "couldn't get bigquery client")
 				}
 
-				if bigQueryClient != nil {
-					persistentCacheClient, err := f.CacheFlags.GetPersistentCacheClient(bigQueryClient)
-					if err != nil {
-						log.WithError(err).Warn("couldn't get persistent cache client")
-					} else {
-						bigQueryClient.PersistentCache = persistentCacheClient
-					}
+				if bigQueryClient != nil && f.CacheFlags.EnablePersistentCaching {
+					bigQueryClient = f.CacheFlags.DecorateBiqQueryClientWithPersistentCache(bigQueryClient)
 				}
 
 				gcsClient, err = gcs.NewGCSClient(context.TODO(),

--- a/cmd/sippy/serve.go
+++ b/cmd/sippy/serve.go
@@ -99,6 +99,15 @@ func NewServeCommand() *cobra.Command {
 					return errors.WithMessage(err, "couldn't get bigquery client")
 				}
 
+				if bigQueryClient != nil {
+					persistentCacheClient, err := f.CacheFlags.GetPersistentCacheClient(bigQueryClient)
+					if err != nil {
+						log.WithError(err).Warn("couldn't get persistent cache client")
+					} else {
+						bigQueryClient.PersistentCache = persistentCacheClient
+					}
+				}
+
 				gcsClient, err = gcs.NewGCSClient(context.TODO(),
 					f.GoogleCloudFlags.ServiceAccountCredentialFile,
 					f.GoogleCloudFlags.OAuthClientCredentialFile,
@@ -176,7 +185,7 @@ func NewServeCommand() *cobra.Command {
 				// Serve our metrics endpoint for prometheus to scrape
 				go func() {
 					http.Handle("/metrics", promhttp.Handler())
-					err := http.ListenAndServe(f.MetricsAddr, nil) //nolint
+					err := http.ListenAndServe(f.MetricsAddr, nil) // nolint
 					if err != nil {
 						panic(err)
 					}

--- a/cmd/sippy/trackregressions.go
+++ b/cmd/sippy/trackregressions.go
@@ -62,6 +62,15 @@ func NewTrackRegressionsCommand() *cobra.Command {
 				log.WithError(err).Fatal("CRITICAL error getting BigQuery client which prevents regression tracking")
 			}
 
+			if bigQueryClient != nil {
+				persistentCacheClient, err := f.CacheFlags.GetPersistentCacheClient(bigQueryClient)
+				if err != nil {
+					log.WithError(err).Warn("couldn't get persistent cache client")
+				} else {
+					bigQueryClient.PersistentCache = persistentCacheClient
+				}
+			}
+
 			cacheOpts := cache.RequestOptions{CRTimeRoundingFactor: f.ComponentReadinessFlags.CRTimeRoundingFactor}
 
 			views, err := f.ComponentReadinessFlags.ParseViewsFile()

--- a/cmd/sippy/trackregressions.go
+++ b/cmd/sippy/trackregressions.go
@@ -62,13 +62,8 @@ func NewTrackRegressionsCommand() *cobra.Command {
 				log.WithError(err).Fatal("CRITICAL error getting BigQuery client which prevents regression tracking")
 			}
 
-			if bigQueryClient != nil {
-				persistentCacheClient, err := f.CacheFlags.GetPersistentCacheClient(bigQueryClient)
-				if err != nil {
-					log.WithError(err).Warn("couldn't get persistent cache client")
-				} else {
-					bigQueryClient.PersistentCache = persistentCacheClient
-				}
+			if bigQueryClient != nil && f.CacheFlags.EnablePersistentCaching {
+				bigQueryClient = f.CacheFlags.DecorateBiqQueryClientWithPersistentCache(bigQueryClient)
 			}
 
 			cacheOpts := cache.RequestOptions{CRTimeRoundingFactor: f.ComponentReadinessFlags.CRTimeRoundingFactor}

--- a/pkg/api/componentreadiness/component_report_test.go
+++ b/pkg/api/componentreadiness/component_report_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/stretchr/testify/assert"
@@ -479,6 +480,8 @@ func TestGenerateComponentReport(t *testing.T) {
 													FailureCount: 49,
 													FlakeCount:   1,
 												},
+												Start: &time.Time{},
+												End:   &time.Time{},
 											},
 											BaseStats: &crtype.TestDetailsReleaseStats{
 												TestDetailsTestStats: crtype.TestDetailsTestStats{
@@ -487,6 +490,8 @@ func TestGenerateComponentReport(t *testing.T) {
 													FailureCount: 90,
 													FlakeCount:   10,
 												},
+												Start: &time.Time{},
+												End:   &time.Time{},
 											},
 										},
 									},
@@ -516,6 +521,8 @@ func TestGenerateComponentReport(t *testing.T) {
 													FailureCount: 19,
 													FlakeCount:   1,
 												},
+												Start: &time.Time{},
+												End:   &time.Time{},
 											},
 											BaseStats: &crtype.TestDetailsReleaseStats{
 												TestDetailsTestStats: crtype.TestDetailsTestStats{
@@ -524,6 +531,8 @@ func TestGenerateComponentReport(t *testing.T) {
 													FailureCount: 90,
 													FlakeCount:   10,
 												},
+												Start: &time.Time{},
+												End:   &time.Time{},
 											},
 										},
 									},
@@ -806,6 +815,8 @@ func TestGenerateComponentReport(t *testing.T) {
 													FailureCount: 14,
 													FlakeCount:   1,
 												},
+												Start: &time.Time{},
+												End:   &time.Time{},
 											},
 											BaseStats: &crtype.TestDetailsReleaseStats{
 												TestDetailsTestStats: crtype.TestDetailsTestStats{
@@ -814,6 +825,8 @@ func TestGenerateComponentReport(t *testing.T) {
 													FailureCount: 90,
 													FlakeCount:   10,
 												},
+												Start: &time.Time{},
+												End:   &time.Time{},
 											},
 										},
 									},
@@ -1039,6 +1052,8 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 			FailureCount: 18,
 			FlakeCount:   8,
 		},
+		Start: &time.Time{},
+		End:   &time.Time{},
 	}
 	baseReleaseStatsTwoHigh := crtype.TestDetailsReleaseStats{
 		Release: testDetailsGenerator.BaseRelease.Release,
@@ -1048,6 +1063,8 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 			FailureCount: 200,
 			FlakeCount:   100,
 		},
+		Start: &time.Time{},
+		End:   &time.Time{},
 	}
 	sampleTestStatsHigh := crtype.TestDetailsTestStats{
 		SuccessRate:  0.9203539823008849,
@@ -1081,6 +1098,8 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 			FailureCount: 9,
 			FlakeCount:   4,
 		},
+		Start: &time.Time{},
+		End:   &time.Time{},
 	}
 	baseReleaseStatsOneHigh := crtype.TestDetailsReleaseStats{
 		Release: testDetailsGenerator.BaseRelease.Release,
@@ -1090,6 +1109,8 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 			FailureCount: 100,
 			FlakeCount:   50,
 		},
+		Start: &time.Time{},
+		End:   &time.Time{},
 	}
 	sampleReleaseStatsOneLow := crtype.TestDetailsReleaseStats{
 		Release: testDetailsGenerator.SampleRelease.Release,
@@ -1099,6 +1120,8 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 			FailureCount: 59,
 			FlakeCount:   4,
 		},
+		Start: &time.Time{},
+		End:   &time.Time{},
 	}
 	baseReleaseStatsOneLow := crtype.TestDetailsReleaseStats{
 		Release: testDetailsGenerator.BaseRelease.Release,
@@ -1108,6 +1131,8 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 			FailureCount: 600,
 			FlakeCount:   50,
 		},
+		Start: &time.Time{},
+		End:   &time.Time{},
 	}
 	tests := []struct {
 		name                    string
@@ -1357,7 +1382,7 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
-			report := tc.generator.internalGenerateTestDetailsReport(context.TODO(), baseStats, sampleStats)
+			report := tc.generator.internalGenerateTestDetailsReport(context.TODO(), baseStats, "", nil, nil, sampleStats)
 			assert.Equal(t, tc.expectedReport.RowIdentification, report.RowIdentification, "expected report row identification %+v, got %+v", tc.expectedReport.RowIdentification, report.RowIdentification)
 			assert.Equal(t, tc.expectedReport.ColumnIdentification, report.ColumnIdentification, "expected report column identification %+v, got %+v", tc.expectedReport.ColumnIdentification, report.ColumnIdentification)
 			assert.Equal(t, tc.expectedReport.BaseStats, report.BaseStats, "expected report base stats %+v, got %+v", tc.expectedReport.BaseStats, report.BaseStats)
@@ -1665,7 +1690,7 @@ func Test_componentReportGenerator_assessComponentStatus(t *testing.T) {
 			c.PassRateRequiredAllTests = tt.requiredPassRateForAllTests
 			c.MinimumFailure = tt.minFail
 
-			testStats := c.assessComponentStatus(0, tt.sampleTotal, tt.sampleSuccess, tt.sampleFlake, tt.baseTotal, tt.baseSuccess, tt.baseFlake, nil, nil, tt.numberOfIgnoredSamples)
+			testStats := c.assessComponentStatus(0, tt.sampleTotal, tt.sampleSuccess, tt.sampleFlake, tt.baseTotal, tt.baseSuccess, tt.baseFlake, nil, tt.numberOfIgnoredSamples, "dummyRelease", nil, nil)
 			assert.Equalf(t, tt.expectedStatus, testStats.ReportStatus, "assessComponentStatus expected status not equal")
 			if tt.expectedFischers != nil {
 				assert.Equalf(t, *tt.expectedFischers, *testStats.FisherExact, "assessComponentStatus expected fischers value not equal")

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -71,7 +71,7 @@ func GetDataFromCacheOrGenerate[T any](
 		}
 
 		if !cacheOptions.ForceRefresh {
-			if res, err := c.Get(string(cacheKey)); err == nil {
+			if res, err := c.Get(ctx, string(cacheKey)); err == nil {
 				log.WithFields(log.Fields{
 					"key":  string(cacheKey),
 					"type": reflect.TypeOf(defaultVal).String(),
@@ -96,7 +96,7 @@ func GetDataFromCacheOrGenerate[T any](
 					// Only cache until the next rounding duration
 					cacheDuration = now.Truncate(cacheOptions.CRTimeRoundingFactor).Add(cacheOptions.CRTimeRoundingFactor).Sub(now)
 				}
-				if err := c.Set(string(cacheKey), cr, cacheDuration); err != nil {
+				if err := c.Set(ctx, string(cacheKey), cr, cacheDuration); err != nil {
 					log.WithError(err).Warningf("couldn't persist new item to cache")
 				} else {
 					log.Debugf("cache set for cache key: %s", string(cacheKey))

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -70,8 +70,16 @@ func GetDataFromCacheOrGenerate[T any](
 			panic(fmt.Sprintf("cache key is empty for %s", reflect.TypeOf(defaultVal)))
 		}
 
+		// require cacheDuration for persistence logic
+		cacheDuration := defaultCacheDuration
+		if cacheOptions.CRTimeRoundingFactor > 0 {
+			now := time.Now().UTC()
+			// Only cache until the next rounding duration
+			cacheDuration = now.Truncate(cacheOptions.CRTimeRoundingFactor).Add(cacheOptions.CRTimeRoundingFactor).Sub(now)
+		}
+
 		if !cacheOptions.ForceRefresh {
-			if res, err := c.Get(ctx, string(cacheKey)); err == nil {
+			if res, err := c.Get(ctx, string(cacheKey), cacheDuration); err == nil {
 				log.WithFields(log.Fields{
 					"key":  string(cacheKey),
 					"type": reflect.TypeOf(defaultVal).String(),
@@ -90,12 +98,6 @@ func GetDataFromCacheOrGenerate[T any](
 		if len(errs) == 0 {
 			cr, err := json.Marshal(result)
 			if err == nil {
-				cacheDuration := defaultCacheDuration
-				if cacheOptions.CRTimeRoundingFactor > 0 {
-					now := time.Now().UTC()
-					// Only cache until the next rounding duration
-					cacheDuration = now.Truncate(cacheOptions.CRTimeRoundingFactor).Add(cacheOptions.CRTimeRoundingFactor).Sub(now)
-				}
 				if err := c.Set(ctx, string(cacheKey), cr, cacheDuration); err != nil {
 					log.WithError(err).Warningf("couldn't persist new item to cache")
 				} else {

--- a/pkg/apis/api/componentreport/types.go
+++ b/pkg/apis/api/componentreport/types.go
@@ -69,6 +69,10 @@ type RequestVariantOptions struct {
 }
 
 // RequestOptions is a struct packaging all the options for a CR request.
+// BaseOverrideRelease is the counterpart to RequestAdvancedOptions.IncludeMultiReleaseAnalysis
+// When multi release analysis is enabled we 'fallback' to the release that has the highest
+// threshold for indicating a regression.  If a release prior to the selected BasRelease has a
+// higher standard it will be set as the BaseOverrideRelease to be included in the TestDetails analysis
 type RequestOptions struct {
 	BaseRelease         RequestReleaseOptions
 	BaseOverrideRelease RequestReleaseOptions

--- a/pkg/apis/cache/cache.go
+++ b/pkg/apis/cache/cache.go
@@ -1,13 +1,14 @@
 package cache
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
 
 type Cache interface {
-	Get(key string) ([]byte, error)
-	Set(key string, content []byte, duration time.Duration) error
+	Get(ctx context.Context, key string) ([]byte, error)
+	Set(ctx context.Context, key string, content []byte, duration time.Duration) error
 }
 
 type APIResponse struct {

--- a/pkg/apis/cache/cache.go
+++ b/pkg/apis/cache/cache.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Cache interface {
-	Get(ctx context.Context, key string) ([]byte, error)
+	Get(ctx context.Context, key string, duration time.Duration) ([]byte, error)
 	Set(ctx context.Context, key string, content []byte, duration time.Duration) error
 }
 

--- a/pkg/bigquery/client.go
+++ b/pkg/bigquery/client.go
@@ -11,9 +11,10 @@ import (
 )
 
 type Client struct {
-	BQ      *bigquery.Client
-	Cache   cache.Cache
-	Dataset string
+	BQ              *bigquery.Client
+	Cache           cache.Cache
+	PersistentCache cache.Cache
+	Dataset         string
 }
 
 func New(ctx context.Context, credentialFile, project, dataset string, c cache.Cache) (*Client, error) {

--- a/pkg/bigquery/client.go
+++ b/pkg/bigquery/client.go
@@ -11,10 +11,9 @@ import (
 )
 
 type Client struct {
-	BQ              *bigquery.Client
-	Cache           cache.Cache
-	PersistentCache cache.Cache
-	Dataset         string
+	BQ      *bigquery.Client
+	Cache   cache.Cache
+	Dataset string
 }
 
 func New(ctx context.Context, credentialFile, project, dataset string, c cache.Cache) (*Client, error) {

--- a/pkg/cache/bigquerycache/bigquery.go
+++ b/pkg/cache/bigquerycache/bigquery.go
@@ -219,7 +219,7 @@ func (c Cache) Set(ctx context.Context, key string, content []byte, duration tim
 		// hope is that it wouldn't get called at all
 		// if our process for updating the cache is running properly
 		persistentCacheReadOnlySetMetric.WithLabelValues().Inc()
-		logrus.Debugf("Set called in readonly mode for: %s", key)
+		logrus.Warnf("Set called in readonly mode for: %s", key)
 		return nil
 	}
 

--- a/pkg/cache/bigquerycache/bigquery.go
+++ b/pkg/cache/bigquerycache/bigquery.go
@@ -1,0 +1,221 @@
+package bigquerycache
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	uuid2 "github.com/google/uuid"
+	"github.com/openshift/sippy/pkg/apis/cache"
+	sippybq "github.com/openshift/sippy/pkg/bigquery"
+	"github.com/openshift/sippy/pkg/cache/compressed"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/api/iterator"
+)
+
+// https://cloud.google.com/bigquery/quotas#streaming_inserts
+// Maximum row size 	10 MB 	Exceeding this value causes invalid errors.
+// HTTP request size limit 	10 MB Exceeding this value causes invalid errors.
+const (
+	cachedTable     = "cached_data"
+	partitionColumn = "modified_time"
+	chunkSize       = 7000000 // ~7MB to stay under the max row limit
+)
+
+type Cache struct {
+	client     *sippybq.Client
+	readOnly   bool
+	expiration time.Duration
+}
+
+func NewBigQueryCache(client *sippybq.Client, expiration time.Duration, readOnly bool) (cache.Cache, error) {
+	c := &Cache{
+		client:     client,
+		readOnly:   readOnly,
+		expiration: expiration,
+	}
+
+	return &compressed.Cache{Cache: c}, nil
+}
+
+type CacheRecord struct {
+	Key        string    `bigquery:"key"`
+	UUID       string    `bigquery:"uuid"`
+	Modified   time.Time `bigquery:"modified_time"`
+	Expiration time.Time `bigquery:"expiration"`
+	Data       []byte    `bigquery:"data"`
+	ChunkIndex int       `bigquery:"chunk_index"`
+}
+
+func (c Cache) Get(ctx context.Context, key string) ([]byte, error) {
+
+	// if we have it in our warm cache use it
+	if c.client.Cache != nil {
+		data, err := c.client.Cache.Get(ctx, key)
+		if err != nil {
+			logrus.Debugf("Failure retrieving %s from warm cache %v", key, err)
+		} else if data != nil {
+			return data, nil
+		}
+	}
+
+	before := time.Now()
+	defer func(key string, before time.Time) {
+		logrus.Infof("BigQuery Cache Get completed in %s for %s", time.Since(before), key)
+	}(key, before)
+
+	// get the most recent modified time for this key along with uuid and checksum
+	// limit the columns so we don't query too much data
+	cacheQuery := fmt.Sprintf("SELECT modified_time, expiration, uuid FROM `%s.%s` WHERE `%s` > TIMESTAMP(\"%s\") AND `%s` > TIMESTAMP(\"%s\") AND %s = '%s' order by %s desc limit 1", c.client.Dataset, cachedTable, partitionColumn, time.Now().Add(-1*c.expiration).Format(time.RFC3339), "expiration", time.Now().Format(time.RFC3339), "key", key, partitionColumn)
+
+	query := c.client.BQ.Query(cacheQuery)
+
+	metadataRecord := CacheRecord{}
+
+	it, err := query.Read(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = it.Next(&metadataRecord)
+	if err != nil {
+		return nil, err
+	}
+
+	// that gives us the modified time
+	// we have to add a +/- 5 second grace as exact match doesn't work
+	// now get the data
+	cacheQuery = fmt.Sprintf("SELECT * FROM `%s.%s` WHERE `%s` > TIMESTAMP(\"%s\") AND `%s` < TIMESTAMP(\"%s\")  AND %s = '%s' AND %s = '%s' order by %s asc", c.client.Dataset, cachedTable, partitionColumn, metadataRecord.Modified.Add(-5*time.Second).Format(time.RFC3339), partitionColumn, metadataRecord.Modified.Add(5*time.Second).Format(time.RFC3339), "key", key, "uuid", metadataRecord.UUID, "chunk_index")
+
+	query = c.client.BQ.Query(cacheQuery)
+
+	record := CacheRecord{}
+	var records [][]byte
+
+	it, err = query.Read(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		err = it.Next(&record)
+		if err != nil {
+			if err == iterator.Done {
+				break
+			}
+			return nil, err
+		}
+		records = append(records, record.Data)
+	}
+
+	// we should have the records, now assemble them into a single array
+	data := unchunk(records)
+
+	// if we have a warm cache, and we had a cache miss we should update it now
+	// we don't have the exact duration so we diff the expiration value and now
+	if data != nil && c.client.Cache != nil {
+		err = c.client.Cache.Set(ctx, key, data, time.Until(metadataRecord.Expiration))
+		if err != nil {
+			logrus.WithError(err).Warn("Error updating warm cache during get")
+		}
+	}
+
+	return data, nil
+}
+
+func (c Cache) Set(ctx context.Context, key string, content []byte, duration time.Duration) error {
+
+	// save to the warm cache too if enabled
+	// but follow through and persist as well
+	if c.client.Cache != nil {
+		err := c.client.Cache.Set(ctx, key, content, duration)
+		if err != nil {
+			logrus.WithError(err).Errorf("Failure setting %s for warm cache", key)
+		}
+	}
+
+	// read only applies to bigquery only (I think)
+	if c.readOnly {
+		// valuable to see how often this gets called
+		// hope is that it wouldn't get called at all
+		// if our process for updating the cache is running properly
+		logrus.Debugf("Set called in readonly mode for: %s", key)
+		return nil
+	}
+	before := time.Now()
+	defer func(key string, before time.Time) {
+		logrus.Infof("BigQuery Cache Set completed in %s for %s", time.Since(before), key)
+	}(key, before)
+
+	t := c.client.BQ.Dataset(c.client.Dataset).Table(cachedTable)
+
+	if t == nil {
+		return fmt.Errorf("failed to retrieve table '%s' from dataset '%s'", cachedTable, c.client.Dataset)
+	}
+
+	i := t.Inserter()
+
+	if i == nil {
+		return fmt.Errorf("failed to retrieve insterter for table '%s' from dataset '%s'", cachedTable, c.client.Dataset)
+	}
+
+	// chunk it
+	chunks := chunk(content, chunkSize)
+	modifiedTime := time.Now()
+	expiration := modifiedTime.Add(duration)
+	uuid := uuid2.New().String()
+
+	// then we upload chunks 1 by 1
+	for index, chunk := range chunks {
+		record := CacheRecord{Key: key, Modified: modifiedTime, Data: chunk, Expiration: expiration, ChunkIndex: index, UUID: uuid}
+		err := i.Put(ctx, bigquery.ValueSaver(&record))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Save implements the ValueSaver interface.
+// Can just use the struct as well
+func (c *CacheRecord) Save() (row map[string]bigquery.Value, insertID string, err error) {
+
+	row = make(map[string]bigquery.Value, 6)
+
+	row["key"] = c.Key
+	row["modified_time"] = c.Modified
+	row["data"] = c.Data
+	row["expiration"] = c.Expiration
+	row["chunk_index"] = c.ChunkIndex
+	row["uuid"] = c.UUID
+
+	return row, fmt.Sprintf("%s-%d", c.UUID, c.ChunkIndex), nil
+}
+
+func chunk(value []byte, maxChunk int) [][]byte {
+	var ret [][]byte
+	max := len(value)
+
+	for i := 0; i < max; i += maxChunk {
+		end := i + maxChunk
+
+		if end > max {
+			end = max
+		}
+
+		ret = append(ret, value[i:end])
+	}
+
+	return ret
+}
+
+func unchunk(chunked [][]byte) []byte {
+	var ret []byte
+
+	for _, chunk := range chunked {
+		ret = append(ret, chunk...)
+	}
+
+	return ret
+}

--- a/pkg/cache/bigquerycache/bigquery_test.go
+++ b/pkg/cache/bigquerycache/bigquery_test.go
@@ -1,0 +1,24 @@
+package bigquerycache
+
+import "testing"
+
+func TestChunk(t *testing.T) {
+	data := "It is useful mainly in compressed network protocols, to ensure that a remote reader has enough data to reconstruct a packet. Flush does not return until the data has been written. If the underlying writer returns an error, Flush returns that error. "
+
+	chunked := chunk([]byte(data), 10)
+
+	if chunked == nil {
+		t.Fatal("Invalid chunked content")
+	}
+
+	unchunked := unchunk(chunked)
+
+	if unchunked == nil {
+		t.Fatal("Invalid compressed content")
+	}
+
+	validation := string(unchunked)
+	if data != validation {
+		t.Fatalf("Invalid unchunked data returned: %s", validation)
+	}
+}

--- a/pkg/cache/bigquerycache/bigquery_test.go
+++ b/pkg/cache/bigquerycache/bigquery_test.go
@@ -1,24 +1,21 @@
 package bigquerycache
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestChunk(t *testing.T) {
 	data := "It is useful mainly in compressed network protocols, to ensure that a remote reader has enough data to reconstruct a packet. Flush does not return until the data has been written. If the underlying writer returns an error, Flush returns that error. "
 
 	chunked := chunk([]byte(data), 10)
-
-	if chunked == nil {
-		t.Fatal("Invalid chunked content")
-	}
+	assert.NotNil(t, chunked, "Invalid chunked content")
 
 	unchunked := unchunk(chunked)
-
-	if unchunked == nil {
-		t.Fatal("Invalid compressed content")
-	}
+	assert.NotNil(t, unchunked, "Invalid unchunked content")
 
 	validation := string(unchunked)
-	if data != validation {
-		t.Fatalf("Invalid unchunked data returned: %s", validation)
-	}
+	assert.Equal(t, data, validation)
+
 }

--- a/pkg/cache/compressed/cache.go
+++ b/pkg/cache/compressed/cache.go
@@ -29,9 +29,9 @@ func NewCompressedCache(c cache.Cache) (*Cache, error) {
 	}, nil
 }
 
-func (c Cache) Get(ctx context.Context, key string) ([]byte, error) {
+func (c Cache) Get(ctx context.Context, key string, duration time.Duration) ([]byte, error) {
 	// add our own prefix to the key
-	b, err := c.Cache.Get(ctx, cachePrefix+key)
+	b, err := c.Cache.Get(ctx, cachePrefix+key, duration)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cache/compressed/cache.go
+++ b/pkg/cache/compressed/cache.go
@@ -1,0 +1,106 @@
+package compressed
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+
+	// simple checksum usage for validation
+	"crypto/md5" // nolint:gosec
+	"fmt"
+	"time"
+
+	"github.com/openshift/sippy/pkg/apis/cache"
+)
+
+const (
+	cachePrefix = "cc:"
+)
+
+type Cache struct {
+	Cache cache.Cache
+}
+
+func NewCompressedCache(c cache.Cache) (*Cache, error) {
+	return &Cache{
+		Cache: c,
+	}, nil
+}
+
+func (c Cache) Get(ctx context.Context, key string) ([]byte, error) {
+	// add our own prefix to the key
+	b, err := c.Cache.Get(ctx, cachePrefix+key)
+	if err != nil {
+		return nil, err
+	}
+
+	dataLen := len(b)
+	if dataLen < 16 {
+		return nil, fmt.Errorf("invalid cache item length")
+	}
+
+	// strip off the last 16 bytes which is the checksum
+	data := b[:dataLen-16]
+	var checksum [16]byte
+	copy(checksum[:], b[dataLen-16:])
+	return uncompress(data, checksum)
+}
+
+func (c Cache) Set(ctx context.Context, key string, content []byte, duration time.Duration) error {
+	// append the checksum
+	data, checksum, err := compress(content)
+	if err != nil {
+		return err
+	}
+	data = append(data, checksum[:]...)
+
+	// add our own prefix
+	return c.Cache.Set(ctx, cachePrefix+key, data, duration)
+}
+
+func compress(value []byte) ([]byte, [16]byte, error) {
+	var buf bytes.Buffer
+	sum := md5.Sum(value) // nolint:gosec
+
+	zw := gzip.NewWriter(&buf)
+
+	_, err := zw.Write(value)
+
+	if err != nil {
+		return nil, sum, err
+	}
+
+	err = zw.Close()
+	if err != nil {
+		return nil, sum, err
+	}
+	return buf.Bytes(), sum, nil
+}
+
+func uncompress(value []byte, vSum [16]byte) ([]byte, error) {
+	var buf, uncompressed bytes.Buffer
+	buf.Write(value)
+
+	zr, err := gzip.NewReader(&buf)
+
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = uncompressed.ReadFrom(zr)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := zr.Close(); err != nil {
+		return nil, err
+	}
+
+	ret := uncompressed.Bytes()
+	sum := md5.Sum(ret) // nolint:gosec
+	if sum != vSum {
+		return nil, fmt.Errorf("check sum validation did not match")
+	}
+
+	return uncompressed.Bytes(), nil
+}

--- a/pkg/cache/compressed/cache_test.go
+++ b/pkg/cache/compressed/cache_test.go
@@ -1,0 +1,74 @@
+package compressed
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type PseudoCache struct {
+	cache map[string][]byte
+}
+
+func (c *PseudoCache) Get(ctx context.Context, key string) ([]byte, error) {
+	return c.cache[key], nil
+}
+
+func (c *PseudoCache) Set(ctx context.Context, key string, content []byte, duration time.Duration) error {
+	c.cache[key] = content
+	return nil
+}
+
+func TestPseudoCache(t *testing.T) {
+	data := "It is useful mainly in compressed network protocols, to ensure that a remote reader has enough data to reconstruct a packet. Flush does not return until the data has been written. If the underlying writer returns an error, Flush returns that error. "
+
+	cache, err := NewCompressedCache(&PseudoCache{cache: make(map[string][]byte)})
+
+	if err != nil {
+		t.Fatalf("Failed to create compression cache")
+	}
+
+	err = cache.Set(context.TODO(), "testKey", []byte(data), time.Hour)
+	if err != nil {
+		t.Fatalf("Failed to set cache data")
+	}
+
+	cacheData, err := cache.Get(context.TODO(), "testKey")
+	if err != nil {
+		t.Fatalf("Failed to get cache data")
+	}
+
+	validation := string(cacheData)
+	if data != validation {
+		t.Fatalf("Invalid uncompressed data returned: %s", validation)
+	}
+
+}
+
+func TestCompression(t *testing.T) {
+	data := "It is useful mainly in compressed network protocols, to ensure that a remote reader has enough data to reconstruct a packet. Flush does not return until the data has been written. If the underlying writer returns an error, Flush returns that error. "
+
+	compressed, checksum, err := compress([]byte(data))
+	if err != nil {
+		t.Fatalf("Compression failed: %v", err)
+	}
+
+	if compressed == nil {
+		t.Fatal("Invalid compressed content")
+	}
+
+	uncompressed, err := uncompress(compressed, checksum)
+
+	if err != nil {
+		t.Fatalf("Compression failed: %v", err)
+	}
+
+	if uncompressed == nil {
+		t.Fatal("Invalid compressed content")
+	}
+
+	validation := string(uncompressed)
+	if data != validation {
+		t.Fatalf("Invalid uncompressed data returned: %s", validation)
+	}
+}

--- a/pkg/cache/compressed/cache_test.go
+++ b/pkg/cache/compressed/cache_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type PseudoCache struct {
@@ -23,52 +25,29 @@ func TestPseudoCache(t *testing.T) {
 	data := "It is useful mainly in compressed network protocols, to ensure that a remote reader has enough data to reconstruct a packet. Flush does not return until the data has been written. If the underlying writer returns an error, Flush returns that error. "
 
 	cache, err := NewCompressedCache(&PseudoCache{cache: make(map[string][]byte)})
-
-	if err != nil {
-		t.Fatalf("Failed to create compression cache")
-	}
+	assert.Nil(t, err, "Failed to create compression cache: %v", err)
 
 	err = cache.Set(context.TODO(), "testKey", []byte(data), time.Hour)
-	if err != nil {
-		t.Fatalf("Failed to set cache data")
-	}
+	assert.Nil(t, err, "Failed to set cache data: %v", err)
 
 	cacheData, err := cache.Get(context.TODO(), "testKey")
-	if err != nil {
-		t.Fatalf("Failed to get cache data")
-	}
+	assert.Nil(t, err, "Failed to get cache data: %v", err)
 
 	validation := string(cacheData)
-	if data != validation {
-		t.Fatalf("Invalid uncompressed data returned: %s", validation)
-	}
-
+	assert.Equal(t, data, validation)
 }
 
 func TestCompression(t *testing.T) {
 	data := "It is useful mainly in compressed network protocols, to ensure that a remote reader has enough data to reconstruct a packet. Flush does not return until the data has been written. If the underlying writer returns an error, Flush returns that error. "
 
 	compressed, checksum, err := compress([]byte(data))
-	if err != nil {
-		t.Fatalf("Compression failed: %v", err)
-	}
-
-	if compressed == nil {
-		t.Fatal("Invalid compressed content")
-	}
+	assert.Nil(t, err, "Compression failed: %v", err)
+	assert.NotNil(t, compressed, "Invalid compressed content")
 
 	uncompressed, err := uncompress(compressed, checksum)
-
-	if err != nil {
-		t.Fatalf("Compression failed: %v", err)
-	}
-
-	if uncompressed == nil {
-		t.Fatal("Invalid compressed content")
-	}
+	assert.Nil(t, err, "Uncompression failed: %v", err)
+	assert.NotNil(t, uncompressed, "Invalid uncompressed content")
 
 	validation := string(uncompressed)
-	if data != validation {
-		t.Fatalf("Invalid uncompressed data returned: %s", validation)
-	}
+	assert.Equal(t, data, validation)
 }

--- a/pkg/cache/compressed/cache_test.go
+++ b/pkg/cache/compressed/cache_test.go
@@ -12,11 +12,11 @@ type PseudoCache struct {
 	cache map[string][]byte
 }
 
-func (c *PseudoCache) Get(ctx context.Context, key string) ([]byte, error) {
+func (c *PseudoCache) Get(_ context.Context, key string, _ time.Duration) ([]byte, error) {
 	return c.cache[key], nil
 }
 
-func (c *PseudoCache) Set(ctx context.Context, key string, content []byte, duration time.Duration) error {
+func (c *PseudoCache) Set(_ context.Context, key string, content []byte, _ time.Duration) error {
 	c.cache[key] = content
 	return nil
 }
@@ -30,7 +30,7 @@ func TestPseudoCache(t *testing.T) {
 	err = cache.Set(context.TODO(), "testKey", []byte(data), time.Hour)
 	assert.Nil(t, err, "Failed to set cache data: %v", err)
 
-	cacheData, err := cache.Get(context.TODO(), "testKey")
+	cacheData, err := cache.Get(context.TODO(), "testKey", time.Hour)
 	assert.Nil(t, err, "Failed to get cache data: %v", err)
 
 	validation := string(cacheData)

--- a/pkg/cache/redis/redis.go
+++ b/pkg/cache/redis/redis.go
@@ -28,7 +28,7 @@ func NewRedisCache(url string) (*Cache, error) {
 	}, nil
 }
 
-func (c Cache) Get(_ context.Context, key string) ([]byte, error) {
+func (c Cache) Get(_ context.Context, key string, _ time.Duration) ([]byte, error) {
 	before := time.Now()
 	defer func(key string, before time.Time) {
 		logrus.Infof("Redis Cache Get completed in %s for %s", time.Since(before), key)

--- a/pkg/cache/redis/redis.go
+++ b/pkg/cache/redis/redis.go
@@ -1,7 +1,10 @@
 package redis
 
 import (
+	"context"
 	"time"
+
+	"github.com/sirupsen/logrus"
 
 	r "gopkg.in/redis.v5"
 )
@@ -25,10 +28,18 @@ func NewRedisCache(url string) (*Cache, error) {
 	}, nil
 }
 
-func (c Cache) Get(key string) ([]byte, error) {
+func (c Cache) Get(_ context.Context, key string) ([]byte, error) {
+	before := time.Now()
+	defer func(key string, before time.Time) {
+		logrus.Infof("Redis Cache Get completed in %s for %s", time.Since(before), key)
+	}(key, before)
 	return c.client.Get(prefix + key).Bytes()
 }
 
-func (c Cache) Set(key string, content []byte, duration time.Duration) error {
+func (c Cache) Set(_ context.Context, key string, content []byte, duration time.Duration) error {
+	before := time.Now()
+	defer func(key string, before time.Time) {
+		logrus.Infof("Redis Cache Set completed in %s for %s", time.Since(before), key)
+	}(key, before)
 	return c.client.Set(prefix+key, content, duration).Err()
 }

--- a/pkg/flags/cache.go
+++ b/pkg/flags/cache.go
@@ -16,7 +16,7 @@ import (
 // CacheFlags holds caching configuration information for Sippy.
 type CacheFlags struct {
 	RedisURL                   string
-	PersistentCacheDuration    time.Duration
+	PersistentCacheDurationMax time.Duration
 	EnablePersistentCacheWrite bool
 	EnablePersistentCaching    bool
 }
@@ -36,10 +36,10 @@ func (f *CacheFlags) BindFlags(fs *pflag.FlagSet) {
 		false,
 		"Enable pesisted cache storage")
 
-	fs.DurationVar(&f.PersistentCacheDuration,
-		"persistent-cache-duration",
+	fs.DurationVar(&f.PersistentCacheDurationMax,
+		"persistent-cache-duration-max",
 		time.Hour*24,
-		"Duration before a cache item is considered expired")
+		"Maximum duration before a cache item is considered expired")
 
 	// if we are running main sippy in RO we can't persist to bigquery
 	// we can have regression tracking priming the cache
@@ -61,7 +61,7 @@ func (f *CacheFlags) GetCacheClient() (cache.Cache, error) {
 
 func (f *CacheFlags) GetPersistentCacheClient(bqclient *bigquery.Client) (cache.Cache, error) {
 	if f.EnablePersistentCaching {
-		return bigquerycache.NewBigQueryCache(bqclient, f.PersistentCacheDuration, !f.EnablePersistentCacheWrite)
+		return bigquerycache.NewBigQueryCache(bqclient, f.PersistentCacheDurationMax, !f.EnablePersistentCacheWrite)
 	}
 
 	return nil, nil

--- a/pkg/flags/cache.go
+++ b/pkg/flags/cache.go
@@ -2,7 +2,11 @@ package flags
 
 import (
 	"os"
+	"time"
 
+	"github.com/openshift/sippy/pkg/bigquery"
+
+	"github.com/openshift/sippy/pkg/cache/bigquerycache"
 	"github.com/spf13/pflag"
 
 	"github.com/openshift/sippy/pkg/apis/cache"
@@ -11,7 +15,10 @@ import (
 
 // CacheFlags holds caching configuration information for Sippy.
 type CacheFlags struct {
-	RedisURL string
+	RedisURL                   string
+	PersistentCacheDuration    time.Duration
+	EnablePersistentCacheWrite bool
+	EnablePersistentCaching    bool
 }
 
 func NewCacheFlags() *CacheFlags {
@@ -23,11 +30,38 @@ func (f *CacheFlags) BindFlags(fs *pflag.FlagSet) {
 		"redis-url",
 		os.Getenv("REDIS_URL"),
 		"Redis URL for caching")
+
+	fs.BoolVar(&f.EnablePersistentCaching,
+		"enable-persistent-cache",
+		false,
+		"Enable pesisted cache storage")
+
+	fs.DurationVar(&f.PersistentCacheDuration,
+		"persistent-cache-duration",
+		time.Hour*24,
+		"Duration before a cache item is considered expired")
+
+	// if we are running main sippy in RO we can't persist to bigquery
+	// we can have regression tracking priming the cache
+	// if we run it with a shorter PersistentCacheDuration
+	// so it will regenerate before main sippy would need it
+	fs.BoolVar(&f.EnablePersistentCacheWrite,
+		"enable-persistent-cache-write",
+		false,
+		"Boolean indicating if the cache should attempt to writ or is read only")
 }
 
 func (f *CacheFlags) GetCacheClient() (cache.Cache, error) {
 	if f.RedisURL != "" {
 		return redis.NewRedisCache(f.RedisURL)
+	}
+
+	return nil, nil
+}
+
+func (f *CacheFlags) GetPersistentCacheClient(bqclient *bigquery.Client) (cache.Cache, error) {
+	if f.EnablePersistentCaching {
+		return bigquerycache.NewBigQueryCache(bqclient, f.PersistentCacheDuration, !f.EnablePersistentCacheWrite)
 	}
 
 	return nil, nil

--- a/pkg/flags/cache.go
+++ b/pkg/flags/cache.go
@@ -22,6 +22,7 @@ type CacheFlags struct {
 	PersistentCacheDurationMin time.Duration
 	EnablePersistentCacheWrite bool
 	EnablePersistentCaching    bool
+	ForcePersistentLookup      bool
 }
 
 func NewCacheFlags() *CacheFlags {
@@ -37,7 +38,12 @@ func (f *CacheFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&f.EnablePersistentCaching,
 		"enable-persistent-cache",
 		false,
-		"Enable pesisted cache storage")
+		"Enable persisted cache storage")
+
+	fs.BoolVar(&f.ForcePersistentLookup,
+		"force-persistent-cache-lookup",
+		false,
+		"Skips any intermediate caching like redis and queries the persisted cache")
 
 	fs.DurationVar(&f.PersistentCacheDurationMax,
 		"persistent-cache-duration-max",
@@ -74,7 +80,7 @@ func (f *CacheFlags) GetPersistentCacheClient(bqclient *bigquery.Client) (cache.
 			BQ:      bqclient.BQ,
 			Cache:   bqclient.Cache,
 			Dataset: bqclient.Dataset,
-		}, f.PersistentCacheDurationMax, f.PersistentCacheDurationMin, !f.EnablePersistentCacheWrite)
+		}, f.PersistentCacheDurationMax, f.PersistentCacheDurationMin, !f.EnablePersistentCacheWrite, f.ForcePersistentLookup)
 	}
 
 	return nil, nil

--- a/pkg/flags/cache.go
+++ b/pkg/flags/cache.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/openshift/sippy/pkg/bigquery"
 
 	"github.com/openshift/sippy/pkg/cache/bigquerycache"
@@ -17,6 +19,7 @@ import (
 type CacheFlags struct {
 	RedisURL                   string
 	PersistentCacheDurationMax time.Duration
+	PersistentCacheDurationMin time.Duration
 	EnablePersistentCacheWrite bool
 	EnablePersistentCaching    bool
 }
@@ -41,6 +44,11 @@ func (f *CacheFlags) BindFlags(fs *pflag.FlagSet) {
 		time.Hour*24,
 		"Maximum duration before a cache item is considered expired")
 
+	fs.DurationVar(&f.PersistentCacheDurationMin,
+		"persistent-cache-duration-min",
+		time.Hour*12,
+		"Minimum duration for persisting a cache item")
+
 	// if we are running main sippy in RO we can't persist to bigquery
 	// we can have regression tracking priming the cache
 	// if we run it with a shorter PersistentCacheDuration
@@ -61,8 +69,25 @@ func (f *CacheFlags) GetCacheClient() (cache.Cache, error) {
 
 func (f *CacheFlags) GetPersistentCacheClient(bqclient *bigquery.Client) (cache.Cache, error) {
 	if f.EnablePersistentCaching {
-		return bigquerycache.NewBigQueryCache(bqclient, f.PersistentCacheDurationMax, !f.EnablePersistentCacheWrite)
+		// create a clone of the bigquery client to preserve the current cache
+		return bigquerycache.NewBigQueryCache(&bigquery.Client{
+			BQ:      bqclient.BQ,
+			Cache:   bqclient.Cache,
+			Dataset: bqclient.Dataset,
+		}, f.PersistentCacheDurationMax, f.PersistentCacheDurationMin, !f.EnablePersistentCacheWrite)
 	}
 
 	return nil, nil
+}
+
+func (f *CacheFlags) DecorateBiqQueryClientWithPersistentCache(bigQueryClient *bigquery.Client) *bigquery.Client {
+	persistentCacheClient, err := f.GetPersistentCacheClient(bigQueryClient)
+	if err != nil {
+		log.WithError(err).Warn("couldn't get persistent cache client")
+	} else if persistentCacheClient != nil {
+		// we want to change out the cache with the persistent version
+		// the persistent cache retains the original cache client if any
+		bigQueryClient.Cache = persistentCacheClient
+	}
+	return bigQueryClient
 }

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1692,7 +1692,7 @@ func (s *Server) cached(duration time.Duration, handler func(w http.ResponseWrit
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		content, err := s.cache.Get(r.RequestURI)
+		content, err := s.cache.Get(context.TODO(), r.RequestURI)
 		if err != nil { // cache miss
 			log.WithError(err).Debugf("cache miss: could not fetch data from cache for %q", r.RequestURI)
 		} else if content != nil && respondFromCache(content, w, r) == nil { // cache hit
@@ -1741,7 +1741,7 @@ func recordResponse(c cache.Cache, duration time.Duration, w http.ResponseWriter
 		log.WithError(err).Warningf("couldn't marshal api response")
 	}
 
-	if err := c.Set(r.RequestURI, apiResponseBytes, duration); err != nil {
+	if err := c.Set(context.TODO(), r.RequestURI, apiResponseBytes, duration); err != nil {
 		log.WithError(err).Warningf("could not cache page")
 	}
 	if _, err := w.Write(content); err != nil {

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1692,7 +1692,7 @@ func (s *Server) cached(duration time.Duration, handler func(w http.ResponseWrit
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		content, err := s.cache.Get(context.TODO(), r.RequestURI)
+		content, err := s.cache.Get(context.TODO(), r.RequestURI, duration)
 		if err != nil { // cache miss
 			log.WithError(err).Debugf("cache miss: could not fetch data from cache for %q", r.RequestURI)
 		} else if content != nil && respondFromCache(content, w, r) == nil { // cache hit

--- a/sippy-ng/src/component_readiness/AdvancedOptions.js
+++ b/sippy-ng/src/component_readiness/AdvancedOptions.js
@@ -5,6 +5,7 @@ import {
   AccordionSummary,
   FormControl,
   FormGroup,
+  Tooltip,
 } from '@mui/material'
 import { ExpandMore } from '@mui/icons-material'
 import { makeStyles } from '@mui/styles'
@@ -26,6 +27,7 @@ export default function AdvancedOptions(props) {
     passRateAllTests,
     ignoreMissing,
     ignoreDisruption,
+    includeMultiReleaseAnalysis,
     setConfidence,
     setPity,
     setMinFail,
@@ -33,6 +35,7 @@ export default function AdvancedOptions(props) {
     setPassRateAllTests,
     setIgnoreMissing,
     setIgnoreDisruption,
+    setIncludeMultiReleaseAnalysis,
   } = props
 
   const useStyles = makeStyles((theme) => ({
@@ -91,6 +94,10 @@ export default function AdvancedOptions(props) {
   }
   const handleChangeIgnoreDisruption = (event, newValue) => {
     setIgnoreDisruption(newValue)
+  }
+
+  const handleChangeIncludeMultiReleaseAnalysis = (event, newValue) => {
+    setIncludeMultiReleaseAnalysis(newValue)
   }
 
   return (
@@ -165,6 +172,18 @@ export default function AdvancedOptions(props) {
               name="ignoreDisruption"
               color="primary"
             />
+            <Tooltip title="Enable analysis across multiple prior releases">
+              <p>
+                Historical release analysis:{' '}
+                {includeMultiReleaseAnalysis ? 'include' : 'exclude'}
+              </p>
+              <Switch
+                checked={includeMultiReleaseAnalysis}
+                onChange={handleChangeIncludeMultiReleaseAnalysis}
+                name="includeMultiReleaseAnalysis"
+                color="primary"
+              />
+            </Tooltip>
           </FormGroup>
         </AccordionDetails>
       </Accordion>
@@ -181,6 +200,7 @@ AdvancedOptions.propTypes = {
   passRateAllTests: PropTypes.number.isRequired,
   ignoreMissing: PropTypes.bool.isRequired,
   ignoreDisruption: PropTypes.bool.isRequired,
+  includeMultiReleaseAnalysis: PropTypes.bool.isRequired,
   setConfidence: PropTypes.func.isRequired,
   setPity: PropTypes.func.isRequired,
   setMinFail: PropTypes.func.isRequired,
@@ -188,4 +208,5 @@ AdvancedOptions.propTypes = {
   setPassRateAllTests: PropTypes.func.isRequired,
   setIgnoreMissing: PropTypes.func.isRequired,
   setIgnoreDisruption: PropTypes.func.isRequired,
+  setIncludeMultiReleaseAnalysis: PropTypes.func.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompCapTestRow.js
+++ b/sippy-ng/src/component_readiness/CompCapTestRow.js
@@ -57,6 +57,7 @@ export default function CompCapTestRow(props) {
             component={component}
             capability={capability}
             testName={testName}
+            regressedTests={columnVal.regressed_tests}
           />
         ))}
       </TableRow>

--- a/sippy-ng/src/component_readiness/CompReadyMainInputs.js
+++ b/sippy-ng/src/component_readiness/CompReadyMainInputs.js
@@ -78,6 +78,7 @@ export default function CompReadyMainInputs(props) {
         passRateAllTests={varsContext.passRateAllTests}
         ignoreMissing={varsContext.ignoreMissing}
         ignoreDisruption={varsContext.ignoreDisruption}
+        includeMultiReleaseAnalysis={varsContext.includeMultiReleaseAnalysis}
         setConfidence={varsContext.setConfidence}
         setPity={varsContext.setPity}
         setMinFail={varsContext.setMinFail}
@@ -85,6 +86,9 @@ export default function CompReadyMainInputs(props) {
         setPassRateAllTests={varsContext.setPassRateAllTests}
         setIgnoreMissing={varsContext.setIgnoreMissing}
         setIgnoreDisruption={varsContext.setIgnoreDisruption}
+        setIncludeMultiReleaseAnalysis={
+          varsContext.setIncludeMultiReleaseAnalysis
+        }
       ></AdvancedOptions>
     </div>
   )

--- a/sippy-ng/src/component_readiness/CompReadyTestCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestCell.js
@@ -1,9 +1,8 @@
 import './ComponentReadiness.css'
 import { ComponentReadinessStyleContext } from './ComponentReadiness'
 import { CompReadyVarsContext } from './CompReadyVars'
+import { generateTestReport } from './CompReadyUtils'
 import { Link } from 'react-router-dom'
-import { safeEncodeURIComponent } from '../helpers'
-import { sortQueryParams } from './CompReadyUtils'
 import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
@@ -23,6 +22,7 @@ export default function CompReadyTestCell(props) {
     component,
     capability,
     testName,
+    regressedTests,
   } = props
   const theme = useTheme()
   const classes = useContext(ComponentReadinessStyleContext)
@@ -46,32 +46,6 @@ export default function CompReadyTestCell(props) {
   )
 
   const { expandEnvironment } = useContext(CompReadyVarsContext)
-
-  // Construct a URL with all existing filters plus testId, environment, and testName.
-  // This is the url used when you click inside a TableCell on page4 on the right.
-  // We pass these arguments to the component that generates the test details report.
-  function generateTestReport(
-    testId,
-    environmentVal,
-    filterVals,
-    componentName,
-    capabilityName,
-    testName
-  ) {
-    const safeComponentName = safeEncodeURIComponent(componentName)
-    const safeTestId = safeEncodeURIComponent(testId)
-    const safeTestName = safeEncodeURIComponent(testName)
-    const retUrl =
-      '/component_readiness/test_details' +
-      filterVals +
-      `&testId=${safeTestId}` +
-      expandEnvironment(environmentVal) +
-      `&component=${safeComponentName}` +
-      `&capability=${capabilityName}` +
-      `&testName=${safeTestName}`
-
-    return sortQueryParams(retUrl)
-  }
 
   if (status === undefined) {
     return (
@@ -98,11 +72,12 @@ export default function CompReadyTestCell(props) {
         <Link
           to={generateTestReport(
             testId,
-            environment,
+            expandEnvironment(environment),
             filterVals,
             component,
             capability,
-            testName
+            testName,
+            regressedTests
           )}
         >
           <CompSeverityIcon status={status} />
@@ -120,4 +95,5 @@ CompReadyTestCell.propTypes = {
   component: PropTypes.string.isRequired,
   capability: PropTypes.string.isRequired,
   testName: PropTypes.string.isRequired,
+  regressedTests: PropTypes.object,
 }

--- a/sippy-ng/src/component_readiness/CompReadyTestPanel.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestPanel.js
@@ -1,0 +1,264 @@
+import { ComponentReadinessStyleContext } from './ComponentReadiness'
+import { Grid, TableContainer, Tooltip, Typography } from '@mui/material'
+import CompReadyTestDetailRow from './CompReadyTestDetailRow'
+import InfoIcon from '@mui/icons-material/Info'
+import PropTypes from 'prop-types'
+import React, { Fragment, useContext, useEffect } from 'react'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+
+export default function CompReadyTestPanel(props) {
+  const { data, isOverride, versions, loadedParams } = props
+  const classes = useContext(ComponentReadinessStyleContext)
+
+  const significanceTitle = `Test results for individual Prow Jobs may not be statistically
+  significant, but when taken in aggregate, there may be a statistically
+  significant difference compared to the historical basis
+  `
+
+  const [showOnlyFailures, setShowOnlyFailures] = React.useState(false)
+
+  const tableCell = (label, idx) => {
+    return (
+      <TableCell className={classes.crColResult} key={'column' + '-' + idx}>
+        <Typography className={classes.crCellName}>{label}</Typography>
+      </TableCell>
+    )
+  }
+
+  const tableTooltipCell = (label, idx, title) => {
+    return (
+      <Tooltip title={title}>
+        <TableCell className={classes.crColResult} key={'column' + '-' + idx}>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <InfoIcon style={{ fontSize: '16px', fontWeight: 'lighter' }} />
+            <Typography className={classes.crCellName}>{label}</Typography>
+          </div>
+        </TableCell>
+      </Tooltip>
+    )
+  }
+
+  const handleFailuresOnlyChange = (event) => {
+    setShowOnlyFailures(event.target.checked)
+  }
+
+  const printParamsAndStats = (
+    statsLabel,
+    stats,
+    from,
+    to,
+    vCrossCompare,
+    variantSelection
+  ) => {
+    const summaryDate = getSummaryDate(from, to, stats.release, versions)
+    return (
+      <Fragment>
+        {statsLabel} Release: <strong>{stats.release}</strong>
+        {summaryDate && (
+          <Fragment>
+            <br />
+            &nbsp;&nbsp;<strong>{summaryDate}</strong>
+          </Fragment>
+        )}
+        <br />
+        &nbsp;&nbsp;Start Time: <strong>{from}</strong>
+        <br />
+        &nbsp;&nbsp;End Time: <strong>{to}</strong>
+        <br />
+        {vCrossCompare && vCrossCompare.length ? (
+          <Fragment>
+            <br />
+            &nbsp;&nbsp;Variant Cross Comparison:
+            <ul>
+              {vCrossCompare.map((group, idx) =>
+                variantSelection[group] ? (
+                  <li>
+                    {group}:&nbsp;
+                    <strong>{variantSelection[group].join(', ')}</strong>
+                  </li>
+                ) : (
+                  <li>
+                    {group}: <strong>(any)</strong>
+                  </li>
+                )
+              )}
+            </ul>
+          </Fragment>
+        ) : (
+          ''
+        )}
+        <br />
+        Statistics:
+        <ul>
+          <li>Success Rate: {(stats.success_rate * 100).toFixed(2)}%</li>
+          <li>Successes: {stats.success_count}</li>
+          <li>Failures: {stats.failure_count}</li>
+          <li>Flakes: {stats.flake_count}</li>
+        </ul>
+      </Fragment>
+    )
+  }
+
+  // getSummaryDate attempts to translate a date into text relative to the version GA
+  // dates we know about.  If there are no versions, there is no translation.
+  const getSummaryDate = (from, to, version, versions) => {
+    const fromDate = new Date(from)
+    const toDate = new Date(to)
+
+    // Go through the versions map from latest release to earliest; ensure that
+    // the ordering is by version (e.g., 4.6 is considered earlier than 4.10).
+    const sortedVersions = Object.keys(versions).sort((a, b) => {
+      const itemA = parseInt(a.toString().replace(/\./g, ''))
+      const itemB = parseInt(b.toString().replace(/\./g, ''))
+      return itemB - itemA
+    })
+
+    if (!versions[version]) {
+      // Handle the case where GA date is undefined (implies under development and not GA)
+      const weeksBefore = Math.floor(
+        (toDate - fromDate) / (1000 * 60 * 60 * 24 * 7)
+      )
+
+      // Calculate the difference between now and toDate in hours
+      const now = new Date()
+      const hoursDifference = Math.abs(now - toDate) / (1000 * 60 * 60)
+
+      if (hoursDifference <= 72) {
+        return weeksBefore
+          ? `Recent ${weeksBefore} week(s) of ${version}`
+          : null
+      } else {
+        // Convert toDate to human-readable format
+        const toDateFormatted = new Date(toDate).toLocaleDateString()
+        return weeksBefore
+          ? `${weeksBefore} week(s) before ${toDateFormatted} of ${version}`
+          : null
+      }
+    }
+
+    for (const version of sortedVersions) {
+      if (!versions[version]) {
+        // We already dealt with a version with no GA date above.
+        continue
+      }
+      const gaDateStr = versions[version]
+      const gaDate = new Date(gaDateStr)
+
+      // Widen the window by 20 weeks prior to GA (because releases seems to be that long) and give
+      // a buffer of 1 week after GA.
+      const twentyWeeksPreGA = new Date(gaDate.getTime())
+      twentyWeeksPreGA.setDate(twentyWeeksPreGA.getDate() - 20 * 7)
+      gaDate.setDate(gaDate.getDate() + 7)
+
+      if (fromDate >= twentyWeeksPreGA && toDate <= gaDate) {
+        // Calculate the time (in milliseconds) to weeks
+        const weeksBefore = Math.floor(
+          (gaDate - fromDate) / (1000 * 60 * 60 * 24 * 7)
+        )
+        return weeksBefore
+          ? `About ${weeksBefore} week(s) before '${version}' GA date`
+          : null
+      }
+    }
+    return null
+  }
+
+  return (
+    <Fragment>
+      <Grid container spacing={2} style={{ marginTop: '10px' }}>
+        {data.base_stats && (
+          <Grid item xs={6}>
+            {printParamsAndStats(
+              'Basis (historical)',
+              data.base_stats,
+              data.base_stats.Start.toString(),
+              data.base_stats.End.toString(),
+              loadedParams.variantCrossCompare,
+              loadedParams.includeVariantsCheckedItems
+            )}
+          </Grid>
+        )}
+        <Grid item xs={6}>
+          {printParamsAndStats(
+            'Sample (being evaluated)',
+            data.sample_stats,
+            data.sample_stats.Start.toString(),
+            data.sample_stats.End.toString(),
+            loadedParams.variantCrossCompare,
+            loadedParams.compareVariantsCheckedItems
+          )}
+        </Grid>
+      </Grid>
+      <div style={{ marginTop: '10px', marginBottom: '10px' }}>
+        <label>
+          <input
+            type="checkbox"
+            checked={showOnlyFailures}
+            onChange={handleFailuresOnlyChange}
+          />
+          Only Show Failures
+        </label>
+      </div>
+      <TableContainer component="div" className="cr-table-wrapper">
+        <Table className="cr-comp-read-table">
+          <TableHead>
+            <TableRow>
+              {tableCell('ProwJob Name', 0)}
+              {tableCell('Basis Info', 1)}
+              {tableCell('Basis Runs', 2)}
+              {tableCell('Sample Info', 3)}
+              {tableCell('Sample Runs', 4)}
+              {tableTooltipCell(
+                'Statistically Significant',
+                5,
+                significanceTitle
+              )}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {/* Ensure we have data before trying to map on it; we need data and rows */}
+            {data && data.job_stats && data.job_stats.length > 0 ? (
+              data.job_stats
+                .sort((a, b) => {
+                  if (a.significant && b.significant) {
+                    return 0
+                  } else if (a.significant) {
+                    // This makes it so that statistically significant ones go to the top.
+                    return -1
+                  } else {
+                    return 1
+                  }
+                })
+                .map((element, idx) => {
+                  return (
+                    <CompReadyTestDetailRow
+                      key={idx}
+                      element={element}
+                      idx={idx}
+                      showOnlyFailures={showOnlyFailures}
+                    ></CompReadyTestDetailRow>
+                  )
+                })
+            ) : (
+              <TableRow>
+                {/* No data to render (possible due to a Cancel */}
+                <TableCell align="center">No data ; reload to retry</TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Fragment>
+  )
+}
+
+CompReadyTestPanel.propTypes = {
+  data: PropTypes.object.isRequired,
+  versions: PropTypes.object.isRequired,
+  isOverride: PropTypes.bool.isRequired,
+  loadedParams: PropTypes.object.isRequired,
+}

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -330,13 +330,13 @@ Flakes: ${stats.flake_count}`
             }}
           >
             {data.base_stats ? (
-            <BugButton
-              testName={testName}
-              component={component}
-              capability={capability}
-              jiraComponentID={data.jira_component_id}
-              labels={['component-regression']}
-              context={`
+              <BugButton
+                testName={testName}
+                component={component}
+                capability={capability}
+                jiraComponentID={data.jira_component_id}
+                labels={['component-regression']}
+                context={`
 (_Feel free to update this bug's summary to be more specific._)
 Component Readiness has found a potential regression in the following test:
 
@@ -360,13 +360,13 @@ View the [test details report|${document.location.href}] for additional context.
             `}
               />
             ) : (
-                <BugButton
-                    testName={testName}
-                    component={component}
-                    capability={capability}
-                    jiraComponentID={data.jira_component_id}
-                    labels={['component-regression']}
-                    context={`
+              <BugButton
+                testName={testName}
+                component={component}
+                capability={capability}
+                jiraComponentID={data.jira_component_id}
+                labels={['component-regression']}
+                context={`
 (_Feel free to update this bug's summary to be more specific._)
 Component Readiness has found a potential regression in the following test:
 

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -3,13 +3,14 @@ import {
   Box,
   Button,
   Grid,
-  Paper,
   Popover,
-  TableContainer,
+  Tab,
+  Tabs,
   Typography,
 } from '@mui/material'
 import {
   cancelledDataTable,
+  generateTestReport,
   getColumns,
   getStatusAndIcon,
   getTestDetailsAPIUrl,
@@ -30,7 +31,7 @@ import BugTable from '../bugs/BugTable'
 import CompReadyCancelled from './CompReadyCancelled'
 import CompReadyPageTitle from './CompReadyPageTitle'
 import CompReadyProgress from './CompReadyProgress'
-import CompReadyTestDetailRow from './CompReadyTestDetailRow'
+import CompReadyTestPanel from './CompReadyTestPanel'
 import CopyPageURL from './CopyPageURL'
 import GeneratedAt from './GeneratedAt'
 import IconButton from '@mui/material/IconButton'
@@ -41,7 +42,6 @@ import Sidebar from './Sidebar'
 import Table from '@mui/material/Table'
 import TableBody from '@mui/material/TableBody'
 import TableCell from '@mui/material/TableCell'
-import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
 
 // Big query requests take a while so give the user the option to
@@ -52,18 +52,63 @@ const cancelFetch = () => {
   abortController.abort()
 }
 
+function tabProps(index) {
+  return {
+    id: `test-report-tab-${index}`,
+    'aria-controls': `test-report-tabpanel-${index}`,
+  }
+}
+
+TestsReportTabPanel.propTypes = {
+  children: PropTypes.node,
+  index: PropTypes.number.isRequired,
+  activeIndex: PropTypes.number.isRequired,
+}
+
+function TestsReportTabPanel(props) {
+  const { children, activeIndex, index, ...other } = props
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={activeIndex !== index}
+      id={`test-report-tabpanel-${index}`}
+      aria-labelledby={`test-report-tab-${index}`}
+      {...other}
+    >
+      {activeIndex === index && (
+        <Box sx={{ p: 3 }}>
+          <Typography>{children}</Typography>
+        </Box>
+      )}
+    </div>
+  )
+}
+
 // This component runs when we see /component_readiness/test_details
 // This is page 5 which runs when you click a test cell on the right of page 4 or page 4a
 export default function CompReadyTestReport(props) {
   const classes = useContext(ComponentReadinessStyleContext)
 
-  const { filterVals, component, capability, testId, environment, testName } =
-    props
+  const [activeTabIndex, setActiveTabIndex] = React.useState(0)
+
+  const handleTabChange = (event, newValue) => {
+    setActiveTabIndex(newValue)
+  }
+
+  const {
+    filterVals,
+    component,
+    capability,
+    testId,
+    environment,
+    testName,
+    testBasisRelease,
+  } = props
 
   const [fetchError, setFetchError] = React.useState('')
   const [isLoaded, setIsLoaded] = React.useState(false)
   const [data, setData] = React.useState({})
-  const [showOnlyFailures, setShowOnlyFailures] = React.useState(false)
   const [versions, setVersions] = React.useState({})
   const releases = useContext(ReleasesContext)
 
@@ -74,6 +119,7 @@ export default function CompReadyTestReport(props) {
   const safeComponent = safeEncodeURIComponent(component)
   const safeCapability = safeEncodeURIComponent(capability)
   const safeTestId = safeEncodeURIComponent(testId)
+  const safeTestBasisRelease = safeEncodeURIComponent(testBasisRelease)
 
   const { expandEnvironment } = useContext(CompReadyVarsContext)
 
@@ -104,6 +150,7 @@ export default function CompReadyTestReport(props) {
     `&component=${safeComponent}` +
     `&capability=${safeCapability}` +
     `&testId=${safeTestId}` +
+    `&testBasisRelease=${safeTestBasisRelease}` +
     (environment ? expandEnvironment(environment) : '')
 
   useEffect(() => {
@@ -177,27 +224,6 @@ export default function CompReadyTestReport(props) {
     `environment: ${environment}`
   )
 
-  const tableCell = (label, idx) => {
-    return (
-      <TableCell className={classes.crColResult} key={'column' + '-' + idx}>
-        <Typography className={classes.crCellName}>{label}</Typography>
-      </TableCell>
-    )
-  }
-
-  const tableTooltipCell = (label, idx, title) => {
-    return (
-      <Tooltip title={title}>
-        <TableCell className={classes.crColResult} key={'column' + '-' + idx}>
-          <div style={{ display: 'flex', alignItems: 'center' }}>
-            <InfoIcon style={{ fontSize: '16px', fontWeight: 'lighter' }} />
-            <Typography className={classes.crCellName}>{label}</Typography>
-          </div>
-        </TableCell>
-      </Tooltip>
-    )
-  }
-
   if (!isLoaded) {
     return <CompReadyProgress apiLink={apiCallStr} cancelFunc={cancelFetch} />
   }
@@ -227,131 +253,23 @@ export default function CompReadyTestReport(props) {
   } else {
     url = new URL(apiCallStr)
   }
+
   const params = new URLSearchParams(url.search)
-  const baseStartTime = params.get('baseStartTime')
-  const baseEndTime = params.get('baseEndTime')
-  const sampleStartTime = params.get('sampleStartTime')
-  const sampleEndTime = params.get('sampleEndTime')
+  const baseRelease = params.get('baseRelease')
 
-  // getSummaryDate attempts to translate a date into text relative to the version GA
-  // dates we know about.  If there are no versions, there is no translation.
-  const getSummaryDate = (from, to, version, versions) => {
-    const fromDate = new Date(from)
-    const toDate = new Date(to)
-
-    // Go through the versions map from latest release to earliest; ensure that
-    // the ordering is by version (e.g., 4.6 is considered earlier than 4.10).
-    const sortedVersions = Object.keys(versions).sort((a, b) => {
-      const itemA = parseInt(a.toString().replace(/\./g, ''))
-      const itemB = parseInt(b.toString().replace(/\./g, ''))
-      return itemB - itemA
-    })
-
-    if (!versions[version]) {
-      // Handle the case where GA date is undefined (implies under development and not GA)
-      const weeksBefore = Math.floor(
-        (toDate - fromDate) / (1000 * 60 * 60 * 24 * 7)
-      )
-
-      // Calculate the difference between now and toDate in hours
-      const now = new Date()
-      const hoursDifference = Math.abs(now - toDate) / (1000 * 60 * 60)
-
-      if (hoursDifference <= 72) {
-        return weeksBefore
-          ? `Recent ${weeksBefore} week(s) of ${version}`
-          : null
-      } else {
-        // Convert toDate to human-readable format
-        const toDateFormatted = new Date(toDate).toLocaleDateString()
-        return weeksBefore
-          ? `${weeksBefore} week(s) before ${toDateFormatted} of ${version}`
-          : null
-      }
-    }
-
-    for (const version of sortedVersions) {
-      if (!versions[version]) {
-        // We already dealt with a version with no GA date above.
-        continue
-      }
-      const gaDateStr = versions[version]
-      const gaDate = new Date(gaDateStr)
-
-      // Widen the window by 20 weeks prior to GA (because releases seems to be that long) and give
-      // a buffer of 1 week after GA.
-      const twentyWeeksPreGA = new Date(gaDate.getTime())
-      twentyWeeksPreGA.setDate(twentyWeeksPreGA.getDate() - 20 * 7)
-      gaDate.setDate(gaDate.getDate() + 7)
-
-      if (fromDate >= twentyWeeksPreGA && toDate <= gaDate) {
-        // Calculate the time (in milliseconds) to weeks
-        const weeksBefore = Math.floor(
-          (gaDate - fromDate) / (1000 * 60 * 60 * 24 * 7)
-        )
-        return weeksBefore
-          ? `About ${weeksBefore} week(s) before '${version}' GA date`
-          : null
-      }
-    }
-    return null
-  }
-
-  const printParamsAndStats = (
-    statsLabel,
-    stats,
-    from,
-    to,
-    vCrossCompare,
-    variantSelection
-  ) => {
-    const summaryDate = getSummaryDate(from, to, stats.release, versions)
-    return (
-      <Fragment>
-        {statsLabel} Release: <strong>{stats.release}</strong>
-        {summaryDate && (
-          <Fragment>
-            <br />
-            &nbsp;&nbsp;<strong>{summaryDate}</strong>
-          </Fragment>
-        )}
-        <br />
-        &nbsp;&nbsp;Start Time: <strong>{from}</strong>
-        <br />
-        &nbsp;&nbsp;End Time: <strong>{to}</strong>
-        <br />
-        {vCrossCompare && vCrossCompare.length ? (
-          <Fragment>
-            <br />
-            &nbsp;&nbsp;Variant Cross Comparison:
-            <ul>
-              {vCrossCompare.map((group, idx) =>
-                variantSelection[group] ? (
-                  <li>
-                    {group}:&nbsp;
-                    <strong>{variantSelection[group].join(', ')}</strong>
-                  </li>
-                ) : (
-                  <li>
-                    {group}: <strong>(any)</strong>
-                  </li>
-                )
-              )}
-            </ul>
-          </Fragment>
-        ) : (
-          ''
-        )}
-        <br />
-        Statistics:
-        <ul>
-          <li>Success Rate: {(stats.success_rate * 100).toFixed(2)}%</li>
-          <li>Successes: {stats.success_count}</li>
-          <li>Failures: {stats.failure_count}</li>
-          <li>Flakes: {stats.flake_count}</li>
-        </ul>
-      </Fragment>
-    )
+  let isBaseOverride = false
+  let baseReleaseTabLabel = baseRelease + ' Basis'
+  let overrideReleaseTabLabel = ''
+  if (
+    data &&
+    data.base_stats &&
+    data.base_stats.release &&
+    data.base_stats.release !== baseRelease &&
+    data.base_override_report
+  ) {
+    isBaseOverride = true
+    overrideReleaseTabLabel = baseReleaseTabLabel
+    baseReleaseTabLabel = data.base_stats.release + ' Basis'
   }
 
   const printStatsText = (statsLabel, stats, from, to) => {
@@ -411,6 +329,7 @@ Flakes: ${stats.flake_count}`
               gap: 2,
             }}
           >
+            {data.base_stats ? (
             <BugButton
               testName={testName}
               component={component}
@@ -427,19 +346,44 @@ ${data.explanations.join('\n')}
 ${printStatsText(
   'Sample (being evaluated)',
   data.sample_stats,
-  sampleStartTime,
-  sampleEndTime
+  data.sample_stats.Start,
+  data.sample_stats.End
 )}
 ${printStatsText(
   'Base (historical)',
   data.base_stats,
-  baseStartTime,
-  baseEndTime
+  data.base_stats.Start,
+  data.base_stats.End
 )}
 
 View the [test details report|${document.location.href}] for additional context.
             `}
-            />
+              />
+            ) : (
+                <BugButton
+                    testName={testName}
+                    component={component}
+                    capability={capability}
+                    jiraComponentID={data.jira_component_id}
+                    labels={['component-regression']}
+                    context={`
+(_Feel free to update this bug's summary to be more specific._)
+Component Readiness has found a potential regression in the following test:
+
+{code:none}${testName}{code}
+
+${data.explanations.join('\n')}
+${printStatsText(
+  'Sample (being evaluated)',
+  data.sample_stats,
+  data.sample_stats.Start,
+  data.sample_stats.End
+)}
+
+View the [test details report|${document.location.href}] for additional context.
+            `}
+              />
+            )}
             <Button
               variant="contained"
               color="secondary"
@@ -474,6 +418,14 @@ View the [test details report|${document.location.href}] for additional context.
             <TableCell>Environment:</TableCell>
             <TableCell>{environment}</TableCell>
           </TableRow>
+          {isBaseOverride ? (
+            <TableRow>
+              <TableCell>{baseRelease} Override:</TableCell>
+              <TableCell>Earlier release had a higher threshold</TableCell>
+            </TableRow>
+          ) : (
+            <Fragment />
+          )}
           <TableRow>
             <TableCell>Assessment:</TableCell>
             <TableCell>
@@ -486,89 +438,41 @@ View the [test details report|${document.location.href}] for additional context.
           </TableRow>
         </TableBody>
       </Table>
-      <Grid container spacing={2} style={{ marginTop: '10px' }}>
-        {data.base_stats && (
-          <Grid item xs={6}>
-            {printParamsAndStats(
-              'Basis (historical)',
-              data.base_stats,
-              loadedParams.baseStartTime.toString(),
-              loadedParams.baseEndTime.toString(),
-              loadedParams.variantCrossCompare,
-              loadedParams.includeVariantsCheckedItems
-            )}
-          </Grid>
-        )}
-        <Grid item xs={6}>
-          {printParamsAndStats(
-            'Sample (being evaluated)',
-            data.sample_stats,
-            loadedParams.sampleStartTime.toString(),
-            loadedParams.sampleEndTime.toString(),
-            loadedParams.variantCrossCompare,
-            loadedParams.compareVariantsCheckedItems
-          )}
-        </Grid>
-      </Grid>
-      <div style={{ marginTop: '10px', marginBottom: '10px' }}>
-        <label>
-          <input
-            type="checkbox"
-            checked={showOnlyFailures}
-            onChange={handleFailuresOnlyChange}
-          />
-          Only Show Failures
-        </label>
-      </div>
-      <TableContainer component="div" className="cr-table-wrapper">
-        <Table className="cr-comp-read-table">
-          <TableHead>
-            <TableRow>
-              {tableCell('ProwJob Name', 0)}
-              {tableCell('Basis Info', 1)}
-              {tableCell('Basis Runs', 2)}
-              {tableCell('Sample Info', 3)}
-              {tableCell('Sample Runs', 4)}
-              {tableTooltipCell(
-                'Statistically Significant',
-                5,
-                significanceTitle
-              )}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {/* Ensure we have data before trying to map on it; we need data and rows */}
-            {data && data.job_stats && data.job_stats.length > 0 ? (
-              data.job_stats
-                .sort((a, b) => {
-                  if (a.significant && b.significant) {
-                    return 0
-                  } else if (a.significant) {
-                    // This makes it so that statistically significant ones go to the top.
-                    return -1
-                  } else {
-                    return 1
-                  }
-                })
-                .map((element, idx) => {
-                  return (
-                    <CompReadyTestDetailRow
-                      key={idx}
-                      element={element}
-                      idx={idx}
-                      showOnlyFailures={showOnlyFailures}
-                    ></CompReadyTestDetailRow>
-                  )
-                })
-            ) : (
-              <TableRow>
-                {/* No data to render (possible due to a Cancel */}
-                <TableCell align="center">No data ; reload to retry</TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </TableContainer>
+      {isBaseOverride ? (
+        <Fragment>
+          <Tabs
+            value={activeTabIndex}
+            onChange={handleTabChange}
+            aria-label="Test Report Tabs"
+          >
+            <Tab label={baseReleaseTabLabel} {...tabProps(0)} />
+            <Tab label={overrideReleaseTabLabel} {...tabProps(1)} />
+          </Tabs>
+          <TestsReportTabPanel activeIndex={activeTabIndex} index={0}>
+            <CompReadyTestPanel
+              data={data}
+              versions={versions}
+              isOverride={false}
+              loadedParams={loadedParams}
+            />
+          </TestsReportTabPanel>
+          <TestsReportTabPanel activeIndex={activeTabIndex} index={1}>
+            <CompReadyTestPanel
+              data={data.base_override_report}
+              versions={versions}
+              isOverride={true}
+              loadedParams={loadedParams}
+            />
+          </TestsReportTabPanel>
+        </Fragment>
+      ) : (
+        <CompReadyTestPanel
+          data={data}
+          versions={versions}
+          isOverride={false}
+          loadedParams={loadedParams}
+        />
+      )}
       <Popover
         id="copyPopover"
         open={copyPopoverOpen}
@@ -598,4 +502,5 @@ CompReadyTestReport.propTypes = {
   testId: PropTypes.string.isRequired,
   environment: PropTypes.string.isRequired,
   testName: PropTypes.string.isRequired,
+  testBasisRelease: PropTypes.string.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -1,5 +1,6 @@
 import { alpha, InputBase, Typography } from '@mui/material'
 import { formatInTimeZone } from 'date-fns-tz'
+import { safeEncodeURIComponent } from '../helpers'
 import { styled } from '@mui/styles'
 import Alert from '@mui/material/Alert'
 import green from './green.svg'
@@ -331,6 +332,7 @@ export function getUpdatedUrlParts(vars) {
     passRateAllTests: vars.passRateAllTests,
     ignoreDisruption: vars.ignoreDisruption,
     ignoreMissing: vars.ignoreMissing,
+    includeMultiReleaseAnalysis: vars.includeMultiReleaseAnalysis,
     //component: vars.component,
   }
 
@@ -610,4 +612,41 @@ export const convertVariantItemsToParam = (groupedVariants) => {
     })
   })
   return param
+}
+
+// Construct a URL with all existing filters plus testId, environment, and testName.
+// This is the url used when you click inside a TableCell on page4 on the right.
+// We pass these arguments to the component that generates the test details report.
+export function generateTestReport(
+  testId,
+  environmentVal,
+  filterVals,
+  componentName,
+  capabilityName,
+  testName,
+  regressedTests
+) {
+  let testBasisRelease = ''
+  if (
+    typeof regressedTests != 'undefined' &&
+    regressedTests.length > 0 &&
+    typeof regressedTests[0].base_stats != 'undefined'
+  ) {
+    testBasisRelease = regressedTests[0].base_stats.release
+  }
+  const safeComponentName = safeEncodeURIComponent(componentName)
+  const safeTestId = safeEncodeURIComponent(testId)
+  const safeTestName = safeEncodeURIComponent(testName)
+  const safeTestBasisRelease = safeEncodeURIComponent(testBasisRelease)
+  const retUrl =
+    '/component_readiness/test_details' +
+    filterVals +
+    `&testBasisRelease=${safeTestBasisRelease}` +
+    `&testId=${safeTestId}` +
+    environmentVal +
+    `&component=${safeComponentName}` +
+    `&capability=${capabilityName}` +
+    `&testName=${safeTestName}`
+
+  return sortQueryParams(retUrl)
 }

--- a/sippy-ng/src/component_readiness/CompReadyVars.js
+++ b/sippy-ng/src/component_readiness/CompReadyVars.js
@@ -19,10 +19,23 @@ import {
 } from './CompReadyUtils'
 import { ReleasesContext } from '../App'
 import { safeEncodeURIComponent } from '../helpers'
+import { useLocation } from 'react-router-dom'
 import CompReadyProgress from './CompReadyProgress'
 import PropTypes from 'prop-types'
 import React, { createContext, useContext, useEffect, useState } from 'react'
 export const CompReadyVarsContext = createContext()
+
+let params = null
+
+function getDefaultIncludeMultiReleaseAnalysis() {
+  if (params != null) {
+    let fallback = params.get('includeMultiReleaseAnalysis')
+    if (fallback != undefined) {
+      return fallback
+    }
+  }
+  return false
+}
 
 export const CompReadyVarsProvider = ({ children }) => {
   const [allJobVariants, setAllJobVariants] = useState([])
@@ -31,6 +44,8 @@ export const CompReadyVarsProvider = ({ children }) => {
   const [isLoaded, setIsLoaded] = useState(false)
   const [fetchError, setFetchError] = useState('')
 
+  let location = useLocation()
+  params = new URLSearchParams(location.search)
   const releases = useContext(ReleasesContext)
 
   // Find the most recent GA
@@ -118,6 +133,10 @@ export const CompReadyVarsProvider = ({ children }) => {
     'ignoreDisruption',
     BooleanParam
   )
+  const [
+    includeMultiReleaseAnalysisParam,
+    setIncludeMultiReleaseAnalysisParam,
+  ] = useQueryParam('includeMultiReleaseAnalysis', BooleanParam)
 
   // Create the variables to be used for api calls; these are initialized to the
   // value of the variables that got their values from the URL.
@@ -283,6 +302,11 @@ export const CompReadyVarsProvider = ({ children }) => {
     ignoreDisruptionParam || true
   )
 
+  const [includeMultiReleaseAnalysis, setIncludeMultiReleaseAnalysis] =
+    React.useState(
+      includeMultiReleaseAnalysisParam ||
+        Boolean(getDefaultIncludeMultiReleaseAnalysis())
+    )
   /******************************************************************************
    * Parameters that are used to refine the query as the user drills down into CR
    ****************************************************************************** */
@@ -350,6 +374,7 @@ export const CompReadyVarsProvider = ({ children }) => {
     setPassRateAllTestsParam(passRateAllTests)
     setIgnoreDisruptionParam(ignoreDisruption)
     setIgnoreMissingParam(ignoreMissing)
+    setIncludeMultiReleaseAnalysisParam(includeMultiReleaseAnalysis)
     setComponentParam(component)
     setEnvironmentParam(environment)
     setCapabilityParam(capability)
@@ -379,6 +404,7 @@ export const CompReadyVarsProvider = ({ children }) => {
     setPassRateAllTestsParam(undefined)
     setIgnoreDisruptionParam(undefined)
     setIgnoreMissingParam(undefined)
+    setIncludeMultiReleaseAnalysisParam(undefined)
 
     setSamplePROrgParam(undefined)
     setSamplePRRepoParam(undefined)
@@ -431,6 +457,13 @@ export const CompReadyVarsProvider = ({ children }) => {
     }
     if (view.advanced_options.hasOwnProperty('ignore_missing')) {
       setIgnoreMissing(view.advanced_options.ignore_missing)
+    }
+    if (
+      view.advanced_options.hasOwnProperty('include_multi_release_analysis')
+    ) {
+      setIncludeMultiReleaseAnalysis(
+        view.advanced_options.include_multi_release_analysis
+      )
     }
   }
 
@@ -597,6 +630,8 @@ export const CompReadyVarsProvider = ({ children }) => {
         setIgnoreMissing,
         ignoreDisruption,
         setIgnoreDisruption,
+        includeMultiReleaseAnalysis,
+        setIncludeMultiReleaseAnalysis,
         component,
         setComponentParam,
         capability,

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -199,9 +199,16 @@ export default function ComponentReadiness(props) {
 
   const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
   const [testNameParam, setTestNameParam] = useQueryParam('testName', String)
+  const [testBasisReleaseParam, setTestBasisReleaseParam] = useQueryParam(
+    'testBasisRelease',
+    String
+  )
 
   const [testId, setTestId] = React.useState(testIdParam)
   const [testName, setTestName] = React.useState(testNameParam)
+  const [testBasisRelease, setTestBasisRelease] = React.useState(
+    testBasisReleaseParam
+  )
 
   const { path, url } = useRouteMatch()
 
@@ -397,6 +404,7 @@ export default function ComponentReadiness(props) {
                   varsContext.setCapabilityParam(varsContext.capability)
                   setTestIdParam(testId)
                   setTestNameParam(testName)
+                  setTestBasisReleaseParam(testBasisRelease)
                   varsContext.setEnvironmentParam(varsContext.environment)
                   return (
                     <CompReadyTestReport
@@ -407,6 +415,7 @@ export default function ComponentReadiness(props) {
                       environment={varsContext.environment}
                       testId={testId}
                       testName={testName}
+                      testBasisRelease={testBasisRelease}
                     ></CompReadyTestReport>
                   )
                 }}

--- a/sippy-ng/src/component_readiness/RegressedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsPanel.js
@@ -19,13 +19,15 @@ function generateTestReport(
   filterVals,
   componentName,
   capabilityName,
-  testName
+  testName,
+  testBasisRelease
 ) {
   const environmentVal = formColumnName({ variants: variants })
   const { expandEnvironment } = useContext(CompReadyVarsContext)
   const safeComponentName = safeEncodeURIComponent(componentName)
   const safeTestId = safeEncodeURIComponent(testId)
   const safeTestName = safeEncodeURIComponent(testName)
+  const safeTestBasisRelease = safeEncodeURIComponent(testBasisRelease)
   let variantsUrl = ''
   Object.entries(variants).forEach(([key, value]) => {
     variantsUrl += '&' + key + '=' + safeEncodeURIComponent(value)
@@ -33,6 +35,7 @@ function generateTestReport(
   const retUrl =
     '/component_readiness/test_details' +
     filterVals +
+    `&testBasisRelease=${safeTestBasisRelease}` +
     `&testId=${safeTestId}` +
     expandEnvironment(environmentVal) +
     `&component=${safeComponentName}` +
@@ -148,7 +151,8 @@ export default function RegressedTestsPanel(props) {
               props.filterVals,
               params.row.component,
               params.row.capability,
-              params.row.test_name
+              params.row.test_name,
+              params.row.base_stats ? params.row.base_stats.release : ''
             )}
           >
             <CompSeverityIcon


### PR DESCRIPTION
- Queries previous releases without variant, capability or testid filtering
- Caches results so navigating down through capabilities doesn't cause the query to run again
- Compares stats from previous releases based on testIdentification and selects the one with the highest pass rate
- Includes Advanced Option for `Historical release analysis` default is exclude currently
- Fallback test details shows both the queried base release status and fallback when applicable
  - Override Release Assessment
  - Fallback Release Assessment
  - Fallback Release basis with dates
  - Override Release basis with dates (new tab)

![image](https://github.com/user-attachments/assets/d81f7c4e-0ec8-418a-90b1-f47a119ea455)

When included the regressed since column will be empty since regression tracking is currently not aware of these

![image](https://github.com/user-attachments/assets/7bed10aa-cf5f-4517-b9af-c37371c6c850)

Test Details Report will show tabs for the requested basis as well as the fallback / historical basis.  It will indicate an override as well as an explanation

![image](https://github.com/user-attachments/assets/0ac92f9b-33ae-4ea3-bdd9-eca2b867f477)


