### PR TITLE
TRT-1808: fix flakes link to include variants in job runs filter

### DIFF
--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -679,7 +679,7 @@ function TestTable(props) {
                   pathForJobRunsWithTestFlake(
                     props.release,
                     params.row.name,
-                    filterModel
+                    jobRunsFilter
                   ),
                   'timestamp',
                   'desc'


### PR DESCRIPTION
When clicking the Flakes icon, it doesn't filter the job run list by the variants for that row on the tests table. We were just using the wrong filter model to pass in.