### PR TITLE
Missing basis is not being reported correctly

### DIFF
--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -11,10 +11,8 @@ import (
 	"sync"
 	"time"
 
-	"cloud.google.com/go/civil"
-	"github.com/openshift/sippy/pkg/util"
-
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
 	"github.com/apache/thrift/lib/go/thrift"
 	fischer "github.com/glycerine/golang-fisher-exact"
 	"github.com/pkg/errors"
@@ -27,6 +25,7 @@ import (
 	bqcachedclient "github.com/openshift/sippy/pkg/bigquery"
 	"github.com/openshift/sippy/pkg/componentreadiness/resolvedissues"
 	"github.com/openshift/sippy/pkg/regressionallowances"
+	"github.com/openshift/sippy/pkg/util"
 	"github.com/openshift/sippy/pkg/util/sets"
 )
 
@@ -1623,7 +1622,7 @@ func (c *componentReportGenerator) buildFisherExactTestStats(requiredConfidence,
 		} else {
 			status = crtype.MissingSample
 		}
-	} else {
+	} else if baseTotal != 0 {
 		// see if we had a significant regression prior to adjusting
 		basePass := baseSuccess + baseFlake
 		samplePass := sampleSuccess + sampleFlake


### PR DESCRIPTION
This link is reporting "Not Significant" when there's no basis runs. This is not the case where it's falling back to pass rate, as I have those set to 0.  It's trying to calculate fishers when there's no basis results producing a NaN and then always returns a not significant result.

This adds a gate so we only calculate fishers if there's a basis to use.

[1] https://qe-component-readiness.dptools.openshift.org/sippy-ng/component_readiness/test_details?Aggregation=none&Architecture=amd64&FeatureSet=default&Installer=ipi&LayeredProduct=none&Network=ovn&NetworkAccess=default&Platform=azure&Procedure=none&Scheduler=default&SecurityMode=default&Suite=unknown&Topology=ha&Upgrade=none&baseEndTime=2024-10-01%2023%3A59%3A59&baseRelease=4.17&baseStartTime=2024-09-01%2000%3A00%3A00&capability=Other&columnGroupBy=Architecture%2CNetwork%2CPlatform&component=Networking%20%2F%20router&confidence=95&dbGroupBy=Platform%2CArchitecture%2CNetwork%2CTopology%2CFeatureSet%2CUpgrade%2CSuite%2CInstaller&environment=amd64%20default%20ipi%20ovn%20azure%20unknown%20ha%20none&flakeAsFailure=false&ignoreDisruption=true&ignoreMissing=false&includeMultiReleaseAnalysis=false&includeVariant=Architecture%3Aamd64&includeVariant=FeatureSet%3Adefault&includeVariant=Installer%3Aipi&includeVariant=Installer%3Aupi&includeVariant=Network%3Aovn&includeVariant=Owner%3Aqe&includeVariant=Owner%3Aservice-delivery&includeVariant=Platform%3Aaws&includeVariant=Platform%3Aazure&includeVariant=Platform%3Agcp&includeVariant=Platform%3Arosa&includeVariant=Platform%3Avsphere&includeVariant=Procedure%3Aautomated-release&includeVariant=Topology%3Aha&minFail=3&passRateAllTests=0&passRateNewTests=0&pity=5&sampleEndTime=2025-01-23%2023%3A59%3A59&sampleRelease=4.17&sampleStartTime=2025-01-16%2000%3A00%3A00&testBasisRelease=&testId=Network_Edge%3A7d434aada1e9944fb5f0efc4dfa659ca&testName=OCP-41042%3Aaiyengar%3ANetwork_Edge%3A%5Bsig-network-edge%5D%20Network_Edge%20Component_Router%20The%20Power-of-two%20balancing%20features%20defaults%20to%20random%20LB%20algorithm%20instead%20of%20leastconn%20for%20REEN%2FEdge%2Finsecure%20routes