### PR TITLE
Use default go version from dnf install

### DIFF
--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -4,23 +4,14 @@
 # [1] https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image
 #
 FROM registry.access.redhat.com/ubi9/ubi:latest
-ARG GOLANG_VERSION="1.22.3"
-ENV PATH="/usr/local/go/bin:${PATH}"
 ARG GOLANGCI_LINT_VERSION="1.56.2"
 RUN curl -Lso /tmp/golangci-lint.rpm \
           "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64.rpm" && \
       dnf module enable nodejs:18 -y && \
       dnf install -y \
         git \
+        go \
         make \
         npm \
         /tmp/golangci-lint.rpm && \
-      rm /tmp/golangci-lint.rpm && \
-    curl -Lso /tmp/golang.linux-amd64.tar.gz \
-          "https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz" && \
-      rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/golang.linux-amd64.tar.gz && \
-      echo $PATH && \
-      export PATH=/usr/local/go/bin:$PATH && \
-      echo $PATH && \
-      rm /tmp/golang.linux-amd64.tar.gz && sh
-
+      rm /tmp/golangci-lint.rpm


### PR DESCRIPTION
The one installed by dnf install is go1.22.7. We don't need to manually install this in the dockerfile. 