### PR TITLE
trt-1768: add feature_set labels

### DIFF
--- a/pkg/api/disruption_report.go
+++ b/pkg/api/disruption_report.go
@@ -17,7 +17,7 @@ import (
 func GetDisruptionVsPrevGAReportFromBigQuery(ctx context.Context, client *bqcachedclient.Client) (apitype.DisruptionReport, []error) {
 	generator := disruptionReportGenerator{
 		client:   client.BQ,
-		ViewName: "BackendDisruptionPercentilesDeltaCurrentVsPrevGA",
+		ViewName: "BackendDisruptionPercentilesDeltaCurrentVsPrevGAV2",
 	}
 
 	return GetDataFromCacheOrGenerate[apitype.DisruptionReport](ctx, client.Cache, cache.RequestOptions{}, GetPrefixedCacheKey("", generator), generator.GenerateReport, apitype.DisruptionReport{})
@@ -26,7 +26,7 @@ func GetDisruptionVsPrevGAReportFromBigQuery(ctx context.Context, client *bqcach
 func GetDisruptionVsTwoWeeksAgoReportFromBigQuery(ctx context.Context, client *bqcachedclient.Client) (apitype.DisruptionReport, []error) {
 	generator := disruptionReportGenerator{
 		client:   client.BQ,
-		ViewName: "BackendDisruptionPercentilesDeltaCurrentVs14DaysAgo",
+		ViewName: "BackendDisruptionPercentilesDeltaCurrentVs14DaysAgoV2",
 	}
 
 	return GetDataFromCacheOrGenerate[apitype.DisruptionReport](ctx, client.Cache, cache.RequestOptions{}, GetPrefixedCacheKey("", generator), generator.GenerateReport, apitype.DisruptionReport{})

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -822,6 +822,7 @@ type DisruptionReportRow struct {
 	Topology                 string  `json:"topology"`
 	Architecture             string  `json:"architecture"`
 	Relevance                int     `json:"relevance"`
+	FeatureSet               string  `json:"feature_set"`
 }
 
 type ReleaseRow struct {

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -108,19 +108,19 @@ var (
 	disruptionVsPrevGAMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: disruptionVsPrevGAMetricName,
 		Help: "Delta of percentiles now vs the 30 days prior to previous release GA date",
-	}, []string{"delta", "release", "compare_release", "platform", "backend", "upgrade_type", "master_nodes_updated", "network", "topology", "architecture", "releaseStatus"})
+	}, []string{"delta", "release", "compare_release", "platform", "backend", "upgrade_type", "master_nodes_updated", "network", "topology", "architecture", "feature_set", "releaseStatus"})
 	disruptionVsPrevGARelevanceMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "sippy_disruption_vs_prev_ga_relevance",
 		Help: "Rating of how relevant we feel our data is for regression detection.",
-	}, []string{"release", "compare_release", "platform", "backend", "upgrade_type", "master_nodes_updated", "network", "topology", "architecture", "releaseStatus"})
+	}, []string{"release", "compare_release", "platform", "backend", "upgrade_type", "master_nodes_updated", "network", "topology", "architecture", "feature_set", "releaseStatus"})
 	disruptionVsTwoWeeksAgo = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "sippy_disruption_vs_two_weeks_ago",
 		Help: "Delta of percentiles now vs two weeks ago for a given release",
-	}, []string{"delta", "release", "platform", "backend", "upgrade_type", "master_nodes_updated", "network", "topology", "architecture", "releaseStatus"})
+	}, []string{"delta", "release", "platform", "backend", "upgrade_type", "master_nodes_updated", "network", "topology", "architecture", "feature_set", "releaseStatus"})
 	disruptionVsTwoWeeksAgoRelevanceMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "sippy_disruption_vs_two_weeks_ago_relevance",
 		Help: "Rating of how relevant we feel our data is for regression detection.",
