### PR TITLE
Add ROSA to 4.19-main dashboard

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -33,15 +33,18 @@ component_readiness:
         Installer:
           - ipi
           - upi
+          - rosa
         Network:
           - ovn
         Owner:
           - eng
+          - service-delivery
         Platform:
           - aws
           - azure
           - gcp
           - metal
+          - rosa
           - vsphere
         Topology:
           - ha


### PR DESCRIPTION
It's green for 4.19 vs 4.18.

<img width="1056" alt="SCR-20241217-jqfh" src="https://github.com/user-attachments/assets/7a6499ae-e93c-4572-9067-197e13668b9e" />

<img width="1112" alt="SCR-20241217-jqgl" src="https://github.com/user-attachments/assets/28257760-1e77-4483-b71f-e9690aba0446" />
