### PR TITLE
Improve test reporting for feature gates

### DIFF
--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -9,6 +9,7 @@ import (
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
 	"github.com/lib/pq"
+
 	crtype "github.com/openshift/sippy/pkg/apis/api/componentreport"
 
 	sippyv1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
@@ -851,4 +852,12 @@ type ReleaseRow struct {
 
 type SippyViews struct {
 	ComponentReadiness []crtype.View `json:"component_readiness" yaml:"component_readiness"`
+}
+
+type FeatureGate struct {
+	Id              int    `json:"id"`
+	Type            string `json:"type"`
+	FeatureGate     string `json:"feature_gate"`
+	Release         string `json:"release"`
+	UniqueTestCount int64  `json:"unique_test_count"`
 }

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -855,7 +855,7 @@ type SippyViews struct {
 }
 
 type FeatureGate struct {
-	Id              int    `json:"id"`
+	ID              int    `json:"id"`
 	Type            string `json:"type"`
 	FeatureGate     string `json:"feature_gate"`
 	Release         string `json:"release"`

--- a/pkg/db/query/feature_gates.go
+++ b/pkg/db/query/feature_gates.go
@@ -1,0 +1,38 @@
+package query
+
+import (
+	"gorm.io/gorm"
+
+	"github.com/openshift/sippy/pkg/apis/api"
+)
+
+func GetFeatureGatesFromDB(dbc *gorm.DB, release string) ([]api.FeatureGate, error) {
+	// Define the query with release filtering
+	query := `
+		SELECT
+			ROW_NUMBER() OVER (ORDER BY release, match[1], match[2]) AS id,
+			match[1] AS type,
+			match[2] AS feature_gate,
+			release,
+			COUNT(DISTINCT name) AS unique_test_count
+		FROM (
+			SELECT 
+				regexp_matches(name, '\[(FeatureGate|OCPFeatureGate):([^\]]+)\]', 'g') AS match,
+				release,
+				name
+			FROM prow_test_report_7d_matview
+			WHERE release = ?
+		) subquery
+		WHERE match IS NOT NULL
+		GROUP BY match[1], match[2], release
+		ORDER BY release, type, feature_gate
+	`
+
+	var results []api.FeatureGate
+	// Execute the query, passing in the release filter
+	if err := dbc.Raw(query, release).Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1271,6 +1271,7 @@ func (s *Server) Serve() {
 			EndpointPath: "/api/tests",
 			Description:  "Reports on tests",
 			Capabilities: []string{LocalDBCapability},
+			CacheTime:    1 * time.Hour,
 			HandlerFunc:  s.jsonTestsReportFromDB,
 		},
 		{
@@ -1305,6 +1306,7 @@ func (s *Server) Serve() {
 			EndpointPath: "/api/tests/bugs",
 			Description:  "Reports bugs in tests",
 			Capabilities: []string{LocalDBCapability},
+			CacheTime:    1 * time.Hour,
 			HandlerFunc:  s.jsonTestBugsFromDB,
 		},
 		{

--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -31,6 +31,7 @@ import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import ComponentReadiness from './component_readiness/ComponentReadiness'
 import Drawer from '@mui/material/Drawer'
+import FeatureGates from './tests/FeatureGates'
 import IconButton from '@mui/material/IconButton'
 import Install from './releases/Install'
 import Jobs from './jobs/Jobs'
@@ -468,6 +469,16 @@ export default function App(props) {
                               title={
                                 'Job results for ' + props.match.params.release
                               }
+                              release={props.match.params.release}
+                            />
+                          )}
+                        />
+
+                        <Route
+                          path="/feature_gates/:release"
+                          render={(props) => (
+                            <FeatureGates
+                              key={'jobs-' + props.match.params.release}
                               release={props.match.params.release}
                             />
                           )}

--- a/sippy-ng/src/components/Sidebar.js
+++ b/sippy-ng/src/components/Sidebar.js
@@ -1,4 +1,5 @@
 import {
+  Apps,
   AppsOutage,
   BugReport,
   Code,
@@ -7,6 +8,7 @@ import {
   ExpandMore,
   Favorite,
   FileCopyOutlined,
+  Flare,
   GitHub,
   NotificationsActive,
 } from '@mui/icons-material'
@@ -329,6 +331,28 @@ export default function Sidebar(props) {
                               <ListItemText primary="Tests" />
                             </StyledListItemButton>
                           </ListItem>
+
+                          <CapabilitiesContext.Consumer>
+                            {(value) => {
+                              if (value.includes('openshift_releases')) {
+                                return (
+                                  <ListItem
+                                    key={'release-feature-gates-' + index}
+                                    component={Link}
+                                    to={'/feature_gates/' + release}
+                                    className={classes.nested}
+                                  >
+                                    <StyledListItemButton>
+                                      <ListItemIcon>
+                                        <Apps />
+                                      </ListItemIcon>
+                                      <ListItemText primary="Feature Gates" />
+                                    </StyledListItemButton>
+                                  </ListItem>
+                                )
+                              }
+                            }}
+                          </CapabilitiesContext.Consumer>
 
                           <CapabilitiesContext.Consumer>
                             {(value) => {

--- a/sippy-ng/src/components/Sidebar.js
+++ b/sippy-ng/src/components/Sidebar.js
@@ -319,7 +319,7 @@ export default function Sidebar(props) {
                                 ],
                                 linkOperator: 'and',
                               }),
-                              'current_pass_percentage',
+                              'net_improvement', // sort by tests that have recently regressed the most
                               'asc'
                             )}
                             className={classes.nested}

--- a/sippy-ng/src/components/Sidebar.js
+++ b/sippy-ng/src/components/Sidebar.js
@@ -313,10 +313,11 @@ export default function Sidebar(props) {
                                   BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                                   BOOKMARKS.NO_STEP_GRAPH,
                                   BOOKMARKS.NO_OPENSHIFT_TESTS_SHOULD_WORK,
+                                  BOOKMARKS.NO_100_FLAKE,
                                 ],
                                 linkOperator: 'and',
                               }),
-                              'current_working_percentage',
+                              'current_pass_percentage',
                               'asc'
                             )}
                             className={classes.nested}

--- a/sippy-ng/src/constants.js
+++ b/sippy-ng/src/constants.js
@@ -1,3 +1,9 @@
+export const FEATURE_GATE_TEST_THRESHOLDS = {
+  success: 5,
+  warning: 2,
+  error: 1,
+}
+
 export const MERGE_FAILURE_THERSHOLDS = {
   success: 1.5,
   warning: 2,

--- a/sippy-ng/src/constants.js
+++ b/sippy-ng/src/constants.js
@@ -120,13 +120,13 @@ export const BOOKMARKS = {
     operatorValue: 'contains',
     value: 'step graph.',
   },
-  HIGH_DELTA_FROM_WORKING_AVERAGE: {
-    columnField: 'delta_from_working_average',
+  HIGH_DELTA_FROM_PASSING_AVERAGE: {
+    columnField: 'delta_from_passing_average',
     operatorValue: '<=',
     value: '20',
   },
   HIGH_STANDARD_DEVIATION: {
-    columnField: 'working_standard_deviation',
+    columnField: 'passing_standard_deviation',
     operatorValue: '>',
     value: '1',
   },
@@ -134,6 +134,12 @@ export const BOOKMARKS = {
     columnField: 'watchlist',
     operatorValue: 'equals',
     value: 'true',
+  },
+  NO_100_FLAKE: {
+    columnField: 'current_flake_percentage',
+    not: true,
+    operatorValue: 'equals',
+    value: '100',
   },
   NO_OPENSHIFT_TESTS_SHOULD_WORK: {
     columnField: 'name',

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -212,6 +212,12 @@ export function pathForTestByVariant(release, test) {
   )
 }
 
+export function pathForTestSubstringByVariant(release, test) {
+  return (
+    `/tests/${release}/details?` + single(filterFor('name', 'contains', test))
+  )
+}
+
 export function pathForTestsWithFilter(release, filter) {
   if (!filter || filter.items === []) {
     return `/tests/${release}`

--- a/sippy-ng/src/releases/PayloadStreamsTable.js
+++ b/sippy-ng/src/releases/PayloadStreamsTable.js
@@ -107,7 +107,7 @@ function PayloadStreamsTable(props) {
   ]
 
   const [fetchError, setFetchError] = React.useState('')
-  const [isLoaded, setLoaded] = React.useState(false)
+  const [isLoaded, seGtLoaded] = React.useState(false)
   const [rows, setRows] = React.useState([])
 
   const [filterModel = props.filterModel, setFilterModel] = useQueryParam(

--- a/sippy-ng/src/releases/ReleaseOverview.js
+++ b/sippy-ng/src/releases/ReleaseOverview.js
@@ -344,7 +344,7 @@ export default function ReleaseOverview(props) {
                     BOOKMARKS.NO_AGGREGATED,
                     BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                     BOOKMARKS.NO_STEP_GRAPH
-                  )}&sortField=net_working_improvement&sort=asc`}
+                  )}&sortField=net_improvement&sort=asc`}
                   style={{ textAlign: 'center' }}
                   variant="h5"
                 >
@@ -357,7 +357,7 @@ export default function ReleaseOverview(props) {
                 <Container size="xl">
                   <TestTable
                     hideControls={true}
-                    sortField="net_working_improvement"
+                    sortField="net_improvement"
                     sort="asc"
                     limit={10}
                     rowsPerPageOptions={[5]}
@@ -368,6 +368,7 @@ export default function ReleaseOverview(props) {
                         BOOKMARKS.NO_AGGREGATED,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                         BOOKMARKS.NO_STEP_GRAPH,
+                        BOOKMARKS.NO_100_FLAKE,
                       ],
                     }}
                     pageSize={5}
@@ -384,12 +385,13 @@ export default function ReleaseOverview(props) {
                   component={Link}
                   to={`/tests/${
                     props.release
-                  }?period=twoDay&sortField=net_working_improvement&sort=asc&${queryForBookmark(
+                  }?period=twoDay&sortField=net_improvement&sort=asc&${queryForBookmark(
                     BOOKMARKS.RUN_2,
                     BOOKMARKS.NO_NEVER_STABLE,
                     BOOKMARKS.NO_AGGREGATED,
                     BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
-                    BOOKMARKS.NO_STEP_GRAPH
+                    BOOKMARKS.NO_STEP_GRAPH,
+                    BOOKMARKS.NO_100_FLAKE
                   )}`}
                   style={{ textAlign: 'center' }}
                   variant="h5"
@@ -402,7 +404,7 @@ export default function ReleaseOverview(props) {
                 <Container size="xl">
                   <TestTable
                     hideControls={true}
-                    sortField="net_working_improvement"
+                    sortField="net_improvement"
                     sort="asc"
                     limit={10}
                     rowsPerPageOptions={[5]}
@@ -434,9 +436,10 @@ export default function ReleaseOverview(props) {
                     BOOKMARKS.NO_AGGREGATED,
                     BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                     BOOKMARKS.NO_STEP_GRAPH,
-                    BOOKMARKS.HIGH_DELTA_FROM_WORKING_AVERAGE,
-                    BOOKMARKS.HIGH_STANDARD_DEVIATION
-                  )}&sortField=delta_from_working_average&sort=asc`}
+                    BOOKMARKS.HIGH_DELTA_FROM_PASSING_AVERAGE,
+                    BOOKMARKS.HIGH_STANDARD_DEVIATION,
+                    BOOKMARKS.NO_100_FLAKE
+                  )}&sortField=delta_from_passing_average&sort=asc`}
                   style={{ textAlign: 'center' }}
                   variant="h5"
                 >
@@ -455,7 +458,7 @@ export default function ReleaseOverview(props) {
                     collapse={false}
                     overall={false}
                     hideControls={true}
-                    sortField="delta_from_working_average"
+                    sortField="delta_from_passing_average"
                     sort="asc"
                     limit={10}
                     rowsPerPageOptions={[5]}
@@ -466,8 +469,9 @@ export default function ReleaseOverview(props) {
                         BOOKMARKS.NO_AGGREGATED,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                         BOOKMARKS.NO_STEP_GRAPH,
-                        BOOKMARKS.HIGH_DELTA_FROM_WORKING_AVERAGE,
+                        BOOKMARKS.HIGH_DELTA_FROM_PASSING_AVERAGE,
                         BOOKMARKS.HIGH_STANDARD_DEVIATION,
+                        BOOKMARKS.NO_100_FLAKE,
                       ],
                     }}
                     pageSize={5}
@@ -487,8 +491,9 @@ export default function ReleaseOverview(props) {
                     BOOKMARKS.NO_NEVER_STABLE,
                     BOOKMARKS.NO_AGGREGATED,
                     BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
-                    BOOKMARKS.NO_STEP_GRAPH
-                  )}&sortField=current_working_percentage&sort=asc`}
+                    BOOKMARKS.NO_STEP_GRAPH,
+                    BOOKMARKS.NO_100_FLAKE
+                  )}&sortField=current_pass_percentage&sort=asc`}
                   style={{ textAlign: 'center' }}
                   variant="h5"
                 >
