### PR TITLE
NO-JIRA: payload diff

### DIFF
--- a/pkg/api/pull_requests.go
+++ b/pkg/api/pull_requests.go
@@ -3,10 +3,15 @@ package api
 import (
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/filter"
 )
 
 func GetPullRequestsReportFromDB(dbc *db.DB, release string, filterOpts *filter.FilterOptions) ([]apitype.PullRequest, error) {
 	return query.PullRequestReport(dbc, filterOpts, release)
+}
+
+func GetPayloadDiffPullRequests(dbc *db.DB, fromPayload, toPayload string) ([]models.ReleasePullRequest, error) {
+	return query.GetPayloadDiff(dbc.DB, fromPayload, toPayload)
 }

--- a/pkg/db/query/payload_queries.go
+++ b/pkg/db/query/payload_queries.go
@@ -1,12 +1,27 @@
 package query
 
 import (
+	"fmt"
 	"time"
 
 	"gorm.io/gorm"
 
 	"github.com/openshift/sippy/pkg/db/models"
 )
+
+func GetPayloadDiff(db *gorm.DB, fromPayload, toPayload string) ([]models.ReleasePullRequest, error) {
+	results := make([]models.ReleasePullRequest, 0)
+	query := fmt.Sprintf(`SELECT url,pull_request_id,name,description,bug_url FROM release_pull_requests 
+		WHERE id IN ( SELECT release_pull_request_id FROM release_tag_pull_requests WHERE release_tag_id IN (SELECT id FROM release_tags WHERE release_tag ='%s')) 
+		AND id NOT IN ( SELECT release_pull_request_id FROM release_tag_pull_requests WHERE release_tag_id IN (SELECT id FROM release_tags WHERE release_tag ='%s')) ORDER BY url`, toPayload, fromPayload)
+	result := db.Raw(query).Scan(&results)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return results, nil
+}
 
 // GetLastAcceptedByArchitectureAndStream returns the last accepted payload for each architecture/stream combo.
 func GetLastAcceptedByArchitectureAndStream(db *gorm.DB, release string, reportEnd time.Time) ([]models.ReleaseTag, error) {

--- a/pkg/db/query/payload_queries.go
+++ b/pkg/db/query/payload_queries.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"fmt"
 	"time"
 
 	"gorm.io/gorm"
@@ -11,10 +10,9 @@ import (
 
 func GetPayloadDiff(db *gorm.DB, fromPayload, toPayload string) ([]models.ReleasePullRequest, error) {
 	results := make([]models.ReleasePullRequest, 0)
-	query := fmt.Sprintf(`SELECT url,pull_request_id,name,description,bug_url FROM release_pull_requests 
-		WHERE id IN ( SELECT release_pull_request_id FROM release_tag_pull_requests WHERE release_tag_id IN (SELECT id FROM release_tags WHERE release_tag ='%s')) 
-		AND id NOT IN ( SELECT release_pull_request_id FROM release_tag_pull_requests WHERE release_tag_id IN (SELECT id FROM release_tags WHERE release_tag ='%s')) ORDER BY url`, toPayload, fromPayload)
-	result := db.Raw(query).Scan(&results)
+	result := db.Raw(`SELECT url,pull_request_id,name,description,bug_url FROM release_pull_requests 
+		WHERE id IN ( SELECT release_pull_request_id FROM release_tag_pull_requests WHERE release_tag_id IN (SELECT id FROM release_tags WHERE release_tag =?)) 
+		AND id NOT IN ( SELECT release_pull_request_id FROM release_tag_pull_requests WHERE release_tag_id IN (SELECT id FROM release_tags WHERE release_tag =?)) ORDER BY url`, toPayload, fromPayload).Scan(&results)
 
 	if result.Error != nil {
 		return nil, result.Error


### PR DESCRIPTION
No UI but we can use the api to get diffs after the release-controller has rolled off older payloads

```
http://127.0.0.1:8080/api/payloads/diff?fromPayload=4.18.0-0.nightly-2024-10-15-171849&toPayload=4.18.0-0.nightly-2024-10-16-001902
```

```
[
  {
    "id": 0,
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z",
    "deleted_at": null,
    "url": "https://github.com/openshift/api/pull/2060",
    "pull_request_id": "2060",
    "name": "cluster-config-api",
    "description": "Ensure custom feature gate mainfest path is passed into generator",
    "bug_url": ""
  },
  {
    "id": 0,
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z",
    "deleted_at": null,
    "url": "https://github.com/openshift/api/pull/2062",
    "pull_request_id": "2062",
    "name": "cluster-config-api",
    "description": "Update crd-schema-checker dependency",
    "bug_url": ""
  },
  {
    "id": 0,
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z",
    "deleted_at": null,
    "url": "https://github.com/openshift/assisted-installer/pull/932",
    "pull_request_id": "932",
    "name": "agent-installer-csr-approver, agent-installer-orchestrator",
    "description": "NO-ISSUE: Bump PGX version (#932)",
    "bug_url": ""
  },
  {
    "id": 0,
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z",
    "deleted_at": null,
    "url": "https://github.com/openshift/cluster-api-operator/pull/54",
    "pull_request_id": "54",
    "name": "cluster-kube-cluster-api-operator",
    "description": ":seedling: Bump github.com/onsi/ginkgo/v2 from 2.7.0 to 2.8.0",
    "bug_url": ""
  },
  {
    "id": 0,
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z",
    "deleted_at": null,
    "url": "https://github.com/openshift/cluster-etcd-operator/pull/1358",
    "pull_request_id": "1358",
    "name": "cluster-etcd-operator",
    "description": "Remove etcd-backup-server StaticPod approach",
    "bug_url": "https://issues.redhat.com/browse/ETCD-686"
  },
  {
    "id": 0,
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z",
    "deleted_at": null,
    "url": "https://github.com/openshift/cluster-monitoring-operator/pull/2495",
    "pull_request_id": "2495",
    "name": "cluster-monitoring-operator",
    "description": "NO-JIRA: fix CMO config for Alertmanager e2e tests",
    "bug_url": ""
  },
  {
    "id": 0,
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z",
    "deleted_at": null,
    "url": "https://github.com/openshift/cluster-node-tuning-operator/pull/1182",
    "pull_request_id": "1182",
    "name": "cluster-node-tuning-operator",
    "description": "NO-JIRA: CI: unblock  (#1182)",
    "bug_url": ""
  },
  {
    "id": 0,
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z",
    "deleted_at": null,
    "url": "https://github.com/openshift/console/pull/14345",
    "pull_request_id": "14345",
    "name": "console",
    "description": "Quick create actions in the masthead toolbar",
    "bug_url": "https://issues.redhat.com/browse/ODC-7703"
  },
  {
    "id": 0,
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z",
    "deleted_at": null,
    "url": "https://github.com/openshift/gcp-pd-csi-driver-operator/pull/130",
    "pull_request_id": "130",
    "name": "gcp-pd-csi-driver-operator",
    "description": "change disk min size to 6GiB",
    "bug_url": "https://issues.redhat.com/browse/STOR-2052"
  },
  {
    "id": 0,
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z",
    "deleted_at": null,
    "url": "https://github.com/openshift/hypershift/pull/4868",
    "pull_request_id": "4868",
    "name": "hypershift",
    "description": "openstack/e2e: re-work nodepool tests",
    "bug_url": "https://issues.redhat.com/browse/OCPBUGS-43087"
  },
  {
    "id": 0,
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z",
    "deleted_at": null,
    "url": "https://github.com/openshift/kubernetes/pull/2112",
    "pull_request_id": "2112",
    "name": "hyperkube, pod",
    "description": "Revert #2067 \"OCPBUGS-39305: log only deprecated api requests\"",
    "bug_url": "https://issues.redhat.com/browse/TRT-1867"
  },
  {
    "id": 0,
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z",
    "deleted_at": null,
    "url": "https://github.com/openshift/monitoring-plugin/pull/220",
    "pull_request_id": "220",
    "name": "monitoring-plugin",
    "description": "Update Konflux references to 674e70f",
    "bug_url": ""
  },
  {
    "id": 0,
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z",
    "deleted_at": null,
    "url": "https://github.com/openshift/oc/pull/1899",
    "pull_request_id": "1899",
    "name": "cli, cli-artifacts, deployer, tools",
    "description": "Do not allow new line in user in create user",
    "bug_url": "https://issues.redhat.com/browse/OCPBUGS-42775"
  },
  {
    "id": 0,
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z",
    "deleted_at": null,
    "url": "https://github.com/openshift/openshift-controller-manager/pull/341",
    "pull_request_id": "341",
    "name": "openshift-controller-manager",
    "description": "NO-JIRA: cleanup root and app OWNERS",
    "bug_url": ""
  }
]
```