### PR TITLE
Allow page loads when test analysis is empty

### DIFF
--- a/sippy-ng/src/tests/TestPassRateCharts.js
+++ b/sippy-ng/src/tests/TestPassRateCharts.js
@@ -77,6 +77,26 @@ export default function TestPassRateCharts(props) {
     )
   }
 
+  // In rare cases, for the time being, tests being in sippy but not bigquery junit tables will
+  // get no analysis here due to optimzations that were made as we try to bring the two data sources together.
+  // For these few tests, we currently will just show no analysis.
+  if (groupedData == null || groupedData['overall'] == null) {
+    return (
+      <Fragment>
+        <Grid item md={12}>
+          <Card className="test-failure-card" elevation={5}>
+            <Typography variant="h5">
+              Pass Rate By{' '}
+              {props.grouping.charAt(0).toUpperCase() +
+                props.grouping.substr(1).toLowerCase()}
+            </Typography>
+            <Typography>No analysis available for this test.</Typography>
+          </Card>
+        </Grid>
+      </Fragment>
+    )
+  }
+
   const colors = scale('Set2')
     .mode('lch')
     .colors(Object.keys(groupedData).length)

--- a/sippy-ng/src/tests/TestStackedChart.js
+++ b/sippy-ng/src/tests/TestStackedChart.js
@@ -71,6 +71,19 @@ export function TestStackedChart(props) {
     )
   }
 
+  if (analysis == null) {
+    return (
+      <Fragment>
+        <Grid item md={12}>
+          <Card className="test-failure-card" elevation={5}>
+            <Typography variant="h5">Overall Results</Typography>
+            <Typography>No analysis available for this test.</Typography>
+          </Card>
+        </Grid>
+      </Fragment>
+    )
+  }
+
   let daySet = new Set()
   analysis.forEach((dt) => {
     daySet.add(dt.date)


### PR DESCRIPTION
This is working around an edge case with our new method of daily
reporting on test analysis via bigquery, rather than matview refreshes.
A few tests exist in sippy but are not imported into bigquery, and as
such no longer have any test analysis available. This was causing the
page to crash.

Show a clear indicator that no analysis is available and keep the page
loading properly for the rest of it.

Example test that doesn't load today until this pr merges: https://sippy.dptools.openshift.org/sippy-ng/tests/4.17/analysis?test=Build%20image%20image-based-install-operator%20from%20the%20repository&filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22Build%20image%20image-based-install-operator%20from%20the%20repository%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22aggregated%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D


<img width="1309" alt="Screenshot 2024-12-18 at 1 47 31 PM" src="https://github.com/user-attachments/assets/26e50f19-d47b-41bd-82c2-a884a102e5ef" />


