### PR TITLE
TRT-1772: Hacky solution to test rarely run jobs results

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -181,6 +181,66 @@ component_readiness:
       enabled: false
     regression_tracking:
       enabled: false
+  - name: 4.18-rarely-run-jobs
+    base_release:
+      release: "4.17"
+      relative_start: ga-1d
+      relative_end: ga
+    sample_release:
+      release: "4.18"
+      # need to look much further back for rarely run jobs
+      relative_start: now-90d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: {}
+        Network: {}
+        Platform: {}
+        Topology: {}
+        Procedure: {}
+      db_group_by:
+        Architecture: {}
+        FeatureSet: {}
+        Installer: {}
+        Network: {}
+        Platform: {}
+        Suite: {}
+        Topology: {}
+        Upgrade: {}
+        Procedure: {}
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        Network:
+          - ovn
+        Owner:
+          - eng
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - metal
+          - vsphere
+        Topology:
+          - ha
+        JobTier:
+          - rare
+    advanced_options:
+      minimum_failure: 2
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+      pass_rate_required_all_tests: 90
+    metrics:
+      enabled: false
+    regression_tracking:
+      enabled: false
   - name: 4.17-main
     base_release:
         release: "4.16"

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -37,6 +38,9 @@ const (
 	openRegressionConfidenceAdjustment = 5
 
 	explanationNoRegression = "No significant regressions found"
+
+	defaultJunitTable   = "junit"
+	rarelyRunJunitTable = "junit_rarely_run_jobs"
 
 	// This query de-dupes the test results. There are multiple issues present in
 	// our data set:
@@ -81,7 +85,7 @@ const (
 					ELSE 0
 				END AS adjusted_flake_count
 			FROM
-				%s.junit
+				%s.%s AS junit
 			INNER JOIN %s.jobs  jobs ON 
 				junit.prowjob_build_id = jobs.prowjob_build_id 
 				AND jobs.prowjob_start >= DATETIME(@From)
@@ -382,6 +386,19 @@ func (c *componentReportGenerator) getCommonTestStatusQuery(allJobVariants crtyp
 		jobNameQueryPortion = pullRequestDynamicJobNameCol
 	}
 
+	// TODO: this is a temporary hack while we explore if rarely run jobs approach is actually going to work.
+	// A scheduled query is copying rarely run job results to a separate much smaller table every day, so we can
+	// query 3 months without spending a fortune. If this proves to work, we will work out a system of processing
+	// this as generically as we can, but it will be difficult.
+	junitTable := defaultJunitTable
+	for k, v := range c.IncludeVariants {
+		if k == "JobTier" {
+			if slices.Contains(v, "rare") {
+				junitTable = rarelyRunJunitTable
+			}
+		}
+	}
+
 	// WARNING: returning additional columns from this query will require explicit parsing in deserializeRowToTestStatus
 	// TODO: jira_component and jira_component_id appear to not be used? Could save bigquery costs if we remove them.
 	queryString := fmt.Sprintf(`WITH latest_component_mapping AS (
@@ -403,7 +420,7 @@ func (c *componentReportGenerator) getCommonTestStatusQuery(allJobVariants crtyp
 					FROM (%s)
 					INNER JOIN latest_component_mapping cm ON testsuite = cm.suite AND test_name = cm.name
 `,
-		c.client.Dataset, c.client.Dataset, selectVariants, fmt.Sprintf(dedupedJunitTable, jobNameQueryPortion, c.client.Dataset, c.client.Dataset))
+		c.client.Dataset, c.client.Dataset, selectVariants, fmt.Sprintf(dedupedJunitTable, jobNameQueryPortion, c.client.Dataset, junitTable, c.client.Dataset))
 
 	queryString += joinVariants
 

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -90,6 +90,19 @@ func (c *componentReportGenerator) getTestDetailsQuery(allJobVariants crtype.Job
 		jobNameQueryPortion = pullRequestDynamicJobNameCol
 	}
 
+	// TODO: this is a temporary hack while we explore if rarely run jobs approach is actually going to work.
+	// A scheduled query is copying rarely run job results to a separate much smaller table every day, so we can
+	// query 3 months without spending a fortune. If this proves to work, we will work out a system of processing
+	// this as generically as we can, but it will be difficult.
+	junitTable := defaultJunitTable
+	for k, v := range c.IncludeVariants {
+		if k == "JobTier" {
+			if slices.Contains(v, "rare") {
+				junitTable = rarelyRunJunitTable
+			}
+		}
+	}
+
 	queryString := fmt.Sprintf(`WITH latest_component_mapping AS (
 						SELECT *
 						FROM %s.component_mapping cm
@@ -109,7 +122,7 @@ func (c *componentReportGenerator) getTestDetailsQuery(allJobVariants crtype.Job
 						SUM(adjusted_flake_count) AS flake_count,
 					FROM (%s)
 					INNER JOIN latest_component_mapping cm ON testsuite = cm.suite AND test_name = cm.name
-`, c.client.Dataset, c.client.Dataset, fmt.Sprintf(dedupedJunitTable, jobNameQueryPortion, c.client.Dataset, c.client.Dataset))
+`, c.client.Dataset, c.client.Dataset, fmt.Sprintf(dedupedJunitTable, jobNameQueryPortion, c.client.Dataset, junitTable, c.client.Dataset))
 
 	joinVariants := ""
 	for variant := range allJobVariants.Variants {


### PR DESCRIPTION
Getting this to work fully in some kind of generic fashion across the UI
and query params will be extremely difficult. We're not even sure the
idea will work, so for now this PR adds a hacky temporary solution.

A scheduled query is doing a full table scan every day and copying
rarely run junit results to a much smaller table in bigquery,
junit_rarely_run_jobs. This allows us to scan it without the immense
cost.

For this temporary view, I added a hack where if we see you're querying
for JobTier rare, we will flip to using this other table.

Side effect, if someone uses the UI and adds in this JobTier, suddenly
their results will be fully busted.
