### PR TITLE
Stop creating ignored tests in db.

### DIFF
--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -1137,6 +1137,9 @@ func (pl *ProwLoader) extractTestCases(suite *junit.TestSuite, suiteID *uint, te
 	testOutputMetadataExtractor := TestFailureMetadataExtractor{}
 
 	for _, tc := range suite.TestCases {
+		if testidentification.IsIgnoredTest(tc.Name) {
+			continue
+		}
 		status := sippyprocessingv1.TestStatusFailure
 		var failureOutput *models.ProwJobRunTestOutput
 		if tc.SkipMessage != nil {


### PR DESCRIPTION
We check if they're ignored before creating test results, but not when
we check if the test record itself needs to be created, leading to many
thousands of tests in the db we do not want.
