### PR TITLE
TRT-1993: Handle TestDetails No Regression / Missing Sample Stats

### DIFF
--- a/hack/gen-resolved-issue.py
+++ b/hack/gen-resolved-issue.py
@@ -874,6 +874,21 @@ def triage_regressions(regressed_tests, triaged_incidents, issue_url, currrent_c
 
                     # grab prowjob.json for the start time:
                     prow_job_json = fetch_json_data(artifacts_dir + 'prowjob.json')
+
+                    # sometimes we get 502 from prow
+                    # don't want to lose what we have in memory so continue on
+                    if prow_job_json is None:
+                        print("Error: no prowjob.json data returned from %s" % artifacts_dir)
+                        continue
+
+                    if prow_job_json["status"] is None:
+                        print("Error: no prowjob status returned for %s" % artifacts_dir)
+                        continue
+
+                    if prow_job_json["status"]["startTime"] is None:
+                        print("Error: no prowjob starttime returned for %s" % artifacts_dir)
+                        continue
+
                     start_time = prow_job_json["status"]["startTime"]
 
                     completion_time = None

--- a/sippy-ng/src/component_readiness/CompReadyTestPanel.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestPanel.js
@@ -182,16 +182,18 @@ export default function CompReadyTestPanel(props) {
             )}
           </Grid>
         )}
-        <Grid item xs={6}>
-          {printParamsAndStats(
-            'Sample (being evaluated)',
-            data.sample_stats,
-            data.sample_stats.Start.toString(),
-            data.sample_stats.End.toString(),
-            loadedParams.variantCrossCompare,
-            loadedParams.compareVariantsCheckedItems
-          )}
-        </Grid>
+        {data.sample_stats && data.sample_stats.Start && data.sample_stats.End && (
+          <Grid item xs={6}>
+            {printParamsAndStats(
+              'Sample (being evaluated)',
+              data.sample_stats,
+              data.sample_stats.Start.toString(),
+              data.sample_stats.End.toString(),
+              loadedParams.variantCrossCompare,
+              loadedParams.compareVariantsCheckedItems
+            )}
+          </Grid>
+        )}
       </Grid>
       <div style={{ marginTop: '10px', marginBottom: '10px' }}>
         <label>


### PR DESCRIPTION
TestDetails is usually accessed via a regression.  But when changing the dates it can come back as not regressed without sample stats.  Add protection for that.  Also add protection in triage script for prow 502 errors.