@@ -501,7 +506,7 @@ export default function ReleaseOverview(props) {
                 <Container size="xl">
                   <TestTable
                     hideControls={true}
-                    sortField="current_working_percentage"
+                    sortField="current_pass_percentage"
                     sort="asc"
                     limit={10}
                     rowsPerPageOptions={[5]}
@@ -512,6 +517,7 @@ export default function ReleaseOverview(props) {
                         BOOKMARKS.NO_AGGREGATED,
                         BOOKMARKS.WITHOUT_OVERALL_JOB_RESULT,
                         BOOKMARKS.NO_STEP_GRAPH,
+                        BOOKMARKS.NO_100_FLAKE,
                       ],
                     }}
                     pageSize={5}

--- a/sippy-ng/src/tests/FeatureGates.js
+++ b/sippy-ng/src/tests/FeatureGates.js
@@ -1,0 +1,175 @@
+import { Container, Typography } from '@mui/material'
+import { DataGrid } from '@mui/x-data-grid'
+import { FEATURE_GATE_TEST_THRESHOLDS } from '../constants'
+import { generateClasses } from '../datagrid/utils'
+import { Link, useHistory } from 'react-router-dom'
+import { pathForTestSubstringByVariant, SafeJSONParam } from '../helpers'
+import { useQueryParam, withDefault } from 'use-query-params'
+import { withStyles } from '@mui/styles'
+import Alert from '@mui/material/Alert'
+import GridToolbar from '../datagrid/GridToolbar'
+import PropTypes from 'prop-types'
+import React, { Fragment, useEffect } from 'react'
+import SimpleBreadcrumbs from '../components/SimpleBreadcrumbs'
+
+/**
+ * Feature gates is the landing page for feature gates.
+ */
+function FeatureGates(props) {
+  const history = useHistory()
+
+  const { classes } = props
+  const [fetchError, setFetchError] = React.useState('')
+  const [isLoaded, setLoaded] = React.useState(false)
+  const [rows, setRows] = React.useState([])
+
+  const [filterModel, setFilterModel] = useQueryParam(
+    'filterModel',
+    withDefault(SafeJSONParam, { items: [] })
+  )
+
+  const [sortModel, setSortModel] = React.useState([
+    { field: 'unique_test_count', sort: 'asc' }, // Default sort
+  ])
+
+  const requestSearch = (searchValue) => {
+    const currentFilters = filterModel
+    currentFilters.items = currentFilters.items.filter(
+      (f) => f.columnField !== 'feature_gate'
+    )
+    currentFilters.items.push({
+      columnField: 'feature_gate',
+      operatorValue: 'contains',
+      value: searchValue,
+    })
+    setFilterModel(currentFilters)
+  }
+
+  const columns = [
+    {
+      field: 'id',
+      hide: true,
+    },
+    {
+      field: 'type',
+      headerName: 'Type',
+      width: 150,
+      renderCell: (params) =>
+        params.value === 'OCPFeatureGate' ? 'OpenShift' : 'Kubernetes',
+    },
+    { field: 'feature_gate', headerName: 'Feature Gate', width: 300 },
+    {
+      field: 'unique_test_count',
+      headerName: 'Unique Test Count',
+      type: 'number',
+      width: 200,
+      renderCell: (params) => {
+        return <Link to={linkForFGTests(params)}>{params.value}</Link>
+      },
+    },
+  ]
+
+  const linkForFGTests = (params) => {
+    const fgAnnotation = `[${params.row.type}:${params.row.feature_gate}]`
+    return pathForTestSubstringByVariant(props.release, fgAnnotation)
+  }
+
+  const fetchData = () => {
+    fetch(
+      process.env.REACT_APP_API_URL +
+        '/api/feature_gates?release=' +
+        props.release
+    )
+      .then((response) => {
+        if (response.status !== 200) {
+          throw new Error('server returned ' + response.status)
+        }
+        return response.json()
+      })
+      .then((json) => {
+        if (json != null) {
+          setRows(json)
+        } else {
+          setRows([])
+        }
+        setLoaded(true)
+      })
+      .catch((error) => {
+        setFetchError(
+          'Could not retrieve tests ' + props.release + ', ' + error
+        )
+      })
+  }
+
+  const onRowClick = (params) => {
+    console.log('clicked')
+    history.push(linkForFGTests(params))
+  }
+
+  useEffect(() => {
+    fetchData()
+    document.title = `Sippy > ${props.release} > Feature Gates`
+  }, [])
+
+  return (
+    <Fragment>
+      <SimpleBreadcrumbs release={props.release} currentPage="Feature Gates" />
+      <Container size="xl">
+        <Typography align="center" variant="h4" sx={{ marginBottom: 2 }}>
+          Feature Gates for {props.release}
+        </Typography>
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Click on a row to view tests for that feature gate.
+        </Alert>
+        {fetchError && (
+          <Typography color="error" align="center">
+            {fetchError}
+          </Typography>
+        )}
+        {isLoaded ? (
+          <DataGrid
+            components={{ Toolbar: GridToolbar }}
+            rows={rows}
+            columns={columns}
+            pageSize={25}
+            autoHeight={true}
+            getRowClassName={(params) =>
+              classes['row-percent-' + Math.round(params.row.unique_test_count)]
+            }
+            rowsPerPageOptions={[10, 25, 50]}
+            sortModel={sortModel} // Controlled sortModel
+            onSortModelChange={(newModel) => setSortModel(newModel)}
+            sx={{
+              '& .MuiDataGrid-row:hover': {
+                cursor: 'pointer', // Change cursor on hover
+              },
+            }}
+            disableSelectionOnClick
+            filterModel={filterModel}
+            onRowClick={onRowClick}
+            componentsProps={{
+              toolbar: {
+                columns: columns,
+                filterModel: filterModel,
+                setFilterModel: setFilterModel,
+                clearSearch: () => requestSearch(''),
+                doSearch: requestSearch,
+              },
+            }}
+          />
+        ) : (
+          <Typography align="center">Loading...</Typography>
+        )}
+      </Container>
+    </Fragment>
+  )
+}
+
+FeatureGates.propTypes = {
+  classes: PropTypes.object,
+  release: PropTypes.string.isRequired,
+}
+
+export default withStyles(generateClasses(FEATURE_GATE_TEST_THRESHOLDS))(
+  FeatureGates
+)

