### PR TITLE
Eliminate the 50+ minute test analysis by variant matview

### DIFF
--- a/pkg/api/test_analysis.go
+++ b/pkg/api/test_analysis.go
@@ -151,7 +151,7 @@ func GetTestAnalysisByVariantFromDB(dbc *db.DB, filters *filter.Filter, release,
 		results["overall"] = overall
 	}
 
-	vq := dbc.DB.Table("prow_test_analysis_by_variant_14d_matview").
+	vq := dbc.DB.Table("prow_test_analysis_by_variant_14d_view").
 		Where("release = ?", release).
 		Where("test_name = ?", testName).
 		Where("date <= ?", reportEnd).

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -18,6 +18,7 @@ type SchemaHashType string
 
 const (
 	hashTypeMatView      SchemaHashType = "matview"
+	hashTypeView         SchemaHashType = "view"
 	hashTypeMatViewIndex SchemaHashType = "matview_index"
 	hashTypeFunction     SchemaHashType = "function"
 )
@@ -146,6 +147,10 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 	}
 
 	if err := syncPostgresMaterializedViews(d.DB, reportEnd); err != nil {
+		return err
+	}
+
+	if err := syncPostgresViews(d.DB, reportEnd); err != nil {
 		return err
 	}
 

--- a/pkg/db/matviews.go
+++ b/pkg/db/matviews.go
@@ -288,7 +288,7 @@ FROM
 	JOIN tests ON tests.id = byjob.test_id
 	JOIN prow_jobs ON prow_jobs.name = byjob.job_name
 WHERE
-	byjob.date >= (now() - '15 days'::interval)
+	byjob.date >= (|||TIMENOW||| - '15 days'::interval)
 GROUP BY
 	tests.name, tests.id, byjob.test_id, byjob.test_name, date, unnest(prow_jobs.variants), prow_jobs.release
 `


### PR DESCRIPTION
Replace by a live normal view that uses the test analysis by job matview, and then joins in the variants and sums the results. This is very fast when filtering for a test. As a matview in testing it was still a bit slow, at least 5 minutes, I'm not sure how long, but given we can live query it that seems the best approach.

The data looks correct with my spot checks:

```
postgres=# select * from prow_test_analysis_by_variant_14d_matview where test_id=34 and date = '2024-10-23' and variant='Network:ovn';
 test_id |            test_name            | watchlist |    date    |   variant   | release | runs | passes | flakes | failures 
---------+---------------------------------+-----------+------------+-------------+---------+------+--------+--------+----------
      34 | install should succeed: overall | f         | 2024-10-23 | Network:ovn | 4.16    |  332 |    324 |      0 |        8
(1 row)  
                                                    
postgres=# select * from prow_test_analysis_by_variant_14d_view where test_id=34 and date = '2024-10-23' and variant='Network:ovn';
 test_id |            test_name            |    date    |   variant   | release | runs | passes | flakes | failures 
---------+---------------------------------+------------+-------------+---------+------+--------+--------+----------
      34 | install should succeed: overall | 2024-10-23 | Network:ovn | 4.16    |  332 |    324 |      0 |        8
(1 row)  


postgres=# select * from prow_test_analysis_by_variant_14d_matview where test_id=34 and date = '2024-10-19' and variant='Network:ovn';
 test_id |            test_name            | watchlist |    date    |   variant   | release | runs | passes | flakes | failures 
---------+---------------------------------+-----------+------------+-------------+---------+------+--------+--------+----------
      34 | install should succeed: overall | f         | 2024-10-19 | Network:ovn | 4.16    |  331 |    327 |      0 |        4
(1 row)

postgres=# select * from prow_test_analysis_by_variant_14d_view where test_id=34 and date = '2024-10-19' and variant='Network:ovn';
 test_id |            test_name            |    date    |   variant   | release | runs | passes | flakes | failures 
---------+---------------------------------+------------+-------------+---------+------+--------+--------+----------
      34 | install should succeed: overall | 2024-10-19 | Network:ovn | 4.16    |  331 |    327 |      0 |        4
(1 row)


postgres=# refresh materialized view prow_test_analysis_by_variant_14d_matview;                           
REFRESH MATERIALIZED VIEW
postgres=# refresh materialized view prow_test_analysis_by_job_14d_matview;                               
REFRESH MATERIALIZED VIEW
postgres=# select count(*) from prow_test_analysis_by_variant_14d_view;                                   
  count  
---------
 1234922
(1 row)

postgres=# select count(*) from prow_test_analysis_by_variant_14d_matview;
  count  
---------
 1234922
(1 row)
```

Note that the _view count will go down over time due to the nature of it's live query, but if you check quickly after refreshes, the counts appear identical.