### PR TITLE
TRT-1859: file jira with helpful summary

### DIFF
--- a/sippy-ng/src/bugs/BugButton.js
+++ b/sippy-ng/src/bugs/BugButton.js
@@ -14,25 +14,27 @@ export default function BugButton(props) {
   const classes = useStyles()
   const [open, setOpen] = useState(false)
 
-  const text = `The following test is failing:
+  const text = `
+The following test is failing more than expected:
   
-  ${props.testName}
+{code:none}${props.testName}{code}
   
-Additional context here:
-  
-  ${document.location.href}`
+See the [sippy test details|${document.location.href}] for additional context.
+  `
+
+  const summary = `Component Readiness: [${props.component}] [${props.capability}] test regressed`
 
   const handleClick = () => {
-    let message = text
-    if (props.context) {
-      message = props.context
-    }
+    let message = props.context || text
     let url = `https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&priority=10200&issuetype=1&description=${safeEncodeURIComponent(
       message
     )}`
 
     if (props.jiraComponentID) {
       url += `&components=${props.jiraComponentID}`
+    }
+    if (props.component) {
+      url += `&summary=${safeEncodeURIComponent(summary)}`
     }
 
     if (Array.isArray(props.labels) && props.labels.length > 0) {
@@ -58,6 +60,8 @@ Additional context here:
 
 BugButton.propTypes = {
   jiraComponentID: PropTypes.string,
+  component: PropTypes.string,
+  capability: PropTypes.string,
   context: PropTypes.string,
   labels: PropTypes.array,
   testName: PropTypes.string.isRequired,

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -413,11 +413,15 @@ Flakes: ${stats.flake_count}`
           >
             <BugButton
               testName={testName}
+              component={component}
+              capability={capability}
               jiraComponentID={data.jira_component_id}
               labels={['component-regression']}
-              context={`Component Readiness has found a potential regression in the following test:
+              context={`
+(_Feel free to update this bug's summary to be more specific._)
+Component Readiness has found a potential regression in the following test:
 
-{code}${testName}{code}
+{code:none}${testName}{code}
 
 ${data.explanations.join('\n')}
 ${printStatsText(
@@ -433,7 +437,7 @@ ${printStatsText(
   baseEndTime
 )}
 
-View the test details report at ${document.location.href}
+View the [test details report|${document.location.href}] for additional context.
             `}
             />
             <Button


### PR DESCRIPTION
e.g. [visit locally](http://localhost:3000/sippy-ng/component_readiness/test_details?Architecture=amd64&Architecture=amd64&FeatureSet=default&FeatureSet=default&Installer=ipi&Installer=ipi&Network=ovn&Network=ovn&NetworkAccess=default&Platform=metal&Platform=metal&Scheduler=default&SecurityMode=default&Suite=unknown&Suite=unknown&Topology=ha&Topology=ha&Upgrade=micro&Upgrade=micro&baseEndTime=2024-10-01%2023%3A59%3A59&baseRelease=4.17&baseStartTime=2024-09-01%2000%3A00%3A00&capability=ClusterUpgrade&columnGroupBy=Architecture%2CNetwork%2CPlatform%2CTopology&component=Cluster%20Version%20Operator&confidence=95&dbGroupBy=Platform%2CArchitecture%2CNetwork%2CTopology%2CFeatureSet%2CUpgrade%2CSuite%2CInstaller&environment=amd64%20default%20ipi%20ovn%20metal%20unknown%20ha%20micro&ignoreDisruption=true&ignoreMissing=false&includeVariant=Architecture%3Aamd64&includeVariant=CGroupMode%3Av2&includeVariant=ContainerRuntime%3Arunc&includeVariant=FeatureSet%3Adefault&includeVariant=Installer%3Aipi&includeVariant=Installer%3Aupi&includeVariant=Network%3Aovn&includeVariant=Owner%3Aeng&includeVariant=Platform%3Aaws&includeVariant=Platform%3Aazure&includeVariant=Platform%3Agcp&includeVariant=Platform%3Ametal&includeVariant=Platform%3Avsphere&includeVariant=Topology%3Aha&includeVariant=Topology%3Amicroshift&minFail=3&passRateAllTests=0&passRateNewTests=95&pity=5&sampleEndTime=2024-11-05%2023%3A59%3A59&sampleRelease=4.18&sampleStartTime=2024-10-29%2000%3A00%3A00&testId=openshift-tests-upgrade%3A46424b24053f349c231a40bc8ae6f29d&testName=%5Bsig-arch%5D%5BFeature%3AClusterUpgrade%5D%20Cluster%20should%20be%20upgradeable%20after%20finishing%20upgrade%20%5BLate%5D%5BSuite%3Aupgrade%5D)  and click "File a new bug" and the summary is filled with `Component Readiness: [Cluster Version Operator] [ClusterUpgrade] test regressed`

(This doesn't affect sippy classic, where it does not have the component/capability available)