### PR TITLE
TRT-1825: pr commenting refactor, add new-test analysis

### DIFF
--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	apitype "github.com/openshift/sippy/pkg/apis/api"
+	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/query"
@@ -100,26 +101,35 @@ func JobsRunsReportFromDB(dbc *db.DB, filterOpts *filter.FilterOptions, release 
 	}, res.Error
 }
 
-func FetchJobRun(dbc *db.DB, jobRunID int64, logger *log.Entry) (*models.ProwJobRun, int, error) {
-
+// FetchJobRun returns a single job run loaded from postgres and populated with the ProwJob and test results.
+// If unknownTests is true, all tests not registered in test_ownerships are loaded; otherwise any failed tests are loaded.
+func FetchJobRun(dbc *db.DB, jobRunID int64, unknownTests bool, logger *log.Entry) (*models.ProwJobRun, error) {
 	jobRun := &models.ProwJobRun{}
-	// Load the ProwJobRun, ProwJob, and failed tests:
+
+	// Load the ProwJobRun, ProwJob, and (failed|unknown) tests:
 	// TODO: we may want to expand to analyzing flakes here in the future
-	res := dbc.DB.Joins("ProwJob").
-		Preload("Tests", "status = 12").
-		Preload("Tests.Test").
-		Preload("Tests.Suite").First(jobRun, jobRunID)
+	q := dbc.DB.Joins("ProwJob")
+	if unknownTests {
+		// this doesn't establish that the tests are new, but it does filter out any that sippy registers
+		q = q.Preload("Tests", "test_id not in (select test_id from test_ownerships)")
+	} else { // load only failures
+		q = q.Preload("Tests", "status = ?", sippyprocessingv1.TestStatusFailure)
+	}
+	res := q.Preload("Tests.Test").
+		Preload("Tests.Suite").
+		First(jobRun, jobRunID)
 	if res.Error != nil {
-		return nil, -1, res.Error
+		return nil, res.Error
 	}
 
 	jobRunTestCount, err := query.JobRunTestCount(dbc, jobRunID)
-	if err != nil {
-		logger.WithError(err).Error("Error getting job run test count")
+	if err != nil { // should be unusual
+		logger.WithError(err).Errorf("Error getting test count for job run %d", jobRunID)
 		jobRunTestCount = -1
 	}
+	jobRun.TestCount = jobRunTestCount
 
-	return jobRun, jobRunTestCount, nil
+	return jobRun, nil
 }
 
 // findReleaseMatchJobNames looks for the first matches with a common root job name specific to the
@@ -136,7 +146,7 @@ func FetchJobRun(dbc *db.DB, jobRunID int64, logger *log.Entry) (*models.ProwJob
 // if we don't have enough data from the current compareRelease we fall back to include the previous release as well
 func findReleaseMatchJobNames(dbc *db.DB, jobRun *models.ProwJobRun, compareRelease string, logger *log.Entry) ([]string, int, error) {
 	segments := strings.Split(jobRun.ProwJob.Name, "-")
-	logger = logger.WithField("func", "findReleaseMatchJobNames")
+	logger = logger.WithField("func", "findReleaseMatchJobNames").WithField("job", jobRun.ProwJob.Name)
 
 	// if we don't find enough jobs to match against we can try the prior release
 	// and see if it has enough, think about cutover to a new release, etc.
@@ -161,7 +171,7 @@ func findReleaseMatchJobNames(dbc *db.DB, jobRun *models.ProwJobRun, compareRele
 			}
 
 			if len(jobs) > 0 {
-				logger.Infof("Found %d matches with: %s", len(jobs), name)
+				logger.Debugf("Found %d potential name matches", len(jobs))
 
 				// the first hit we get
 				// compare the variants
@@ -224,7 +234,7 @@ func joinSegments(segments []string, start int, separator string) string {
 
 // JobRunRiskAnalysis checks the test failures and linked bugs for a job run, and reports back an estimated
 // risk level for each failed test, and the job run overall.
-func JobRunRiskAnalysis(dbc *db.DB, jobRun *models.ProwJobRun, jobRunTestCount int, logger *log.Entry) (apitype.ProwJobRunRiskAnalysis, error) {
+func JobRunRiskAnalysis(dbc *db.DB, jobRun *models.ProwJobRun, logger *log.Entry) (apitype.ProwJobRunRiskAnalysis, error) {
 	logger = logger.WithField("func", "JobRunRiskAnalysis")
 	// If this job is a Presubmit, compare to test results from master, not presubmits, which may perform
 	// worse due to dev code that hasn't merged. We do not presently track presubmits on branches other than
@@ -253,10 +263,10 @@ func JobRunRiskAnalysis(dbc *db.DB, jobRun *models.ProwJobRun, jobRunTestCount i
 	}
 
 	// -1 indicates an error getting the jobRunTest count we will log an error and skip this validation
-	if jobRunTestCount < 0 {
+	if jobRun.TestCount < 0 {
 		logger.Error("Unable to determine job run test count, initializing to historical count")
-		jobRunTestCount = historicalCount
-	} else if jobRunTestCount == 0 {
+		jobRun.TestCount = historicalCount
+	} else if jobRun.TestCount == 0 {
 		// hack since we don't currently get the jobRunTestCount for 4.12 jobs.
 		// If the jobRunTestCount is 0 and we are pre 4.13 set the jobRunTestCount to the historicalCount
 		preSupportVersion, _ := version.NewVersion("4.12")
@@ -264,7 +274,7 @@ func JobRunRiskAnalysis(dbc *db.DB, jobRun *models.ProwJobRun, jobRunTestCount i
 		if err != nil {
 			logger.WithError(err).Errorf("Failed to parse release '%s' for prow job %d", compareRelease, jobRun.ProwJob.ID)
 		} else if preSupportVersion.GreaterThanOrEqual(currentVersion) {
-			jobRunTestCount = historicalCount
+			jobRun.TestCount = historicalCount
 		}
 	}
 
@@ -305,7 +315,7 @@ func JobRunRiskAnalysis(dbc *db.DB, jobRun *models.ProwJobRun, jobRunTestCount i
 		}
 	}
 
-	logger.Infof("Found %d matching jobs for: %s", len(jobNames), jobRun.ProwJob.Name)
+	logger.Infof("Found %d matching job(s) for: %s", len(jobNames), jobRun.ProwJob.Name)
 
 	// NOTE: we are including bugs for all releases, may want to filter here in future to just those
 	// with an AffectsVersions that seems to match our compareRelease?
@@ -323,14 +333,14 @@ func JobRunRiskAnalysis(dbc *db.DB, jobRun *models.ProwJobRun, jobRunTestCount i
 			if err != nil {
 				logger.WithError(err).Errorf("Error evaluating bugs for prow job: %d, test name: %s", jobRun.ProwJob.ID, tr.Test.Name)
 			} else {
-				logger.Infof("Found %d bugs for test %s", len(bugs), tr.Test.Name)
+				logger.Debugf("Found %d bugs for test '%s'", len(bugs), tr.Test.Name)
 				tr.Test.Bugs = bugs
 				jobRun.Tests[i] = tr
 			}
 		}
 	}
 
-	return runJobRunAnalysis(jobRun, compareRelease, jobRunTestCount, historicalCount, neverStableJob, jobNames, logger, jobNamesTestResultFunc(dbc), variantsTestResultFunc(dbc))
+	return runJobRunAnalysis(jobRun, compareRelease, historicalCount, neverStableJob, jobNames, logger, jobNamesTestResultFunc(dbc), variantsTestResultFunc(dbc))
 }
 
 // testResultsByJobNameFunc is used for injecting db responses in unit tests.
@@ -413,23 +423,22 @@ func variantsTestResultFunc(dbc *db.DB) testResultsByVariantsFunc {
 	}
 }
 
-func runJobRunAnalysis(jobRun *models.ProwJobRun, compareRelease string, jobRunTestCount int, historicalRunTestCount int, neverStableJob bool, jobNames []string, logger *log.Entry,
+func runJobRunAnalysis(jobRun *models.ProwJobRun, compareRelease string, historicalRunTestCount int, neverStableJob bool, jobNames []string, logger *log.Entry,
 	testResultsJobNameFunc testResultsByJobNameFunc, testResultsVariantsFunc testResultsByVariantsFunc) (apitype.ProwJobRunRiskAnalysis, error) {
 
-	logger = logger.WithField("func", "runJobRunAnalysis")
-	logger.Info("loaded prow job run for analysis")
-	logger.Infof("this job run has %d failed tests", len(jobRun.Tests))
+	logger = logger.WithField("func", "runJobRunAnalysis").WithField("job", jobRun.ProwJob.Name)
+	logger.Infof("analyzing prow job run with %d failed test(s)", len(jobRun.Tests))
 
 	response := apitype.ProwJobRunRiskAnalysis{
 		ProwJobRunID:   jobRun.ID,
 		ProwJobName:    jobRun.ProwJob.Name,
 		Release:        jobRun.ProwJob.Release,
 		CompareRelease: compareRelease,
-		Tests:          []apitype.ProwJobRunTestRiskAnalysis{},
+		Tests:          []apitype.TestRiskAnalysis{},
 		OverallRisk: apitype.JobFailureRisk{
 			Level:                  apitype.FailureRiskLevelNone,
 			Reasons:                []string{},
-			JobRunTestCount:        jobRunTestCount,
+			JobRunTestCount:        jobRun.TestCount,
 			JobRunTestFailures:     len(jobRun.Tests),
 			NeverStableJob:         neverStableJob,
 			HistoricalRunTestCount: historicalRunTestCount,
@@ -442,10 +451,10 @@ func runJobRunAnalysis(jobRun *models.ProwJobRun, compareRelease string, jobRunT
 	// Return early if we see a large gap in the number of tests:
 	// order matters, if we have 0 tests that ran && 0 tests that failed we
 	// want to compare that here before the 'no test failures' case
-	case jobRunTestCount < (int(float64(historicalRunTestCount) * .75)):
+	case jobRun.TestCount < (int(float64(historicalRunTestCount) * .75)):
 		response.OverallRisk.Level = apitype.FailureRiskLevelIncompleteTests
 		response.OverallRisk.Reasons = append(response.OverallRisk.Reasons,
-			fmt.Sprintf("Tests for this run (%d) are below the historical average (%d): IncompleteTests (not enough tests ran to make a reasonable risk analysis; this could be due to infra, installation, or upgrade problems)", jobRunTestCount, historicalRunTestCount))
+			fmt.Sprintf("Tests for this run (%d) are below the historical average (%d): IncompleteTests (not enough tests ran to make a reasonable risk analysis; this could be due to infra, installation, or upgrade problems)", jobRun.TestCount, historicalRunTestCount))
 		return response, nil
 
 	// Return early if no tests failed in this run:
@@ -471,7 +480,7 @@ func runJobRunAnalysis(jobRun *models.ProwJobRun, compareRelease string, jobRunT
 			continue
 		}
 
-		loggerFields := logger.WithFields(log.Fields{"name": ft.Test.Name})
+		loggerFields := logger.WithField("test", ft.Test.Name)
 		analysis, err := runTestRunAnalysis(ft, jobRun, compareRelease, loggerFields, testResultsJobNameFunc, jobNames, testResultsVariantsFunc, neverStableJob)
 		if err != nil {
 			continue // ignore runs where analysis failed
@@ -491,7 +500,7 @@ func runJobRunAnalysis(jobRun *models.ProwJobRun, compareRelease string, jobRunT
 
 // For a failed test, query its pass rates by NURPs, find a matching variant combo, and
 // see how often we've passed in the last week.
-func runTestRunAnalysis(failedTest models.ProwJobRunTest, jobRun *models.ProwJobRun, compareRelease string, logger *log.Entry, testResultsJobNameFunc testResultsByJobNameFunc, jobNames []string, testResultsVariantsFunc testResultsByVariantsFunc, neverStableJob bool) (apitype.ProwJobRunTestRiskAnalysis, error) {
+func runTestRunAnalysis(failedTest models.ProwJobRunTest, jobRun *models.ProwJobRun, compareRelease string, logger *log.Entry, testResultsJobNameFunc testResultsByJobNameFunc, jobNames []string, testResultsVariantsFunc testResultsByVariantsFunc, neverStableJob bool) (apitype.TestRiskAnalysis, error) {
 
 	logger.Debug("failed test")
 
@@ -531,10 +540,10 @@ func runTestRunAnalysis(failedTest models.ProwJobRunTest, jobRun *models.ProwJob
 	if errJobNames != nil && errVariants != nil {
 		logger.WithError(errVariants).Error("Failed test results by variants")
 		logger.WithError(errJobNames).Error("Failed test results job names")
-		return apitype.ProwJobRunTestRiskAnalysis{}, errJobNames
+		return apitype.TestRiskAnalysis{}, errJobNames
 	}
 
-	analysis := apitype.ProwJobRunTestRiskAnalysis{
+	analysis := apitype.TestRiskAnalysis{
 		Name:     failedTest.Test.Name,
 		TestID:   failedTest.Test.ID,
 		OpenBugs: failedTest.Test.Bugs,

--- a/pkg/api/job_runs_test.go
+++ b/pkg/api/job_runs_test.go
@@ -252,7 +252,7 @@ func TestRunJobAnalysis(t *testing.T) {
 				}
 			}
 
-			result, err := runJobRunAnalysis(fakeProwJobRun, "4.12", 5, 5, false, tc.jobNames, log.WithField("jobRunID", "test"), testResultsJobNamesLookupFunc, testResultsVariantsLookupFunc)
+			result, err := runJobRunAnalysis(fakeProwJobRun, "4.12", 5, false, tc.jobNames, log.WithField("jobRunID", "test"), testResultsJobNamesLookupFunc, testResultsVariantsLookupFunc)
 
 			require.NoError(t, err)
 			assert.Equal(t, len(tc.expectedTestRisks), len(result.Tests))
@@ -291,6 +291,7 @@ func buildFakeProwJobRun() *models.ProwJobRun {
 		ProwJobID:             1000000000,
 		URL:                   "https://example.com/run/1000000000",
 		Tests:                 []models.ProwJobRunTest{}, // will be populated in the test cases
+		TestCount:             5,
 		Failed:                true,
 		InfrastructureFailure: false,
 		Succeeded:             false,
@@ -299,7 +300,7 @@ func buildFakeProwJobRun() *models.ProwJobRun {
 	return fakeProwJobRun
 }
 
-func getTestRisk(result apitype.ProwJobRunRiskAnalysis, testName string) *apitype.ProwJobRunTestRiskAnalysis {
+func getTestRisk(result apitype.ProwJobRunRiskAnalysis, testName string) *apitype.TestRiskAnalysis {
 	for _, ta := range result.Tests {
 		if ta.Name == testName {
 			return &ta

--- a/pkg/api/jobrunintervals/job_run_intervals.go
+++ b/pkg/api/jobrunintervals/job_run_intervals.go
@@ -35,7 +35,7 @@ func JobRunIntervals(gcsClient *storage.Client, dbc *db.DB, jobRunID int64, gcsB
 		// This is here to support older prow jobs where only the jobID was passed.  Eventually,
 		// we will not have to fallback because we will expect all jobs to pass in enough
 		// information to construct a full GCS bucket path.
-		jobRun, _, err := api.FetchJobRun(dbc, jobRunID, logger)
+		jobRun, err := api.FetchJobRun(dbc, jobRunID, false, logger)
 		if err != nil {
 			logger.WithError(err).Error("error querying job run")
 			return nil, err

--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -245,7 +245,7 @@ func BuildTestsResults(dbc *db.DB, release, period string, collapse, includeOver
 	log.WithFields(log.Fields{
 		"elapsed": elapsed,
 		"reports": len(testReports),
-	}).Info("BuildTestsResults completed")
+	}).Debug("BuildTestsResults completed")
 
 	return testReports, overallTest, nil
 }

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -744,12 +744,12 @@ type ProwJobRunRiskAnalysis struct {
 	ProwJobRunID   uint
 	Release        string
 	CompareRelease string
-	Tests          []ProwJobRunTestRiskAnalysis
+	Tests          []TestRiskAnalysis
 	OverallRisk    JobFailureRisk
 	OpenBugs       []models.Bug
 }
 
-type ProwJobRunTestRiskAnalysis struct {
+type TestRiskAnalysis struct {
 	Name     string
 	TestID   uint
 	Risk     TestFailureRisk
@@ -775,7 +775,8 @@ type TestFailureRisk struct {
 
 type RiskSummary struct {
 	OverallRisk JobFailureRisk
-	Tests       []ProwJobRunTestRiskAnalysis
+	Tests       []TestRiskAnalysis
+	// NewTests    []JobNewTestRisks
 }
 
 type RiskLevel struct {

--- a/pkg/apis/sippyprocessing/v1/types.go
+++ b/pkg/apis/sippyprocessing/v1/types.go
@@ -1,4 +1,4 @@
-// this package is used to produce a reporting structure for rendering html pages.
+// Package v1 is used to produce a reporting structure for rendering html pages.
 // it also contains intermediate types used in the processing pipeline.
 package v1
 

--- a/pkg/db/models/pr_commenting.go
+++ b/pkg/db/models/pr_commenting.go
@@ -10,6 +10,7 @@ const (
 	CommentTypeRiskAnalysis CommentType = 0
 )
 
+// PullRequestComment tracks the risk analysis comment lifecycle for a single PR
 type PullRequestComment struct {
 	CreatedAt             time.Time
 	UpdatedAt             time.Time

--- a/pkg/db/query/job_queries.go
+++ b/pkg/db/query/job_queries.go
@@ -29,18 +29,14 @@ func LoadProwJobCache(dbc *db.DB) (map[string]*models.ProwJob, error) {
 }
 
 func JobRunTestCount(dbc *db.DB, jobRunID int64) (int, error) {
-	var prowJobRunTestCount int
-	var tests []models.ProwJobRunTest
+	var prowJobRunTestCount int64
 
-	res := dbc.DB.Find(&tests, "prow_job_run_id = ?", jobRunID)
-
+	res := dbc.DB.Model(&models.ProwJobRunTest{}).Where("prow_job_run_id = ?", jobRunID).Count(&prowJobRunTestCount)
 	if res.Error != nil {
 		return -1, res.Error
 	}
 
-	prowJobRunTestCount = len(tests)
-
-	return prowJobRunTestCount, nil
+	return int(prowJobRunTestCount), nil
 }
 
 func ProwJobSimilarName(dbc *db.DB, rootName, release string) ([]models.ProwJob, error) {
@@ -183,6 +179,6 @@ func LoadBugsForJobs(dbc *db.DB,
 	if res.Error != nil {
 		return results, res.Error
 	}
-	log.Infof("found %d bugs for job", len(job.Bugs))
+	log.Debugf("LoadBugsForJobs found %d bugs for job", len(job.Bugs))
 	return job.Bugs, nil
 }

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -224,7 +224,7 @@ func LoadBugsForTest(dbc *db.DB, testName string, filterClosed bool) ([]models.B
 			results = append(results, b)
 		}
 	}
-	log.Infof("found %d bugs for test %s", len(results), testName)
+	log.Debugf("LoadBugsForTest found %d bugs for test '%s'", len(results), testName)
 
 	return results, nil
 }

--- a/pkg/github/commenter/ghcommenter.go
+++ b/pkg/github/commenter/ghcommenter.go
@@ -320,7 +320,7 @@ func (ghc *GitHubCommenter) QueryPRPendingComments(org, repo string, number int,
 	return pullRequestComments, nil
 }
 
-func (ghc *GitHubCommenter) QueryPendingComments(commentType models.CommentType) ([]models.PullRequestComment, error) {
+func (ghc *GitHubCommenter) QueryForPotentialComments(commentType models.CommentType) ([]models.PullRequestComment, error) {
 	pullRequestComments := make([]models.PullRequestComment, 0)
 
 	res := ghc.dbc.DB.Table("pull_request_comments").

--- a/pkg/sippyserver/pr_commenting_processor.go
+++ b/pkg/sippyserver/pr_commenting_processor.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"html"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -27,7 +27,6 @@ import (
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/github/commenter"
 	"github.com/openshift/sippy/pkg/util"
-	"github.com/openshift/sippy/pkg/util/sets"
 )
 
 var (
@@ -60,11 +59,6 @@ var (
 	}, []string{"type"})
 )
 
-type RiskAnalysisEntry struct {
-	Key   string
-	Value RiskAnalysisSummary
-}
-
 // dbc: our database
 // gcsBucket: handle to our root gcs bucket
 // commentAnalysisWorkers: the number of threads active to process pending comment jobs
@@ -78,6 +72,7 @@ func NewWorkProcessor(dbc *db.DB, gcsBucket *storage.BucketHandle, commentAnalys
 		commentUpdaterRate:     commentUpdaterRate,
 		commentAnalysisWorkers: commentAnalysisWorkers,
 		dryRunOnly:             dryRunOnly,
+		newTestsWorker:         StandardNewTestsWorker(dbc),
 	}
 	return wp
 }
@@ -90,6 +85,7 @@ type WorkProcessor struct {
 	gcsBucket              *storage.BucketHandle
 	ghCommenter            *commenter.GitHubCommenter
 	dryRunOnly             bool
+	newTestsWorker         *NewTestsWorker
 }
 
 type PendingComment struct {
@@ -114,6 +110,7 @@ type AnalysisWorker struct {
 	riskAnalysisLocator *regexp.Regexp
 	pendingAnalysis     chan models.PullRequestComment
 	pendingComments     chan PendingComment
+	newTestsWorker      *NewTestsWorker
 }
 
 type RiskAnalysisSummary struct {
@@ -121,18 +118,13 @@ type RiskAnalysisSummary struct {
 	URL              string
 	RiskLevel        api.RiskLevel
 	OverallReasons   []string
-	TestRiskAnalysis []api.ProwJobRunTestRiskAnalysis
+	TestRiskAnalysis []api.TestRiskAnalysis
 }
 
-type RiskAnalysisEntryList []RiskAnalysisEntry
-
-func (r RiskAnalysisEntryList) Len() int      { return len(r) }
-func (r RiskAnalysisEntryList) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
-func (r RiskAnalysisEntryList) Less(i, j int) bool {
-	if r[i].Value.RiskLevel.Level == r[j].Value.RiskLevel.Level {
-		return r[i].Value.Name > r[j].Value.Name
-	}
-	return r[i].Value.RiskLevel.Level > r[j].Value.RiskLevel.Level
+func SortByJobNameRA(ras []RiskAnalysisSummary) {
+	slices.SortFunc(ras, func(a, b RiskAnalysisSummary) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 }
 
 func (wp *WorkProcessor) Run(ctx context.Context) {
@@ -168,7 +160,14 @@ func (wp *WorkProcessor) Run(ctx context.Context) {
 	defer close(pendingWork)
 
 	for i := 0; i < wp.commentAnalysisWorkers; i++ {
-		analysisWorker := AnalysisWorker{riskAnalysisLocator: gcs.GetDefaultRiskAnalysisSummaryFile(), dbc: wp.dbc, gcsBucket: wp.gcsBucket, pendingAnalysis: pendingWork, pendingComments: pendingComments}
+		analysisWorker := AnalysisWorker{
+			riskAnalysisLocator: gcs.GetDefaultRiskAnalysisSummaryFile(),
+			dbc:                 wp.dbc,
+			gcsBucket:           wp.gcsBucket,
+			pendingAnalysis:     pendingWork,
+			pendingComments:     pendingComments,
+			newTestsWorker:      wp.newTestsWorker,
+		}
 		go analysisWorker.Run()
 	}
 
@@ -420,7 +419,7 @@ func (aw *AnalysisWorker) Run() {
 	for i := range aw.pendingAnalysis {
 
 		if i.CommentType == int(models.CommentTypeRiskAnalysis) {
-			aw.processRiskAnalysisComment(i)
+			aw.processPendingPrComment(i)
 		} else {
 			log.Warningf("Unsupported comment type: %d for %s/%s/%d/%s", i.CommentType, i.Org, i.Repo, i.PullNumber, i.SHA)
 		}
@@ -428,12 +427,13 @@ func (aw *AnalysisWorker) Run() {
 	}
 }
 
-func (aw *AnalysisWorker) processRiskAnalysisComment(prPendingComment models.PullRequestComment) {
+func (aw *AnalysisWorker) processPendingPrComment(pendingPrComment models.PullRequestComment) {
 
-	logger := log.WithField("org", prPendingComment.Org).
-		WithField("repo", prPendingComment.Repo).
-		WithField("Number", prPendingComment.PullNumber).
-		WithField("sha", prPendingComment.SHA)
+	logger := log.WithField("func", "processPendingPrComment").
+		WithField("org", pendingPrComment.Org).
+		WithField("repo", pendingPrComment.Repo).
+		WithField("pull", pendingPrComment.PullNumber).
+		WithField("sha", pendingPrComment.SHA)
 
 	start := time.Now()
 	logger.Debug("Processing item")
@@ -441,101 +441,133 @@ func (aw *AnalysisWorker) processRiskAnalysisComment(prPendingComment models.Pul
 	// we will likely pull in PRs hours before the jobs finish,
 	// so there may be many cycles before a PR is ready for commenting.
 	// check to see if all jobs have completed before doing the more intensive query / gcs locate for analysis.
-	allCompleted, _ := aw.buildPRJobRiskAnalysis(logger, prPendingComment.ProwJobRoot, true)
-	if !allCompleted {
+	completedJobs := aw.getPrJobsIfFinished(logger, pendingPrComment.ProwJobRoot)
+	if completedJobs == nil {
 		logger.Debug("Jobs are still active")
 
+		// record how long it took to decide the jobs are still active
 		t := float64(time.Now().UnixMilli() - start.UnixMilli())
-		checkCommentReady.WithLabelValues(prPendingComment.Org, prPendingComment.Repo).Observe(t)
+		checkCommentReady.WithLabelValues(pendingPrComment.Org, pendingPrComment.Repo).Observe(t)
 		return
 	}
 
 	defer func() {
+		// record how long it took to determine what the comment should be
 		t := float64(time.Now().UnixMilli() - start.UnixMilli())
-		buildCommentMetric.WithLabelValues(prPendingComment.Org, prPendingComment.Repo).Observe(t)
+		buildCommentMetric.WithLabelValues(pendingPrComment.Org, pendingPrComment.Repo).Observe(t)
 	}()
 
-	// do the full pass if all are finished (will still re-validate that all are completed - could have retries)
-	allCompleted, analysis := aw.buildPRJobRiskAnalysis(logger, prPendingComment.ProwJobRoot, false)
-	if !allCompleted {
-		logger.Debug("Jobs are still active")
-		return
-	}
-	if analysis == nil {
-		logger.Errorf("Invalid Risk Analysis result")
-		return
+	// having determined the PR is ready, scan all the runs for each job so we can find the latest
+	for idx, jobInfo := range completedJobs {
+		completedJobs[idx].prowJobRuns = aw.buildProwJobRuns(logger, jobInfo.bucketPrefix)
+		completedJobs[idx].prShaSum = pendingPrComment.SHA // so we can check whether runs are against the expected PR commit
 	}
 
-	// when the comment processor sees an empty comment it will
-	// not create a comment but will delete the comment record
-	comment := ""
-	if len(analysis) > 0 {
-
-		sortedAnalysis := make(RiskAnalysisEntryList, 0)
-		for k, v := range analysis {
-			sortedAnalysis = append(sortedAnalysis, RiskAnalysisEntry{k, v})
-		}
-		sort.Sort(sortedAnalysis)
-
-		comment = buildComment(sortedAnalysis, prPendingComment.SHA)
-	}
-
+	riskAnalyses := aw.buildPRJobRiskAnalysis(logger, completedJobs)
+	newTestRisks := aw.newTestsWorker.analyzeRisks(logger, completedJobs)
 	pendingComment := PendingComment{
-		comment:     comment,
-		sha:         prPendingComment.SHA,
-		org:         prPendingComment.Org,
-		repo:        prPendingComment.Repo,
-		number:      prPendingComment.PullNumber,
-		commentType: prPendingComment.CommentType,
+		comment:     buildComment(riskAnalyses, newTestRisks, pendingPrComment.SHA),
+		sha:         pendingPrComment.SHA,
+		org:         pendingPrComment.Org,
+		repo:        pendingPrComment.Repo,
+		number:      pendingPrComment.PullNumber,
+		commentType: pendingPrComment.CommentType,
 	}
 
-	// will block if the buffer is full
+	// will block if the buffer is full.
+	// also if the comment processor sees an empty comment,
+	// it will not create a comment but will delete the pending comment record in the db
 	log.Debugf("Adding comment to pendingComments: %s/%s/%s", pendingComment.org, pendingComment.repo, pendingComment.sha)
 	aw.pendingComments <- pendingComment
 	log.Debugf("Comment added to pendingComments: %s/%s/%s", pendingComment.org, pendingComment.repo, pendingComment.sha)
 }
 
-func buildComment(sortedAnalysis RiskAnalysisEntryList, sha string) string {
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("Job Failure Risk Analysis for sha: %s\n\n| Job Name | Failure Risk |\n|:---|:---|\n", sha))
+func buildComment(riskAnalyses []RiskAnalysisSummary, newTestRisks []*JobNewTestRisks, sha string) string {
+	sb := &strings.Builder{}
+	if len(riskAnalyses) == 0 && len(newTestRisks) == 0 {
+		return ""
+	}
+	if len(riskAnalyses) > 0 {
+		buildRiskAnalysisComment(sb, riskAnalyses, sha)
+		sb.WriteString("\n\n")
+	}
+	if len(newTestRisks) > 0 {
+		buildNewTestRisksComment(sb, newTestRisks, sha)
+	}
+
+	return sb.String()
+}
+
+func buildNewTestRisksComment(sb *strings.Builder, jobRisks []*JobNewTestRisks, sha string) {
+	notableJobRisks, testSummaries := summarizeNewTestRisks(jobRisks)
+	if len(notableJobRisks) > 0 || len(testSummaries) > 0 {
+		sb.WriteString("Risk analysis has seen new tests most likely introduced by this PR.\n")
+		sb.WriteString("Please ensure that new tests meet [guidelines for naming and stability](https://github.com/openshift-eng/ci-test-mapping/?tab=readme-ov-file#test-sources).\n\n")
+	}
+
+	if len(notableJobRisks) > 0 {
+		SortByJobNameNT(notableJobRisks)
+		sb.WriteString(fmt.Sprintf("New Test Risks for sha: %s\n\n", sha))
+		sb.WriteString("| Job Name | New Test Risk |\n|:---|:---|\n")
+		for _, jr := range notableJobRisks {
+			for _, risk := range sortedTestRisks(jr.NewTestRisks) {
+				sb.WriteString(fmt.Sprintf("|%s|**%s** - *%q* **%s**|\n",
+					jr.JobName, risk.Level.Name, risk.TestName, risk.Reason))
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(testSummaries) > 0 {
+		sb.WriteString(fmt.Sprintf("New tests seen in this PR at sha: %s\n\n", sha))
+		for _, test := range testSummaries {
+			sb.WriteString(fmt.Sprintf("- *%q* [Total: %d, Pass: %d, Fail: %d, Flake: %d]\n",
+				test.TestName, test.Runs, test.Runs-test.Failures, test.Failures, test.Flakes))
+		}
+		sb.WriteString("\n")
+	}
+}
+
+func buildRiskAnalysisComment(sb *strings.Builder, riskAnalyses []RiskAnalysisSummary, sha string) {
+	SortByJobNameRA(riskAnalyses)
+	sb.WriteString(fmt.Sprintf("Job Failure Risk Analysis for sha: %s\n\n", sha))
+	sb.WriteString("| Job Name | Failure Risk |\n|:---|:---|\n")
 
 	// don't want the comment to be too large so if we have a high number of jobs to analyze
 	// reduce the max tests / reasons we show
 	maxSubRows := 3
-	if len(sortedAnalysis) > 10 {
+	if len(riskAnalyses) > 10 {
 		maxSubRows = 1
 	}
 
-	for a, value := range sortedAnalysis {
-		tableKey := value.Key
-
-		// top 20 should be more than enough
-		if a > 19 {
-			sb.WriteString(fmt.Sprintf("\nShowing %d of %d jobs analysis", a, len(sortedAnalysis)))
-			break
+	for idx, analysis := range riskAnalyses {
+		if idx > 19 {
+			sb.WriteString(fmt.Sprintf("\nShowing %d of %d jobs analysis", idx, len(riskAnalyses)))
+			break // top 20 should be more than enough
 		}
 
-		if value.Value.URL != "" {
-			tableKey = fmt.Sprintf("[%s](%s)", value.Key, value.Value.URL)
+		tableKey := analysis.Name
+		if analysis.URL != "" {
+			tableKey = fmt.Sprintf("[%s](%s)", analysis.Name, analysis.URL)
 		}
 
 		var riskSb strings.Builder
-		riskSb.WriteString(fmt.Sprintf("**%s**", value.Value.RiskLevel.Name))
+		riskSb.WriteString(fmt.Sprintf("**%s**", analysis.RiskLevel.Name))
 
 		// if we don't have any TestRiskAnalysis use the OverallReasons
-		if len(value.Value.TestRiskAnalysis) == 0 {
-			for j, r := range value.Value.OverallReasons {
+		if len(analysis.TestRiskAnalysis) == 0 {
+			for j, r := range analysis.OverallReasons {
 				if j > maxSubRows {
-					riskSb.WriteString(fmt.Sprintf("<br>Showing %d of %d test risk reasons", j, len(value.Value.OverallReasons)))
+					riskSb.WriteString(fmt.Sprintf("<br>Showing %d of %d test risk reasons", j, len(analysis.OverallReasons)))
 					break
 				}
 				riskSb.WriteString(fmt.Sprintf("<br>%s", r))
 			}
 		} else {
 
-			for i, t := range value.Value.TestRiskAnalysis {
+			for i, t := range analysis.TestRiskAnalysis {
 				if i > maxSubRows {
-					riskSb.WriteString(fmt.Sprintf("<br>---<br>Showing %d of %d test results", i, len(value.Value.TestRiskAnalysis)))
+					riskSb.WriteString(fmt.Sprintf("<br>---<br>Showing %d of %d test results", i, len(analysis.TestRiskAnalysis)))
 					break
 				}
 				if i > 0 {
@@ -567,17 +599,24 @@ func buildComment(sortedAnalysis RiskAnalysisEntryList, sha string) string {
 			}
 		}
 		sb.WriteString(fmt.Sprintf("|%s|%s|\n", tableKey, riskSb.String()))
-
 	}
-
-	return sb.String()
 }
 
-// buildPRJobRiskAnalysis walks the GCS path for this PR to find the most recent job runs;
-// returns false if any have not finished.
-// otherwise, returns a map of test names to each test's overall RiskAnalysis.
+type prJobInfo struct {
+	name          string
+	jobID         string          // sippy ID of the job itself
+	prShaSum      string          // sha of the PR at the time it was loaded
+	bucketPrefix  string          // where the job is found in the GCS bucket
+	latestRunID   string          // sippy ID of the latest run
+	latestRunPath string          // path to the latest run in the GCS bucket
+	prowJobRuns   []*prow.ProwJob // sorted list of ProwJobs (runs for this job)
+}
+
+// getPrJobsIfFinished walks the GCS path for this PR to find the most recent run of each PR job;
+// returns nil if any have not finished. otherwise, returns a list of jobs found.
 // if the map is empty, it indicates that either all tests passed or any analysis for failures was unknown.
-func (aw *AnalysisWorker) buildPRJobRiskAnalysis(logger *log.Entry, prRoot string, dryrun bool) (bool, map[string]RiskAnalysisSummary) {
+func (aw *AnalysisWorker) getPrJobsIfFinished(logger *log.Entry, prRoot string) (jobs []prJobInfo) {
+	logger = logger.WithField("prRoot", prRoot).WithField("func", "getPrJobsIfFinished")
 
 	// get the list of objects one level down from our root. the hierarchy looks like pr-logs/pull/org_repo/number/
 	it := aw.gcsBucket.Objects(context.Background(), &storage.Query{
@@ -585,16 +624,15 @@ func (aw *AnalysisWorker) buildPRJobRiskAnalysis(logger *log.Entry, prRoot strin
 		Delimiter: "/",
 	})
 
-	analysisByJobs := make(map[string]RiskAnalysisSummary)
-	jobRun := gcs.NewGCSJobRun(aw.gcsBucket, "")
+	gcsJobRun := gcs.NewGCSJobRun(aw.gcsBucket, "") // dummy instance for looking up bucket content
 
 	for {
 		attrs, err := it.Next()
-		if err == iterator.Done {
+		if errors.Is(err, iterator.Done) {
 			break
 		}
 		if err != nil {
-			logger.WithError(err).Warningf("gcs bucket iterator returned error")
+			logger.WithError(err).Warningf("gcs bucket iterator failed looking for PR jobs")
 			continue
 		}
 		if attrs == nil || len(attrs.Name) > 0 {
@@ -608,15 +646,17 @@ func (aw *AnalysisWorker) buildPRJobRiskAnalysis(logger *log.Entry, prRoot strin
 							    .  finished.json
 							    .  build-log.txt
 		*/
-		// record last segment as name; final split is "" so get penultimate
 		jobPath := strings.Split(attrs.Prefix, "/")
-		jobName := jobPath[len(jobPath)-2]
+		job := prJobInfo{
+			bucketPrefix: attrs.Prefix,
+			name:         jobPath[len(jobPath)-2], // record last segment as name; final split is "" so get penultimate
+		}
 
 		// we have to get the job run id from latest-build.txt and then check for finished.json in that path
-		bytes, err := jobRun.GetContent(context.TODO(), fmt.Sprintf("%s%s", attrs.Prefix, "latest-build.txt"))
+		bytes, err := gcsJobRun.GetContent(context.TODO(), fmt.Sprintf("%s%s", job.bucketPrefix, "latest-build.txt"))
 		if err != nil {
-			logger.WithError(err).Errorf("Failed to get latest build info for: %s", attrs.Prefix)
-			return false, nil // latest job result not recorded, consider testing incomplete for the PR
+			logger.WithError(err).Errorf("Failed to get latest build info for: %s", job.bucketPrefix)
+			return nil // latest job result not recorded, so consider testing incomplete for the PR
 		}
 
 		latest := string(bytes)
@@ -624,175 +664,139 @@ func (aw *AnalysisWorker) buildPRJobRiskAnalysis(logger *log.Entry, prRoot strin
 		finishedJSON := fmt.Sprintf("%sfinished.json", latestPath)
 
 		// currently we only validate that the file exists, we aren't pulling anything out of it
-		if !jobRun.ContentExists(context.TODO(), finishedJSON) {
-			return false, nil // testing not yet complete for the PR
+		if !gcsJobRun.ContentExists(context.TODO(), finishedJSON) {
+			return nil // testing not yet complete for the PR
 		}
 
-		if dryrun {
-			// we only want to evaluate if job run finished or not
-			continue
-		}
+		jobs = append(jobs, job) // officially a finished job if the latest run has finished
+	}
+	return
+}
 
-		// we don't only want the latest run, we want to scan all the runs
-		// so we can find the most recent run prior to latest.
-		// we build the risk analysis for latest but only include failed tests that
-		// also occurred in latest-1.
-		prowJobMap, mostRecentStartTime := aw.buildProwJobMap(logger.WithField("job", jobName), attrs.Prefix)
-
+// buildPRJobRiskAnalysis walks the runs for a PR job to sort out which to analyze;
+// if the map is empty, it indicates that either all tests passed or any analysis for failures was unknown.
+func (aw *AnalysisWorker) buildPRJobRiskAnalysis(logger *log.Entry, jobs []prJobInfo) []RiskAnalysisSummary {
+	logger = logger.WithField("func", "buildPRJobRiskAnalysis")
+	riskAnalysisSummaries := make([]RiskAnalysisSummary, 0)
+	for _, jobInfo := range jobs {
 		// we don't report risk on jobs without 2 or more runs.
 		// this is so we can compare failed tests against latest and latest-1,
-		// only returning analysis on tests that have failed in both
-		if len(prowJobMap) < 2 {
+		// only returning analysis on tests that have failed in both.
+		if len(jobInfo.prowJobRuns) < 2 {
 			continue
 		}
 
-		var latestProwJob, priorProwJob *prow.ProwJob
-		var priorTime time.Time
-		var prowLink string
+		latest := jobInfo.prowJobRuns[0]
+		previous := jobInfo.prowJobRuns[1]
 
-		for timestamp, job := range prowJobMap {
-			pjCopy := job // don't reference a changing loop var, reference an ephemeral copy
-
-			// if we have the latestProwJob mark it
-			if job.Status.BuildID == latest {
-				latestProwJob = &pjCopy
-				prowLink = latestProwJob.Status.URL
-			} else {
-				if latestProwJob != nil {
-					if latestProwJob.Status.CompletionTime.Before(timestamp) {
-						// shouldn't be the case
-						continue
-					}
-				}
-				if priorTime.Before(timestamp) {
-					priorTime = timestamp
-					priorProwJob = &pjCopy
-				}
-			}
-		}
-
-		// we didn't find the latest so log a warning and continue on
-		if latestProwJob == nil {
-			logger.Warnf("Failed to find latest prowjob for: %s", latestPath)
+		if latest.Spec.Refs.Pulls[0].SHA != jobInfo.prShaSum {
+			logger.Infof(
+				"Skipping risk analysis for job %s as latest completed run %s is not against the PR's shasum %s",
+				jobInfo.name, latest.Status.BuildID, jobInfo.prShaSum)
 			continue
 		}
 
-		// at times it appears that we add a comment that reflects the prior job
-		// and then update again shortly after
-		if latestProwJob.Status.StartTime.Before(mostRecentStartTime) {
-			logger.Warnf("Latest prowjob start time: %s is before mostRecentStartTime: %s", latestProwJob.Status.StartTime.Format(time.RFC3339), mostRecentStartTime.Format(time.RFC3339))
-			continue
-		}
+		_, priorRiskAnalysis := aw.getRiskSummary(
+			previous.Status.BuildID,
+			fmt.Sprintf("%s%s/", jobInfo.bucketPrefix, previous.Status.BuildID),
+			nil,
+		)
 
-		// job count is > 1, but we didn't find a valid prior job
-		// Completion time is validated in buildProwJobMap
-		if priorProwJob == nil || latestProwJob.Status.CompletionTime.Before(*priorProwJob.Status.CompletionTime) {
-			logger.Warnf("Invalid prior prowjob for: %s", latestPath)
-			continue
-		}
-
-		priorRunID := priorProwJob.Status.BuildID
-		// lastly sanity check that our priorRun && latest are not the same
-		if latest == priorRunID {
-			logger.Warnf("Prior prowjob: %s and latest: %s are the same", priorRunID, latest)
-			continue
-		}
-
-		_, priorRiskAnalysis := aw.getRiskSummary(priorRunID, fmt.Sprintf("%s%s/", attrs.Prefix, priorRunID), nil)
-
-		// if the priorRiskAnalysis is nil then skip since we require consecutive test failures
-		// this can happen if the job hasn't been imported yet
-		// and the prior risk analysis artifact failed to be created in gcs
+		// if the priorRiskAnalysis is nil then skip since we require consecutive test failures;
+		// this can happen if the job hasn't been imported yet and its risk analysis artifact failed to be created in gcs.
 		if priorRiskAnalysis == nil {
-			logger.Warnf("Failed to determine prior risk analysis for prowjob: %s", priorRunID)
+			logger.Warnf("Failed to determine prior risk analysis for prowjob: %s", previous.Status.BuildID)
 			continue
 		}
 
-		riskSummary, _ := aw.getRiskSummary(latest, latestPath, priorRiskAnalysis)
+		riskSummary, _ := aw.getRiskSummary(
+			latest.Status.BuildID,
+			fmt.Sprintf("%s%s/", jobInfo.bucketPrefix, latest.Status.BuildID),
+			priorRiskAnalysis,
+		)
 
-		// don't include none or unknown in our report
+		// report any risk worth mentioning for this job
 		if riskSummary.OverallRisk.Level != api.FailureRiskLevelNone && riskSummary.OverallRisk.Level != api.FailureRiskLevelUnknown {
-			riskAnalysisSummary := RiskAnalysisSummary{Name: jobName, URL: prowLink, RiskLevel: riskSummary.OverallRisk.Level, OverallReasons: riskSummary.OverallRisk.Reasons, TestRiskAnalysis: riskSummary.Tests}
-			analysisByJobs[jobName] = riskAnalysisSummary
+			riskAnalysisSummaries = append(riskAnalysisSummaries, RiskAnalysisSummary{
+				Name:             jobInfo.name,
+				URL:              latest.Status.URL,
+				RiskLevel:        riskSummary.OverallRisk.Level,
+				OverallReasons:   riskSummary.OverallRisk.Reasons,
+				TestRiskAnalysis: riskSummary.Tests,
+			})
 		}
 	}
 
-	// if we get here it means all the latest jobRuns have finished
-	return true, analysisByJobs
+	return riskAnalysisSummaries
 }
 
-// buildProwJobMap Walks the GCS path for this job to find the completed job runs
-// returning a map keyed by the completion time to the job and the most recent job start time
-// if no jobs are completed it will return an empty map
-func (aw *AnalysisWorker) buildProwJobMap(logger *log.Entry, prJobRoot string) (map[time.Time]prow.ProwJob, time.Time) {
+// buildProwJobRuns Walks the GCS path for this job to find its job runs,
+// returning a list of completed runs sorted by decreasing completion time
+func (aw *AnalysisWorker) buildProwJobRuns(logger *log.Entry, prJobRoot string) []*prow.ProwJob {
+	logger = logger.WithField("func", "buildProwJobRuns").WithField("jobRoot", prJobRoot)
 	// get the list of objects one level down from our root
 	it := aw.gcsBucket.Objects(context.Background(), &storage.Query{
 		Prefix:    prJobRoot,
 		Delimiter: "/",
 	})
 
-	buildIDSet := sets.String{}
-	jobsByTime := make(map[time.Time]prow.ProwJob)
-	jobRun := gcs.NewGCSJobRun(aw.gcsBucket, "")
-	mostRecentStartTime := time.Time{}
+	jobRuns := make([]*prow.ProwJob, 0)
+	lookup := gcs.NewGCSJobRun(aw.gcsBucket, "") // dummy instance to look up bucket content
 
 	for {
 		attrs, err := it.Next()
 		if errors.Is(err, iterator.Done) {
-			break
+			break // no more paths to look at
 		}
-
-		// want empty Name indicating a folder
 		if len(attrs.Name) > 0 {
-			continue
+			continue // look for empty Name which indicates a folder which should be a job run
 		}
 
-		bytes, err := jobRun.GetContent(context.TODO(), fmt.Sprintf("%s%s", attrs.Prefix, "prowjob.json"))
-		if err != nil {
+		// load the prowjob recorded in this run
+		var pj prow.ProwJob
+		if bytes, err := lookup.GetContent(context.TODO(), fmt.Sprintf("%s%s", attrs.Prefix, "prowjob.json")); err != nil {
 			logger.WithError(err).Errorf("Failed to get prowjob for: %s", attrs.Prefix)
 			continue
-		}
-
-		var pj prow.ProwJob
-		if err := json.Unmarshal(bytes, &pj); err != nil {
+		} else if err := json.Unmarshal(bytes, &pj); err != nil {
 			logger.WithError(err).Errorf("Failed to unmarshall prowjob for: %s", attrs.Prefix)
 			continue
 		}
 
-		// CompletionTime can be nil
-		// validate it isn't prior to adding
-		if pj.Status.CompletionTime != nil {
-
-			// not sure if we sometimes get duplicate jobs with different completion times
-			// but adding defensive check in case
-			if buildIDSet.Has(pj.Status.BuildID) {
-				logger.Warnf("BuildID: %s has been processed already", pj.Status.BuildID)
-				continue
-			}
-
-			jobsByTime[*pj.Status.CompletionTime] = pj
-			buildIDSet.Insert(pj.Status.BuildID)
+		// validate that this job is valid for our purposes. we checked that the job had a complete latest run,
+		// but the jobs before that could be in invalid states, and prow could have started a new run in the meantime,
+		// so guard against some of these edge cases.
+		if pj.Status.CompletionTime == nil {
+			logger.Debugf("ignoring prowjob %s with no completion time", pj.Status.BuildID)
+			continue
+		} else if pj.Status.State != prow.SuccessState && pj.Status.State != prow.FailureState {
+			logger.Debugf("ignoring prowjob %s in state %s", pj.Status.BuildID, pj.Status.State)
+			continue // filter out jobs that were aborted, failed to launch, just started, etc
+		} else if !strings.HasSuffix(attrs.Prefix, pj.Status.BuildID+"/") {
+			logger.Warnf("saw prowjob in folder %s with mismatched BuildId %s", attrs.Prefix, pj.Status.BuildID)
+			continue // the build id should match the folder name, else WTF?
 		}
 
-		if pj.Status.StartTime.After(mostRecentStartTime) {
-			mostRecentStartTime = pj.Status.StartTime
-		}
+		jobRuns = append(jobRuns, &pj)
 	}
 
-	return jobsByTime, mostRecentStartTime
+	slices.SortFunc(jobRuns, func(a, b *prow.ProwJob) int {
+		return b.Status.CompletionTime.Compare(*a.Status.CompletionTime)
+	})
+	return jobRuns
 }
 
 func (aw *AnalysisWorker) getRiskSummary(jobRunID, jobRunIDPath string, priorRiskAnalysis *api.ProwJobRunRiskAnalysis) (api.RiskSummary, *api.ProwJobRunRiskAnalysis) {
-	logger := log.WithField("jobRunIDPath", jobRunIDPath).WithField("func", "getRiskSummary")
+	logger := log.WithField("jobRunID", jobRunID).WithField("func", "getRiskSummary")
+	logger.Infof("Summarize risks for job run at %s", jobRunIDPath)
 
 	if jobRunIntID, err := strconv.ParseInt(jobRunID, 10, 64); err != nil {
 		log.WithError(err).Errorf("Failed to parse jobRunId id: %s for: %s", jobRunID, jobRunIDPath)
-	} else if jobRun, jobRunTestCount, err := jobQueries.FetchJobRun(aw.dbc, jobRunIntID, logger); err != nil {
+	} else if jobRun, err := jobQueries.FetchJobRun(aw.dbc, jobRunIntID, false, logger); err != nil {
 		// RecordNotFound can be expected if the jobRunId job isn't in sippy yet. log any other error
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			logger.WithError(err).Errorf("Error fetching job run for: %s", jobRunIDPath)
 		}
-	} else if ra, err := jobQueries.JobRunRiskAnalysis(aw.dbc, jobRun, jobRunTestCount, logger); err != nil {
+	} else if ra, err := jobQueries.JobRunRiskAnalysis(aw.dbc, jobRun, logger); err != nil {
 		logger.WithError(err).Errorf("Error querying risk analysis for: %s", jobRunIDPath)
 	} else {
 		// query succeeded so use the riskAnalysis we got
@@ -835,7 +839,7 @@ func buildRiskSummary(riskAnalysis, priorRiskAnalysis *api.ProwJobRunRiskAnalysi
 	return riskSummary
 }
 
-func isTestFiltered(test api.ProwJobRunTestRiskAnalysis, priorRiskAnalysis *api.ProwJobRunRiskAnalysis) bool {
+func isTestFiltered(test api.TestRiskAnalysis, priorRiskAnalysis *api.ProwJobRunRiskAnalysis) bool {
 	// TODO: Observe how restrictive this is
 	// Many PRs don't appear to have multiple runs
 	// Those that do don't have the same failures (because the failures are flakes and not regressions?)

--- a/pkg/sippyserver/pr_commenting_processor.go
+++ b/pkg/sippyserver/pr_commenting_processor.go
@@ -46,13 +46,13 @@ var (
 		Buckets: prometheus.LinearBuckets(0, 5000, 10),
 	}, []string{"org", "repo"})
 
-	checkCommentReady = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	checkCommentReadyMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "sippy_repo_check_ready_comment",
 		Help:    "Tracks the call made to verify a pr is ready for a pr comment",
 		Buckets: prometheus.LinearBuckets(0, 500, 10),
 	}, []string{"org", "repo"})
 
-	buildPendingWork = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	buildPendingWorkMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "sippy_repo_build_pending_comment_work",
 		Help:    "Tracks the call made to query db and add items to the pending work queue",
 		Buckets: prometheus.LinearBuckets(0, 500, 10),
@@ -213,7 +213,7 @@ func (wp *WorkProcessor) work(ctx context.Context, pendingWork chan models.PullR
 	start := time.Now()
 	defer func() {
 		end := time.Now()
-		buildPendingWork.WithLabelValues("work-processor").Observe(float64(end.UnixMilli() - start.UnixMilli()))
+		buildPendingWorkMetric.WithLabelValues("work-processor").Observe(float64(end.UnixMilli() - start.UnixMilli()))
 	}()
 
 	log.Debug("Checking for work")
@@ -447,7 +447,7 @@ func (aw *AnalysisWorker) processPendingPrComment(pendingPrComment models.PullRe
 
 		// record how long it took to decide the jobs are still active
 		t := float64(time.Now().UnixMilli() - start.UnixMilli())
-		checkCommentReady.WithLabelValues(pendingPrComment.Org, pendingPrComment.Repo).Observe(t)
+		checkCommentReadyMetric.WithLabelValues(pendingPrComment.Org, pendingPrComment.Repo).Observe(t)
 		return
 	}
 

--- a/pkg/sippyserver/pr_commenting_processor.go
+++ b/pkg/sippyserver/pr_commenting_processor.go
@@ -59,6 +59,7 @@ var (
 	}, []string{"type"})
 )
 
+// NewWorkProcessor creates a standard work processor from parameters.
 // dbc: our database
 // gcsBucket: handle to our root gcs bucket
 // commentAnalysisWorkers: the number of threads active to process pending comment jobs
@@ -77,6 +78,7 @@ func NewWorkProcessor(dbc *db.DB, gcsBucket *storage.BucketHandle, commentAnalys
 	return wp
 }
 
+// WorkProcessor coordinates the initialization, connection, and execution of all the workers that go into generating PR comments
 type WorkProcessor struct {
 	commentUpdaterRate     time.Duration
 	commentAnalysisRate    time.Duration

--- a/pkg/sippyserver/pr_commenting_processor.go
+++ b/pkg/sippyserver/pr_commenting_processor.go
@@ -430,6 +430,7 @@ func (aw *AnalysisWorker) Run() {
 	}
 }
 
+// determinePrComment evaluates the potential for a PR comment and produces that comment if appropriate
 func (aw *AnalysisWorker) determinePrComment(prCommentProspect models.PullRequestComment) {
 
 	logger := log.WithField("func", "determinePrComment").
@@ -605,6 +606,7 @@ func buildRiskAnalysisComment(sb *strings.Builder, riskAnalyses []RiskAnalysisSu
 	}
 }
 
+// prJobInfo is an internal record built to represent a job running at least once against a commit on a PR
 type prJobInfo struct {
 	name          string
 	jobID         string          // sippy ID of the job itself

--- a/pkg/sippyserver/pr_commenting_processor_test.go
+++ b/pkg/sippyserver/pr_commenting_processor_test.go
@@ -108,13 +108,13 @@ func TestAnalysisWorker(t *testing.T) {
 		riskAnalysisLocator: gcs.GetDefaultRiskAnalysisSummaryFile(),
 		dbc:                 dbc,
 		gcsBucket:           gcsBucket,
-		pendingAnalysis:     pendingWork,
+		prCommentProspects:  pendingWork,
 		preparedComments:    preparedComments,
 		newTestsWorker:      ntw,
 	}
 
 	prPendingComment := models.PullRequestComment{Org: "openshift", Repo: "origin", PullNumber: 29512, SHA: "8849ed78d4c51e2add729a68a2cbf8551c6d60c9", ProwJobRoot: "pr-logs/pull/29512/"} // PR constructed for testing new-test analysis
-	analysisWorker.processPendingPrComment(prPendingComment)
+	analysisWorker.determinePrComment(prPendingComment)
 
 	pc := <-preparedComments
 	logrus.Infof("Pending comment: %+v", pc)
@@ -135,28 +135,28 @@ func TestRunCommentAnalysis(t *testing.T) {
 		riskAnalysisLocator: gcs.GetDefaultRiskAnalysisSummaryFile(),
 		dbc:                 dbc,
 		gcsBucket:           getGcsBucket(t),
-		pendingAnalysis:     pendingWork,
+		prCommentProspects:  pendingWork,
 		preparedComments:    preparedComments,
 		newTestsWorker:      StandardNewTestsWorker(dbc),
 	}
 
 	tests := map[string]struct {
-		prPendingComment models.PullRequestComment
-		logLevel         logrus.Level
+		prCommentProspect models.PullRequestComment
+		logLevel          logrus.Level
 	}{
 		"28075": {
-			prPendingComment: models.PullRequestComment{Org: "openshift", Repo: "origin", PullNumber: 28075, SHA: "79d237196d93eb92ed58c66497d8718259264226", ProwJobRoot: "pr-logs/pull/28075/"},
-			logLevel:         logrus.DebugLevel,
+			prCommentProspect: models.PullRequestComment{Org: "openshift", Repo: "origin", PullNumber: 28075, SHA: "79d237196d93eb92ed58c66497d8718259264226", ProwJobRoot: "pr-logs/pull/28075/"},
+			logLevel:          logrus.DebugLevel,
 		},
 		"has RA comment already": {
-			prPendingComment: models.PullRequestComment{Org: "openshift", Repo: "origin", PullNumber: 29474, SHA: "58a8615189ebd164a1ce87ffe9b078965a9f4b14", ProwJobRoot: "pr-logs/pull/29474/"},
-			logLevel:         logrus.InfoLevel,
+			prCommentProspect: models.PullRequestComment{Org: "openshift", Repo: "origin", PullNumber: 29474, SHA: "58a8615189ebd164a1ce87ffe9b078965a9f4b14", ProwJobRoot: "pr-logs/pull/29474/"},
+			logLevel:          logrus.InfoLevel,
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			logrus.SetLevel(tc.logLevel)
-			analysisWorker.processPendingPrComment(tc.prPendingComment)
+			analysisWorker.determinePrComment(tc.prCommentProspect)
 
 			select {
 			case pc := <-preparedComments:

--- a/pkg/sippyserver/pr_new_tests_worker.go
+++ b/pkg/sippyserver/pr_new_tests_worker.go
@@ -1,0 +1,441 @@
+package sippyserver
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+
+	sippyApi "github.com/openshift/sippy/pkg/api"
+	apiModels "github.com/openshift/sippy/pkg/apis/api"
+	"github.com/openshift/sippy/pkg/apis/prow"
+	spv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/openshift/sippy/pkg/db/query"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// NewTest represents a test result whose name has not been seen in merged code before.
+// we want to call out these out in comments alongside risk analysis.
+type NewTest struct {
+	JobName  string
+	JobRunID uint
+	TestName string
+	Success  bool
+	Failure  bool // and if both, it's a flake
+}
+
+// NewTestRisk is created for the following scenarios:
+// 1. Any PR job adds a new test that appears in one run and not another at the same sha - high risk
+// 2. PR adds new test that appears in only a single job and:
+//   - it fails at all - high risk
+//   - it succeeds or flakes - medium risk (might not be intended for multiple jobs)
+//
+// 3. PR adds new test that appears in more than one job and (at latest sha):
+//   - it fails at all  - high risk
+//   - it succeeds or flakes - no risk (only included in list of all new tests)
+type NewTestRisk struct {
+	TestName   string
+	AnyMissing bool // it was a new test in one run but missing in another at same sha
+	Runs       int  // how many job runs did we examine
+	Failures   int  // how many of the test results were failure
+	Flakes     int  // or flakes
+	OnlyInOne  bool // new test was only seen in one job of multiple for this PR
+	NewTests   []NewTest
+	Level      apiModels.RiskLevel
+	Reason     string
+}
+
+// JobNewTestRisks represents the new test risks for (all runs of) a single job
+type JobNewTestRisks struct {
+	JobName      string
+	NewTestRisks map[string]*NewTestRisk // one risk record per new test name
+}
+
+func SortByJobNameNT(risks []*JobNewTestRisks) {
+	slices.SortFunc(risks, func(a, b *JobNewTestRisks) int {
+		return strings.Compare(a.JobName, b.JobName)
+	})
+}
+
+type NewTestFilter interface {
+	// IsNewTest given a candidate test determines if it is really new with this PR
+	IsNewTest(logger *logrus.Entry, test models.ProwJobRunTest) (bool, error)
+}
+
+// pgNewTestFilter queries postgres to determine if a test is new. We can share
+// a single instance between workers and cache results so we are not constantly
+// querying postgres for the same test.
+type pgNewTestFilter struct {
+	dbc         *db.DB
+	notNewTests sets.Set[uint] // cache of test names that turn out not to be new
+	nnTmutex    *sync.Mutex    // protect notNewTests from concurrent access
+}
+
+type JobRunFilter interface {
+	// OnlyLatestSha filters out runs that are not against the PR's latest sha
+	OnlyLatestSha(entry *logrus.Entry, info prJobInfo) []*prow.ProwJob
+	// JobFailedEarly determines if a run did not get far enough to be included in new test analysis
+	JobFailedEarly(logger *logrus.Entry, run *models.ProwJobRun) bool
+}
+
+type pgJobRunFilter struct {
+	dbc                 *db.DB
+	historicalTestCount map[uint]int // in-memory cache of historical test counts per job id
+}
+
+// NewTestsWorker analyzes PR jobs looking for new tests and determining their risks.
+type NewTestsWorker struct {
+	dbc           *db.DB
+	newTestFilter NewTestFilter
+	jobRunFilter  JobRunFilter
+	fetchJobRun   func(dbc *db.DB, jobRunID int64, unknownTests bool, logger *logrus.Entry) (*models.ProwJobRun, error)
+}
+
+// StandardNewTestsWorker is a convenience method to create a NewTestsWorker with standard filters
+func StandardNewTestsWorker(dbc *db.DB) *NewTestsWorker {
+	_, ntw := internalNewTestsWorker(dbc)
+	return ntw
+}
+func internalNewTestsWorker(dbc *db.DB) (*pgNewTestFilter, *NewTestsWorker) {
+	ntf := &pgNewTestFilter{dbc: dbc, notNewTests: sets.Set[uint]{}, nnTmutex: &sync.Mutex{}}
+	jrf := &pgJobRunFilter{dbc: dbc, historicalTestCount: map[uint]int{}}
+	ntw := &NewTestsWorker{
+		dbc:           dbc,
+		newTestFilter: ntf,
+		jobRunFilter:  jrf,
+		fetchJobRun:   sippyApi.FetchJobRun,
+	}
+	return ntf, ntw // for tests it can be useful to have these explicitly
+}
+
+// analyzeRisks processes one job's runs looking for new tests and assessing their risk
+func (ntw *NewTestsWorker) analyzeRisks(logger *logrus.Entry, jobs []prJobInfo) []*JobNewTestRisks {
+	logger = logger.WithField("func", "analyzeRisks")
+	jobRisks := []*JobNewTestRisks{}
+	for _, jobInfo := range jobs {
+		latestRuns := ntw.jobRunFilter.OnlyLatestSha(logger, jobInfo)
+		if latestRuns == nil {
+			logger.Infof(
+				"Skipping new test analysis for job %s as there are no completed runs against the PR's shasum %s",
+				jobInfo.name, jobInfo.prShaSum)
+			continue
+		}
+
+		risks := ntw.assessJobRisks(logger, latestRuns)
+		if risks != nil { // there were runs to analyze and check for new tests
+			jobRisks = append(jobRisks, &JobNewTestRisks{JobName: jobInfo.name, NewTestRisks: risks})
+		} // else all runs were excluded; do not use this job's lack of new tests for comparison
+	}
+
+	if len(jobRisks) > 0 {
+		// look across the PR's jobs and upgrade risks for new tests that are only found in one job.
+		// a new test that is only seen in one job is a risk similar to one not seen across all runs.
+		assessCrossJobRisks(jobRisks, jobs)
+		// and finally, assign risk levels given everything we know about the new tests
+		assignRiskLevels(jobRisks)
+	}
+
+	return jobRisks
+}
+
+// look across the PR's jobs and upgrade risks for new tests that are only found in one job
+func assessCrossJobRisks(jobRisks []*JobNewTestRisks, jobs []prJobInfo) {
+	if len(jobs) < 2 {
+		return // we need at least two jobs to compare new tests
+	}
+
+	// first figure out how many jobs saw each new test
+	newTestJobCount := make(map[string]int)
+	for _, jobRisk := range jobRisks {
+		for testName := range jobRisk.NewTestRisks {
+			newTestJobCount[testName]++
+		}
+	}
+
+	// upgrade risk of any new test that is unique to one job
+	for _, jobRisk := range jobRisks {
+		for testName, risk := range jobRisk.NewTestRisks {
+			if newTestJobCount[testName] == 1 {
+				risk.OnlyInOne = true
+			}
+		}
+	}
+}
+
+// update the risk record of each new test, assigning a risk level and reason based on risk factors seen
+func assignRiskLevels(jobRisks []*JobNewTestRisks) {
+	for _, jobRisk := range jobRisks {
+		for _, risk := range jobRisk.NewTestRisks {
+			if risk.AnyMissing {
+				// 1. Any PR job adds a new test that appears in one run and not another at the same sha - high risk
+				risk.Level = apiModels.FailureRiskLevelHigh
+				risk.Reason = "is a new test that was not present in all runs against the current commit."
+				if risk.Failures > 0 {
+					risk.Reason = fmt.Sprintf("is a new test that was not present in all runs against the current commit, and also failed %d time(s).", risk.Failures)
+				}
+			} else if risk.OnlyInOne {
+				// 2. PR adds new test that appears in only a single job and:
+				if risk.Failures > 0 {
+					//   - it fails at all - high risk
+					risk.Level = apiModels.FailureRiskLevelHigh
+					risk.Reason = fmt.Sprintf("is a new test, was only seen in one job, and failed %d time(s) against the current commit.", risk.Failures)
+				} else {
+					//   - it succeeds or flakes - medium risk (might not be intended for multiple jobs)
+					risk.Level = apiModels.FailureRiskLevelMedium
+					risk.Reason = "is a new test, and was only seen in one job."
+				}
+			} else {
+				// 3. PR adds new test that appears in more than one job and (at latest sha):
+				if risk.Failures > 0 {
+					//   - it fails at all - high risk
+					risk.Level = apiModels.FailureRiskLevelHigh
+					risk.Reason = fmt.Sprintf("is a new test that failed %d time(s) against the current commit", risk.Failures)
+				} else {
+					//   - it succeeds or flakes - no risk (only included in list of all new tests)
+					risk.Level = apiModels.FailureRiskLevelNone
+				}
+			}
+		}
+	}
+}
+
+// OnlyLatestSha allows only runs against the PR's current shasum (do not flag new tests from earlier shasums)
+func (jrf *pgJobRunFilter) OnlyLatestSha(logger *logrus.Entry, jobInfo prJobInfo) []*prow.ProwJob {
+	logger = logger.WithField("func", "OnlyLatestSha").WithField("job", jobInfo.name).WithField("sha", jobInfo.prShaSum)
+	var latestRuns []*prow.ProwJob
+	for idx, run := range jobInfo.prowJobRuns {
+		if sha := run.Spec.Refs.Pulls[0].SHA; sha != jobInfo.prShaSum {
+			logger.Debugf("Excluding run %s against sha %s", run.Status.BuildID, sha)
+			continue
+		}
+		logger.Debugf("Including run %s", run.Status.BuildID)
+		latestRuns = append(latestRuns, jobInfo.prowJobRuns[idx])
+	}
+	return latestRuns
+}
+
+// JobFailedEarly filters out runs with significantly fewer tests than usual;
+// when looking for new tests, runs that broke before running all the tests will muddy the analysis.
+// such runs should be left to risk analysis for comment.
+// if any errors occur, return true so the run is not included in the new test analysis.
+func (jrf *pgJobRunFilter) JobFailedEarly(logger *logrus.Entry, run *models.ProwJobRun) bool {
+	logger = logger.WithField("func", "JobFailedEarly").WithField("job", run.ProwJob.Name).WithField("run", run.ID)
+	if run.TestCount <= 0 { // this can in theory happen when building the run, filter these out
+		logger.Warn("Failed to count tests earlier, ignoring this run")
+		return true
+	}
+	// figure out how many runs this job usually has
+	historicalCount, ok := jrf.historicalTestCount[run.ProwJob.ID]
+	if !ok {
+		var err error
+		historicalCount, err = query.ProwJobHistoricalTestCounts(jrf.dbc, run.ProwJobID)
+		if err != nil {
+			logger.WithError(err).Error("Error determining historical job test count, ignoring this run")
+			return true
+		}
+		jrf.historicalTestCount[run.ProwJob.ID] = historicalCount
+	}
+
+	if run.TestCount*100 < historicalCount*75 {
+		logger.Infof("Much fewer tests ran (%d) than historically (%d), ignoring this run", run.TestCount, historicalCount)
+		return true
+	}
+	return false
+}
+
+// assessJobRisks walks the runs for a job looking for new tests and assessing their risk.
+// returns map of risks by test name. this will likely be empty, meaning no risks were found.
+// if it is nil, all job runs were excluded, so this job should not be included in the analysis.
+func (ntw *NewTestsWorker) assessJobRisks(logger *logrus.Entry, jobRuns []*prow.ProwJob) map[string]*NewTestRisk {
+	logger = logger.WithField("func", "assessJobRisks").WithField("runs", len(jobRuns))
+
+	// find the new tests in all the comparable runs we have for one job
+	newTestsByName := map[string][]NewTest{}
+	sawValidRun := false // track whether any runs were not excluded
+	for _, run := range jobRuns {
+		logger.Infof("Finding new tests for job %s run %s", run.Spec.Job, run.Status.BuildID)
+		if newTests, err := ntw.getNewTestsForJobRun(logger, run); err == nil {
+			sawValidRun = true
+			for _, test := range newTests {
+				newTestsByName[test.TestName] = append(newTestsByName[test.TestName], test)
+			}
+		}
+	}
+
+	if !sawValidRun {
+		return nil // no runs to analyze, do not consider this job in the analysis
+	}
+
+	// evaluate this job's run(s) of each new test for risk
+	risksByName := map[string]*NewTestRisk{}
+	for testName, tests := range newTestsByName {
+		risksByName[testName] = makeNewTestRisk(testName, len(jobRuns), tests)
+	}
+	// later, we can further compare new tests across multiple jobs, for the same PR.
+	return risksByName
+}
+
+// makeNewTestRisk builds the risk record of a new test based on multiple runs of one job
+func makeNewTestRisk(testName string, jobRuns int, tests []NewTest) *NewTestRisk {
+	// new tests in general are a low risk if they succeed, mainly we want to record their existence
+	risk := NewTestRisk{
+		TestName:   testName,
+		AnyMissing: false,
+		Runs:       jobRuns,
+		NewTests:   tests,
+	}
+
+	// new tests that fail in any runs are a high risk
+	for _, test := range tests {
+		if test.Failure && test.Success {
+			// sometimes new tests are deliberately introduced to flake;
+			// count these for informational purposes but do not consider them an extra risk
+			risk.Flakes++
+		} else if test.Failure {
+			risk.Failures++
+		}
+	}
+
+	// with multiple runs, check whether new tests also showed up in all runs;
+	// if not, they likely either have dynamic names or do not consistently run, either of which is a risk
+	if len(tests) < jobRuns {
+		risk.AnyMissing = true
+	}
+	return &risk
+}
+
+// getNewTestsForJobRun builds sippy's model of a job run and searches it for new tests.
+func (ntw *NewTestsWorker) getNewTestsForJobRun(logger *logrus.Entry, prowjob *prow.ProwJob) (newTests []NewTest, err error) {
+	logger = logger.WithField("func", "getNewTestsForJobRun").WithField("job", prowjob.Spec.Job).WithField("run", prowjob.Status.BuildID)
+	var jobRun *models.ProwJobRun
+	if jobRunIntID, err := strconv.ParseInt(prowjob.Status.BuildID, 10, 64); err != nil {
+		logger.WithError(err).Error("Failed to parse jobRunId id") // this would be exceedingly strange
+		return nil, err
+	} else if jobRun, err = ntw.fetchJobRun(ntw.dbc, jobRunIntID, true, logger); err != nil {
+		// RecordNotFound can be expected if the jobRunId job isn't in sippy yet. log any other error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			logger.Debug("Job run not found")
+		} else {
+			logger.WithError(err).Error("Error fetching job run")
+		}
+		return nil, err
+	} else if ntw.jobRunFilter.JobFailedEarly(logger, jobRun) {
+		return nil, errors.New("job run failed early, ignore")
+	}
+
+	for _, test := range jobRun.Tests {
+		test.ProwJobRun = *jobRun // sometimes handy for a test to know whence it came
+		if isNew, err := ntw.newTestFilter.IsNewTest(logger, test); err != nil {
+			logger.WithError(err).Error("Error checking if test is new")
+			return nil, err // if this errors, it muddies this job's analysis, so throw it out
+		} else if isNew {
+			newTests = append(newTests, NewTest{
+				JobName:  prowjob.Spec.Job,
+				JobRunID: jobRun.ID,
+				TestName: test.Test.Name,
+				Success:  test.Status == int(spv1.TestStatusSuccess) || test.Status == int(spv1.TestStatusFlake),
+				Failure:  test.Status == int(spv1.TestStatusFailure) || test.Status == int(spv1.TestStatusFlake),
+			})
+		}
+	}
+	return newTests, nil
+}
+
+/*
+IsNewTest queries postgres to determine if a test not registered in `test_ownerships`
+is in fact new. For various $reasons, not all tests that we import in sippy are registered
+in that table, so we need additional verification to prevent flagging the same test as
+"new" over and over again.
+
+The search strategy is to look for instances of the test that ran against
+PRs that merged before the test under consideration began. If there are any,
+we can cache that test name as not new. If there are none, then consider this
+a new test.
+Records for PRs and pending PR comments are both created/updated at the same time,
+so this should be a reasonably robust strategy, though not infallible.
+*/
+func (ntf *pgNewTestFilter) IsNewTest(logger *logrus.Entry, testRun models.ProwJobRunTest) (bool, error) {
+	logger = logger.WithField("func", "IsNewTest").WithField("test", testRun.Test.Name)
+	ntf.nnTmutex.Lock()
+	if ntf.notNewTests.Has(testRun.TestID) {
+		// some past query found a PR that merged with this test.
+		logger.Debug("Test previously cached as not new")
+		ntf.nnTmutex.Unlock()
+		return false, nil
+	}
+	ntf.nnTmutex.Unlock()
+
+	pjpr := models.ProwPullRequest{}
+	res := ntf.dbc.DB.
+		Table("prow_job_run_tests as t").
+		Joins("INNER JOIN prow_job_run_prow_pull_requests as prmap on prmap.prow_job_run_id = t.prow_job_run_id").
+		Joins("INNER JOIN prow_pull_requests as prs on prs.id = prmap.prow_pull_request_id").
+		Where("t.test_id = ?", testRun.TestID).
+		Where("merged_at is not null").
+		Select("org, repo, number, sha, merged_at").
+		Limit(1).Find(&pjpr) // any result demonstrates this is not new
+	if res.Error != nil {
+		logger.WithError(res.Error).Error("Error querying for PRs that included this test.")
+		return false, res.Error
+	}
+	if pjpr.MergedAt != nil {
+		// means such a record was found, so this is not new
+		logger.Debugf("Test ran in previously-merged PR %s/%s#%d@%s", pjpr.Org, pjpr.Repo, pjpr.Number, pjpr.SHA)
+		ntf.nnTmutex.Lock()
+		ntf.notNewTests.Insert(testRun.TestID) // do not need to look up next time
+		ntf.nnTmutex.Unlock()
+		return false, nil
+	}
+	// query succeeded but no such record was found, so this is new
+	logger.Debug("Test has not run in any previously-merged PR, considering it new.")
+	return true, nil
+}
+
+// summarizeNewTestRisks looks at all the risks spread across jobs and consolidates the stats;
+// it also removes the "risks" that are None, as those are for new tests with no issues, leaving
+// only the actual risks to report by job.
+func summarizeNewTestRisks(jobRisks []*JobNewTestRisks) ([]*JobNewTestRisks, []NewTestRisk) {
+	notableJobRisks := []*JobNewTestRisks{}          // filter out jobs with only "risks" that are None
+	testSummariesByName := map[string]*NewTestRisk{} // sum up the runs we saw
+	for _, jr := range jobRisks {
+		actualRisks := map[string]*NewTestRisk{} // filter out the test "risks" that are None
+		for name, risk := range jr.NewTestRisks {
+			if risk.Level != apiModels.FailureRiskLevelNone {
+				actualRisks[name] = risk
+			}
+			summary, exists := testSummariesByName[name]
+			if !exists {
+				summary = &NewTestRisk{TestName: name}
+			}
+			summary.Failures += risk.Failures
+			summary.Flakes += risk.Flakes
+			summary.Runs += risk.Runs
+			testSummariesByName[name] = summary
+		}
+		if len(actualRisks) > 0 { // only note jobs including actual risks
+			notableJobRisks = append(notableJobRisks, &JobNewTestRisks{
+				JobName:      jr.JobName,
+				NewTestRisks: actualRisks,
+			})
+		}
+	}
+
+	return notableJobRisks, sortedTestRisks(testSummariesByName)
+}
+
+func sortedTestRisks(testSummariesByName map[string]*NewTestRisk) []NewTestRisk {
+	testSummaries := []NewTestRisk{}
+	for _, summary := range testSummariesByName {
+		testSummaries = append(testSummaries, *summary)
+	}
+	slices.SortFunc(testSummaries, func(a, b NewTestRisk) int {
+		return strings.Compare(a.TestName, b.TestName)
+	})
+	return testSummaries
+}

--- a/pkg/sippyserver/pr_new_tests_worker.go
+++ b/pkg/sippyserver/pr_new_tests_worker.go
@@ -357,7 +357,7 @@ The search strategy is to look for instances of the test that ran against
 PRs that merged before the test under consideration began. If there are any,
 we can cache that test name as not new. If there are none, then consider this
 a new test.
-Records for PRs and pending PR comments are both created/updated at the same time,
+Records for PRs and potential PR comments are both created/updated at the same time,
 so this should be a reasonably robust strategy, though not infallible.
 */
 func (ntf *pgNewTestFilter) IsNewTest(logger *logrus.Entry, testRun models.ProwJobRunTest) (bool, error) {

--- a/pkg/sippyserver/pr_new_tests_worker_test.go
+++ b/pkg/sippyserver/pr_new_tests_worker_test.go
@@ -1,0 +1,446 @@
+package sippyserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+	gormLogger "gorm.io/gorm/logger"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/openshift/sippy/pkg/apis/api"
+	"github.com/openshift/sippy/pkg/apis/prow"
+	v1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+	"github.com/openshift/sippy/pkg/dataloader/prowloader/gcs"
+	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/models"
+)
+
+/*
+	  many of these are functional tests requiring a live database and/or GCS bucket with known data to run,
+	  so we do not want them trying to run during CI. We will skip tests whose required environment variables are not set.
+	  don't risk checking in credentials with code; supply them with environment variables:
+		TEST_DB_LOG_LEVEL: "silent" or "info" or "warn" or "error" - the log level for gorm database methods
+		TEST_SIPPY_DATABASE_DSN: the DSN for the sippy postgres database e.g. postgresql://sippyro:...@sippy-postgresql...amazonaws.com/sippy_openshift
+		TEST_GCS_CREDS_PATH: the path to a local GCS credentials file, e.g. /home/$USER/git/sippy/openshift-sippy-ro.creds.json
+*/
+func getDbHandle(t *testing.T) *db.DB {
+	dbLogLevel := os.Getenv("TEST_DB_LOG_LEVEL") // e.g. "info" or "silent"
+	if dbLogLevel == "" {
+		dbLogLevel = "silent"
+	}
+	gormLogLevel, err := db.ParseGormLogLevel(dbLogLevel)
+	if err != nil {
+		logrus.WithError(err).Errorf("Cannot parse TEST_DB_LOG_LEVEL %s", dbLogLevel)
+		gormLogLevel = gormLogger.Silent
+	}
+
+	dsn := os.Getenv("TEST_SIPPY_DATABASE_DSN")
+	if dsn == "" {
+		t.Skip("TEST_SIPPY_DATABASE_DSN environment variable is not set; skipping database tests")
+	}
+	dbc, err := db.New(dsn, gormLogLevel)
+	if err != nil {
+		logrus.WithError(err).Fatal("Cannot connect to database")
+	}
+	return dbc
+}
+
+func getGcsBucket(t *testing.T) *storage.BucketHandle {
+	pathToGcsCredentials := os.Getenv("TEST_GCS_CREDS_PATH")
+	if pathToGcsCredentials == "" {
+		t.Skip("TEST_GCS_CREDS_PATH environment variable is not set; skipping GCS tests")
+	}
+	gcsClient, err := gcs.NewGCSClient(context.TODO(), pathToGcsCredentials, "")
+	if err != nil {
+		logrus.WithError(err).Fatalf("CRITICAL error getting GCS client with credentials at %s", pathToGcsCredentials)
+	}
+	return gcsClient.Bucket("test-platform-results")
+}
+
+func TestBuildJobMap(t *testing.T) {
+	// initialize AnalysisWorker
+	gcsBucket := getGcsBucket(t)
+	aw := AnalysisWorker{gcsBucket: gcsBucket}
+	logrus.SetLevel(logrus.DebugLevel)
+	logger := logrus.WithContext(context.TODO())
+	runs := aw.buildProwJobRuns(logger, "pr-logs/pull/29501/pull-ci-openshift-origin-master-e2e-aws-ovn-edge-zones/")
+	if assert.Greater(t, len(runs), 1, "expect multiple job runs") {
+		cmpTime := time.Now() // expect these to be sorted by decreasing start time
+		for _, run := range runs {
+			nextTime := run.Status.StartTime
+			assert.Truef(t, nextTime.Before(cmpTime), "expect %s start time %v to be before %v", run.Status.BuildID, nextTime, cmpTime)
+			cmpTime = nextTime
+			assert.Equal(t, "pull-ci-openshift-origin-master-e2e-aws-ovn-edge-zones", run.Spec.Job)
+		}
+	}
+}
+
+func TestAssessJobRisks(t *testing.T) {
+	logger := logrus.WithContext(context.TODO())
+	logrus.SetLevel(logrus.InfoLevel)
+
+	ntw := StandardNewTestsWorker(getDbHandle(t))
+
+	// Initialize GCS client and look up known job in the bucket
+	bucket := getGcsBucket(t)
+	aw := AnalysisWorker{gcsBucket: bucket, newTestsWorker: ntw}
+	jobRuns := aw.buildProwJobRuns(logger, "pr-logs/pull/29512/pull-ci-openshift-origin-master-e2e-aws-ovn-single-node/")
+	numRuns := len(jobRuns)
+	if !assert.True(t, numRuns > 0, "Failed to load job runs") {
+		return
+	}
+	if !assert.Equal(t, "1885131315280351232", jobRuns[numRuns-1].Status.BuildID, "Unexpected build ID") {
+		return // expected to use the earliest job run (last in list) as a test subject
+	}
+
+	// Assess single job risks
+	jobRisks := ntw.assessJobRisks(logger, []*prow.ProwJob{jobRuns[numRuns-1]})
+	if !assert.Equalf(t, numRuns, 2, "expect risks only for the two that were new; saw %+v", jobRisks) {
+		return
+	}
+	risks := []*JobNewTestRisks{{JobName: "some-job", NewTestRisks: jobRisks}}
+	assignRiskLevels(risks)
+	failed, ok := jobRisks["a failed test that has never been seen before"]
+	if assert.True(t, ok, "Should have found failed test") {
+		assert.Equal(t, 1, failed.Failures, "Unexpected number of failures")
+		assert.Equal(t, api.FailureRiskLevelHigh, failed.Level, "Expected high risk for failing test")
+	}
+	passed, ok := jobRisks["a passed test that has never been seen before"]
+	if assert.True(t, ok, "Should have found failed test") {
+		assert.Equal(t, 0, passed.Failures, "Unexpected failure found")
+		assert.Equal(t, api.FailureRiskLevelNone, passed.Level, "Expected no risk for passing test")
+	}
+
+	// Assess multi run risks where new tests go missing
+	if !assert.True(t, numRuns > 1, "Expected at least 2 job runs") {
+		return
+	}
+	// skippingNewTestFilter alternately filters out new tests found to simulate missing tests
+	ntw.newTestFilter = &skippingNewTestFilter{newTestFilter: ntw.newTestFilter, sawPrevious: map[string]bool{}}
+	jobRisks = ntw.assessJobRisks(logger, jobRuns)
+	failed, ok = jobRisks["a failed test that has never been seen before"]
+	if assert.True(t, ok, "Should have found failed test") {
+		if !assert.True(t, failed.AnyMissing, "Expected test missing in at least one run") {
+			return
+		}
+	}
+	risks = []*JobNewTestRisks{{JobName: "some-job", NewTestRisks: jobRisks}}
+	assignRiskLevels(risks)
+	failed, ok = risks[0].NewTestRisks["a failed test that has never been seen before"]
+	if assert.True(t, ok, "Should have found failed test") {
+		assert.Equal(t, api.FailureRiskLevelHigh, failed.Level, "Expected high risk for failing intermittent test")
+	}
+	passed, ok = risks[0].NewTestRisks["a passed test that has never been seen before"]
+	if assert.True(t, ok, "Should have found passed test") {
+		assert.Equal(t, api.FailureRiskLevelHigh, passed.Level, "Expected high risk for passing intermittent test")
+		assert.NotContains(t, passed.Reason, "failed", "Risk reason is not due to failure")
+	}
+}
+
+func TestAssessCrossJobRisks(t *testing.T) {
+	// setting up unit tests for this would be atrocious, but a functional test
+	// for ntw.analyzeRisks runs assessCrossJobRisks() so just use real data and tricks to test
+	logger := logrus.WithContext(context.TODO())
+	logrus.SetLevel(logrus.InfoLevel)
+
+	// look up test-bed PR jobs in the bucket
+	ntw := StandardNewTestsWorker(getDbHandle(t))
+	aw := AnalysisWorker{gcsBucket: getGcsBucket(t), newTestsWorker: ntw}
+	completedJobs := aw.getPrJobsIfFinished(logger, "pr-logs/pull/29512/")
+	if !assert.Greater(t, len(completedJobs), 2, "Failed to load all job runs") {
+		return
+	}
+
+	// run just the new test analysis, but only find new tests in one job
+	ntw.newTestFilter = &oneJobNewTestFilter{newTestFilter: ntw.newTestFilter, jobName: "pull-ci-openshift-origin-master-e2e-aws-ovn-single-node"}
+	for idx, jobInfo := range completedJobs {
+		completedJobs[idx].prowJobRuns = aw.buildProwJobRuns(logger, jobInfo.bucketPrefix)
+		completedJobs[idx].prShaSum = "8849ed78d4c51e2add729a68a2cbf8551c6d60c9" // so we can check whether runs are against the expected PR commit
+	}
+	risks := ntw.analyzeRisks(logger, completedJobs)
+	if !assert.Greater(t, len(risks), 1, "Expected a risk each for the two new tests") {
+		return
+	}
+
+	// check that risks match expectations
+	var sawPassedTest, sawFailedTest bool
+	for _, jobRisk := range risks {
+		if jobRisk.JobName == "pull-ci-openshift-origin-master-e2e-vsphere-ovn-upi" {
+			// this is a test for JobFailedEarly as well...
+			assert.Fail(t, "JobFailedEarly should have filtered out this job's broken run")
+		}
+		for _, testRisk := range jobRisk.NewTestRisks {
+			fmt.Printf("risk: %q: %+v\n", jobRisk.JobName, *testRisk)
+			switch testRisk.TestName {
+			case "a failed test that has never been seen before":
+				assert.True(t, testRisk.OnlyInOne, "Expected test to only be seen in one job")
+				assert.Equal(t, api.FailureRiskLevelHigh, testRisk.Level,
+					"Expected high risk for failing test seen in one job")
+				sawFailedTest = true
+			case "a passed test that has never been seen before":
+				assert.True(t, testRisk.OnlyInOne, "Expected test to only be seen in one job")
+				assert.Equal(t, api.FailureRiskLevelMedium, testRisk.Level,
+					"Expected medium risk for passing test seen in one job")
+				sawPassedTest = true
+			default:
+				t.Errorf("Did not expect to see new test %q", testRisk.TestName)
+			}
+		}
+	}
+	assert.True(t, sawPassedTest, "Should have found risk for passed test")
+	assert.True(t, sawFailedTest, "Should have found risk for failed test")
+}
+
+func newTest(name string, success, failure bool) NewTest {
+	return NewTest{
+		TestName: name,
+		Success:  success,
+		Failure:  failure,
+	}
+}
+
+func TestRiskScenarios(t *testing.T) {
+	cases := []struct {
+		name     string
+		tests    []NewTest
+		expected NewTestRisk
+	}{ // all assume two job runs
+		{
+			name: "AllTestsPassing",
+			tests: []NewTest{
+				newTest("test", true, false),
+				newTest("test", true, false),
+			},
+			expected: NewTestRisk{
+				Failures:   0,
+				Flakes:     0,
+				AnyMissing: false,
+			},
+		},
+		{
+			name: "SomeTestsFailing",
+			tests: []NewTest{
+				newTest("something", true, false),
+				newTest("something", false, true),
+			},
+			expected: NewTestRisk{
+				Failures:   1,
+				Flakes:     0,
+				AnyMissing: false,
+			},
+		},
+		{
+			name: "FlakyTest and MissingTest",
+			tests: []NewTest{
+				newTest("test", true, true),
+			},
+			expected: NewTestRisk{
+				Failures:   0,
+				Flakes:     1,
+				AnyMissing: true,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			risk := makeNewTestRisk("test", 2, c.tests)
+			assert.Equal(t, c.expected.Failures, risk.Failures)
+			assert.Equal(t, c.expected.Flakes, risk.Flakes)
+			assert.Equal(t, c.expected.AnyMissing, risk.AnyMissing)
+		})
+	}
+}
+
+func TestUnit_getNewTestsForJobRun(t *testing.T) {
+	logger := logrus.NewEntry(logrus.New())
+	jobRun := &prow.ProwJob{
+		Spec:   prow.ProwJobSpec{Job: "test-jobRun"},
+		Status: prow.ProwJobStatus{BuildID: "12345"},
+	}
+	tests := []struct {
+		name          string
+		fetchJobRun   func(dbc *db.DB, jobRunID int64, unknownTests bool, logger *logrus.Entry) (*models.ProwJobRun, error)
+		testFilter    NewTestFilter
+		expectedTests []NewTest
+		expectedError error
+	}{
+		{
+			name: "successful fetch",
+			fetchJobRun: func(dbc *db.DB, jobRunID int64, unknownTests bool, logger *logrus.Entry) (*models.ProwJobRun, error) {
+				pjr := models.ProwJobRun{
+					Tests: []models.ProwJobRunTest{
+						{Test: models.Test{Name: "test1"}, Status: int(v1.TestStatusSuccess)},
+						{Test: models.Test{Name: "test2"}, Status: int(v1.TestStatusFailure)},
+						{Test: models.Test{Name: "test3"}, Status: int(v1.TestStatusFlake)},
+					},
+				}
+				pjr.ID = 12345 // Gorm model ID for some reason can't be put in the struct literal
+				return &pjr, nil
+			},
+			testFilter: &oneNewTestFilter{}, // filters to only "test2"
+			expectedTests: []NewTest{
+				{JobName: "test-jobRun", JobRunID: 12345, TestName: "test2", Success: false, Failure: true},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "error on filtering",
+			fetchJobRun: func(dbc *db.DB, jobRunID int64, unknownTests bool, logger *logrus.Entry) (*models.ProwJobRun, error) {
+				pjr := models.ProwJobRun{
+					Tests: []models.ProwJobRunTest{
+						{Test: models.Test{Name: "test1"}, Status: int(v1.TestStatusSuccess)},
+					},
+				}
+				pjr.ID = 12345 // Gorm model ID for some reason can't be put in the struct literal
+				return &pjr, nil
+			},
+			testFilter:    &errorNewTestFilter{}, // mocks a failure in the filter
+			expectedTests: nil,
+			expectedError: errors.New("filter error"),
+		},
+		{
+			name: "jobRun run not found",
+			fetchJobRun: func(dbc *db.DB, jobRunID int64, unknownTests bool, logger *logrus.Entry) (*models.ProwJobRun, error) {
+				return nil, gorm.ErrRecordNotFound
+			},
+			expectedTests: nil,
+			expectedError: gorm.ErrRecordNotFound,
+		},
+		{
+			name: "error fetching jobRun run",
+			fetchJobRun: func(dbc *db.DB, jobRunID int64, unknownTests bool, logger *logrus.Entry) (*models.ProwJobRun, error) {
+				return nil, errors.New("fetch error")
+			},
+			expectedTests: nil,
+			expectedError: errors.New("fetch error"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ntw := &NewTestsWorker{
+				dbc:           nil,
+				newTestFilter: tt.testFilter,
+				fetchJobRun:   tt.fetchJobRun,
+				jobRunFilter:  &jobRunUnfiltered{},
+			}
+			newTests, err := ntw.getNewTestsForJobRun(logger, jobRun)
+			assert.Equal(t, tt.expectedTests, newTests)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}
+
+type oneNewTestFilter struct{}
+type errorNewTestFilter struct{}
+type skippingNewTestFilter struct { // alternate skipping or including actual new tests
+	newTestFilter NewTestFilter
+	sawPrevious   map[string]bool
+}
+type oneJobNewTestFilter struct { // only return new tests against one job
+	newTestFilter NewTestFilter
+	jobName       string
+}
+
+func (m *oneNewTestFilter) IsNewTest(_ *logrus.Entry, test models.ProwJobRunTest) (bool, error) {
+	if test.Test.Name == "test2" {
+		return true, nil
+	}
+	return false, nil
+}
+func (m *errorNewTestFilter) IsNewTest(_ *logrus.Entry, _ models.ProwJobRunTest) (bool, error) {
+	return false, errors.New("filter error")
+}
+
+func (ntf *skippingNewTestFilter) IsNewTest(logger *logrus.Entry, test models.ProwJobRunTest) (bool, error) {
+	if isNew, err := ntf.newTestFilter.IsNewTest(logger, test); err != nil {
+		return false, err
+	} else if isNew {
+		ntf.sawPrevious[test.Test.Name] = !ntf.sawPrevious[test.Test.Name] // alternate skipping or including actual new tests
+		if ntf.sawPrevious[test.Test.Name] {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+func (ntf *oneJobNewTestFilter) IsNewTest(logger *logrus.Entry, test models.ProwJobRunTest) (bool, error) {
+
+	if isNew, err := ntf.newTestFilter.IsNewTest(logger, test); err != nil {
+		return false, err
+	} else if isNew && ntf.jobName == test.ProwJobRun.ProwJob.Name {
+		return true, nil
+	}
+	return false, nil
+}
+
+type jobRunUnfiltered struct{}
+
+func (n *jobRunUnfiltered) OnlyLatestSha(_ *logrus.Entry, jobInfo prJobInfo) []*prow.ProwJob {
+	return jobInfo.prowJobRuns
+}
+
+func (n *jobRunUnfiltered) JobFailedEarly(_ *logrus.Entry, _ *models.ProwJobRun) bool {
+	return false
+}
+
+func TestFunc_getNewTestsForJobRun(t *testing.T) {
+	ntf, ntw := internalNewTestsWorker(getDbHandle(t))
+
+	// try with a known job run
+	jobRun := &prow.ProwJob{
+		Spec:   prow.ProwJobSpec{Job: "pull-ci-openshift-origin-master-e2e-aws-ovn-single-node"},
+		Status: prow.ProwJobStatus{BuildID: "1885131315280351232"},
+	}
+	logrus.SetLevel(logrus.DebugLevel)
+	logger := logrus.WithContext(context.TODO())
+	newTests, err := ntw.getNewTestsForJobRun(logger, jobRun)
+
+	fmt.Printf("new tests: %v\n", newTests)
+	assert.NoError(t, err, "Failed to get new tests")
+	assert.Equal(t, 2, len(newTests), "Unexpected number of new tests")
+	assert.True(t, ntf.notNewTests.Has(522), "Test 522 should be considered not new")
+	assert.False(t, ntf.notNewTests.Has(160471), "Test 160471 should be left out to be considered new")
+	assert.False(t, ntf.notNewTests.Has(160472), "Test 160472 should be left out to be considered new")
+}
+
+func TestIsNewTest(t *testing.T) {
+	dbc := getDbHandle(t)
+
+	ntf := &pgNewTestFilter{
+		dbc:         dbc,
+		notNewTests: sets.Set[uint]{},
+		nnTmutex:    &sync.Mutex{},
+	}
+	logrus.SetLevel(logrus.DebugLevel)
+	logger := logrus.WithContext(context.TODO())
+
+	test := models.Test{Name: "[sig-sippy] openshift-tests should work"}
+	test.ID = 522
+	testRun := models.ProwJobRunTest{
+		Test:      test,
+		TestID:    test.ID,
+		CreatedAt: time.Now(),
+	}
+	isNew, err := ntf.IsNewTest(logger, testRun)
+
+	assert.Nil(t, err, "Failed to check if test is new")
+	assert.Equal(t, false, isNew, "Test should not be new")
+
+	test.Name = "a failed test that has never been seen before"
+	test.ID = 160471
+	testRun.Test = test
+	testRun.TestID = test.ID
+	isNew, err = ntf.IsNewTest(logger, testRun)
+
+	assert.Nil(t, err, "Failed to check if test is new")
+	assert.Equal(t, true, isNew, "Test should be new")
+}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -981,7 +981,6 @@ func (s *Server) jsonJobRunRiskAnalysis(w http.ResponseWriter, req *http.Request
 	logger := log.WithField("func", "jsonJobRunRiskAnalysis")
 
 	jobRun := &models.ProwJobRun{}
-	var jobRunTestCount int
 
 	// API path one where we return a risk analysis for a prow job run ID we already know about:
 	jobRunIDStr := req.URL.Query().Get("prow_job_run_id")
@@ -996,7 +995,7 @@ func (s *Server) jsonJobRunRiskAnalysis(w http.ResponseWriter, req *http.Request
 		logger = logger.WithField("jobRunID", jobRunID)
 
 		// lookup prowjob and run count
-		jobRun, jobRunTestCount, err = api.FetchJobRun(s.db, jobRunID, logger)
+		jobRun, err = api.FetchJobRun(s.db, jobRunID, false, logger)
 
 		if err != nil {
 			failureResponse(w, http.StatusBadRequest, err.Error())
@@ -1028,8 +1027,6 @@ func (s *Server) jsonJobRunRiskAnalysis(w http.ResponseWriter, req *http.Request
 			return
 		}
 
-		jobRunTestCount = jobRun.TestCount
-
 		// We don't expect the caller to fully populate the ProwJob, just its name;
 		// override the input by looking up the actual ProwJob so we have access to release and variants.
 		job := &models.ProwJob{}
@@ -1056,7 +1053,7 @@ func (s *Server) jsonJobRunRiskAnalysis(w http.ResponseWriter, req *http.Request
 	}
 
 	logger.Infof("job run = %+v", *jobRun)
-	result, err := api.JobRunRiskAnalysis(s.db, jobRun, jobRunTestCount, logger.WithField("func", "JobRunRiskAnalysis"))
+	result, err := api.JobRunRiskAnalysis(s.db, jobRun, logger)
 	if err != nil {
 		failureResponse(w, http.StatusBadRequest, err.Error())
 		return


### PR DESCRIPTION
We have an issue where new tests often don't reliably produce success results, or have other issues like dynamic components in the test name (e.g. a namespace).

Expand the risk analysis PR commenter to report on all never-before-seen tests in presubmits, with a link/reminder of our test standards.

[Example comment](https://github.com/openshift/origin/pull/29512#issuecomment-2678344068)