### PR TITLE
component readiness: enforce techpreview in 4.19+

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -29,6 +29,7 @@ component_readiness:
           - amd64
         FeatureSet:
           - default
+          - techpreview
         Installer:
           - ipi
           - upi


### PR DESCRIPTION
Starting in 4.19 we'd like to enforce TP reliability by having it in the main dashboard.