### PR TITLE
TRT-1781: sanitize sippy-server parameter inputs

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,3 +7,4 @@ approvers:
 - neisw
 - stbenjam
 - xueqzhan
+- sosiouxme

--- a/pkg/api/job_analysis.go
+++ b/pkg/api/job_analysis.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"time"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
@@ -50,7 +49,7 @@ func PrintJobAnalysisJSONFromDB(
 	sums := make([]resultSum, 0)
 	prowJobRunsFiltered := jobRunsFilter.ToSQL(dbc.DB.Table("prow_job_runs"), apitype.JobRun{})
 	sumResults := dbc.DB.Table("(?) as prow_job_runs", prowJobRunsFiltered).
-		Select(fmt.Sprintf(`date_trunc('%s', timestamp)        AS period,
+		Select(`date_trunc(?, timestamp)        AS period,
 	           count(*)                                              AS total_runs,
 	           sum(case when overall_result = 'S' then 1 else 0 end) AS "S",
 	           sum(case when overall_result = 'F' then 1 else 0 end) AS "F",
@@ -60,10 +59,10 @@ func PrintJobAnalysisJSONFromDB(
 	           sum(case when overall_result = 'N' then 1 else 0 end) AS "N",
 	           sum(case when overall_result = 'n' then 1 else 0 end) AS "n",
 	           sum(case when overall_result = 'R' then 1 else 0 end) AS "R",
-	           sum(case when overall_result = 'A' then 1 else 0 end) AS "A"`, period)).
+	           sum(case when overall_result = 'A' then 1 else 0 end) AS "A"`, period).
 		Joins("INNER JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id").
 		Where("prow_jobs.id IN ?", jobs).
-		Group(fmt.Sprintf(`date_trunc('%s', timestamp)`, period))
+		Group("period")
 
 	sumResults.Scan(&sums)
 

--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/filter"
 	"github.com/openshift/sippy/pkg/testidentification"
+	"github.com/openshift/sippy/pkg/util/param"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -29,8 +30,8 @@ const (
 var nonDeterministicRiskLevels = []int{apitype.FailureRiskLevelUnknown.Level, apitype.FailureRiskLevelIncompleteTests.Level, apitype.FailureRiskLevelMissingData.Level}
 
 func (runs apiRunResults) sort(req *http.Request) apiRunResults {
-	sortField := req.URL.Query().Get("sortField")
-	sort := apitype.Sort(req.URL.Query().Get("sort"))
+	sortField := param.SafeRead(req, "sortField")
+	sort := apitype.Sort(param.SafeRead(req, "sort"))
 
 	if sortField == "" {
 		sortField = "test_failures"

--- a/pkg/api/jobs.go
+++ b/pkg/api/jobs.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/filter"
+	"github.com/openshift/sippy/pkg/util/param"
 
 	v1sippyprocessing "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 )
@@ -25,8 +26,8 @@ const periodTwoDay = "twoDay"
 const currentPassPercentage = "current_pass_percentage"
 
 func (jobs jobsAPIResult) sort(req *http.Request) jobsAPIResult {
-	sortField := req.URL.Query().Get("sortField")
-	sort := apitype.Sort(req.URL.Query().Get("sort"))
+	sortField := param.SafeRead(req, "sortField")
+	sort := apitype.Sort(param.SafeRead(req, "sort"))
 
 	if sortField == "" {
 		sortField = currentPassPercentage

--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/filter"
 	"github.com/openshift/sippy/pkg/html/installhtml"
+	"github.com/openshift/sippy/pkg/util/param"
 )
 
 const (
@@ -70,8 +71,8 @@ func GetTestDurationsFromDB(dbc *db.DB, release, test string, filters *filter.Fi
 type testsAPIResult []apitype.Test
 
 func (tests testsAPIResult) sort(req *http.Request) testsAPIResult {
-	sortField := req.URL.Query().Get("sortField")
-	sort := req.URL.Query().Get("sort")
+	sortField := param.SafeRead(req, "sortField")
+	sort := param.SafeRead(req, "sort")
 
 	if sortField == "" {
 		sortField = "current_pass_percentage"

--- a/pkg/filter/filterable.go
+++ b/pkg/filter/filterable.go
@@ -13,6 +13,7 @@ import (
 	"gorm.io/gorm/clause"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
+	apiparam "github.com/openshift/sippy/pkg/util/param"
 )
 
 // LinkOperator determines how to chain multiple filters together, 'AND' and 'OR'
@@ -261,8 +262,8 @@ func FilterOptionsFromRequest(req *http.Request, defaultSortField string, defaul
 		filterOpts.Limit = limit
 	}
 
-	sortField := req.URL.Query().Get("sortField")
-	sort := apitype.Sort(req.URL.Query().Get("sort"))
+	sortField := apiparam.SafeRead(req, "sortField")
+	sort := apitype.Sort(apiparam.SafeRead(req, "sort"))
 	if sortField == "" {
 		sortField = defaultSortField
 	}
@@ -280,7 +281,7 @@ func ExtractFilters(req *http.Request) (*Filter, error) {
 	queryFilter := req.URL.Query().Get("filter")
 	if queryFilter != "" {
 		if err := json.Unmarshal([]byte(queryFilter), filter); err != nil {
-			return nil, fmt.Errorf("could not marshal filter: %w", err)
+			return nil, fmt.Errorf("could not unmarshal filter: %w", err)
 		}
 	}
 

--- a/pkg/sippyserver/install_details.go
+++ b/pkg/sippyserver/install_details.go
@@ -4,18 +4,17 @@ import (
 	"net/http"
 
 	"github.com/openshift/sippy/pkg/api"
+	"github.com/openshift/sippy/pkg/util/param"
 )
 
 func (s *Server) jsonUpgradeReportFromDB(w http.ResponseWriter, req *http.Request) {
-	release := req.URL.Query().Get("release")
+	release := param.SafeRead(req, "release")
 
 	api.PrintUpgradeJSONReportFromDB(w, req, s.db, release)
 }
 
 func (s *Server) jsonInstallReportFromDB(w http.ResponseWriter, req *http.Request) {
-	release := req.URL.Query().Get("release")
+	release := param.SafeRead(req, "release")
 
-	api.PrintInstallJSONReportFromDB(w, s.db,
-		release,
-	)
+	api.PrintInstallJSONReportFromDB(w, s.db, release)
 }

--- a/pkg/sippyserver/parameters.go
+++ b/pkg/sippyserver/parameters.go
@@ -9,8 +9,8 @@ import (
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/filter"
-
 	"github.com/openshift/sippy/pkg/util"
+	"github.com/openshift/sippy/pkg/util/param"
 )
 
 const (
@@ -19,12 +19,12 @@ const (
 )
 
 func getISO8601Date(paramName string, req *http.Request) (*time.Time, error) {
-	param := req.URL.Query().Get(paramName)
-	if param == "" {
+	valueStr := req.URL.Query().Get(paramName)
+	if valueStr == "" {
 		return nil, nil
 	}
 
-	date, err := time.Parse("2006-01-02T15:04:05Z", param)
+	date, err := time.Parse("2006-01-02T15:04:05Z", valueStr)
 	if err != nil {
 		return nil, err
 	}
@@ -48,11 +48,11 @@ func getPeriodDates(defaultPeriod string, req *http.Request, reportEnd time.Time
 }
 
 func getDateParam(paramName string, req *http.Request) *time.Time {
-	param := req.URL.Query().Get(paramName)
-	if param != "" {
-		t, err := time.Parse("2006-01-02", param)
+	valueStr := req.URL.Query().Get(paramName)
+	if valueStr != "" {
+		t, err := time.Parse("2006-01-02", valueStr)
 		if err != nil {
-			log.WithError(err).Warningf("error decoding %q param: %s", param, err.Error())
+			log.WithError(err).Warningf("error decoding %q param: %s", valueStr, err.Error())
 			return nil
 		}
 		return &t
@@ -62,7 +62,7 @@ func getDateParam(paramName string, req *http.Request) *time.Time {
 }
 
 func getPeriod(req *http.Request, defaultValue string) string {
-	period := req.URL.Query().Get("period")
+	period := param.SafeRead(req, "period")
 	if period == "" {
 		return defaultValue
 	}
@@ -101,8 +101,8 @@ func getPaginationParams(req *http.Request) (*apitype.Pagination, error) {
 }
 
 func getSortParams(req *http.Request) (string, apitype.Sort) {
-	sortField := req.URL.Query().Get("sortField")
-	sort := apitype.Sort(req.URL.Query().Get("sort"))
+	sortField := param.SafeRead(req, "sortField")
+	sort := apitype.Sort(param.SafeRead(req, "sort"))
 	if sortField == "" {
 		sortField = defaultSortField
 	}

--- a/pkg/util/param/param.go
+++ b/pkg/util/param/param.go
@@ -1,0 +1,67 @@
+package param
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Cleanse removes unexpected characters from an input parameter value.
+// This is useful for sanitizing dynamic SQL queries built from user input.
+func Cleanse(name string) string {
+	return strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			return r
+		}
+		return -1
+	}, name)
+}
+
+// when requesting a param, also validate it against a regexp to ensure it is what we expect
+var wordRegexp = regexp.MustCompile(`^[\w]+$`)
+var numRegexp = regexp.MustCompile(`^[\d]+$`)
+var nameRegexp = regexp.MustCompile(`^[-.\w]+$`)
+var releaseRegexp = regexp.MustCompile(`^[\d]+\.[\d]+$`)
+var paramRegexp = map[string]*regexp.Regexp{
+	// sippy classic params
+	"release":         regexp.MustCompile(`^(Presubmits|[\d]+\.[\d]+)$`),
+	"period":          wordRegexp,
+	"stream":          wordRegexp,
+	"arch":            wordRegexp,
+	"payload":         nameRegexp,
+	"fromPayload":     nameRegexp,
+	"toPayload":       nameRegexp,
+	"job":             nameRegexp,
+	"job_name":        nameRegexp,
+	"test":            regexp.MustCompile(`^.+$`), // tests can be anything, so always parameterize in sql
+	"prow_job_run_id": numRegexp,
+	"file":            nameRegexp,
+	"repo_info":       nameRegexp,
+	"pull_number":     numRegexp,
+	"sort":            wordRegexp,
+	"sortField":       wordRegexp,
+	// component readiness params
+	"baseRelease":      releaseRegexp,
+	"sampleRelease":    releaseRegexp,
+	"testBasisRelease": releaseRegexp,
+	"samplePROrg":      nameRegexp,
+	"samplePRRepo":     nameRegexp,
+	"samplePRNumber":   numRegexp,
+}
+
+// SafeRead returns the value of a query parameter only if it matches the given regexp.
+// this should be used to validate query parameters that are not otherwise validated.
+func SafeRead(req *http.Request, name string) string {
+	re, ok := paramRegexp[name]
+	if !ok {
+		log.Fatalf("code BUG: request for unknown param %s", name) // revive:disable-line:deep-exit
+	}
+	value := req.URL.Query().Get(name)
+	if value == "" || re.MatchString(value) {
+		return value
+	}
+	log.Warnf("invalid value for %s param: %q", name, value)
+	return ""
+}


### PR DESCRIPTION
this also helps a bit with [TRT-1890](https://issues.redhat.com//browse/TRT-1890) (normalization) since values all go into named parameters instead of directly in the query.