### PR TITLE
TRT-1813: fix bug omitting some variants from test_details filter

### DIFF
--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -2,6 +2,7 @@ package componentreadiness
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -138,11 +139,11 @@ func (c *componentReportGenerator) getTestDetailsQuery(allJobVariants crtype.Job
 	}
 
 	for k, vs := range c.IncludeVariants {
-		// only add in include variants that aren't part of the request or compare arrays
+		// only add in include variants that aren't part of the requested or cross-compared variants
 		if _, ok := c.RequestedVariants[k]; ok {
 			continue
 		}
-		if _, ok := c.CompareVariants[k]; ok {
+		if slices.Contains(c.VariantCrossCompare, k) {
 			continue
 		}
 
@@ -166,7 +167,7 @@ func (c *componentReportGenerator) getTestDetailsQuery(allJobVariants crtype.Job
 	return queryString, groupString, commonParams
 }
 
-// filterByCrossCompareVariants adds the where clause for any variants being cross-compared (which are not included in RequiredVariants).
+// filterByCrossCompareVariants adds the where clause for any variants being cross-compared (which are not included in RequestedVariants).
 // As a side effect, it also appends any necessary parameters for the clause.
 func filterByCrossCompareVariants(crossCompare []string, variantGroups map[string][]string, params *[]bigquery2.QueryParameter) (whereClause string) {
 	if len(variantGroups) == 0 {


### PR DESCRIPTION
This was introduced with the variant cross-compare; originally the CompareVariants would only include variants under cross-compare, so I used that to determine whether this bit of code needed to add the variant filter or not. Later I updated the code to fill out CompareVariants with all the variants, which caused this bit to skip adding basically everything. Thus Owner, which is not in the RequestedVariants, if not in the cross-comparison would never be filtered. By scoping the exclusion to the variant groups under cross-comparison, it returns to its original intent.