### PR TITLE
Display last failure time for regressed tests

### DIFF
--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"cloud.google.com/go/civil"
 	"github.com/openshift/sippy/pkg/util"
 
 	"cloud.google.com/go/bigquery"
@@ -454,6 +455,7 @@ func (c *componentReportGenerator) getCommonTestStatusQuery(allJobVariants crtyp
 						COUNT(cm.id) AS total_count,
 						SUM(adjusted_success_val) AS success_count,
 						SUM(adjusted_flake_count) AS flake_count,
+						MAX(CASE WHEN adjusted_success_val = 0 THEN modified_time ELSE NULL END) AS last_failure,
 						ANY_VALUE(cm.component) AS component,
 						ANY_VALUE(cm.capabilities) AS capabilities,
 					FROM (%s)
@@ -1106,6 +1108,17 @@ func deserializeRowToTestStatus(row []bigquery.Value, schema bigquery.Schema) (s
 			cts.SuccessCount = int(row[i].(int64))
 		case col == "flake_count":
 			cts.FlakeCount = int(row[i].(int64))
+		case col == "last_failure":
+			// ignore when we cant parse, its usually null
+			var err error
+			if row[i] != nil {
+				layout := "2006-01-02T15:04:05"
+				lftCivilDT := row[i].(civil.DateTime)
+				cts.LastFailure, err = time.Parse(layout, lftCivilDT.String())
+				if err != nil {
+					log.WithError(err).Error("error parsing last failure time from bigquery")
+				}
+			}
 		case col == "component":
 			cts.Component = row[i].(string)
 		case col == "capabilities":
@@ -1814,6 +1827,9 @@ func (c *componentReportGenerator) generateComponentTestReport(ctx context.Conte
 				log.Infof("Overrode base stats using release %s for Test: %s - %s", matchedBaseRelease, baseStats.TestName, testIdentification)
 				overriddenBaseMatches++
 			}
+			if !sampleStats.LastFailure.IsZero() {
+				testStats.LastFailure = &sampleStats.LastFailure
+			}
 
 			if testStats.IsTriaged() {
 				// we are within the triage range
@@ -1888,6 +1904,10 @@ func (c *componentReportGenerator) generateComponentTestReport(ctx context.Conte
 			if len(triagedIncidents) > 0 && canClearReportStatus {
 				testStats.ReportStatus = crtype.NotSignificant
 			}
+		}
+		if !sampleStats.LastFailure.IsZero() {
+			lastFailure := sampleStats.LastFailure
+			testStats.LastFailure = &lastFailure
 		}
 
 		rowIdentifications, columnIdentification, err := c.getRowColumnIdentifications(testIdentification, sampleStats)

--- a/pkg/apis/api/componentreport/types.go
+++ b/pkg/apis/api/componentreport/types.go
@@ -116,14 +116,15 @@ type RequestAdvancedOptions struct {
 }
 
 type TestStatus struct {
-	TestName     string   `json:"test_name"`
-	TestSuite    string   `json:"test_suite"`
-	Component    string   `json:"component"`
-	Capabilities []string `json:"capabilities"`
-	Variants     []string `json:"variants"`
-	TotalCount   int      `json:"total_count"`
-	SuccessCount int      `json:"success_count"`
-	FlakeCount   int      `json:"flake_count"`
+	TestName     string    `json:"test_name"`
+	TestSuite    string    `json:"test_suite"`
+	Component    string    `json:"component"`
+	Capabilities []string  `json:"capabilities"`
+	Variants     []string  `json:"variants"`
+	TotalCount   int       `json:"total_count"`
+	SuccessCount int       `json:"success_count"`
+	FlakeCount   int       `json:"flake_count"`
+	LastFailure  time.Time `json:"last_failure"`
 }
 
 func (ts TestStatus) GetTotalSuccessFailFlakeCounts() (int, int, int, int) {
@@ -230,6 +231,9 @@ type ReportTestStats struct {
 
 	// BaseStats may not be present in the response, i.e. new tests regressed because of their pass rate.
 	BaseStats *TestDetailsReleaseStats `json:"base_stats,omitempty"`
+
+	// LastFailure is the last time the regressed test failed.
+	LastFailure *time.Time `json:"last_failure"`
 }
 
 // IsTriaged returns true if this tests status is within the triaged regression range.

--- a/sippy-ng/src/component_readiness/RegressedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsPanel.js
@@ -115,6 +115,19 @@ export default function RegressedTestsPanel(props) {
       ),
     },
     {
+      field: 'last_failure',
+      headerName: 'Last Failure',
+      flex: 12,
+      valueGetter: (params) => {
+        if (!params.row.last_failure) {
+          return ''
+        }
+        const lastFailureDate = new Date(params.row.last_failure)
+        return relativeTime(lastFailureDate, new Date())
+      },
+      renderCell: (param) => <div className="last-failure">{param.value}</div>,
+    },
+    {
       field: 'test_id',
       flex: 5,
       headerName: 'ID',


### PR DESCRIPTION
New column for regressed tests with the last failure time, in the same x days ago format we use for regressed since.

I'd like to get bug data into this chart but its logistically more challenging, it could be done, but it ties the app to the jira caching structure Brad built, or we pull it from our postgres which may not be enabled if the deployment is just running component readiness.