### PR TITLE
TRT-1864: enable 4.19 views

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -1,5 +1,247 @@
 ---
 component_readiness:
+  - name: 4.19-main
+    base_release:
+      release: "4.18"
+      relative_start: now-30d
+      relative_end: now
+    sample_release:
+      release: "4.19"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: {}
+        Network: {}
+        Platform: {}
+        Topology: {}
+      db_group_by:
+        Architecture: {}
+        FeatureSet: {}
+        Installer: {}
+        Network: {}
+        Platform: {}
+        Suite: {}
+        Topology: {}
+        Upgrade: {}
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        Network:
+          - ovn
+        Owner:
+          - eng
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - metal
+          - vsphere
+        Topology:
+          - ha
+          - microshift
+        CGroupMode:
+          - v2
+        ContainerRuntime:
+          - runc
+          - crun
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+      pass_rate_required_new_tests: 95
+      include_multi_release_analysis: true
+    metrics:
+      enabled: true
+    regression_tracking:
+      enabled: true
+  - name: 4.19-ha-vs-single
+    base_release:
+      release: "4.19"
+      relative_start: now-7d
+      relative_end: now
+    sample_release:
+      release: "4.19"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: {}
+        Network: {}
+        Platform: {}
+      db_group_by:
+        Architecture: {}
+        FeatureSet: {}
+        Installer: {}
+        Network: {}
+        Platform: {}
+        Suite: {}
+        Upgrade: {}
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        Owner:
+          - eng
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - metal
+          - vsphere
+        Topology:
+          - ha
+        CGroupMode:
+          - v2
+        ContainerRuntime:
+          - runc
+          - crun
+      compare_variants:
+        Topology:
+          - single
+      variant_cross_compare:
+        - Topology
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+    metrics:
+      enabled: false
+    regression_tracking:
+      enabled: false
+  - name: 4.19-runc-vs-crun
+    base_release:
+      release: "4.19"
+      relative_start: now-7d
+      relative_end: now
+    sample_release:
+      release: "4.19"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: {}
+        Network: {}
+        Platform: {}
+      db_group_by:
+        Architecture: {}
+        FeatureSet: {}
+        Installer: {}
+        Network: {}
+        Platform: {}
+        Suite: {}
+        Topology: {}
+        Upgrade: {}
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        Owner:
+          - eng
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - metal
+          - vsphere
+        Topology:
+          - ha
+        CGroupMode:
+          - v2
+        ContainerRuntime:
+          - runc
+      compare_variants:
+        ContainerRuntime:
+          - crun
+      variant_cross_compare:
+        - ContainerRuntime
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+    metrics:
+      enabled: false
+    regression_tracking:
+      enabled: false
+  - name: 4.19-rarely-run-jobs
+    base_release:
+      release: "4.18"
+      relative_start: now-1d
+      relative_end: now
+    sample_release:
+      release: "4.19"
+      # need to look much further back for rarely run jobs
+      relative_start: now-90d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: {}
+        Network: {}
+        Platform: {}
+        Topology: {}
+        Procedure: {}
+      db_group_by:
+        Architecture: {}
+        FeatureSet: {}
+        Installer: {}
+        Network: {}
+        Platform: {}
+        Suite: {}
+        Topology: {}
+        Upgrade: {}
+        Procedure: {}
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        Network:
+          - ovn
+        Owner:
+          - eng
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - metal
+          - vsphere
+        Topology:
+          - ha
+        JobTier:
+          - rare
+    advanced_options:
+      minimum_failure: 2
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+      pass_rate_required_all_tests: 90
+    metrics:
+      enabled: false
+    regression_tracking:
+      enabled: false
   - name: 4.18-main
     base_release:
       release: "4.17"

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -30,6 +30,7 @@ export const initialPageTable = {
           empty: 'None',
           status: 3, // Let's start with success
           regressed_tests: [],
+          variants: [],
         },
       ],
     },
@@ -43,6 +44,7 @@ export const noDataTable = {
         {
           empty: 'None',
           status: 3, // Let's start with success
+          variants: [],
         },
       ],
     },
@@ -56,6 +58,7 @@ export const cancelledDataTable = {
         {
           empty: 'None',
           status: 3, // Let's start with success
+          variants: [],
         },
       ],
     },

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -320,7 +320,11 @@ export default function ComponentReadiness(props) {
         return response.json()
       })
       .then((json) => {
-        if (Object.keys(json).length === 0 || json.rows.length === 0) {
+        if (
+          Object.keys(json).length === 0 ||
+          json.rows === undefined ||
+          json.rows.length === 0
+        ) {
           // The api call returned 200 OK but the data was empty
           setData(noDataTable)
         } else {


### PR DESCRIPTION
Currently 4.19-rarely-run-jobs returns no json in the response ~~causing errors in the UI~~

CR Shows 92 regressions with historical release analysis (fallback) enabled vs 63 without