### PR TITLE
Fix ROSA Variants

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -11,11 +11,12 @@ import (
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/storage"
 	"github.com/hashicorp/go-version"
-	v1 "github.com/openshift/sippy/pkg/apis/config/v1"
-	"github.com/openshift/sippy/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
+
+	v1 "github.com/openshift/sippy/pkg/apis/config/v1"
+	"github.com/openshift/sippy/pkg/util"
 
 	"github.com/openshift/sippy/pkg/dataloader/prowloader"
 	"github.com/openshift/sippy/pkg/dataloader/prowloader/gcs"
@@ -220,6 +221,12 @@ func (v *OCPVariantLoader) CalculateVariantsForJob(jLog logrus.FieldLogger, jobN
 			})
 
 			switch k {
+			case VariantPlatform:
+				// ROSA is identified as AWS, but we want to keep it in a separate bucket
+				if jnv == "rosa" {
+					continue
+				}
+				variants[k] = v
 			case VariantArch:
 				// Job name identification wins for arch, heterogenous jobs can show cluster data with
 				// amd64 as it's read from a single node.

--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -267,7 +267,7 @@ var (
 	cpuPartitioning = regexp.MustCompile(`(?i)-cpu-partitioning`)
 	etcdScaling     = regexp.MustCompile(`(?i)-etcd-scaling`)
 	fipsRegex       = regexp.MustCompile(`(?i)-fips`)
-	hypershiftRegex = regexp.MustCompile(`(?i)-hypershift`)
+	hypershiftRegex = regexp.MustCompile(`(?i)(-hypershift|-hcp|_hcp)`)
 	upiRegex        = regexp.MustCompile(`(?i)-upi`)
 	libvirtRegex    = regexp.MustCompile(`(?i)-libvirt`)
 	metalRegex      = regexp.MustCompile(`(?i)-metal`)

--- a/pkg/variantregistry/ocp_test.go
+++ b/pkg/variantregistry/ocp_test.go
@@ -3,9 +3,10 @@ package variantregistry
 import (
 	"testing"
 
-	v1 "github.com/openshift/sippy/pkg/apis/config/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+
+	v1 "github.com/openshift/sippy/pkg/apis/config/v1"
 )
 
 func TestVariantSyncer(t *testing.T) {
@@ -44,8 +45,10 @@ func TestVariantSyncer(t *testing.T) {
 			},
 		},
 		{
-			job:          "periodic-ci-openshift-osde2e-main-nightly-4.17-conformance-rosa-classic-sts",
-			variantsFile: map[string]string{},
+			job: "periodic-ci-openshift-osde2e-main-nightly-4.17-conformance-rosa-classic-sts",
+			variantsFile: map[string]string{
+				"Platform": "aws", // should be ignored
+			},
 			expected: map[string]string{
 				VariantRelease:          "4.17",
 				VariantReleaseMajor:     "4",
@@ -99,6 +102,36 @@ func TestVariantSyncer(t *testing.T) {
 				VariantScheduler:        VariantDefaultValue,
 				"Foo":                   "bar",
 				VariantContainerRuntime: "runc",
+				VariantCGroupMode:       "v2",
+				VariantLayeredProduct:   VariantNoValue,
+			},
+		},
+		{
+			job: "periodic-ci-openshift-release-master-nightly-4.19-e2e-rosa-sts-ovn",
+			variantsFile: map[string]string{
+				"Platform": "aws", // should be ignored
+			},
+			expected: map[string]string{
+				VariantRelease:          "4.19",
+				VariantReleaseMajor:     "4",
+				VariantReleaseMinor:     "19",
+				VariantArch:             "amd64",
+				VariantInstaller:        "rosa",
+				VariantPlatform:         "rosa",
+				VariantProcedure:        "none",
+				VariantJobTier:          "standard",
+				VariantNetwork:          "ovn",
+				VariantNetworkStack:     "ipv4",
+				VariantOwner:            "service-delivery",
+				VariantTopology:         "ha",
+				VariantSuite:            "unknown",
+				VariantUpgrade:          VariantNoValue,
+				VariantAggregation:      VariantNoValue,
+				VariantFeatureSet:       VariantDefaultValue,
+				VariantNetworkAccess:    VariantDefaultValue,
+				VariantScheduler:        VariantDefaultValue,
+				VariantSecurityMode:     VariantDefaultValue,
+				VariantContainerRuntime: "crun",
 				VariantCGroupMode:       "v2",
 				VariantLayeredProduct:   VariantNoValue,
 			},


### PR DESCRIPTION
- origin reports these clusters as "AWS" - make sure we accept the ROSA override
- Perfscale and SD use "HCP" in hypershift job names
