### PR TITLE
[wip] TRT-1972: Support capability/component filters in views

### DIFF
--- a/config/qe-views.yaml
+++ b/config/qe-views.yaml
@@ -1,5 +1,61 @@
 ---
 component_readiness:
+  - name: 4.17-qe-level0
+    base_release:
+      release: "4.17"
+      relative_start: "2025-01-06T00:00:00Z"
+      relative_end: "2025-01-20T23:59:59Z"
+    sample_release:
+      release: "4.17"
+      relative_start: now-7d
+      relative_end: now
+    test_id_options:
+      capability: LEVEL0
+    variant_options:
+      column_group_by:
+        Architecture: {}
+        Network: {}
+        Platform: {}
+      db_group_by:
+        Architecture: {}
+        FeatureSet: {}
+        Installer: {}
+        Network: {}
+        Platform: {}
+        Suite: {}
+        Topology: {}
+        Upgrade: {}
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        Network:
+          - ovn
+        Owner:
+          - qe
+          - service-delivery
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - rosa
+          - vsphere
+        Topology:
+          - ha
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+    metrics:
+      enabled: true
+    regression_tracking:
+      enabled: false
   - name: 4.17-qe-main
     base_release:
       release: "4.16"

--- a/config/qe-views.yaml
+++ b/config/qe-views.yaml
@@ -9,6 +9,8 @@ component_readiness:
       release: "4.17"
       relative_start: now-7d
       relative_end: now
+    test_id_options:
+      capability: LEVEL0
     variant_options:
       column_group_by:
         Architecture: {}

--- a/pkg/api/componentreadiness/queryparamparser.go
+++ b/pkg/api/componentreadiness/queryparamparser.go
@@ -33,6 +33,7 @@ func ParseComponentReportRequest(
 	if view != nil {
 		// set params from view
 		opts.VariantOption = view.VariantOptions
+		opts.TestIDOption = view.TestIDOption
 		opts.AdvancedOption = view.AdvancedOptions
 		opts.BaseRelease, err = GetViewReleaseOptions(releases, "basis", view.BaseRelease, crTimeRoundingFactor)
 		if err != nil {
@@ -107,12 +108,16 @@ func ParseComponentReportRequest(
 	}
 
 	// Params below this point can be used with and without views:
+	if opts.TestIDOption.Component == "" {
+		opts.TestIDOption.Component = req.URL.Query().Get("component")
+	}
 
-	opts.TestIDOption = crtype.RequestTestIdentificationOptions{
-		// these are semi-freeform and only used in lookup keys, so don't need validation
-		Component:  req.URL.Query().Get("component"),
-		Capability: req.URL.Query().Get("capability"),
-		TestID:     req.URL.Query().Get("testId"),
+	if opts.TestIDOption.Capability == "" {
+		opts.TestIDOption.Capability = req.URL.Query().Get("capability")
+	}
+
+	if opts.TestIDOption.TestID == "" {
+		opts.TestIDOption.TestID = req.URL.Query().Get("testId")
 	}
 
 	opts.CacheOption.ForceRefresh, err = ParseBoolArg(req, "forceRefresh", false)

--- a/pkg/api/componentreadiness/regressiontracker.go
+++ b/pkg/api/componentreadiness/regressiontracker.go
@@ -9,13 +9,14 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/api/iterator"
+
 	crtype "github.com/openshift/sippy/pkg/apis/api/componentreport"
 	"github.com/openshift/sippy/pkg/apis/cache"
 	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 	sippybigquery "github.com/openshift/sippy/pkg/bigquery"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
-	"google.golang.org/api/iterator"
 )
 
 const (
@@ -193,12 +194,13 @@ func (rt *RegressionTracker) syncRegressionsForView(
 
 	variantOption := view.VariantOptions
 	advancedOption := view.AdvancedOptions
+	testIdOption := view.TestIDOption
 
 	// Get component readiness report
 	reportOpts := crtype.RequestOptions{
 		BaseRelease:    baseRelease,
 		SampleRelease:  sampleRelease,
-		TestIDOption:   crtype.RequestTestIdentificationOptions{},
+		TestIDOption:   testIdOption,
 		VariantOption:  variantOption,
 		AdvancedOption: advancedOption,
 		CacheOption:    rt.cacheOpts,

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -337,7 +337,14 @@ export function getUpdatedUrlParts(vars) {
     ignoreMissing: vars.ignoreMissing,
     flakeAsFailure: vars.flakeAsFailure,
     includeMultiReleaseAnalysis: vars.includeMultiReleaseAnalysis,
-    //component: vars.component,
+  }
+
+  if (vars.capability) {
+    valuesMap.capability = vars.capability
+  }
+
+  if (vars.component) {
+    valuesMap.component = vars.component
   }
 
   if (vars.samplePROrg && vars.samplePRRepo && vars.samplePRNumber) {


### PR DESCRIPTION
This allows making a view that only looks at a particular capability or component.  I want to use this to make a QE view for "LEVEL0" capability tests.  Not exposed in the UI currently, it's a view-only option for now.