--- a/sippy-ng/src/tests/FeatureGates.js
+++ b/sippy-ng/src/tests/FeatureGates.js
@@ -119,7 +119,8 @@ function FeatureGates(props) {
           Feature Gates for {props.release}
         </Typography>
         <Alert severity="info" sx={{ mb: 2 }}>
-          Click on a row to view tests for that feature gate.
+          Click on a row to view tests for that feature gate. Row color is based
+          on number of tests only; a feature gate should have at least 5 tests.
         </Alert>
         {fetchError && (
           <Typography color="error" align="center">

--- a/sippy-ng/src/tests/TestAnalysis.js
+++ b/sippy-ng/src/tests/TestAnalysis.js
@@ -142,17 +142,17 @@ export function TestAnalysis(props) {
             <SummaryCard
               key="test-summary"
               threshold={TEST_THRESHOLDS}
-              name="Overall"
+              name="7 Day Overall"
               success={test.current_successes}
               flakes={test.current_flakes}
               caption={
                 <Fragment>
                   <Tooltip title={`${test.current_runs} runs`}>
-                    <span>{test.current_working_percentage.toFixed(2)}%</span>
+                    <span>{test.current_pass_percentage.toFixed(2)}%</span>
                   </Tooltip>
                   <PassRateIcon improvement={test.net_improvement} />
                   <Tooltip title={`${test.previous_runs} runs`}>
-                    <span>{test.previous_working_percentage.toFixed(2)}%</span>
+                    <span>{test.previous_pass_percentage.toFixed(2)}%</span>
                   </Tooltip>
                 </Fragment>
               }
@@ -295,7 +295,7 @@ export function TestAnalysis(props) {
                 hideControls={true}
                 collapse={false}
                 release={props.release}
-                sortField="delta_from_working_average"
+                sortField="delta_from_passing_average"
                 sort="asc"
                 filterModel={filterModel}
               />

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -995,14 +995,14 @@ TestTable.defaultProps = {
   hideControls: false,
   pageSize: 25,
   period: 'default',
-  view: 'Working',
+  view: 'Passing',
   rowsPerPageOptions: [5, 10, 25, 50, 100],
   briefTable: false,
   simpleLoading: false,
   filterModel: {
     items: [],
   },
-  sortField: 'current_working_percentage',
+  sortField: 'current_pass_percentage',
   sort: 'asc',
 }
 

--- a/sippy-ng/src/tests/Tests.js
+++ b/sippy-ng/src/tests/Tests.js
@@ -92,7 +92,7 @@ export default function Tests(props) {
                           linkOperator: 'and',
                         }
                       ),
-                      'current_working_percentage',
+                      'current_pass_percentage',
                       'asc'
                     )}
                   />


### PR DESCRIPTION
Sippy has historically showed the "working" percentage (success +
flake), but we're ready to deprecate this concept and show pass rate
only (strict success).  This is the first part: only in core sippy.  CR will come later.

We already do this for the o/api feature gate analyzer, which uses strict success. This
results in confusion when people try to do archeology in Sippy and see the rates
reported (working) don't match o/api's requirements (success).

While Sippy users can change the view from Working -> Passing, it's not
very discoverable.

This PR:

- Adds a "Feature Gates" page per release, that links to the tests-by-variant
- Deprecates "Working" reporting from sippy -- only show success pass rates
- Caches test result pages for speedier loading 