### PR TITLE
component readiness: single node to blocking for 4.19-main

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -49,6 +49,7 @@ component_readiness:
         Topology:
           - ha
           - microshift
+          - single
         CGroupMode:
           - v2
         ContainerRuntime:


### PR DESCRIPTION
Establish regression protection on single node, the current handful of SNO regressions look tackable before 4.19 GA.