-	}, []string{"release", "compare_release", "platform", "backend", "upgrade_type", "master_nodes_updated", "network", "topology", "architecture", "releaseStatus"})
+	}, []string{"release", "compare_release", "platform", "backend", "upgrade_type", "master_nodes_updated", "network", "topology", "architecture", "feature_set", "releaseStatus"})
 )
 
 func getReleaseStatus(releases []v1.Release, release string) string {
@@ -431,19 +431,19 @@ func refreshDisruptionMetrics(client *bqclient.Client, releases []v1.Release) er
 		releaseStatus := getReleaseStatus(releases, row.Release)
 		disruptionVsPrevGAMetric.WithLabelValues("P50",
 			row.Release, row.CompareRelease, row.Platform, row.BackendName, row.UpgradeType,
-			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, releaseStatus).Set(float64(row.P50))
+			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, row.FeatureSet, releaseStatus).Set(float64(row.P50))
 		disruptionVsPrevGAMetric.WithLabelValues("P75",
 			row.Release, row.CompareRelease, row.Platform, row.BackendName, row.UpgradeType,
-			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, releaseStatus).Set(float64(row.P75))
+			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, row.FeatureSet, releaseStatus).Set(float64(row.P75))
 		disruptionVsPrevGAMetric.WithLabelValues("P95",
 			row.Release, row.CompareRelease, row.Platform, row.BackendName, row.UpgradeType,
-			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, releaseStatus).Set(float64(row.P95))
+			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, row.FeatureSet, releaseStatus).Set(float64(row.P95))
 		disruptionVsPrevGAMetric.WithLabelValues("PercentageAboveZero",
 			row.Release, row.CompareRelease, row.Platform, row.BackendName, row.UpgradeType,
-			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, releaseStatus).Set(float64(row.PercentageAboveZeroDelta))
+			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, row.FeatureSet, releaseStatus).Set(float64(row.PercentageAboveZeroDelta))
 		disruptionVsPrevGARelevanceMetric.WithLabelValues(
 			row.Release, row.CompareRelease, row.Platform, row.BackendName, row.UpgradeType,
-			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, releaseStatus).Set(float64(row.Relevance))
+			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, row.FeatureSet, releaseStatus).Set(float64(row.Relevance))
 	}
 
 	disruptionReport, err = api.GetDisruptionVsTwoWeeksAgoReportFromBigQuery(context.Background(), client)
@@ -455,19 +455,19 @@ func refreshDisruptionMetrics(client *bqclient.Client, releases []v1.Release) er
 		releaseStatus := getReleaseStatus(releases, row.Release)
 		disruptionVsTwoWeeksAgo.WithLabelValues("P50",
 			row.Release, row.Platform, row.BackendName, row.UpgradeType,
-			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, releaseStatus).Set(float64(row.P50))
+			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, row.FeatureSet, releaseStatus).Set(float64(row.P50))
 		disruptionVsTwoWeeksAgo.WithLabelValues("P75",
 			row.Release, row.Platform, row.BackendName, row.UpgradeType,
-			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, releaseStatus).Set(float64(row.P75))
+			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, row.FeatureSet, releaseStatus).Set(float64(row.P75))
 		disruptionVsTwoWeeksAgo.WithLabelValues("P95",
 			row.Release, row.Platform, row.BackendName, row.UpgradeType,
-			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, releaseStatus).Set(float64(row.P95))
+			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, row.FeatureSet, releaseStatus).Set(float64(row.P95))
 		disruptionVsTwoWeeksAgo.WithLabelValues("PercentageAboveZero",
 			row.Release, row.Platform, row.BackendName, row.UpgradeType,
-			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, releaseStatus).Set(float64(row.PercentageAboveZeroDelta))
+			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, row.FeatureSet, releaseStatus).Set(float64(row.PercentageAboveZeroDelta))
 		disruptionVsTwoWeeksAgoRelevanceMetric.WithLabelValues(
 			row.Release, row.CompareRelease, row.Platform, row.BackendName, row.UpgradeType,
-			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, releaseStatus).Set(float64(row.Relevance))
+			row.MasterNodesUpdated, row.Network, row.Topology, row.Architecture, row.FeatureSet, releaseStatus).Set(float64(row.Relevance))
 	}
 
 	return nil


### PR DESCRIPTION
Created V2 views to transition to the additional feature_set variant
Verified locally the feature_set label is populated
```
sippy_disruption_vs_prev_ga{architecture="amd64",backend="aws-network-liveness-new-connections",compare_release="4.17",delta="P75",feature_set="techpreview",master_nodes_updated="N",network="ovn",platform="gcp",release="4.19",releaseStatus="Development",topology="ha",upgrade_type="none"} 0
sippy_disruption_vs_prev_ga{architecture="amd64",backend="aws-network-liveness-new-connections",compare_release="4.17",delta="P75",feature_set="default",master_nodes_updated="Y",network="ovn",platform="gcp",release="4.19",releaseStatus="Development",topology="ha",upgrade_type="minor"} 0
```