### PR TITLE
Revert "Temporarily disable job run risk analysis"

### DIFF
--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -954,11 +954,6 @@ func (s *Server) jsonJobRunsReportFromDB(w http.ResponseWriter, req *http.Reques
 	api.RespondWithJSON(http.StatusOK, w, result)
 }
 
-// jsonDisabledEndpoint is used to disable an API endpoint temporarily.
-func (s *Server) jsonDisabledEndpoint(w http.ResponseWriter, _ *http.Request) {
-	failureResponse(w, http.StatusTeapot, "This API is currently disabled.")
-}
-
 // jsonJobRunRiskAnalysis is an API to make a guess at the severity of failures in a prow job run, based on historical
 // pass rates for each failed test, on-going incidents, and other factors.
 //
@@ -970,6 +965,7 @@ func (s *Server) jsonDisabledEndpoint(w http.ResponseWriter, _ *http.Request) {
 // be stored in the job run artifacts, then imported with the job run, and will ultimately be the
 // data that is returned by the get by ID version.
 func (s *Server) jsonJobRunRiskAnalysis(w http.ResponseWriter, req *http.Request) {
+
 	logger := log.WithField("func", "jsonJobRunRiskAnalysis")
 
 	jobRun := &models.ProwJobRun{}
@@ -1260,7 +1256,7 @@ func (s *Server) Serve() {
 			EndpointPath: "/api/jobs/runs/risk_analysis",
 			Description:  "Analyzes risks of job runs",
 			Capabilities: []string{LocalDBCapability},
-			HandlerFunc:  s.jsonDisabledEndpoint, // disabled, was: s.jsonJobRunRiskAnalysis
+			HandlerFunc:  s.jsonJobRunRiskAnalysis,
 		},
 		{
 			EndpointPath: "/api/jobs/runs/intervals",


### PR DESCRIPTION
We've added an index targeting the problem query, and lightened the load in other ways; see what happens with RA back on now.