### PR TITLE
TRT-1849: Remove metal from QE platforms

### DIFF
--- a/config/qe-views.yaml
+++ b/config/qe-views.yaml
@@ -41,7 +41,6 @@ component_readiness:
           - aws
           - azure
           - gcp
-          - metal
           - rosa
           - vsphere
         Topology:
@@ -97,7 +96,6 @@ component_readiness:
           - aws
           - azure
           - gcp
-          - metal
           - rosa
           - vsphere
         Topology:


### PR DESCRIPTION
They don't have any metal jobs in their tables.  I had thought the error was coming from the hardcoded list in the frontend code, but metal was accidentally listed in their views when I copied and pasted it from engineering's.