### PR TITLE
Attempt a fix for postgres CPU

### DIFF
--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -345,7 +345,9 @@ func jobNamesTestResultFunc(dbc *db.DB) testResultsByJobNameFunc {
 			return nil, nil
 		}
 
-		q := dbc.DB.Raw(query.QueryTestAnalysis, testName, jobNames)
+		analyzeSince := time.Now().Add(-14 * 24 * time.Hour)
+
+		q := dbc.DB.Raw(query.QueryTestAnalysis, analyzeSince, testName, jobNames)
 		if q.Error != nil {
 			return nil, q.Error
 		}

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -64,7 +64,7 @@ const (
         from (
             select sum(runs) as current_runs, sum(passes) as current_successes
             from test_analysis_by_job_by_dates 
-            where test_name = ? AND job_name IN ?
+            where date >= ? AND test_name = ? AND job_name IN ?
         ) t`
 )
 


### PR DESCRIPTION
In working on reducing matview CPU, I recently moved us to a partitioned
table test_analysis_by_job_by_dates, updated once a day, and we do not
prune old dates as we intended to allow configurable ranges to generate
the test pass rate graphs.

I analyzed running queries on postgres and found many risk analysis
queries, tracing back to this use of the new table without a filter on
dates. This means jobs are constantly running and requesting risk
analysis, and scanning this table that's growing larger and larger
without a date filter. Fixing this may well fix our problem with the
matviews as this could be what's taking all the cpu.
