### PR TITLE
TRT-1836: wire up contexts for http requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ test: builddir npm
 	LANG=en_US.utf-8 LC_ALL=en_US.utf-8 cd sippy-ng; CI=true npm test -- --coverage --passWithNoTests
 
 lint: builddir npm
+	./hack/go-lint.sh run ./...
 	# See https://github.com/facebook/create-react-app/issues/11174 about
 	# why we only audit production deps:
 	cd sippy-ng; npm audit --production
-	./hack/go-lint.sh run ./...
 	cd sippy-ng; npx eslint .
 
 npm:

--- a/cmd/sippy/component_readiness.go
+++ b/cmd/sippy/component_readiness.go
@@ -182,7 +182,9 @@ func (f *ComponentReadinessFlags) runServerMode() error {
 
 	if f.MetricsAddr != "" {
 		// Do an immediate metrics update
-		err = metrics.RefreshMetricsDB(nil,
+		err = metrics.RefreshMetricsDB(
+			context.Background(),
+			nil,
 			bigQueryClient,
 			f.ProwFlags.URL,
 			f.GoogleCloudFlags.StorageBucket,
@@ -204,6 +206,7 @@ func (f *ComponentReadinessFlags) runServerMode() error {
 				case <-ticker.C:
 					log.Info("tick")
 					err := metrics.RefreshMetricsDB(
+						context.Background(),
 						nil,
 						bigQueryClient,
 						f.ProwFlags.URL,

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -19,8 +19,14 @@ else
     exit 1
   fi
 
+  # Check if running on Linux
+  VOLUME_OPTION=""
+  if [[ "$(uname -s)" == "Linux" ]]; then
+    VOLUME_OPTION=":z"
+  fi
+
   $DOCKER run --rm \
-    --volume "${PWD}:/go/src/github.com/openshift/sippy:z" \
+    --volume "${PWD}:/go/src/github.com/openshift/sippy${VOLUME_OPTION}" \
     --workdir /go/src/github.com/openshift/sippy \
     docker.io/golangci/golangci-lint:v1.54.2 \
     golangci-lint "${@}"

--- a/pkg/api/componentreadiness/component_report_test.go
+++ b/pkg/api/componentreadiness/component_report_test.go
@@ -2,12 +2,14 @@
 package componentreadiness
 
 import (
+	"context"
 	"encoding/json"
-	crtype "github.com/openshift/sippy/pkg/apis/api/componentreport"
 	"strings"
 	"testing"
 
+	crtype "github.com/openshift/sippy/pkg/apis/api/componentreport"
 	"github.com/openshift/sippy/pkg/util/sets"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -963,7 +965,7 @@ func TestGenerateComponentReport(t *testing.T) {
 	componentAndCapabilityGetter = fakeComponentAndCapabilityGetter
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			report, err := tc.generator.generateComponentTestReport(tc.baseStatus, tc.sampleStatus)
+			report, err := tc.generator.generateComponentTestReport(context.TODO(), tc.baseStatus, tc.sampleStatus)
 			assert.NoError(t, err, "error generating component report")
 			assert.Equal(t, tc.expectedReport, report, "expected report %+v, got %+v", tc.expectedReport, report)
 		})
@@ -1332,7 +1334,7 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
-			report := tc.generator.internalGenerateTestDetailsReport(baseStats, sampleStats)
+			report := tc.generator.internalGenerateTestDetailsReport(context.TODO(), baseStats, sampleStats)
 			assert.Equal(t, tc.expectedReport.RowIdentification, report.RowIdentification, "expected report row identification %+v, got %+v", tc.expectedReport.RowIdentification, report.RowIdentification)
 			assert.Equal(t, tc.expectedReport.ColumnIdentification, report.ColumnIdentification, "expected report column identification %+v, got %+v", tc.expectedReport.ColumnIdentification, report.ColumnIdentification)
 			assert.Equal(t, tc.expectedReport.BaseStats, report.BaseStats, "expected report base stats %+v, got %+v", tc.expectedReport.BaseStats, report.BaseStats)

--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -10,13 +10,13 @@ import (
 	"time"
 
 	"github.com/lib/pq"
-	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
 	"gorm.io/gorm"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
+	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 	bqcachedclient "github.com/openshift/sippy/pkg/bigquery"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
@@ -481,13 +481,13 @@ func releaseFilter(req *http.Request, dbc *gorm.DB) *gorm.DB {
 }
 
 // GetReleasesFromBigQuery gets all releases defined in the Releases table in BigQuery
-func GetReleasesFromBigQuery(client *bqcachedclient.Client) ([]v1.Release, error) {
+func GetReleasesFromBigQuery(ctx context.Context, client *bqcachedclient.Client) ([]v1.Release, error) {
 	releases := []v1.Release{}
 
 	queryString := "SELECT * FROM openshift-ci-data-analysis.ci_data.Releases ORDER BY DevelStartDate DESC"
 
 	q := client.BQ.Query(queryString)
-	it, err := q.Read(context.TODO())
+	it, err := q.Read(ctx)
 	if err != nil {
 		log.WithError(err).Error("error querying releases data from bigquery")
 		return releases, err


### PR DESCRIPTION
goroutines need to be terminated when an HTTP request ends, currently without a context they keep running.   We also need to pass these into `bigquery.Query()` so the DB query terminates too.

If you wanted to test this PR:
1. Start up component readiness and click on an uncached square
2. Immediately close the browser tab -- notice the queries are terminated (you'll see context cancelled in the logs)

If you try this without this PR, the queries will continue executing. 

New goroutines should follow this pattern:

```go

	go func() {
                wg.Add(1)
		defer wg.Done()
		select {
		case <-ctx.Done():
			logrus.Infof("Context canceled while fetching base job run test status")
			return
		default:
                       // work to do
		}
```

