### PR TITLE
[WIP] TRT-1922: Use JobTier for filtering jobs

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -25,6 +25,10 @@ component_readiness:
         Topology: {}
         Upgrade: {}
       include_variants:
+        JobTier:
+          - informing
+          - blocking
+          - standard
         Architecture:
           - amd64
         FeatureSet:
@@ -88,6 +92,10 @@ component_readiness:
         Topology: {}
         Upgrade: {}
       include_variants:
+        JobTier:
+          - informing
+          - blocking
+          - standard
         Architecture:
           - amd64
         FeatureSet:
@@ -147,6 +155,10 @@ component_readiness:
         Suite: {}
         Upgrade: {}
       include_variants:
+        JobTier:
+          - informing
+          - blocking
+          - standard
         Architecture:
           - amd64
         FeatureSet:
@@ -271,6 +283,10 @@ component_readiness:
         Topology: {}
         Upgrade: {}
       include_variants:
+        JobTier:
+          - informing
+          - blocking
+          - standard
         Architecture:
           - amd64
         FeatureSet:
@@ -333,6 +349,10 @@ component_readiness:
         Suite: {}
         Upgrade: {}
       include_variants:
+        JobTier:
+          - informing
+          - blocking
+          - standard
         Architecture:
           - amd64
         FeatureSet:
@@ -460,6 +480,10 @@ component_readiness:
             Topology: {}
             Upgrade: {}
         include_variants:
+            JobTier:
+                - informing
+                - blocking
+                - standard
             Architecture:
                 - amd64
             FeatureSet:
@@ -520,6 +544,10 @@ component_readiness:
         Topology: {}
         Upgrade: {}
       include_variants:
+        JobTier:
+          - informing
+          - blocking
+          - standard
         Architecture:
           - amd64
         FeatureSet:

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/civil"
+
 	"github.com/openshift/sippy/pkg/util"
 
 	"cloud.google.com/go/bigquery"
@@ -32,8 +33,6 @@ import (
 
 const (
 	triagedIncidentsTableID = "triaged_incidents"
-
-	ignoredJobsRegexp = `-okd|-recovery|aggregator-|alibaba|-disruptive|-rollback|-out-of-change|-sno-fips-recert`
 
 	// openRegressionConfidenceAdjustment is subtracted from the requested confidence for regressed tests that have
 	// an open regression.
@@ -1784,18 +1783,11 @@ func (c *componentReportGenerator) getUniqueJUnitColumnValuesLast60Days(ctx cont
 					FROM
 						%s.junit %s
 					WHERE
-						NOT REGEXP_CONTAINS(prowjob_name, @IgnoredJobs)
-						AND modified_time > DATETIME_SUB(CURRENT_DATETIME(), INTERVAL 60 DAY)
+						modified_time > DATETIME_SUB(CURRENT_DATETIME(), INTERVAL 60 DAY)
 					ORDER BY
 						name`, field, c.client.Dataset, unnest)
 
 	query := c.client.BQ.Query(queryString)
-	query.Parameters = []bigquery.QueryParameter{
-		{
-			Name:  "IgnoredJobs",
-			Value: ignoredJobsRegexp,
-		},
-	}
 
 	return getSingleColumnResultToSlice(ctx, query)
 }

--- a/pkg/testidentification/ocp_variants.go
+++ b/pkg/testidentification/ocp_variants.go
@@ -33,6 +33,7 @@ var importantVariants = []string{
 	"Upgrade",
 	"SecurityMode",
 	"Installer",
+	"JobTier",
 }
 
 const (

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -271,7 +271,10 @@ export function filterFor(column, operator, value) {
 }
 
 export function withoutUnstable() {
-  return [not(filterFor('variants', 'contains', 'never-stable'))]
+  return [
+    not(filterFor('variants', 'contains', 'never-stable')),
+    not(filterFor('variants', 'contains', 'JobTier:excluded')),
+  ]
 }
 
 export function multiple(...filters) {


### PR DESCRIPTION
Start setting `JobTier` to excluded on jobs we don't know about in Sippy's config. This makes Sippy's config authoritative for both CR and Sippy -- it should allow the data to match between the two, and for jobs we don't explicitly opt-in to to stop showing up in Component Readiness.