### PR TITLE
Introduce middleware for release fallback and intentional regressions (attempt 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN mkdir -p /config
 COPY --from=builder /go/src/sippy/sippy /bin/sippy
 COPY --from=builder /go/src/sippy/sippy-daemon /bin/sippy-daemon
 COPY --from=builder /go/src/sippy/scripts/fetchdata.sh /bin/fetchdata.sh
-COPY --from=builder /go/src/sippy/historical-data /historical-data/
 COPY --from=builder /go/src/sippy/config/*.yaml /config/
 ENTRYPOINT ["/bin/sippy"]
 EXPOSE 8080

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -12,9 +11,13 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
-	"cloud.google.com/go/civil"
 	"github.com/apache/thrift/lib/go/thrift"
 	fischer "github.com/glycerine/golang-fisher-exact"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/middleware"
+	regressionallowances2 "github.com/openshift/sippy/pkg/api/componentreadiness/middleware/regressionallowances"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/middleware/releasefallback"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/query"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
 	configv1 "github.com/openshift/sippy/pkg/apis/config/v1"
 	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 	"github.com/pkg/errors"
@@ -34,8 +37,6 @@ import (
 const (
 	triagedIncidentsTableID = "triaged_incidents"
 
-	ignoredJobsRegexp = `-okd|-recovery|aggregator-|alibaba|-disruptive|-rollback|-out-of-change|-sno-fips-recert|-bgp-`
-
 	// openRegressionConfidenceAdjustment is subtracted from the requested confidence for regressed tests that have
 	// an open regression.
 	openRegressionConfidenceAdjustment = 5
@@ -53,16 +54,9 @@ var (
 	DefaultDBGroupBy     = "Platform,Architecture,Network,Topology,FeatureSet,Upgrade,Suite,Installer"
 )
 
-func newFallbackReleases() crtype.FallbackReleases {
-	fb := crtype.FallbackReleases{
-		Releases: map[string]crtype.ReleaseTestMap{},
-	}
-	return fb
-}
-
-func getSingleColumnResultToSlice(ctx context.Context, query *bigquery.Query) ([]string, error) {
+func getSingleColumnResultToSlice(ctx context.Context, q *bigquery.Query) ([]string, error) {
 	names := []string{}
-	it, err := query.Read(ctx)
+	it, err := q.Read(ctx)
 	if err != nil {
 		log.WithError(err).Error("error querying test status from bigquery")
 		return names, err
@@ -83,13 +77,13 @@ func getSingleColumnResultToSlice(ctx context.Context, query *bigquery.Query) ([
 	return names, nil
 }
 
-// TODO: in several of the below functions we instantiate an entire componentReportGenerator
+// TODO: in several of the below functions we instantiate an entire ComponentReportGenerator
 // to fetch some small piece of data. These look like they should be broken out. The partial
 // instantiation of a complex object is risky in terms of bugs and maintenance.
 
 func GetComponentTestVariantsFromBigQuery(ctx context.Context, client *bqcachedclient.Client,
 	gcsBucket string) (crtype.TestVariants, []error) {
-	generator := componentReportGenerator{
+	generator := ComponentReportGenerator{
 		client:    client,
 		gcsBucket: gcsBucket,
 	}
@@ -98,18 +92,10 @@ func GetComponentTestVariantsFromBigQuery(ctx context.Context, client *bqcachedc
 		api.GetPrefixedCacheKey("TestVariants~", generator), generator.GenerateVariants, crtype.TestVariants{})
 }
 
-func GetReleaseDatesFromBigQuery(ctx context.Context, client *bqcachedclient.Client) ([]crtype.Release, []error) {
-	generator := componentReportGenerator{
-		client: client,
-	}
-
-	return api.GetDataFromCacheOrGenerate[[]crtype.Release](ctx, client.Cache, cache.RequestOptions{}, api.GetPrefixedCacheKey("CRReleaseDates~", generator), generator.GenerateReleaseDates, []crtype.Release{})
-}
-
 func GetJobVariantsFromBigQuery(ctx context.Context, client *bqcachedclient.Client,
 	gcsBucket string) (crtype.JobVariants,
 	[]error) {
-	generator := componentReportGenerator{
+	generator := ComponentReportGenerator{
 		client:    client,
 		gcsBucket: gcsBucket,
 	}
@@ -126,61 +112,56 @@ func GetComponentReportFromBigQuery(
 	variantJunitTableOverrides []configv1.VariantJunitTableOverride,
 ) (crtype.ComponentReport, []error) {
 
-	generator := componentReportGenerator{
-		client:                           client,
-		prowURL:                          prowURL,
-		gcsBucket:                        gcsBucket,
-		cacheOption:                      reqOptions.CacheOption,
-		BaseRelease:                      reqOptions.BaseRelease,
-		SampleRelease:                    reqOptions.SampleRelease,
-		triagedIssues:                    nil,
-		RequestTestIdentificationOptions: reqOptions.TestIDOption,
-		RequestVariantOptions:            reqOptions.VariantOption,
-		RequestAdvancedOptions:           reqOptions.AdvancedOption,
-		variantJunitTableOverrides:       variantJunitTableOverrides,
+	// TODO: generator is used as a cache key, public fields get included when we serialize it.
+	// This muddles cache key with actual public/private fields and complicates use of the object
+	// in other packages. Cache key to me looks like it should just be RequestOptions. With exception
+	// of cacheOptions which are private, we are otherwise just breaking apart RequestOptions.
+	// Watch out for BaseOverrideRelease which is not included here today. May only be used on test details...
+	generator := ComponentReportGenerator{
+		client:                     client,
+		prowURL:                    prowURL,
+		gcsBucket:                  gcsBucket,
+		ReqOptions:                 reqOptions,
+		triagedIssues:              nil,
+		variantJunitTableOverrides: variantJunitTableOverrides,
 	}
 
 	return api.GetDataFromCacheOrGenerate[crtype.ComponentReport](
 		ctx,
-		generator.client.Cache, generator.cacheOption,
+		generator.client.Cache, generator.ReqOptions.CacheOption,
+		// TODO: how are we not specifying anything specific for cache key?
 		generator.GetComponentReportCacheKey(ctx, "ComponentReport~"),
 		generator.GenerateReport,
 		crtype.ComponentReport{})
 }
 
-// componentReportGenerator contains the information needed to generate a CR report. Do
+// ComponentReportGenerator contains the information needed to generate a CR report. Do
 // not add public fields to this struct if they are not valid as a cache key.
 // GeneratorVersion is used to indicate breaking changes in the versions of
 // the cached data.  It is used when the struct
 // is marshalled for the cache key and should be changed when the object being
 // cached changes in a way that will no longer be compatible with any prior cached version.
-type componentReportGenerator struct {
+type ComponentReportGenerator struct {
 	ReportModified             *time.Time
 	client                     *bqcachedclient.Client
 	prowURL                    string
 	gcsBucket                  string
-	cacheOption                cache.RequestOptions
-	BaseRelease                crtype.RequestReleaseOptions
-	BaseOverrideRelease        crtype.RequestReleaseOptions
-	SampleRelease              crtype.RequestReleaseOptions
 	triagedIssues              *resolvedissues.TriagedIncidentsForRelease
-	cachedFallbackTestStatuses *crtype.FallbackReleases
-	crtype.RequestTestIdentificationOptions
-	crtype.RequestVariantOptions
-	crtype.RequestAdvancedOptions
+	ReqOptions                 crtype.RequestOptions
 	openRegressions            []*crtype.TestRegression
 	variantJunitTableOverrides []configv1.VariantJunitTableOverride
+	middlewares                []middleware.Middleware
 }
 
-func (c *componentReportGenerator) GetComponentReportCacheKey(ctx context.Context, prefix string) api.CacheData {
+func (c *ComponentReportGenerator) GetComponentReportCacheKey(ctx context.Context, prefix string) api.CacheData {
 	// Make sure we have initialized the report modified field
 	if c.ReportModified == nil {
-		c.ReportModified = c.GetLastReportModifiedTime(ctx, c.client, c.cacheOption)
+		c.ReportModified = c.GetLastReportModifiedTime(ctx, c.client, c.ReqOptions.CacheOption)
 	}
 	return api.GetPrefixedCacheKey(prefix, c)
 }
 
-func (c *componentReportGenerator) GenerateVariants(ctx context.Context) (crtype.TestVariants, []error) {
+func (c *ComponentReportGenerator) GenerateVariants(ctx context.Context) (crtype.TestVariants, []error) {
 	errs := []error{}
 	columns := make(map[string][]string)
 
@@ -203,25 +184,7 @@ func (c *componentReportGenerator) GenerateVariants(ctx context.Context) (crtype
 	}, errs
 }
 
-func (c *componentReportGenerator) GenerateReleaseDates(ctx context.Context) ([]crtype.Release, []error) {
-	releases, err := api.GetReleasesFromBigQuery(ctx, c.client)
-	if err != nil {
-		return nil, []error{err}
-	}
-	crReleases := []crtype.Release{}
-	for _, release := range releases {
-		crRelease := crtype.Release{Release: release.Release}
-		if release.GADate != nil {
-			prior := util.AdjustReleaseTime(*release.GADate, true, "30", c.cacheOption.CRTimeRoundingFactor)
-			crRelease.Start = &prior
-			crRelease.End = release.GADate
-		}
-		crReleases = append(crReleases, crRelease)
-	}
-	return crReleases, nil
-}
-
-func (c *componentReportGenerator) GenerateJobVariants(ctx context.Context) (crtype.JobVariants, []error) {
+func (c *ComponentReportGenerator) GenerateJobVariants(ctx context.Context) (crtype.JobVariants, []error) {
 	errs := []error{}
 	variants := crtype.JobVariants{Variants: map[string][]string{}}
 	queryString := fmt.Sprintf(`SELECT variant_name, ARRAY_AGG(DISTINCT variant_value ORDER BY variant_value) AS variant_values
@@ -231,8 +194,8 @@ func (c *componentReportGenerator) GenerateJobVariants(ctx context.Context) (crt
 						variant_value!=""
 					GROUP BY
 						variant_name`, c.client.Dataset)
-	query := c.client.BQ.Query(queryString)
-	it, err := query.Read(ctx)
+	q := c.client.BQ.Query(queryString)
+	it, err := q.Read(ctx)
 	if err != nil {
 		log.WithError(err).Errorf("error querying variants from bigquery for %s", queryString)
 		return variants, []error{err}
@@ -275,8 +238,18 @@ func (c *componentReportGenerator) GenerateJobVariants(ctx context.Context) (crt
 }
 
 // GenerateReport is the main entry point for generation of a component readiness report.
-func (c *componentReportGenerator) GenerateReport(ctx context.Context) (crtype.ComponentReport, []error) {
+func (c *ComponentReportGenerator) GenerateReport(ctx context.Context) (crtype.ComponentReport, []error) {
 	before := time.Now()
+
+	// TODO: move to a constructor or similar
+	c.middlewares = []middleware.Middleware{}
+	// Initialize all our middleware applicable to this request.
+	// TODO: Should middleware constructors do the interpretation of the request
+	// and decide if they want to take part? Return nil if not?
+	c.middlewares = append(c.middlewares, regressionallowances2.NewRegressionAllowancesMiddleware(c.ReqOptions))
+	if c.ReqOptions.AdvancedOption.IncludeMultiReleaseAnalysis {
+		c.middlewares = append(c.middlewares, releasefallback.NewReleaseFallbackMiddleware(c.client, c.ReqOptions))
+	}
 
 	// Load all test pass/fail counts from bigquery, both sample and basis
 	componentReportTestStatus, errs := c.getTestStatusFromBigQuery(ctx)
@@ -284,21 +257,32 @@ func (c *componentReportGenerator) GenerateReport(ctx context.Context) (crtype.C
 		return crtype.ComponentReport{}, errs
 	}
 
+	// Allow all middlware a chance to transform the base/sample TestStatuses before we analyze:
+	var err error
+	for _, mw := range c.middlewares {
+		componentReportTestStatus.BaseStatus, componentReportTestStatus.SampleStatus, err =
+			mw.Transform(componentReportTestStatus.BaseStatus, componentReportTestStatus.SampleStatus)
+		if err != nil {
+			return crtype.ComponentReport{}, []error{err}
+		}
+	}
+
 	// Load current regression data from bigquery, used to enhance the response with information such as how long
 	// this regression has been appearing in a tracked view.
 	bqs := NewBigQueryRegressionStore(c.client)
-	var err error
 	allRegressions, err := bqs.ListCurrentRegressions(ctx)
 	if err != nil {
+		log.WithError(err).Error("error listing current regressions")
 		errs = append(errs, err)
 		return crtype.ComponentReport{}, errs
 	}
-	c.openRegressions = FilterRegressionsForRelease(allRegressions, c.SampleRelease.Release)
+	c.openRegressions = FilterRegressionsForRelease(allRegressions, c.ReqOptions.SampleRelease.Release)
 
 	// perform analysis and generate report:
 	report, err := c.generateComponentTestReport(ctx, componentReportTestStatus.BaseStatus,
 		componentReportTestStatus.SampleStatus)
 	if err != nil {
+		log.WithError(err).Error("error generating report")
 		errs = append(errs, err)
 		return crtype.ComponentReport{}, errs
 	}
@@ -309,13 +293,13 @@ func (c *componentReportGenerator) GenerateReport(ctx context.Context) (crtype.C
 }
 
 // getBaseQueryStatus builds the basis query, executes it, and returns the basis test status.
-func (c *componentReportGenerator) getBaseQueryStatus(ctx context.Context,
+func (c *ComponentReportGenerator) getBaseQueryStatus(ctx context.Context,
 	allJobVariants crtype.JobVariants) (map[string]crtype.TestStatus, []error) {
 
-	generator := newBaseQueryGenerator(c, allJobVariants)
+	generator := query.NewBaseQueryGenerator(c.client, c.ReqOptions, allJobVariants)
 
 	componentReportTestStatus, errs := api.GetDataFromCacheOrGenerate[crtype.ReportTestStatus](ctx, c.client.Cache,
-		generator.cacheOption, api.GetPrefixedCacheKey("BaseTestStatus~", generator), generator.queryTestStatus, crtype.ReportTestStatus{})
+		generator.ReqOptions.CacheOption, api.GetPrefixedCacheKey("BaseTestStatus~", generator), generator.QueryTestStatus, crtype.ReportTestStatus{})
 
 	if len(errs) > 0 {
 		return nil, errs
@@ -324,39 +308,20 @@ func (c *componentReportGenerator) getBaseQueryStatus(ctx context.Context,
 	return componentReportTestStatus.BaseStatus, nil
 }
 
-func (c *componentReportGenerator) getFallbackBaseQueryStatus(ctx context.Context,
-	allJobVariants crtype.JobVariants,
-	release string, start, end time.Time) []error {
-	generator := newFallbackTestQueryReleasesGenerator(c, allJobVariants, release, start, end)
-
-	cachedFallbackTestStatuses, errs := api.GetDataFromCacheOrGenerate[*crtype.FallbackReleases](
-		ctx, c.client.Cache, generator.cacheOption,
-		api.GetPrefixedCacheKey("FallbackReleases~", generator),
-		generator.getTestFallbackReleases,
-		&crtype.FallbackReleases{})
-
-	if len(errs) > 0 {
-		return errs
-	}
-
-	c.cachedFallbackTestStatuses = cachedFallbackTestStatuses
-	return nil
-}
-
 // getSampleQueryStatus builds the sample query, executes it, and returns the sample test status.
-func (c *componentReportGenerator) getSampleQueryStatus(
+func (c *ComponentReportGenerator) getSampleQueryStatus(
 	ctx context.Context,
 	allJobVariants crtype.JobVariants,
 	includeVariants map[string][]string,
 	start, end time.Time,
 	junitTable string) (map[string]crtype.TestStatus, []error) {
 
-	generator := newSampleQueryGenerator(c, allJobVariants, includeVariants, start, end, junitTable)
+	generator := query.NewSampleQueryGenerator(c.client, c.ReqOptions, allJobVariants, includeVariants, start, end, junitTable)
 
 	componentReportTestStatus, errs := api.GetDataFromCacheOrGenerate[crtype.ReportTestStatus](ctx,
-		c.client.Cache, c.cacheOption,
+		c.client.Cache, c.ReqOptions.CacheOption,
 		api.GetPrefixedCacheKey("SampleTestStatus~", generator),
-		generator.queryTestStatus, crtype.ReportTestStatus{})
+		generator.QueryTestStatus, crtype.ReportTestStatus{})
 
 	if len(errs) > 0 {
 		return nil, errs
@@ -367,7 +332,7 @@ func (c *componentReportGenerator) getSampleQueryStatus(
 
 // getTestStatusFromBigQuery orchestrates the actual fetching of junit test run data for both basis and sample.
 // goroutines are used to concurrently request the data for basis, sample, and various other edge cases.
-func (c *componentReportGenerator) getTestStatusFromBigQuery(ctx context.Context) (crtype.ReportTestStatus, []error) {
+func (c *ComponentReportGenerator) getTestStatusFromBigQuery(ctx context.Context) (crtype.ReportTestStatus, []error) {
 	before := time.Now()
 	fLog := log.WithField("func", "getTestStatusFromBigQuery")
 	allJobVariants, errs := GetJobVariantsFromBigQuery(ctx, c.client, c.gcsBucket)
@@ -377,27 +342,19 @@ func (c *componentReportGenerator) getTestStatusFromBigQuery(ctx context.Context
 	}
 
 	var baseStatus, sampleStatus map[string]crtype.TestStatus
+	baseStatusCh := make(chan map[string]crtype.TestStatus) // TODO: not hooked up yet, just in place for the interface for now
 	var baseErrs, sampleErrs []error
 	wg := sync.WaitGroup{}
 
 	// channels for status as we may collect status from multiple queries run in separate goroutines
-	statusCh := make(chan map[string]crtype.TestStatus)
-	statusErrCh := make(chan error)
+	sampleStatusCh := make(chan map[string]crtype.TestStatus)
+	errCh := make(chan error)
 	statusDoneCh := make(chan struct{})     // To signal when all processing is done
 	statusErrsDoneCh := make(chan struct{}) // To signal when all processing is done
 
-	if c.IncludeMultiReleaseAnalysis {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			select {
-			case <-ctx.Done():
-				fLog.Infof("Context canceled while fetching fallback query status")
-				return
-			default:
-				c.getFallbackBaseQueryStatus(ctx, allJobVariants, c.BaseRelease.Release, c.BaseRelease.Start, c.BaseRelease.End)
-			}
-		}()
+	// Invoke the Query phase for each of our configured middlewares:
+	for _, mw := range c.middlewares {
+		mw.Query(ctx, &wg, allJobVariants, baseStatusCh, sampleStatusCh, errCh)
 	}
 
 	wg.Add(1)
@@ -418,25 +375,26 @@ func (c *componentReportGenerator) getTestStatusFromBigQuery(ctx context.Context
 		case <-ctx.Done():
 			return
 		default:
-			includeVariants, skipQuery := copyIncludeVariantsAndRemoveOverrides(c.variantJunitTableOverrides, -1, c.IncludeVariants)
+			includeVariants, skipQuery := copyIncludeVariantsAndRemoveOverrides(c.variantJunitTableOverrides, -1, c.ReqOptions.VariantOption.IncludeVariants)
 			if skipQuery {
-				fLog.Infof("skipping default status query as all values for a variant were overridden")
+				fLog.Infof("skipping default sample query as all values for a variant were overridden")
 				return
 			}
-			fLog.Infof("running default status query with includeVariants: %+v", includeVariants)
-			status, errs := c.getSampleQueryStatus(ctx, allJobVariants, includeVariants, c.SampleRelease.Start, c.SampleRelease.End, defaultJunitTable)
+			fLog.Infof("running default sample query with includeVariants: %+v", includeVariants)
+			status, errs := c.getSampleQueryStatus(ctx, allJobVariants, includeVariants, c.ReqOptions.SampleRelease.Start, c.ReqOptions.SampleRelease.End, query.DefaultJunitTable)
 			fLog.Infof("received %d test statuses and %d errors from default query", len(status), len(errs))
-			statusCh <- status
+			sampleStatusCh <- status
 			for _, err := range errs {
-				statusErrCh <- err
+				errCh <- err
 			}
 		}
 
 	}()
 
 	// fork additional sample queries for the overrides
+	// TODO: move to a variantjunitoverride middleware with Query implemented
 	for i, or := range c.variantJunitTableOverrides {
-		if !containsOverriddenVariant(c.IncludeVariants, or.VariantName, or.VariantValue) {
+		if !containsOverriddenVariant(c.ReqOptions.VariantOption.IncludeVariants, or.VariantName, or.VariantValue) {
 			continue
 		}
 		// only do this additional query if the specified override variant is actually included in this request
@@ -447,25 +405,25 @@ func (c *componentReportGenerator) getTestStatusFromBigQuery(ctx context.Context
 			case <-ctx.Done():
 				return
 			default:
-				includeVariants, skipQuery := copyIncludeVariantsAndRemoveOverrides(c.variantJunitTableOverrides, i, c.IncludeVariants)
+				includeVariants, skipQuery := copyIncludeVariantsAndRemoveOverrides(c.variantJunitTableOverrides, i, c.ReqOptions.VariantOption.IncludeVariants)
 				if skipQuery {
-					fLog.Infof("skipping override status query as all values for a variant were overridden")
+					fLog.Infof("skipping override sample query as all values for a variant were overridden")
 					return
 				}
-				fLog.Infof("running override status query for %+v with includeVariants: %+v", or, includeVariants)
+				fLog.Infof("running override sample query for %+v with includeVariants: %+v", or, includeVariants)
 				// Calculate a start time relative to the requested end time: (i.e. for rarely run jobs)
-				end := c.SampleRelease.End
+				end := c.ReqOptions.SampleRelease.End
 				start, err := util.ParseCRReleaseTime([]v1.Release{}, "", or.RelativeStart,
-					true, &c.SampleRelease.End, c.cacheOption.CRTimeRoundingFactor)
+					true, &c.ReqOptions.SampleRelease.End, c.ReqOptions.CacheOption.CRTimeRoundingFactor)
 				if err != nil {
-					statusErrCh <- err
+					errCh <- err
 					return
 				}
 				status, errs := c.getSampleQueryStatus(ctx, allJobVariants, includeVariants, start, end, or.TableName)
 				fLog.Infof("received %d test statuses and %d errors from override query", len(status), len(errs))
-				statusCh <- status
+				sampleStatusCh <- status
 				for _, err := range errs {
-					statusErrCh <- err
+					errCh <- err
 				}
 			}
 
@@ -474,13 +432,14 @@ func (c *componentReportGenerator) getTestStatusFromBigQuery(ctx context.Context
 
 	go func() {
 		wg.Wait()
-		close(statusCh)
-		close(statusErrCh)
+		close(baseStatusCh)
+		close(sampleStatusCh)
+		close(errCh)
 	}()
 
 	go func() {
 
-		for status := range statusCh {
+		for status := range sampleStatusCh {
 			fLog.Infof("received %d test statuses over channel", len(status))
 			for k, v := range status {
 				if sampleStatus == nil {
@@ -499,7 +458,7 @@ func (c *componentReportGenerator) getTestStatusFromBigQuery(ctx context.Context
 	}()
 
 	go func() {
-		for err := range statusErrCh {
+		for err := range errCh {
 			sampleErrs = append(sampleErrs, err)
 		}
 		close(statusErrsDoneCh)
@@ -589,20 +548,20 @@ func containsOverriddenVariant(includeVariants map[string][]string, key, value s
 	return false
 }
 
-var componentAndCapabilityGetter func(test crtype.TestIdentification, stats crtype.TestStatus) (string, []string)
+var componentAndCapabilityGetter func(test crtype.TestWithVariantsKey, stats crtype.TestStatus) (string, []string)
 
-func testToComponentAndCapability(_ crtype.TestIdentification, stats crtype.TestStatus) (string, []string) {
+func testToComponentAndCapability(_ crtype.TestWithVariantsKey, stats crtype.TestStatus) (string, []string) {
 	return stats.Component, stats.Capabilities
 }
 
 // getRowColumnIdentifications defines the rows and columns since they are variable. For rows, different pages have different row titles (component, capability etc)
 // Columns titles depends on the columnGroupBy parameter user requests. A particular test can belong to multiple rows of different capabilities.
-func (c *componentReportGenerator) getRowColumnIdentifications(testIDStr string, stats crtype.TestStatus) ([]crtype.RowIdentification, []crtype.ColumnID, error) {
-	var test crtype.TestIdentification
-	columnGroupByVariants := c.ColumnGroupBy
+func (c *ComponentReportGenerator) getRowColumnIdentifications(testIDStr string, stats crtype.TestStatus) ([]crtype.RowIdentification, []crtype.ColumnID, error) {
+	var test crtype.TestWithVariantsKey
+	columnGroupByVariants := c.ReqOptions.VariantOption.ColumnGroupBy
 	// We show column groups by DBGroupBy only for the last page before test details
-	if c.TestID != "" {
-		columnGroupByVariants = c.DBGroupBy
+	if c.ReqOptions.TestIDOption.TestID != "" {
+		columnGroupByVariants = c.ReqOptions.VariantOption.DBGroupBy
 	}
 	// TODO: is this too slow?
 	err := json.Unmarshal([]byte(testIDStr), &test)
@@ -613,26 +572,26 @@ func (c *componentReportGenerator) getRowColumnIdentifications(testIDStr string,
 	component, capabilities := componentAndCapabilityGetter(test, stats)
 	rows := []crtype.RowIdentification{}
 	// First Page with no component requested
-	if c.Component == "" {
+	if c.ReqOptions.TestIDOption.Component == "" {
 		rows = append(rows, crtype.RowIdentification{Component: component})
-	} else if c.Component == component {
+	} else if c.ReqOptions.TestIDOption.Component == component {
 		// Exact test match
-		if c.TestID != "" {
+		if c.ReqOptions.TestIDOption.TestID != "" {
 			row := crtype.RowIdentification{
 				Component: component,
 				TestID:    test.TestID,
 				TestName:  stats.TestName,
 				TestSuite: stats.TestSuite,
 			}
-			if c.Capability != "" {
-				row.Capability = c.Capability
+			if c.ReqOptions.TestIDOption.Capability != "" {
+				row.Capability = c.ReqOptions.TestIDOption.Capability
 			}
 			rows = append(rows, row)
 		} else {
 			for _, capability := range capabilities {
 				// Exact capability match only produces one row
-				if c.Capability != "" {
-					if c.Capability == capability {
+				if c.ReqOptions.TestIDOption.Capability != "" {
+					if c.ReqOptions.TestIDOption.Capability == capability {
 						row := crtype.RowIdentification{
 							Component:  component,
 							TestID:     test.TestID,
@@ -663,182 +622,6 @@ func (c *componentReportGenerator) getRowColumnIdentifications(testIDStr string,
 	columns = append(columns, crtype.ColumnID(columnKeyBytes))
 
 	return rows, columns, nil
-}
-
-// deserializeRowToTestStatus deserializes a single row into a testID string and matching status.
-// This is where we handle the dynamic variant_ columns, parsing these into a map on the test identification.
-// Other fixed columns we expect are serialized directly to their appropriate columns.
-func deserializeRowToTestStatus(row []bigquery.Value, schema bigquery.Schema) (string, crtype.TestStatus, error) {
-	if len(row) != len(schema) {
-		log.Infof("row is %+v, schema is %+v", row, schema)
-		return "", crtype.TestStatus{}, fmt.Errorf("number of values in row doesn't match schema length")
-	}
-
-	// Expect:
-	//
-	// INFO[2024-04-22T13:31:23.123-03:00] test_id = openshift-tests:75895eeec137789cab3570a252306058
-	// INFO[2024-04-22T13:31:23.123-03:00] variants = [standard]
-	// INFO[2024-04-22T13:31:23.123-03:00] variant_Network = ovn
-	// INFO[2024-04-22T13:31:23.123-03:00] variant_Upgrade = none
-	// INFO[2024-04-22T13:31:23.123-03:00] variant_Architecture = amd64
-	// INFO[2024-04-22T13:31:23.123-03:00] variant_Platform = gcp
-	// INFO[2024-04-22T13:31:23.123-03:00] flat_variants = fips,serial
-	// INFO[2024-04-22T13:31:23.123-03:00] variants = [fips serial]
-	// INFO[2024-04-22T13:31:23.123-03:00] total_count = %!s(int64=1)
-	// INFO[2024-04-22T13:31:23.123-03:00] success_count = %!s(int64=1)
-	// INFO[2024-04-22T13:31:23.123-03:00] flake_count = %!s(int64=0)
-	// INFO[2024-04-22T13:31:23.124-03:00] component = Cluster Version Operator
-	// INFO[2024-04-22T13:31:23.124-03:00] capabilities = [Other]
-	// INFO[2024-04-22T13:31:23.124-03:00] jira_component = Cluster Version Operator
-	// INFO[2024-04-22T13:31:23.124-03:00] jira_component_id = 12367602000000000/1000000000
-	// INFO[2024-04-22T13:31:23.124-03:00] test_name = [sig-storage] [Serial] Volume metrics Ephemeral should create volume metrics in Volume Manager [Suite:openshift/conformance/serial] [Suite:k8s]
-	// INFO[2024-04-22T13:31:23.124-03:00] test_suite = openshift-tests
-	tid := crtype.TestIdentification{
-		Variants: map[string]string{},
-	}
-	cts := crtype.TestStatus{}
-	for i, fieldSchema := range schema {
-		col := fieldSchema.Name
-		// Some rows we know what to expect, others are dynamic (variants) and go into the map.
-		switch {
-		case col == "test_id":
-			tid.TestID = row[i].(string)
-		case col == "test_name":
-			cts.TestName = row[i].(string)
-		case col == "test_suite":
-			cts.TestSuite = row[i].(string)
-		case col == "total_count":
-			cts.TotalCount = int(row[i].(int64))
-		case col == "success_count":
-			cts.SuccessCount = int(row[i].(int64))
-		case col == "flake_count":
-			cts.FlakeCount = int(row[i].(int64))
-		case col == "last_failure":
-			// ignore when we cant parse, its usually null
-			var err error
-			if row[i] != nil {
-				layout := "2006-01-02T15:04:05"
-				lftCivilDT := row[i].(civil.DateTime)
-				cts.LastFailure, err = time.Parse(layout, lftCivilDT.String())
-				if err != nil {
-					log.WithError(err).Error("error parsing last failure time from bigquery")
-				}
-			}
-		case col == "component":
-			cts.Component = row[i].(string)
-		case col == "capabilities":
-			capArr := row[i].([]bigquery.Value)
-			cts.Capabilities = make([]string, len(capArr))
-			for i := range capArr {
-				cts.Capabilities[i] = capArr[i].(string)
-			}
-		case strings.HasPrefix(col, "variant_"):
-			variantName := col[len("variant_"):]
-			if row[i] != nil {
-				tid.Variants[variantName] = row[i].(string)
-			}
-		default:
-			log.Warnf("ignoring column in query: %s", col)
-		}
-	}
-
-	// Create a string representation of the test ID so we can use it as a map key throughout:
-	// TODO: json better? reversible if we do...
-	testIDBytes, err := json.Marshal(tid)
-
-	return string(testIDBytes), cts, err
-}
-
-func getMajor(in string) (int, error) {
-	major, err := strconv.ParseInt(strings.Split(in, ".")[0], 10, 32)
-	if err != nil {
-		return 0, err
-	}
-	return int(major), err
-}
-
-func getMinor(in string) (int, error) {
-	minor, err := strconv.ParseInt(strings.Split(in, ".")[1], 10, 32)
-	if err != nil {
-		return 0, err
-	}
-	return int(minor), err
-}
-
-func previousRelease(release string) (string, error) {
-	prev := release
-	var err error
-	var major, minor int
-	if major, err = getMajor(release); err == nil {
-		if minor, err = getMinor(release); err == nil && minor > 0 {
-			prev = fmt.Sprintf("%d.%d", major, minor-1)
-		}
-	}
-
-	return prev, err
-}
-
-func (c *componentReportGenerator) normalizeProwJobName(prowName string) string {
-	name := prowName
-	if c.BaseRelease.Release != "" {
-		name = strings.ReplaceAll(name, c.BaseRelease.Release, "X.X")
-		if prev, err := previousRelease(c.BaseRelease.Release); err == nil {
-			name = strings.ReplaceAll(name, prev, "X.X")
-		}
-	}
-	if c.BaseOverrideRelease.Release != "" {
-		name = strings.ReplaceAll(name, c.BaseOverrideRelease.Release, "X.X")
-		if prev, err := previousRelease(c.BaseOverrideRelease.Release); err == nil {
-			name = strings.ReplaceAll(name, prev, "X.X")
-		}
-	}
-	if c.SampleRelease.Release != "" {
-		name = strings.ReplaceAll(name, c.SampleRelease.Release, "X.X")
-		if prev, err := previousRelease(c.SampleRelease.Release); err == nil {
-			name = strings.ReplaceAll(name, prev, "X.X")
-		}
-	}
-	// Some jobs encode frequency in their name, which can change
-	re := regexp.MustCompile(`-f\d+`)
-	name = re.ReplaceAllString(name, "-fXX")
-
-	return name
-}
-
-func (c *componentReportGenerator) fetchJobRunTestStatusResults(ctx context.Context,
-	query *bigquery.Query) (map[string][]crtype.JobRunTestStatusRow, []error) {
-	errs := []error{}
-	status := map[string][]crtype.JobRunTestStatusRow{}
-	log.Infof("Fetching job run test details with:\n%s\nParameters:\n%+v\n", query.Q, query.Parameters)
-
-	it, err := query.Read(ctx)
-	if err != nil {
-		log.WithError(err).Error("error querying job run test status from bigquery")
-		errs = append(errs, err)
-		return status, errs
-	}
-
-	for {
-		testStatus := crtype.JobRunTestStatusRow{}
-		err := it.Next(&testStatus)
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			log.WithError(err).Error("error parsing component from bigquery")
-			errs = append(errs, errors.Wrap(err, "error parsing prowjob from bigquery"))
-			continue
-		}
-		prowName := c.normalizeProwJobName(testStatus.ProwJob)
-		rows, ok := status[prowName]
-		if !ok {
-			status[prowName] = []crtype.JobRunTestStatusRow{testStatus}
-		} else {
-			rows = append(rows, testStatus)
-			status[prowName] = rows
-		}
-	}
-	return status, errs
 }
 
 type cellStatus struct {
@@ -945,14 +728,14 @@ func updateCellStatus(rowIdentifications []crtype.RowIdentification,
 	}
 }
 
-func (c *componentReportGenerator) getTriagedIssuesFromBigQuery(ctx context.Context,
+func (c *ComponentReportGenerator) getTriagedIssuesFromBigQuery(ctx context.Context,
 	testID crtype.ReportTestIdentification) (
 	int, []crtype.TriagedIncident, []error) {
 	generator := triagedIncidentsGenerator{
-		ReportModified: c.GetLastReportModifiedTime(ctx, c.client, c.cacheOption),
+		ReportModified: c.GetLastReportModifiedTime(ctx, c.client, c.ReqOptions.CacheOption),
 		client:         c.client,
-		cacheOption:    c.cacheOption,
-		SampleRelease:  c.SampleRelease,
+		cacheOption:    c.ReqOptions.CacheOption,
+		SampleRelease:  c.ReqOptions.SampleRelease,
 	}
 
 	// we want to fetch this once per generator instance which should be once per UI load
@@ -968,12 +751,12 @@ func (c *componentReportGenerator) getTriagedIssuesFromBigQuery(ctx context.Cont
 		}
 		c.triagedIssues = &releaseTriagedIncidents
 	}
-	impactedRuns, triagedIncidents := triagedIssuesFor(c.triagedIssues, testID.ColumnIdentification, testID.TestID, c.SampleRelease.Start, c.SampleRelease.End)
+	impactedRuns, triagedIncidents := triagedIssuesFor(c.triagedIssues, testID.ColumnIdentification, testID.TestID, c.ReqOptions.SampleRelease.Start, c.ReqOptions.SampleRelease.End)
 
 	return impactedRuns, triagedIncidents, nil
 }
 
-func (c *componentReportGenerator) GetLastReportModifiedTime(ctx context.Context, client *bqcachedclient.Client,
+func (c *ComponentReportGenerator) GetLastReportModifiedTime(ctx context.Context, client *bqcachedclient.Client,
 	options cache.RequestOptions) *time.Time {
 
 	if c.ReportModified == nil {
@@ -1000,7 +783,7 @@ func (c *componentReportGenerator) GetLastReportModifiedTime(ctx context.Context
 			LastModifiedStartTime: &initLastModifiedTime,
 		}
 
-		// this gets called a lot, so we want to set it once on the componentReportGenerator
+		// this gets called a lot, so we want to set it once on the ComponentReportGenerator
 		lastModifiedTime, errs := api.GetDataFromCacheOrGenerate[*time.Time](ctx, generator.client.Cache,
 			generator.cacheOption, api.GetPrefixedCacheKey("TriageLastModified~", generator), generator.generateTriagedIssuesLastModifiedTime, generator.LastModifiedStartTime)
 
@@ -1056,11 +839,11 @@ func (t *triagedIncidentsModifiedTimeGenerator) queryTriagedIssuesLastModified(c
 }
 
 func (t *triagedIncidentsModifiedTimeGenerator) fetchLastModified(ctx context.Context,
-	query *bigquery.Query) (*time.Time,
+	q *bigquery.Query) (*time.Time,
 	[]error) {
-	log.Infof("Fetching triaged incidents last modified time with:\n%s\nParameters:\n%+v\n", query.Q, query.Parameters)
+	log.Infof("Fetching triaged incidents last modified time with:\n%s\nParameters:\n%+v\n", q.Q, q.Parameters)
 
-	it, err := query.Read(ctx)
+	it, err := q.Read(ctx)
 	if err != nil {
 		log.WithError(err).Error("error querying triaged incidents last modified time from bigquery")
 		return nil, []error{err}
@@ -1188,13 +971,13 @@ func (t *triagedIncidentsGenerator) queryTriagedIssues(ctx context.Context) ([]c
 }
 
 func (t *triagedIncidentsGenerator) fetchTriagedIssues(ctx context.Context,
-	query *bigquery.Query) ([]crtype.TriagedIncident,
+	q *bigquery.Query) ([]crtype.TriagedIncident,
 	[]error) {
 	errs := make([]error, 0)
 	incidents := make([]crtype.TriagedIncident, 0)
-	log.Infof("Fetching triaged incidents with:\n%s\nParameters:\n%+v\n", query.Q, query.Parameters)
+	log.Infof("Fetching triaged incidents with:\n%s\nParameters:\n%+v\n", q.Q, q.Parameters)
 
-	it, err := query.Read(ctx)
+	it, err := q.Read(ctx)
 	if err != nil {
 		log.WithError(err).Error("error querying triaged incidents from bigquery")
 		errs = append(errs, err)
@@ -1217,7 +1000,7 @@ func (t *triagedIncidentsGenerator) fetchTriagedIssues(ctx context.Context,
 	return incidents, errs
 }
 
-func (c *componentReportGenerator) triagedIncidentsFor(ctx context.Context,
+func (c *ComponentReportGenerator) triagedIncidentsFor(ctx context.Context,
 	testID crtype.ReportTestIdentification) (int,
 	[]crtype.TriagedIncident) {
 	// handle test case / missing client
@@ -1247,143 +1030,31 @@ func (c *componentReportGenerator) triagedIncidentsFor(ctx context.Context,
 //
 // ie. if the request was for 95% confidence, but we see that a test has an open regression (meaning at some point recently
 // we were over 95% certain of a regression), we're going to only require 90% certainty to mark that test red.
-func (c *componentReportGenerator) getRequiredConfidence(testID string, variants map[string]string) int {
+func (c *ComponentReportGenerator) getRequiredConfidence(testID string, variants map[string]string) int {
 	if len(c.openRegressions) > 0 {
 		view := c.openRegressions[0].View // grab view from first regression, they were queried only for sample release
 		or := FindOpenRegression(view, testID, variants, c.openRegressions)
 		if or != nil {
 			log.Debugf("adjusting required regression confidence from %d to %d because %s (%v) has an open regression since %s",
-				c.RequestAdvancedOptions.Confidence,
-				c.RequestAdvancedOptions.Confidence-openRegressionConfidenceAdjustment,
+				c.ReqOptions.AdvancedOption.Confidence,
+				c.ReqOptions.AdvancedOption.Confidence-openRegressionConfidenceAdjustment,
 				testID,
 				variants,
 				or.Opened)
-			return c.RequestAdvancedOptions.Confidence - openRegressionConfidenceAdjustment
+			return c.ReqOptions.AdvancedOption.Confidence - openRegressionConfidenceAdjustment
 		}
 	}
-	return c.RequestAdvancedOptions.Confidence
-}
-
-// matchBaseRegression returns a testStatus that reflects the allowances specified
-// in an intentional regression that accepted a lower threshold but maintains the higher
-// threshold when used as a basis.  It will ignore intentional regressions if we are relying
-// on fallback to find the highest threshold.  It will return the original testStatus if there
-// is no intentional regression or the testStatus has a higher threshold
-func (c *componentReportGenerator) matchBaseRegression(testID crtype.ReportTestIdentification, baseRelease string, baseStats crtype.TestStatus) (crtype.TestStatus, string) {
-	var baseRegression *regressionallowances.IntentionalRegression
-	if !c.IncludeMultiReleaseAnalysis && len(c.VariantCrossCompare) == 0 {
-		// only really makes sense when not cross-comparing variants:
-		// look for corresponding regressions we can account for in the analysis
-		// only if we are ignoring fallback, otherwise we will let fallback determine the threshold
-		baseRegression = regressionallowances.IntentionalRegressionFor(baseRelease, testID.ColumnIdentification, testID.TestID)
-
-		// This could go away if we remove the option for ignoring fallback
-		if baseRegression != nil && baseRegression.PreviousPassPercentage(c.FlakeAsFailure) > c.getTestStatusPassRate(baseStats) {
-			// override with  the basis regression previous values
-			// testStats will reflect the expected threshold, not the computed values from the release with the allowed regression
-			baseRegressionPreviousRelease, err := previousRelease(c.BaseRelease.Release)
-			if err != nil {
-				log.WithError(err).Error("Failed to determine the previous release for baseRegression")
-			} else {
-				// create a clone since we might be updating a cached item though the same regression would likely apply each time...
-				updatedStats := crtype.TestStatus{TestName: baseStats.TestName, TestSuite: baseStats.TestSuite, Capabilities: baseStats.Capabilities,
-					Component: baseStats.Component, Variants: baseStats.Variants,
-					FlakeCount:   baseRegression.PreviousFlakes,
-					SuccessCount: baseRegression.PreviousSuccesses,
-					TotalCount:   baseRegression.PreviousFailures + baseRegression.PreviousFlakes + baseRegression.PreviousSuccesses,
-				}
-				baseStats = updatedStats
-				baseRelease = baseRegressionPreviousRelease
-				log.Infof("BaseRegression - PreviousPassPercentage overrides baseStats.  Release: %s, Successes: %d, Flakes: %d, Total: %d", baseRelease, baseStats.SuccessCount, baseStats.FlakeCount, baseStats.TotalCount)
-			}
-		}
-	}
-
-	return baseStats, baseRelease
-}
-
-// matchBestBaseStats returns the testStatus, release and reportTestStatus
-// that has the highest threshold across the basis release and previous releases included
-// in fallback comparison.
-func (c *componentReportGenerator) matchBestBaseStats(
-	testID crtype.ReportTestIdentification,
-	testIdentification, baseRelease string,
-	baseStats, sampleStats crtype.TestStatus,
-	requiredConfidence int,
-	approvedRegression *regressionallowances.IntentionalRegression,
-	numberOfIgnoredSampleJobRuns int) (crtype.TestStatus, string, crtype.ReportTestStats) {
-
-	// The hope is that this goes away
-	// once we agree we don't need to honor a higher intentional regression pass percentage
-	baseStats, baseRelease = c.matchBaseRegression(testID, baseRelease, baseStats)
-	baseStatsTotal := baseStats.TotalCount
-
-	baseTestStats := c.assessComponentStatus(requiredConfidence, sampleStats.TotalCount, sampleStats.SuccessCount,
-		sampleStats.FlakeCount, baseStats.TotalCount, baseStats.SuccessCount,
-		baseStats.FlakeCount, approvedRegression, numberOfIgnoredSampleJobRuns, baseRelease, nil, nil)
-
-	if !c.IncludeMultiReleaseAnalysis {
-		return baseStats, baseRelease, baseTestStats
-	}
-
-	if c.cachedFallbackTestStatuses == nil {
-		log.Errorf("Invalid fallback test statuses")
-		return baseStats, baseRelease, baseTestStats
-	}
-
-	var priorRelease = baseRelease
-	var err error
-	for err == nil {
-		var cachedTestStatuses crtype.ReleaseTestMap
-		var cTestStats crtype.TestStatus
-		ok := false
-		priorRelease, err = previousRelease(priorRelease)
-		// if we fail to determine the previous release then stop
-		if err != nil {
-			return baseStats, baseRelease, baseTestStats
-		}
-		// if we hit a missing release then stop
-		if cachedTestStatuses, ok = c.cachedFallbackTestStatuses.Releases[priorRelease]; !ok {
-			return baseStats, baseRelease, baseTestStats
-		}
-		// it's ok if we don't have a testIdentification for this release
-		// we likely won't have it for earlier releases either, but we can keep going
-		if cTestStats, ok = cachedTestStatuses.Tests[testIdentification]; ok {
-
-			// what is our base total compared to the original base
-			// this happens when jobs shift like sdn -> ovn
-			// if we get below threshold that's a sign we are reducing our base signal
-			if float64(cTestStats.TotalCount)/float64(baseStatsTotal) < .6 {
-				log.Debugf("Fallback base total: %d to low for fallback analysis compared to original: %d", cTestStats.TotalCount, baseStatsTotal)
-				return baseStats, baseRelease, baseTestStats
-			}
-
-			cTestStats, priorRelease = c.matchBaseRegression(testID, priorRelease, cTestStats)
-
-			priorTestStats := c.assessComponentStatus(requiredConfidence, sampleStats.TotalCount, sampleStats.SuccessCount,
-				sampleStats.FlakeCount, cTestStats.TotalCount, cTestStats.SuccessCount,
-				cTestStats.FlakeCount, approvedRegression, numberOfIgnoredSampleJobRuns, priorRelease, cachedTestStatuses.Start, cachedTestStatuses.End)
-
-			if priorTestStats.ReportStatus < baseTestStats.ReportStatus {
-				baseStats = cTestStats
-				baseTestStats = priorTestStats
-				baseRelease = priorRelease
-			}
-		}
-	}
-
-	return baseStats, baseRelease, baseTestStats
+	return c.ReqOptions.AdvancedOption.Confidence
 }
 
 // TODO: break this function down and remove this nolint
 // nolint:gocyclo
-func (c *componentReportGenerator) generateComponentTestReport(ctx context.Context,
+func (c *ComponentReportGenerator) generateComponentTestReport(ctx context.Context,
 	baseStatus map[string]crtype.TestStatus,
 	sampleStatus map[string]crtype.TestStatus) (crtype.ComponentReport, error) {
 	report := crtype.ComponentReport{
 		Rows: []crtype.ReportRow{},
 	}
-
 	// aggregatedStatus is the aggregated status based on the requested rows and columns
 	aggregatedStatus := map[crtype.RowIdentification]map[crtype.ColumnID]cellStatus{}
 	// allRows and allColumns are used to make sure rows are ordered and all rows have the same columns in the same order
@@ -1398,43 +1069,35 @@ func (c *componentReportGenerator) generateComponentTestReport(ctx context.Conte
 	//
 	// understand we use this to find tests associated with base that we don't see now in sample
 	// meaning they have been renamed or removed
-	baseReleaseMatches := 0
-	baseReleaseMisses := 0
-	overriddenBaseMatches := 0
 
-	for testIdentification, baseStats := range baseStatus {
-		testID, err := buildTestID(baseStats, testIdentification)
+	for testKeyStr, baseStats := range baseStatus {
+		testKey, err := utils.DeserializeTestKey(baseStats, testKeyStr)
 		if err != nil {
 			return crtype.ComponentReport{}, err
 		}
 
-		var testStats crtype.ReportTestStats
+		var testStats crtype.ReportTestStats // This is the actual stats we return over the API
 		var triagedIncidents []crtype.TriagedIncident
 		var resolvedIssueCompensation int // triaged job run failures to ignore
-		sampleStats, ok := sampleStatus[testIdentification]
+		sampleStats, ok := sampleStatus[testKeyStr]
 		if !ok {
 			testStats.ReportStatus = crtype.MissingSample
 		} else {
 			// requiredConfidence is lowered for on-going regressions to prevent cells from flapping:
-			requiredConfidence := c.getRequiredConfidence(testID.TestID, testID.Variants)
-			var approvedRegression *regressionallowances.IntentionalRegression
-			if len(c.VariantCrossCompare) == 0 { // only really makes sense when not cross-comparing variants:
-				// look for corresponding regressions we can account for in the analysis
-				approvedRegression = regressionallowances.IntentionalRegressionFor(c.SampleRelease.Release, testID.ColumnIdentification, testID.TestID)
-				// ignore triage if we have an intentional regression
-				if approvedRegression == nil {
-					resolvedIssueCompensation, triagedIncidents = c.triagedIncidentsFor(ctx, testID)
-				}
-			}
+			requiredConfidence := c.getRequiredConfidence(testKey.TestID, testKey.Variants)
 
-			// this is where we look to see if a previous release has a higher pass rate
-			matchedBaseRelease := c.BaseRelease.Release
-			baseStats, matchedBaseRelease, testStats = c.matchBestBaseStats(testID, testIdentification, matchedBaseRelease, baseStats, sampleStats, requiredConfidence, approvedRegression, resolvedIssueCompensation)
-
-			if matchedBaseRelease != c.BaseRelease.Release {
-				log.Infof("Overrode base stats using release %s for Test: %s - %s", matchedBaseRelease, baseStats.TestName, testIdentification)
-				overriddenBaseMatches++
+			// Check if the TestStatus is decorated with info indicating it's release was overridden, and use that data if so
+			matchedBaseRelease := c.ReqOptions.BaseRelease.Release
+			var baseStart, baseEnd *time.Time
+			if baseStats.Release != nil {
+				matchedBaseRelease = baseStats.Release.Release
+				baseStart = baseStats.Release.Start
+				baseEnd = baseStats.Release.End
 			}
+			testStats = c.assessComponentStatus(requiredConfidence, sampleStats.TotalCount, sampleStats.SuccessCount,
+				sampleStats.FlakeCount, baseStats.TotalCount, baseStats.SuccessCount,
+				baseStats.FlakeCount, nil, resolvedIssueCompensation, matchedBaseRelease, baseStart, baseEnd)
+
 			if !sampleStats.LastFailure.IsZero() {
 				testStats.LastFailure = &sampleStats.LastFailure
 			}
@@ -1447,7 +1110,7 @@ func (c *componentReportGenerator) generateComponentTestReport(ctx context.Conte
 					if ti.Issue.Type != string(resolvedissues.TriageIssueTypeInfrastructure) {
 						// if a non Infrastructure regression isn't marked resolved or the resolution date is after the end of our sample query
 						// then we won't clear it.  Otherwise, we can.
-						if !ti.Issue.ResolutionDate.Valid || ti.Issue.ResolutionDate.Timestamp.After(c.SampleRelease.End) {
+						if !ti.Issue.ResolutionDate.Valid || ti.Issue.ResolutionDate.Timestamp.After(c.ReqOptions.SampleRelease.End) {
 							canClearReportStatus = false
 						}
 					}
@@ -1459,21 +1122,19 @@ func (c *componentReportGenerator) generateComponentTestReport(ctx context.Conte
 				}
 			}
 		}
-		delete(sampleStatus, testIdentification)
+		delete(sampleStatus, testKeyStr)
 
-		rowIdentifications, columnIdentifications, err := c.getRowColumnIdentifications(testIdentification, baseStats)
+		rowIdentifications, columnIdentifications, err := c.getRowColumnIdentifications(testKeyStr, baseStats)
 		if err != nil {
 			return crtype.ComponentReport{}, err
 		}
-		updateCellStatus(rowIdentifications, columnIdentifications, testID, testStats, aggregatedStatus, allRows, allColumns, triagedIncidents, c.openRegressions)
+		updateCellStatus(rowIdentifications, columnIdentifications, testKey, testStats, aggregatedStatus, allRows, allColumns, triagedIncidents, c.openRegressions)
 	}
-
-	log.Infof("BaseStats: %d, baseMatches: %d, baseMisses: %d.  Overridden base stats: %d", len(baseStatus), baseReleaseMatches, baseReleaseMisses, overriddenBaseMatches)
 
 	// Anything we saw in the basis was removed above, all that remains are tests with no basis, typically new
 	// tests, or tests that were renamed without submitting a rename to the test mapping repo.
-	for testIdentification, sampleStats := range sampleStatus {
-		testID, err := buildTestID(sampleStats, testIdentification)
+	for testKey, sampleStats := range sampleStatus {
+		testID, err := utils.DeserializeTestKey(sampleStats, testKey)
 		if err != nil {
 			return crtype.ComponentReport{}, err
 		}
@@ -1482,17 +1143,12 @@ func (c *componentReportGenerator) generateComponentTestReport(ctx context.Conte
 		var testStats crtype.ReportTestStats
 		var triagedIncidents []crtype.TriagedIncident
 		var resolvedIssueCompensation int // triaged job run failures to ignore
-		// look for corresponding regressions we can account for in the analysis
-		approvedRegression := regressionallowances.IntentionalRegressionFor(c.SampleRelease.Release, testID.ColumnIdentification, testID.TestID)
-		// ignore triage if we have an intentional regression
-		if approvedRegression == nil {
-			resolvedIssueCompensation, triagedIncidents = c.triagedIncidentsFor(ctx, testID)
-		}
+		resolvedIssueCompensation, triagedIncidents = c.triagedIncidentsFor(ctx, testID)
 
 		requiredConfidence := 0 // irrelevant for pass rate comparison
 		testStats = c.assessComponentStatus(requiredConfidence, sampleStats.TotalCount, sampleStats.SuccessCount,
 			sampleStats.FlakeCount, 0, 0, 0, // pass 0s for base stats
-			approvedRegression, resolvedIssueCompensation, "", nil, nil)
+			nil, resolvedIssueCompensation, "", nil, nil)
 
 		if testStats.IsTriaged() {
 			// we are within the triage range
@@ -1502,7 +1158,7 @@ func (c *componentReportGenerator) generateComponentTestReport(ctx context.Conte
 				if ti.Issue.Type != string(resolvedissues.TriageIssueTypeInfrastructure) {
 					// if a non Infrastructure regression isn't marked resolved or the resolution date is after the end of our sample query
 					// then we won't clear it.  Otherwise, we can.
-					if !ti.Issue.ResolutionDate.Valid || ti.Issue.ResolutionDate.Timestamp.After(c.SampleRelease.End) {
+					if !ti.Issue.ResolutionDate.Valid || ti.Issue.ResolutionDate.Timestamp.After(c.ReqOptions.SampleRelease.End) {
 						canClearReportStatus = false
 					}
 				}
@@ -1518,7 +1174,7 @@ func (c *componentReportGenerator) generateComponentTestReport(ctx context.Conte
 			testStats.LastFailure = &lastFailure
 		}
 
-		rowIdentifications, columnIdentification, err := c.getRowColumnIdentifications(testIdentification, sampleStats)
+		rowIdentifications, columnIdentification, err := c.getRowColumnIdentifications(testKey, sampleStats)
 		if err != nil {
 			return crtype.ComponentReport{}, err
 		}
@@ -1613,33 +1269,6 @@ func buildReport(sortedRows []crtype.RowIdentification, sortedColumns []crtype.C
 	return regressionRows, nil
 }
 
-func buildTestID(stats crtype.TestStatus, testIdentificationStr string) (crtype.ReportTestIdentification, error) {
-	// TODO: function needs a rename, there's a lot of references to test ID/identification around.
-	var testIdentification crtype.TestIdentification
-	// TODO: is this too slow?
-	err := json.Unmarshal([]byte(testIdentificationStr), &testIdentification)
-	if err != nil {
-		log.WithError(err).Errorf("trying to unmarshel %s", testIdentificationStr)
-		return crtype.ReportTestIdentification{}, err
-	}
-	testID := crtype.ReportTestIdentification{
-		RowIdentification: crtype.RowIdentification{
-			Component: stats.Component,
-			TestName:  stats.TestName,
-			TestSuite: stats.TestSuite,
-			TestID:    testIdentification.TestID,
-		},
-		ColumnIdentification: crtype.ColumnIdentification{
-			Variants: testIdentification.Variants,
-		},
-	}
-	// Take the first cap for now. When we reach to a cell with specific capability, we will override the value.
-	if len(stats.Capabilities) > 0 {
-		testID.Capability = stats.Capabilities[0]
-	}
-	return testID, nil
-}
-
 func getFailureCount(status crtype.JobRunTestStatusRow) int {
 	failure := status.TotalCount - status.SuccessCount - status.FlakeCount
 	if failure < 0 {
@@ -1648,19 +1277,12 @@ func getFailureCount(status crtype.JobRunTestStatusRow) int {
 	return failure
 }
 
-func (c *componentReportGenerator) getTestStatusPassRate(testStatus crtype.TestStatus) float64 {
+func (c *ComponentReportGenerator) getTestStatusPassRate(testStatus crtype.TestStatus) float64 {
 	return c.getPassRate(testStatus.SuccessCount, testStatus.TotalCount-testStatus.SuccessCount-testStatus.FlakeCount, testStatus.FlakeCount)
 }
 
-func (c *componentReportGenerator) getPassRate(success, failure, flake int) float64 {
-	total := success + failure + flake
-	if total == 0 {
-		return 0.0
-	}
-	if c.FlakeAsFailure {
-		return float64(success) / float64(total)
-	}
-	return float64(success+flake) / float64(total)
+func (c *ComponentReportGenerator) getPassRate(success, failure, flake int) float64 {
+	return utils.CalculatePassRate(c.ReqOptions, success, failure, flake)
 }
 
 func getRegressionStatus(basisPassPercentage, samplePassPercentage float64, isTriage bool) crtype.Status {
@@ -1677,26 +1299,30 @@ func getRegressionStatus(basisPassPercentage, samplePassPercentage float64, isTr
 	return crtype.SignificantRegression
 }
 
-func (c *componentReportGenerator) getEffectivePityFactor(basisPassPercentage float64, approvedRegression *regressionallowances.IntentionalRegression) int {
+func (c *ComponentReportGenerator) getEffectivePityFactor(basisPassPercentage float64, approvedRegression *regressionallowances.IntentionalRegression) int {
 	if approvedRegression != nil && approvedRegression.RegressedFailures > 0 {
-		regressedPassPercentage := approvedRegression.RegressedPassPercentage(c.FlakeAsFailure)
+		regressedPassPercentage := approvedRegression.RegressedPassPercentage(c.ReqOptions.AdvancedOption.FlakeAsFailure)
 		if regressedPassPercentage < basisPassPercentage {
 			// product owner chose a required pass percentage, so we allow pity to cover that approved pass percent
 			// plus the existing pity factor to limit, "well, it's just *barely* lower" arguments.
-			effectivePityFactor := int(basisPassPercentage*100) - int(regressedPassPercentage*100) + c.PityFactor
+			effectivePityFactor := int(basisPassPercentage*100) - int(regressedPassPercentage*100) + c.ReqOptions.AdvancedOption.PityFactor
 
-			if effectivePityFactor < c.PityFactor {
+			if effectivePityFactor < c.ReqOptions.AdvancedOption.PityFactor {
 				log.Errorf("effective pity factor for %+v is below zero: %d", approvedRegression, effectivePityFactor)
-				effectivePityFactor = c.PityFactor
+				effectivePityFactor = c.ReqOptions.AdvancedOption.PityFactor
 			}
 
 			return effectivePityFactor
 		}
 	}
-	return c.PityFactor
+	return c.ReqOptions.AdvancedOption.PityFactor
 }
 
-func (c *componentReportGenerator) assessComponentStatus(
+// TODO: this will eventually become the analyze step on a Middleware, or possibly a separate
+// set of objects relating to analysis, as there's not a lot of overlap between the analyzers
+// (fishers, pass rate, bayes (future)) and the middlewares (fallback, intentional regressions,
+// cross variant compare, rarely run jobs, etc.)
+func (c *ComponentReportGenerator) assessComponentStatus(
 	requiredConfidence,
 	sampleTotal,
 	sampleSuccess,
@@ -1712,8 +1338,8 @@ func (c *componentReportGenerator) assessComponentStatus(
 
 	// if we don't have a valid set of start and end dates we default to the baseRelease values
 	if baseStart == nil || baseEnd == nil {
-		baseStart = &c.BaseRelease.Start
-		baseEnd = &c.BaseRelease.End
+		baseStart = &c.ReqOptions.BaseRelease.Start
+		baseEnd = &c.ReqOptions.BaseRelease.End
 	}
 	// preserve the initial sampleTotal, so we can check
 	// to see if numberOfIgnoredSampleJobRuns impacts the status
@@ -1733,7 +1359,7 @@ func (c *componentReportGenerator) assessComponentStatus(
 	}
 	baseFailure := baseTotal - baseSuccess - baseFlake
 
-	if baseTotal == 0 && c.RequestAdvancedOptions.PassRateRequiredNewTests > 0 {
+	if baseTotal == 0 && c.ReqOptions.AdvancedOption.PassRateRequiredNewTests > 0 {
 		// If we have no base stats, fall back to a raw pass rate comparison for new or improperly renamed tests:
 		// Swap out sample with approvedRegression if we have it
 		if approvedRegression != nil {
@@ -1742,14 +1368,14 @@ func (c *componentReportGenerator) assessComponentStatus(
 			sampleSuccess = approvedRegression.PreviousSuccesses
 		}
 		testStats := c.buildPassRateTestStats(sampleSuccess, sampleFailure, sampleFlake,
-			float64(c.RequestAdvancedOptions.PassRateRequiredNewTests))
+			float64(c.ReqOptions.AdvancedOption.PassRateRequiredNewTests))
 		// If a new test reports no regression, and we're not using pass rate mode for all tests, we alter
 		// status to be missing basis for the pre-existing Fisher Exact behavior:
-		if testStats.ReportStatus == crtype.NotSignificant && c.RequestAdvancedOptions.PassRateRequiredAllTests == 0 {
+		if testStats.ReportStatus == crtype.NotSignificant && c.ReqOptions.AdvancedOption.PassRateRequiredAllTests == 0 {
 			testStats.ReportStatus = crtype.MissingBasis
 		}
 		return testStats
-	} else if c.RequestAdvancedOptions.PassRateRequiredAllTests > 0 {
+	} else if c.ReqOptions.AdvancedOption.PassRateRequiredAllTests > 0 {
 		// If requested, switch to pass rate only testing to see what does not meet the criteria:
 		// Swap out sample with approvedRegression if we have it
 		if approvedRegression != nil {
@@ -1758,7 +1384,7 @@ func (c *componentReportGenerator) assessComponentStatus(
 			sampleSuccess = approvedRegression.PreviousSuccesses
 		}
 		testStats := c.buildPassRateTestStats(sampleSuccess, sampleFailure, sampleFlake,
-			float64(c.RequestAdvancedOptions.PassRateRequiredAllTests))
+			float64(c.ReqOptions.AdvancedOption.PassRateRequiredAllTests))
 		// include base stats even though we didn't do fishers exact here, this is helpful
 		// for the test details page to give a visual on how the test behaved in the basis
 		testStats.BaseStats = &crtype.TestDetailsReleaseStats{
@@ -1781,7 +1407,7 @@ func (c *componentReportGenerator) assessComponentStatus(
 	return testStats
 }
 
-func (c *componentReportGenerator) buildFisherExactTestStats(requiredConfidence, sampleTotal, sampleSuccess, sampleFlake, sampleFailure, baseTotal, baseSuccess, baseFlake, baseFailure int, approvedRegression *regressionallowances.IntentionalRegression, initialSampleTotal int, baseRelease string, baseStart, baseEnd *time.Time) crtype.ReportTestStats {
+func (c *ComponentReportGenerator) buildFisherExactTestStats(requiredConfidence, sampleTotal, sampleSuccess, sampleFlake, sampleFailure, baseTotal, baseSuccess, baseFlake, baseFailure int, approvedRegression *regressionallowances.IntentionalRegression, initialSampleTotal int, baseRelease string, baseStart, baseEnd *time.Time) crtype.ReportTestStats {
 
 	fisherExact := 0.0
 	baseStats := &crtype.TestDetailsReleaseStats{
@@ -1799,9 +1425,9 @@ func (c *componentReportGenerator) buildFisherExactTestStats(requiredConfidence,
 	testStats := crtype.ReportTestStats{
 		Comparison: crtype.FisherExact,
 		SampleStats: crtype.TestDetailsReleaseStats{
-			Release: c.SampleRelease.Release,
-			Start:   &c.SampleRelease.Start,
-			End:     &c.SampleRelease.End,
+			Release: c.ReqOptions.SampleRelease.Release,
+			Start:   &c.ReqOptions.SampleRelease.Start,
+			End:     &c.ReqOptions.SampleRelease.End,
 			TestDetailsTestStats: crtype.TestDetailsTestStats{
 				SuccessRate:  c.getPassRate(sampleSuccess, sampleFailure, sampleFlake),
 				SuccessCount: sampleSuccess,
@@ -1815,7 +1441,7 @@ func (c *componentReportGenerator) buildFisherExactTestStats(requiredConfidence,
 	status := crtype.MissingBasis
 	// if the unadjusted sample was 0 then nothing to do
 	if initialSampleTotal == 0 {
-		if c.IgnoreMissing {
+		if c.ReqOptions.AdvancedOption.IgnoreMissing {
 			status = crtype.NotSignificant
 		} else {
 			status = crtype.MissingSample
@@ -1824,7 +1450,7 @@ func (c *componentReportGenerator) buildFisherExactTestStats(requiredConfidence,
 		// see if we had a significant regression prior to adjusting
 		basePass := baseSuccess + baseFlake
 		samplePass := sampleSuccess + sampleFlake
-		if c.FlakeAsFailure {
+		if c.ReqOptions.AdvancedOption.FlakeAsFailure {
 			basePass = baseSuccess
 			samplePass = sampleSuccess
 		}
@@ -1836,7 +1462,7 @@ func (c *componentReportGenerator) buildFisherExactTestStats(requiredConfidence,
 		// only consider wasSignificant if the sampleTotal has been changed and our sample
 		// pass percentage is below the basis
 		if initialSampleTotal > sampleTotal && initialPassPercentage < basisPassPercentage {
-			if basisPassPercentage-initialPassPercentage > float64(c.PityFactor)/100 {
+			if basisPassPercentage-initialPassPercentage > float64(c.ReqOptions.AdvancedOption.PityFactor)/100 {
 				wasSignificant, _ = c.fischerExactTest(requiredConfidence, initialSampleTotal-samplePass, samplePass, baseTotal-basePass, basePass)
 			}
 			// if it was significant without the adjustment use
@@ -1848,7 +1474,7 @@ func (c *componentReportGenerator) buildFisherExactTestStats(requiredConfidence,
 
 		if sampleTotal == 0 {
 			if !wasSignificant {
-				if c.IgnoreMissing {
+				if c.ReqOptions.AdvancedOption.IgnoreMissing {
 					status = crtype.NotSignificant
 
 				} else {
@@ -1872,7 +1498,7 @@ func (c *componentReportGenerator) buildFisherExactTestStats(requiredConfidence,
 		samplePassPercentage := float64(samplePass) / float64(sampleTotal)
 
 		// did we remove enough failures that we are below the MinimumFailure threshold?
-		if c.MinimumFailure != 0 && (sampleTotal-samplePass) < c.MinimumFailure {
+		if c.ReqOptions.AdvancedOption.MinimumFailure != 0 && (sampleTotal-samplePass) < c.ReqOptions.AdvancedOption.MinimumFailure {
 			testStats.ReportStatus = status
 			testStats.FisherExact = thrift.Float64Ptr(0.0)
 			return testStats
@@ -1910,7 +1536,7 @@ func (c *componentReportGenerator) buildFisherExactTestStats(requiredConfidence,
 				testStats.SampleStats.SuccessRate*float64(100)),
 		}
 		// check for override
-		if baseRelease != c.BaseRelease.Release {
+		if baseRelease != c.ReqOptions.BaseRelease.Release {
 			testStats.Explanations = append(testStats.Explanations, fmt.Sprintf("Overrode base stats using release %s", baseRelease))
 		}
 	}
@@ -1918,7 +1544,7 @@ func (c *componentReportGenerator) buildFisherExactTestStats(requiredConfidence,
 	return testStats
 }
 
-func (c *componentReportGenerator) buildPassRateTestStats(sampleSuccess, sampleFailure, sampleFlake int, requiredSuccessRate float64) crtype.ReportTestStats {
+func (c *ComponentReportGenerator) buildPassRateTestStats(sampleSuccess, sampleFailure, sampleFlake int, requiredSuccessRate float64) crtype.ReportTestStats {
 	successRate := c.getPassRate(sampleSuccess, sampleFailure, sampleFlake)
 
 	// Assume 2x our allowed failure rate = an extreme regression.
@@ -1929,7 +1555,7 @@ func (c *componentReportGenerator) buildPassRateTestStats(sampleSuccess, sampleF
 	// Require 7 runs in the sample (typically 1 week) for us to consider a pass rate requirement for a new test:
 	sufficientRuns := (sampleSuccess + sampleFailure + sampleFlake) >= 7
 
-	if sufficientRuns && successRate*100 < requiredSuccessRate && sampleFailure >= c.MinimumFailure {
+	if sufficientRuns && successRate*100 < requiredSuccessRate && sampleFailure >= c.ReqOptions.AdvancedOption.MinimumFailure {
 		rStatus := crtype.SignificantRegression
 		if successRate*100 < severeRegressionSuccessRate {
 			rStatus = crtype.ExtremeRegression
@@ -1941,9 +1567,9 @@ func (c *componentReportGenerator) buildPassRateTestStats(sampleSuccess, sampleF
 			},
 			Comparison: crtype.PassRate,
 			SampleStats: crtype.TestDetailsReleaseStats{
-				Release: c.SampleRelease.Release,
-				Start:   &c.SampleRelease.Start,
-				End:     &c.SampleRelease.End,
+				Release: c.ReqOptions.SampleRelease.Release,
+				Start:   &c.ReqOptions.SampleRelease.Start,
+				End:     &c.ReqOptions.SampleRelease.End,
 				TestDetailsTestStats: crtype.TestDetailsTestStats{
 					SuccessRate:  successRate,
 					SuccessCount: sampleSuccess,
@@ -1959,7 +1585,7 @@ func (c *componentReportGenerator) buildPassRateTestStats(sampleSuccess, sampleF
 	}
 }
 
-func (c *componentReportGenerator) fischerExactTest(confidenceRequired, sampleFailure, sampleSuccess, baseFailure, baseSuccess int) (bool, float64) {
+func (c *ComponentReportGenerator) fischerExactTest(confidenceRequired, sampleFailure, sampleSuccess, baseFailure, baseSuccess int) (bool, float64) {
 	_, _, r, _ := fischer.FisherExactTest(sampleFailure,
 		sampleSuccess,
 		baseFailure,
@@ -1967,7 +1593,7 @@ func (c *componentReportGenerator) fischerExactTest(confidenceRequired, sampleFa
 	return r < 1-float64(confidenceRequired)/100, r
 }
 
-func (c *componentReportGenerator) getUniqueJUnitColumnValuesLast60Days(ctx context.Context, field string,
+func (c *ComponentReportGenerator) getUniqueJUnitColumnValuesLast60Days(ctx context.Context, field string,
 	nested bool) ([]string,
 	error) {
 	unnest := ""
@@ -1986,15 +1612,15 @@ func (c *componentReportGenerator) getUniqueJUnitColumnValuesLast60Days(ctx cont
 					ORDER BY
 						name`, field, c.client.Dataset, unnest)
 
-	query := c.client.BQ.Query(queryString)
-	query.Parameters = []bigquery.QueryParameter{
+	q := c.client.BQ.Query(queryString)
+	q.Parameters = []bigquery.QueryParameter{
 		{
 			Name:  "IgnoredJobs",
-			Value: ignoredJobsRegexp,
+			Value: query.IgnoredJobsRegexp,
 		},
 	}
 
-	return getSingleColumnResultToSlice(ctx, query)
+	return getSingleColumnResultToSlice(ctx, q)
 }
 
 func init() {

--- a/pkg/api/componentreadiness/component_report_test.go
+++ b/pkg/api/componentreadiness/component_report_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
 	v1 "github.com/openshift/sippy/pkg/apis/config/v1"
 	"github.com/stretchr/testify/assert"
 
@@ -18,7 +19,7 @@ import (
 	"github.com/openshift/sippy/pkg/util/sets"
 )
 
-func fakeComponentAndCapabilityGetter(test crtype.TestIdentification, stats crtype.TestStatus) (string, []string) {
+func fakeComponentAndCapabilityGetter(test crtype.TestWithVariantsKey, stats crtype.TestStatus) (string, []string) {
 	name := stats.TestName
 	known := map[string]struct {
 		component    string
@@ -51,13 +52,15 @@ var (
 	}
 	defaultColumnGroupByVariants    = sets.NewString(strings.Split(DefaultColumnGroupBy, ",")...)
 	defaultDBGroupByVariants        = sets.NewString(strings.Split(DefaultDBGroupBy, ",")...)
-	defaultComponentReportGenerator = componentReportGenerator{
+	defaultComponentReportGenerator = ComponentReportGenerator{
 		gcsBucket: "test-platform-results",
-		RequestVariantOptions: crtype.RequestVariantOptions{
-			ColumnGroupBy: defaultColumnGroupByVariants,
-			DBGroupBy:     defaultDBGroupByVariants,
+		ReqOptions: crtype.RequestOptions{
+			VariantOption: crtype.RequestVariantOptions{
+				ColumnGroupBy: defaultColumnGroupByVariants,
+				DBGroupBy:     defaultDBGroupByVariants,
+			},
+			AdvancedOption: defaultAdvancedOption,
 		},
-		RequestAdvancedOptions: defaultAdvancedOption,
 	}
 	flakeFailAdvancedOption = crtype.RequestAdvancedOptions{
 		Confidence:     95,
@@ -65,76 +68,88 @@ var (
 		MinimumFailure: 3,
 		FlakeAsFailure: true,
 	}
-	flakeFailComponentReportGenerator = componentReportGenerator{
+	flakeFailComponentReportGenerator = ComponentReportGenerator{
 		gcsBucket: "test-platform-results",
-		RequestVariantOptions: crtype.RequestVariantOptions{
-			ColumnGroupBy: defaultColumnGroupByVariants,
-			DBGroupBy:     defaultDBGroupByVariants,
+		ReqOptions: crtype.RequestOptions{
+			VariantOption: crtype.RequestVariantOptions{
+				ColumnGroupBy: defaultColumnGroupByVariants,
+				DBGroupBy:     defaultDBGroupByVariants,
+			},
+			AdvancedOption: flakeFailAdvancedOption,
 		},
-		RequestAdvancedOptions: flakeFailAdvancedOption,
 	}
 	installerColumnGroupByVariants           = sets.NewString("Platform", "Architecture", "Network", "Installer")
-	groupByInstallerComponentReportGenerator = componentReportGenerator{
+	groupByInstallerComponentReportGenerator = ComponentReportGenerator{
 		gcsBucket: "test-platform-results",
-		RequestVariantOptions: crtype.RequestVariantOptions{
-			ColumnGroupBy: installerColumnGroupByVariants,
-			DBGroupBy:     defaultDBGroupByVariants,
-		},
-		RequestAdvancedOptions: defaultAdvancedOption,
-	}
-	componentPageGenerator = componentReportGenerator{
-		gcsBucket: "test-platform-results",
-		RequestTestIdentificationOptions: crtype.RequestTestIdentificationOptions{
-			Component: "component 2",
-		},
-		RequestVariantOptions: crtype.RequestVariantOptions{
-			ColumnGroupBy: defaultColumnGroupByVariants,
-			DBGroupBy:     defaultDBGroupByVariants,
-		},
-		RequestAdvancedOptions: defaultAdvancedOption,
-	}
-	capabilityPageGenerator = componentReportGenerator{
-		gcsBucket: "test-platform-results",
-		RequestTestIdentificationOptions: crtype.RequestTestIdentificationOptions{
-			Component:  "component 2",
-			Capability: "cap22",
-		},
-		RequestVariantOptions: crtype.RequestVariantOptions{
-			ColumnGroupBy: defaultColumnGroupByVariants,
-			DBGroupBy:     defaultDBGroupByVariants,
-		},
-		RequestAdvancedOptions: defaultAdvancedOption,
-	}
-	testPageGenerator = componentReportGenerator{
-		gcsBucket: "test-platform-results",
-		RequestTestIdentificationOptions: crtype.RequestTestIdentificationOptions{
-			Component:  "component 2",
-			Capability: "cap22",
-			TestID:     "2",
-		},
-		RequestVariantOptions: crtype.RequestVariantOptions{
-			ColumnGroupBy: defaultColumnGroupByVariants,
-			DBGroupBy:     defaultDBGroupByVariants,
-		},
-		RequestAdvancedOptions: defaultAdvancedOption,
-	}
-	testDetailsGenerator = componentReportGenerator{
-		gcsBucket: "test-platform-results",
-		RequestTestIdentificationOptions: crtype.RequestTestIdentificationOptions{
-			Component:  "component 1",
-			Capability: "cap11",
-			TestID:     "1",
-		},
-		RequestVariantOptions: crtype.RequestVariantOptions{
-			ColumnGroupBy: defaultColumnGroupByVariants,
-			DBGroupBy:     defaultDBGroupByVariants,
-			RequestedVariants: map[string]string{
-				"Platform":     "aws",
-				"Architecture": "amd64",
-				"Network":      "ovn",
+		ReqOptions: crtype.RequestOptions{
+			VariantOption: crtype.RequestVariantOptions{
+				ColumnGroupBy: installerColumnGroupByVariants,
+				DBGroupBy:     defaultDBGroupByVariants,
 			},
+			AdvancedOption: defaultAdvancedOption,
 		},
-		RequestAdvancedOptions: defaultAdvancedOption,
+	}
+	componentPageGenerator = ComponentReportGenerator{
+		gcsBucket: "test-platform-results",
+		ReqOptions: crtype.RequestOptions{
+			TestIDOption: crtype.RequestTestIdentificationOptions{
+				Component: "component 2",
+			},
+			VariantOption: crtype.RequestVariantOptions{
+				ColumnGroupBy: defaultColumnGroupByVariants,
+				DBGroupBy:     defaultDBGroupByVariants,
+			},
+			AdvancedOption: defaultAdvancedOption,
+		},
+	}
+	capabilityPageGenerator = ComponentReportGenerator{
+		gcsBucket: "test-platform-results",
+		ReqOptions: crtype.RequestOptions{
+			TestIDOption: crtype.RequestTestIdentificationOptions{
+				Component:  "component 2",
+				Capability: "cap22",
+			},
+			VariantOption: crtype.RequestVariantOptions{
+				ColumnGroupBy: defaultColumnGroupByVariants,
+				DBGroupBy:     defaultDBGroupByVariants,
+			},
+			AdvancedOption: defaultAdvancedOption,
+		},
+	}
+	testPageGenerator = ComponentReportGenerator{
+		gcsBucket: "test-platform-results",
+		ReqOptions: crtype.RequestOptions{
+			TestIDOption: crtype.RequestTestIdentificationOptions{
+				Component:  "component 2",
+				Capability: "cap22",
+				TestID:     "2",
+			},
+			VariantOption: crtype.RequestVariantOptions{
+				ColumnGroupBy: defaultColumnGroupByVariants,
+				DBGroupBy:     defaultDBGroupByVariants,
+			},
+			AdvancedOption: defaultAdvancedOption,
+		},
+	}
+	testDetailsGenerator = ComponentReportGenerator{
+		gcsBucket: "test-platform-results",
+		ReqOptions: crtype.RequestOptions{
+			TestIDOption: crtype.RequestTestIdentificationOptions{
+				Component:  "component 1",
+				Capability: "cap11",
+				TestID:     "1",
+			},
+			VariantOption: crtype.RequestVariantOptions{
+				ColumnGroupBy: defaultColumnGroupByVariants,
+				DBGroupBy:     defaultDBGroupByVariants,
+				RequestedVariants: map[string]string{
+					"Platform":     "aws",
+					"Architecture": "amd64",
+					"Network":      "ovn",
+				},
+			},
+			AdvancedOption: defaultAdvancedOption,
+		},
 	}
 )
 
@@ -149,7 +164,7 @@ func filterColumnIDByDefault(id crtype.ColumnIdentification) crtype.ColumnIdenti
 }
 
 func TestGenerateComponentReport(t *testing.T) {
-	awsAMD64OVNTest := crtype.TestIdentification{
+	awsAMD64OVNTest := crtype.TestWithVariantsKey{
 		TestID: "1",
 		Variants: map[string]string{
 			"Platform":     "aws",
@@ -166,7 +181,7 @@ func TestGenerateComponentReport(t *testing.T) {
 	if err != nil {
 		assert.NoError(t, err, "error marshalling awsAMD64OVNTest")
 	}
-	awsAMD64SDNTest := crtype.TestIdentification{
+	awsAMD64SDNTest := crtype.TestWithVariantsKey{
 		TestID: "2",
 		Variants: map[string]string{
 			"Platform":     "aws",
@@ -183,7 +198,7 @@ func TestGenerateComponentReport(t *testing.T) {
 	if err != nil {
 		assert.NoError(t, err, "error marshalling awsAMD64SDNTest")
 	}
-	awsAMD64SDNInstallerUPITest := crtype.TestIdentification{
+	awsAMD64SDNInstallerUPITest := crtype.TestWithVariantsKey{
 		TestID: "2",
 		Variants: map[string]string{
 			"Platform":     "aws",
@@ -200,7 +215,7 @@ func TestGenerateComponentReport(t *testing.T) {
 	if err != nil {
 		assert.NoError(t, err, "error marshalling awsAMD64SDNInstallerUPITest")
 	}
-	awsAMD64OVN2Test := crtype.TestIdentification{
+	awsAMD64OVN2Test := crtype.TestWithVariantsKey{
 		TestID: "3",
 		Variants: map[string]string{
 			"Platform":     "aws",
@@ -213,7 +228,7 @@ func TestGenerateComponentReport(t *testing.T) {
 	if err != nil {
 		assert.NoError(t, err, "error marshalling awsAMD64OVN2Test")
 	}
-	awsAMD64OVNInstallerIPITest := crtype.TestIdentification{
+	awsAMD64OVNInstallerIPITest := crtype.TestWithVariantsKey{
 		TestID: "1",
 		Variants: map[string]string{
 			"Platform":     "aws",
@@ -398,7 +413,7 @@ func TestGenerateComponentReport(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		generator      componentReportGenerator
+		generator      ComponentReportGenerator
 		baseStatus     map[string]crtype.TestStatus
 		sampleStatus   map[string]crtype.TestStatus
 		expectedReport crtype.ComponentReport
@@ -779,14 +794,16 @@ func TestGenerateComponentReport(t *testing.T) {
 		},
 		{
 			name: "top page test confidence 90 result in regression",
-			generator: componentReportGenerator{
-				RequestVariantOptions: crtype.RequestVariantOptions{
-					ColumnGroupBy: defaultColumnGroupByVariants,
-				},
-				RequestAdvancedOptions: crtype.RequestAdvancedOptions{
-					Confidence:     90,
-					PityFactor:     5,
-					MinimumFailure: 3,
+			generator: ComponentReportGenerator{
+				ReqOptions: crtype.RequestOptions{
+					VariantOption: crtype.RequestVariantOptions{
+						ColumnGroupBy: defaultColumnGroupByVariants,
+					},
+					AdvancedOption: crtype.RequestAdvancedOptions{
+						Confidence:     90,
+						PityFactor:     5,
+						MinimumFailure: 3,
+					},
 				},
 			},
 			baseStatus: map[string]crtype.TestStatus{
@@ -873,14 +890,16 @@ func TestGenerateComponentReport(t *testing.T) {
 		},
 		{
 			name: "top page test confidence 90 pity 10 result in no regression",
-			generator: componentReportGenerator{
-				RequestVariantOptions: crtype.RequestVariantOptions{
-					ColumnGroupBy: defaultColumnGroupByVariants,
-				},
-				RequestAdvancedOptions: crtype.RequestAdvancedOptions{
-					Confidence:     90,
-					PityFactor:     10,
-					MinimumFailure: 3,
+			generator: ComponentReportGenerator{
+				ReqOptions: crtype.RequestOptions{
+					VariantOption: crtype.RequestVariantOptions{
+						ColumnGroupBy: defaultColumnGroupByVariants,
+					},
+					AdvancedOption: crtype.RequestAdvancedOptions{
+						Confidence:     90,
+						PityFactor:     10,
+						MinimumFailure: 3,
+					},
 				},
 			},
 			baseStatus: map[string]crtype.TestStatus{
@@ -1144,6 +1163,27 @@ func TestGenerateComponentReport(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			report, err := tc.generator.generateComponentTestReport(context.TODO(), tc.baseStatus, tc.sampleStatus)
 			assert.NoError(t, err, "error generating component report")
+
+			// WARNING: PC and Mac differ on floating point comparisons when you get far enough into the precision.
+			// We need to do fuzzy floating point comparions which poses a problem for the way these tests are
+			// written to compare an entire report object. To avoid having to surgically compare everything, we
+			// will first iterate all rows cols and regressed tests to compare any floating point vals we need to.
+			// Then we nil them out and deep compare the rest of the object. This prevents any missed bugs where we
+			// add new data to the report, but forget to explicitly compare it.
+			assert.Equal(t, len(tc.expectedReport.Rows), len(report.Rows))
+			for ir := range report.Rows {
+				assert.Equal(t, tc.expectedReport.Rows[ir].RowIdentification, report.Rows[ir].RowIdentification)
+				assert.Equal(t, len(tc.expectedReport.Rows[ir].Columns), len(report.Rows[ir].Columns))
+				for ic := range report.Rows[ir].Columns {
+					assert.Equal(t, len(tc.expectedReport.Rows[ir].Columns[ic].RegressedTests), len(report.Rows[ir].Columns[ic].RegressedTests))
+					for it, regTest := range report.Rows[ir].Columns[ic].RegressedTests {
+						assert.InDelta(t, *tc.expectedReport.Rows[ir].Columns[ic].RegressedTests[it].FisherExact, *regTest.FisherExact, 0.000001)
+						tc.expectedReport.Rows[ir].Columns[ic].RegressedTests[it].FisherExact = nil
+						report.Rows[ir].Columns[ic].RegressedTests[it].FisherExact = nil
+
+					}
+				}
+			}
 			assert.Equal(t, tc.expectedReport, report, "expected report %+v, got %+v", tc.expectedReport, report)
 		})
 	}
@@ -1182,15 +1222,15 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		Flake:   4,
 	}
 	testDetailsRowIdentification := crtype.RowIdentification{
-		TestID:     testDetailsGenerator.TestID,
-		Component:  testDetailsGenerator.Component,
-		Capability: testDetailsGenerator.Capability,
+		TestID:     testDetailsGenerator.ReqOptions.TestIDOption.TestID,
+		Component:  testDetailsGenerator.ReqOptions.TestIDOption.Component,
+		Capability: testDetailsGenerator.ReqOptions.TestIDOption.Capability,
 	}
 	testDetailsColumnIdentification := crtype.ColumnIdentification{
-		Variants: testDetailsGenerator.RequestedVariants,
+		Variants: testDetailsGenerator.ReqOptions.VariantOption.RequestedVariants,
 	}
 	sampleReleaseStatsTwoHigh := crtype.TestDetailsReleaseStats{
-		Release: testDetailsGenerator.SampleRelease.Release,
+		Release: testDetailsGenerator.ReqOptions.SampleRelease.Release,
 		TestDetailsTestStats: crtype.TestDetailsTestStats{
 			SuccessRate:  0.9203539823008849,
 			SuccessCount: 200,
@@ -1201,7 +1241,7 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		End:   &time.Time{},
 	}
 	baseReleaseStatsTwoHigh := crtype.TestDetailsReleaseStats{
-		Release: testDetailsGenerator.BaseRelease.Release,
+		Release: testDetailsGenerator.ReqOptions.BaseRelease.Release,
 		TestDetailsTestStats: crtype.TestDetailsTestStats{
 			SuccessRate:  0.9130434782608695,
 			SuccessCount: 2000,
@@ -1236,7 +1276,7 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		FlakeCount:   50,
 	}
 	sampleReleaseStatsOneHigh := crtype.TestDetailsReleaseStats{
-		Release: testDetailsGenerator.SampleRelease.Release,
+		Release: testDetailsGenerator.ReqOptions.SampleRelease.Release,
 		TestDetailsTestStats: crtype.TestDetailsTestStats{
 			SuccessRate:  0.9203539823008849,
 			SuccessCount: 100,
@@ -1247,7 +1287,7 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		End:   &time.Time{},
 	}
 	baseReleaseStatsOneHigh := crtype.TestDetailsReleaseStats{
-		Release: testDetailsGenerator.BaseRelease.Release,
+		Release: testDetailsGenerator.ReqOptions.BaseRelease.Release,
 		TestDetailsTestStats: crtype.TestDetailsTestStats{
 			SuccessRate:  0.9130434782608695,
 			SuccessCount: 1000,
@@ -1258,7 +1298,7 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		End:   &time.Time{},
 	}
 	sampleReleaseStatsOneLow := crtype.TestDetailsReleaseStats{
-		Release: testDetailsGenerator.SampleRelease.Release,
+		Release: testDetailsGenerator.ReqOptions.SampleRelease.Release,
 		TestDetailsTestStats: crtype.TestDetailsTestStats{
 			SuccessRate:  0.4778761061946903,
 			SuccessCount: 50,
@@ -1269,7 +1309,7 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		End:   &time.Time{},
 	}
 	baseReleaseStatsOneLow := crtype.TestDetailsReleaseStats{
-		Release: testDetailsGenerator.BaseRelease.Release,
+		Release: testDetailsGenerator.ReqOptions.BaseRelease.Release,
 		TestDetailsTestStats: crtype.TestDetailsTestStats{
 			SuccessRate:  0.4782608695652174,
 			SuccessCount: 500,
@@ -1281,7 +1321,7 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 	}
 	tests := []struct {
 		name                    string
-		generator               componentReportGenerator
+		generator               ComponentReportGenerator
 		baseRequiredJobStats    []requiredJobStats
 		sampleRequiredJobStats  []requiredJobStats
 		expectedReport          crtype.ReportTestDetails
@@ -1579,15 +1619,15 @@ func Test_componentReportGenerator_normalizeProwJobName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &componentReportGenerator{}
+			c := &ComponentReportGenerator{}
 			if tt.baseRelease != "" {
-				c.BaseRelease = crtype.RequestReleaseOptions{Release: tt.baseRelease}
+				c.ReqOptions.BaseRelease = crtype.RequestReleaseOptions{Release: tt.baseRelease}
 			}
 			if tt.sampleRelease != "" {
-				c.SampleRelease = crtype.RequestReleaseOptions{Release: tt.sampleRelease}
+				c.ReqOptions.SampleRelease = crtype.RequestReleaseOptions{Release: tt.sampleRelease}
 			}
 
-			assert.Equalf(t, tt.want, c.normalizeProwJobName(tt.jobName), "normalizeProwJobName(%v)", tt.jobName)
+			assert.Equalf(t, tt.want, utils.NormalizeProwJobName(tt.jobName, c.ReqOptions), "normalizeProwJobName(%v)", tt.jobName)
 		})
 	}
 }
@@ -1830,10 +1870,10 @@ func Test_componentReportGenerator_assessComponentStatus(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &componentReportGenerator{}
-			c.PassRateRequiredNewTests = tt.requiredPassRateForNewTests
-			c.PassRateRequiredAllTests = tt.requiredPassRateForAllTests
-			c.MinimumFailure = tt.minFail
+			c := &ComponentReportGenerator{}
+			c.ReqOptions.AdvancedOption.PassRateRequiredNewTests = tt.requiredPassRateForNewTests
+			c.ReqOptions.AdvancedOption.PassRateRequiredAllTests = tt.requiredPassRateForAllTests
+			c.ReqOptions.AdvancedOption.MinimumFailure = tt.minFail
 
 			testStats := c.assessComponentStatus(0, tt.sampleTotal, tt.sampleSuccess, tt.sampleFlake, tt.baseTotal, tt.baseSuccess, tt.baseFlake, nil, tt.numberOfIgnoredSamples, "dummyRelease", nil, nil)
 			assert.Equalf(t, tt.expectedStatus, testStats.ReportStatus, "assessComponentStatus expected status not equal")

--- a/pkg/api/componentreadiness/middleware/interface.go
+++ b/pkg/api/componentreadiness/middleware/interface.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"context"
+	"sync"
+
+	crtype "github.com/openshift/sippy/pkg/apis/api/componentreport"
+)
+
+type Middleware interface {
+	// Query phase allows middleware to inject additional TestStatus beyond the normal base/sample queries.
+	// Base and sample status can be submitted using the provided channels for a map of ALL test keys
+	// (ID plus variant info serialized) to TestStatus.
+	Query(ctx context.Context, wg *sync.WaitGroup, allJobVariants crtype.JobVariants,
+		baseStatusCh, sampleStatusCh chan map[string]crtype.TestStatus, errCh chan error)
+
+	// Transform gives middleware opportunity to adjust the queried base and sample TestStatuses before we
+	// proceed to analysis.
+	Transform(baseStatus, sampleStatus map[string]crtype.TestStatus) (map[string]crtype.TestStatus, map[string]crtype.TestStatus, error)
+}

--- a/pkg/api/componentreadiness/middleware/regressionallowances/regressionallowances.go
+++ b/pkg/api/componentreadiness/middleware/regressionallowances/regressionallowances.go
@@ -1,0 +1,100 @@
+package regressionallowances
+
+import (
+	"context"
+	"sync"
+
+	"github.com/openshift/sippy/pkg/api/componentreadiness/middleware"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
+	"github.com/openshift/sippy/pkg/regressionallowances"
+	log "github.com/sirupsen/logrus"
+
+	crtype "github.com/openshift/sippy/pkg/apis/api/componentreport"
+)
+
+var _ middleware.Middleware = &RegressionAllowances{}
+
+func NewRegressionAllowancesMiddleware(reqOptions crtype.RequestOptions) *RegressionAllowances {
+	return &RegressionAllowances{
+		log:                  log.WithField("middleware", "RegressionAllowances"),
+		reqOptions:           reqOptions,
+		regressionGetterFunc: regressionallowances.IntentionalRegressionFor,
+	}
+}
+
+// RegressionAllowances middleware checks if there was an accepted intentional regression in the basis release, and if so
+// overrides the test pass data to what was specified in the allowance. (typically the data from the prior release)
+// This allows us to make sure the current branch compares against the good data from two releases ago, instead of the
+// prior release which had a regression in the window prior to GA.
+type RegressionAllowances struct {
+	cachedFallbackTestStatuses *crtype.FallbackReleases
+	log                        log.FieldLogger
+	reqOptions                 crtype.RequestOptions
+
+	// regressionGetterFunc allows us to unit test without relying on real regression data
+	regressionGetterFunc func(releaseString string, variant crtype.ColumnIdentification, testID string) *regressionallowances.IntentionalRegression
+}
+
+func (r *RegressionAllowances) Query(_ context.Context, _ *sync.WaitGroup, _ crtype.JobVariants,
+	_, _ chan map[string]crtype.TestStatus, _ chan error) {
+	// unused
+}
+
+// Transform iterates the base status looking for any with an accepted regression in the basis release, and if found
+// swaps out the stats with the better pass rate data specified in the intentional regression allowance.
+func (r *RegressionAllowances) Transform(baseStatus, sampleStatus map[string]crtype.TestStatus) (map[string]crtype.TestStatus, map[string]crtype.TestStatus, error) {
+	for testKeyStr, baseStats := range baseStatus {
+		testKey, err := utils.DeserializeTestKey(baseStats, testKeyStr)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		newBaseStatus, newBaseRelease := r.matchBaseRegression(testKey, r.reqOptions.BaseRelease.Release, baseStats)
+		if newBaseRelease != r.reqOptions.BaseRelease.Release {
+			baseStatus[testKeyStr] = newBaseStatus
+		}
+	}
+
+	return baseStatus, sampleStatus, nil
+}
+
+// matchBaseRegression returns a testStatus that reflects the allowances specified
+// in an intentional regression that accepted a lower threshold but maintains the higher
+// threshold when used as a basis.
+// It will return the original testStatus if there is no intentional regression.
+func (r *RegressionAllowances) matchBaseRegression(testID crtype.ReportTestIdentification, baseRelease string, baseStats crtype.TestStatus) (crtype.TestStatus, string) {
+	var baseRegression *regressionallowances.IntentionalRegression
+
+	// TODO: knowledge of variant cross compare here would be nice to eliminate
+	if len(r.reqOptions.VariantOption.VariantCrossCompare) == 0 {
+		// only really makes sense when not cross-comparing variants:
+		// look for corresponding regressions we can account for in the analysis
+		// only if we are ignoring fallback, otherwise we will let fallback determine the threshold
+		baseRegression = r.regressionGetterFunc(baseRelease, testID.ColumnIdentification, testID.TestID)
+
+		_, success, fail, flake := baseStats.GetTotalSuccessFailFlakeCounts()
+		basePassRate := utils.CalculatePassRate(r.reqOptions, success, fail, flake)
+		if baseRegression != nil && baseRegression.PreviousPassPercentage(r.reqOptions.AdvancedOption.FlakeAsFailure) > basePassRate {
+			// override with  the basis regression previous values
+			// testStats will reflect the expected threshold, not the computed values from the release with the allowed regression
+			baseRegressionPreviousRelease, err := utils.PreviousRelease(r.reqOptions.BaseRelease.Release)
+			if err != nil {
+				log.WithError(err).Error("Failed to determine the previous release for baseRegression")
+			} else {
+				// create a clone since we might be updating a cached item though the same regression would likely apply each time...
+				updatedStats := crtype.TestStatus{TestName: baseStats.TestName, TestSuite: baseStats.TestSuite, Capabilities: baseStats.Capabilities,
+					Component: baseStats.Component, Variants: baseStats.Variants,
+					FlakeCount:   baseRegression.PreviousFlakes,
+					SuccessCount: baseRegression.PreviousSuccesses,
+					TotalCount:   baseRegression.PreviousFailures + baseRegression.PreviousFlakes + baseRegression.PreviousSuccesses,
+				}
+				baseStats = updatedStats
+				baseRelease = baseRegressionPreviousRelease
+				log.Infof("BaseRegression - PreviousPassPercentage overrides baseStats.  Release: %s, Successes: %d, Flakes: %d, Total: %d",
+					baseRelease, baseStats.SuccessCount, baseStats.FlakeCount, baseStats.TotalCount)
+			}
+		}
+	}
+
+	return baseStats, baseRelease
+}

--- a/pkg/api/componentreadiness/middleware/regressionallowances/regressionallowances_test.go
+++ b/pkg/api/componentreadiness/middleware/regressionallowances/regressionallowances_test.go
@@ -1,0 +1,112 @@
+package regressionallowances
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	crtype "github.com/openshift/sippy/pkg/apis/api/componentreport"
+	"github.com/openshift/sippy/pkg/regressionallowances"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Transform(t *testing.T) {
+	test1ID := "test1ID"
+	variants := map[string]string{
+		"Arch":     "amd64",
+		"Platform": "aws",
+	}
+	regressionGetter := func(releaseString string, variant crtype.ColumnIdentification, testID string) *regressionallowances.IntentionalRegression {
+		if releaseString == "4.18" && reflect.DeepEqual(variant.Variants, variants) && testID == test1ID {
+			return &regressionallowances.IntentionalRegression{
+				JiraComponent:      "foo",
+				TestID:             test1ID,
+				TestName:           "test1",
+				Variant:            variant,
+				PreviousSuccesses:  100,
+				PreviousFailures:   0,
+				PreviousFlakes:     0,
+				RegressedSuccesses: 75,
+				RegressedFailures:  25,
+				RegressedFlakes:    0,
+			}
+
+		}
+		return &regressionallowances.IntentionalRegression{}
+	}
+	reqOpts419 := crtype.RequestOptions{
+		BaseRelease: crtype.RequestReleaseOptions{
+			Release: "4.18",
+		},
+		AdvancedOption: crtype.RequestAdvancedOptions{IncludeMultiReleaseAnalysis: true},
+	}
+	test1Variants := []string{"Arch:amd64", "Platform:aws"}
+	test1Key := crtype.TestWithVariantsKey{
+		TestID:   test1ID,
+		Variants: variants,
+	}
+	test1KeyBytes, err := json.Marshal(test1Key)
+	test1KeyStr := string(test1KeyBytes)
+	assert.NoError(t, err)
+
+	test2ID := "test2ID"
+	test2Key := crtype.TestWithVariantsKey{
+		TestID:   test2ID,
+		Variants: variants,
+	}
+	test2KeyBytes, err := json.Marshal(test2Key)
+	test2KeyStr := string(test2KeyBytes)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		reqOpts        crtype.RequestOptions
+		baseStatus     map[string]crtype.TestStatus
+		expectedStatus map[string]crtype.TestStatus
+	}{
+		{
+			name:    "swap base stats using regression allowance",
+			reqOpts: reqOpts419,
+			baseStatus: map[string]crtype.TestStatus{
+				test1KeyStr: buildTestStatus("test1", test1Variants, 100, 75, 0, nil),
+			},
+			expectedStatus: map[string]crtype.TestStatus{
+				test1KeyStr: buildTestStatus("test1", test1Variants, 100, 100, 0, nil),
+			},
+		},
+		{
+			name:    "do not swap base stats if no regression allowance",
+			reqOpts: reqOpts419,
+			baseStatus: map[string]crtype.TestStatus{
+				test2KeyStr: buildTestStatus("test2", test1Variants, 100, 75, 0, nil),
+			},
+			expectedStatus: map[string]crtype.TestStatus{
+				test2KeyStr: buildTestStatus("test2", test1Variants, 100, 75, 0, nil),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rfb := NewRegressionAllowancesMiddleware(test.reqOpts)
+			rfb.regressionGetterFunc = regressionGetter
+			baseStatus, _, err := rfb.Transform(test.baseStatus, map[string]crtype.TestStatus{})
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedStatus, baseStatus)
+		})
+	}
+}
+
+//nolint:unparam
+func buildTestStatus(testName string, variants []string, total, success, flake int, release *crtype.Release) crtype.TestStatus {
+	return crtype.TestStatus{
+		TestName:     testName,
+		TestSuite:    "conformance",
+		Component:    "foo",
+		Capabilities: nil,
+		Variants:     variants,
+		TotalCount:   total,
+		SuccessCount: success,
+		FlakeCount:   flake,
+		Release:      release,
+	}
+}

--- a/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
+++ b/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
@@ -1,0 +1,382 @@
+package releasefallback
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/middleware"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/query"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/openshift/sippy/pkg/api"
+	crtype "github.com/openshift/sippy/pkg/apis/api/componentreport"
+	"github.com/openshift/sippy/pkg/apis/cache"
+	bqcachedclient "github.com/openshift/sippy/pkg/bigquery"
+)
+
+const (
+	// consider fallback data good for 7 days
+	fallbackQueryTimeRoundingOverride = 24 * 7 * time.Hour
+)
+
+var _ middleware.Middleware = &ReleaseFallback{}
+
+func NewReleaseFallbackMiddleware(client *bqcachedclient.Client,
+	reqOptions crtype.RequestOptions,
+) *ReleaseFallback {
+	return &ReleaseFallback{
+		client:     client,
+		log:        log.WithField("middleware", "ReleaseFallback"),
+		reqOptions: reqOptions,
+	}
+}
+
+// ReleaseFallback middleware allows us to use the best pass rate data from the past
+// several releases for our basis instead of just the requested basis. This helps prevent
+// minor gradual degredation of quality, and also simplifies the process of accepting
+// intentional regressions shortly before release, as we'll then automatically use the data
+// from prior releases.
+//
+// It is responsible for querying basis test status for those several releases, and
+// then replacing any basis test stats with a better releases test stats, when appropriate.
+// This is done when we have sufficient test coverage, and a better pass rate.
+type ReleaseFallback struct {
+	client                     *bqcachedclient.Client
+	cachedFallbackTestStatuses *crtype.FallbackReleases
+	log                        log.FieldLogger
+	reqOptions                 crtype.RequestOptions
+}
+
+func (r *ReleaseFallback) Query(ctx context.Context, wg *sync.WaitGroup, allJobVariants crtype.JobVariants,
+	_, _ chan map[string]crtype.TestStatus, errCh chan error) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		select {
+		case <-ctx.Done():
+			r.log.Infof("Context canceled while fetching fallback query status")
+			return
+		default:
+			// TODO: should we pass the same wg through rather than using another?
+			errs := r.getFallbackBaseQueryStatus(ctx, allJobVariants, r.reqOptions.BaseRelease.Release, r.reqOptions.BaseRelease.Start, r.reqOptions.BaseRelease.End)
+			if len(errs) > 0 {
+				for _, err := range errs {
+					errCh <- err
+				}
+			}
+		}
+	}()
+}
+
+// Transform iterates the base status looking for any statuses that had a better pass rate in the prior releases
+// we queried earlier.
+func (r *ReleaseFallback) Transform(baseStatus, sampleStatus map[string]crtype.TestStatus) (map[string]crtype.TestStatus, map[string]crtype.TestStatus, error) {
+	for testKeyStr, baseStats := range baseStatus {
+		newBaseStatus := r.matchBestBaseStats(testKeyStr, r.reqOptions.BaseRelease.Release, baseStats)
+		if newBaseStatus.Release != nil && newBaseStatus.Release.Release != r.reqOptions.BaseRelease.Release {
+			baseStatus[testKeyStr] = newBaseStatus
+		}
+	}
+
+	return baseStatus, sampleStatus, nil
+}
+
+// matchBestBaseStats returns the testStatus, release and reportTestStatus
+// that has the highest threshold across the basis release and previous releases included
+// in fallback comparison.
+func (r *ReleaseFallback) matchBestBaseStats(
+	testKeyStr, baseRelease string,
+	baseStats crtype.TestStatus) crtype.TestStatus {
+
+	if !r.reqOptions.AdvancedOption.IncludeMultiReleaseAnalysis {
+		return baseStats
+	}
+
+	if r.cachedFallbackTestStatuses == nil {
+		r.log.Errorf("Invalid fallback test statuses")
+		return baseStats
+	}
+
+	var priorRelease = baseRelease
+	var err error
+	for err == nil {
+		var cachedReleaseTestStatuses crtype.ReleaseTestMap
+		var cTestStats crtype.TestStatus
+		ok := false
+		priorRelease, err = utils.PreviousRelease(priorRelease)
+		// if we fail to determine the previous release then stop
+		if err != nil {
+			return baseStats
+		}
+
+		// if we hit a missing release then stop
+		if cachedReleaseTestStatuses, ok = r.cachedFallbackTestStatuses.Releases[priorRelease]; !ok {
+			return baseStats
+		}
+
+		// it's ok if we don't have a testKeyStr for this release
+		// we likely won't have it for earlier releases either, but we can keep going
+		if cTestStats, ok = cachedReleaseTestStatuses.Tests[testKeyStr]; ok {
+
+			// what is our base total compared to the original base
+			// this happens when jobs shift like sdn -> ovn
+			// if we get below threshold that's a sign we are reducing our base signal
+			if float64(cTestStats.TotalCount)/float64(baseStats.TotalCount) < .6 {
+				r.log.Debugf("Fallback base total: %d to low for fallback analysis compared to original: %d",
+					cTestStats.TotalCount, baseStats.TotalCount)
+				return baseStats
+			}
+			_, success, fail, flake := baseStats.GetTotalSuccessFailFlakeCounts()
+			basePassRate := utils.CalculatePassRate(r.reqOptions, success, fail, flake)
+
+			_, success, fail, flake = cTestStats.GetTotalSuccessFailFlakeCounts()
+			cPassRate := utils.CalculatePassRate(r.reqOptions, success, fail, flake)
+			if cPassRate > basePassRate {
+				baseStats = cTestStats
+				// If we swapped out base stats for better ones from a prior release, we need to communicate
+				// this back to the core report generator so it can include the adjusted release/start/end dates in
+				// the report, and ultimately the UI.
+				baseStats.Release = &cachedReleaseTestStatuses.Release
+				r.log.Infof("Overrode base stats (%.4f) using release %s (%.4f) for test: %s - %s",
+					basePassRate, baseStats.Release.Release, cPassRate, baseStats.TestName, testKeyStr)
+			}
+		}
+	}
+
+	return baseStats
+}
+
+func (r *ReleaseFallback) getFallbackBaseQueryStatus(ctx context.Context,
+	allJobVariants crtype.JobVariants,
+	release string, start, end time.Time) []error {
+	generator := newFallbackTestQueryReleasesGenerator(r.client, r.reqOptions, allJobVariants, release, start, end)
+
+	cachedFallbackTestStatuses, errs := api.GetDataFromCacheOrGenerate[*crtype.FallbackReleases](
+		ctx, r.client.Cache, generator.cacheOption,
+		api.GetPrefixedCacheKey("FallbackReleases~", generator),
+		generator.getTestFallbackReleases,
+		&crtype.FallbackReleases{})
+
+	if len(errs) > 0 {
+		return errs
+	}
+
+	r.cachedFallbackTestStatuses = cachedFallbackTestStatuses
+	return nil
+}
+
+// fallbackTestQueryReleasesGenerator iterates the configured number of past releases, querying base status for
+// each, which can then be used to return the best basis data from those past releases for comparison.
+type fallbackTestQueryReleasesGenerator struct {
+	client                     *bqcachedclient.Client
+	cacheOption                cache.RequestOptions
+	allJobVariants             crtype.JobVariants
+	BaseRelease                string
+	BaseStart                  time.Time
+	BaseEnd                    time.Time
+	CachedFallbackTestStatuses crtype.FallbackReleases
+	lock                       *sync.Mutex
+	ReqOptions                 crtype.RequestOptions
+}
+
+func newFallbackTestQueryReleasesGenerator(
+	client *bqcachedclient.Client,
+	reqOptions crtype.RequestOptions,
+	allJobVariants crtype.JobVariants,
+	release string, start, end time.Time) fallbackTestQueryReleasesGenerator {
+
+	generator := fallbackTestQueryReleasesGenerator{
+		client:         client,
+		allJobVariants: allJobVariants,
+		cacheOption: cache.RequestOptions{
+			ForceRefresh: reqOptions.CacheOption.ForceRefresh,
+			// increase the time that fallback queries are cached for
+			CRTimeRoundingFactor: fallbackQueryTimeRoundingOverride,
+		},
+		BaseRelease: release,
+		BaseStart:   start,
+		BaseEnd:     end,
+		lock:        &sync.Mutex{},
+		ReqOptions:  reqOptions,
+	}
+	return generator
+
+}
+
+func (f *fallbackTestQueryReleasesGenerator) getTestFallbackReleases(ctx context.Context) (*crtype.FallbackReleases, []error) {
+	wg := sync.WaitGroup{}
+	f.CachedFallbackTestStatuses = newFallbackReleases()
+	releases, errs := query.GetReleaseDatesFromBigQuery(ctx, f.client, f.ReqOptions)
+
+	if errs != nil {
+		return nil, errs
+	}
+
+	// currently gets current base plus previous 3
+	// current base is just for testing but use could be
+	// extended to no longer require the base query
+	var selectedReleases []*crtype.Release
+	fallbackRelease := f.BaseRelease
+
+	// Get up to 3 fallback releases
+	for i := 0; i < 3; i++ {
+		var crRelease *crtype.Release
+
+		fallbackRelease, err := utils.PreviousRelease(fallbackRelease)
+		if err != nil {
+			log.WithError(err).Errorf("Failure determining fallback release for %s", fallbackRelease)
+			break
+		}
+
+		for i := range releases {
+			if releases[i].Release == fallbackRelease {
+				crRelease = &releases[i]
+				break
+			}
+		}
+
+		if crRelease != nil {
+			selectedReleases = append(selectedReleases, crRelease)
+		}
+	}
+
+	for _, crRelease := range selectedReleases {
+
+		start := f.BaseStart
+		end := f.BaseEnd
+
+		// we want our base release validation to match the base release report dates
+		if crRelease.Release != f.BaseRelease && crRelease.End != nil && crRelease.Start != nil {
+			end = *crRelease.End
+			start = *crRelease.Start
+		}
+
+		wg.Add(1)
+		go func(queryRelease crtype.Release, queryStart, queryEnd time.Time) {
+			defer wg.Done()
+			select {
+			case <-ctx.Done():
+				log.Infof("Context canceled while fetching fallback base query status")
+				return
+			default:
+				stats, errs := f.getTestFallbackRelease(ctx, f.client, queryRelease.Release, queryStart, queryEnd)
+				if len(errs) > 0 {
+					log.Errorf("FallbackBaseQueryStatus for %s failed with: %v", queryRelease, errs)
+					return
+				}
+
+				f.updateTestStatuses(queryRelease, stats.BaseStatus)
+			}
+		}(*crRelease, start, end)
+	}
+	wg.Wait()
+
+	return &f.CachedFallbackTestStatuses, nil
+}
+
+func (f *fallbackTestQueryReleasesGenerator) updateTestStatuses(release crtype.Release, updateStatuses map[string]crtype.TestStatus) {
+
+	var testStatuses crtype.ReleaseTestMap
+	var ok bool
+	// since we  can be called for multiple releases and
+	// we update the map below we need to block concurrent map writes
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	if testStatuses, ok = f.CachedFallbackTestStatuses.Releases[release.Release]; !ok {
+		testStatuses = crtype.ReleaseTestMap{Release: release, Tests: map[string]crtype.TestStatus{}}
+		f.CachedFallbackTestStatuses.Releases[release.Release] = testStatuses
+	}
+
+	for key, value := range updateStatuses {
+		testStatuses.Tests[key] = value
+	}
+}
+
+func (f *fallbackTestQueryReleasesGenerator) getTestFallbackRelease(ctx context.Context, client *bqcachedclient.Client, release string, start, end time.Time) (crtype.ReportTestStatus, []error) {
+	generator := newFallbackBaseQueryGenerator(client, f.ReqOptions, f.allJobVariants, release, start, end)
+
+	testStatuses, errs := api.GetDataFromCacheOrGenerate[crtype.ReportTestStatus](ctx, f.client.Cache, generator.cacheOption, api.GetPrefixedCacheKey("FallbackBaseTestStatus~", generator), generator.getTestFallbackRelease, crtype.ReportTestStatus{})
+
+	if len(errs) > 0 {
+		return crtype.ReportTestStatus{}, errs
+	}
+
+	return testStatuses, nil
+}
+
+type fallbackTestQueryGenerator struct {
+	client      *bqcachedclient.Client
+	cacheOption cache.RequestOptions
+	allVariants crtype.JobVariants
+	BaseRelease string
+	BaseStart   time.Time
+	BaseEnd     time.Time
+	ReqOptions  crtype.RequestOptions
+}
+
+func newFallbackBaseQueryGenerator(client *bqcachedclient.Client, reqOptions crtype.RequestOptions, allVariants crtype.JobVariants,
+	baseRelease string, baseStart, baseEnd time.Time) fallbackTestQueryGenerator {
+	generator := fallbackTestQueryGenerator{
+		client:      client,
+		allVariants: allVariants,
+		ReqOptions:  reqOptions,
+		cacheOption: cache.RequestOptions{
+			ForceRefresh: reqOptions.CacheOption.ForceRefresh,
+			// increase the time that base query is cached for since it shouldn't be changing
+			CRTimeRoundingFactor: fallbackQueryTimeRoundingOverride,
+		},
+		BaseRelease: baseRelease,
+		BaseStart:   baseStart,
+		BaseEnd:     baseEnd,
+	}
+	return generator
+}
+
+func (f *fallbackTestQueryGenerator) getTestFallbackRelease(ctx context.Context) (crtype.ReportTestStatus, []error) {
+	commonQuery, groupByQuery, queryParameters := query.BuildCommonTestStatusQuery(
+		f.client,
+		f.ReqOptions,
+		f.allVariants, f.ReqOptions.VariantOption.IncludeVariants,
+		query.DefaultJunitTable, false, true)
+	before := time.Now()
+	log.Infof("Starting Fallback (%s) QueryTestStatus", f.BaseRelease)
+	errs := []error{}
+	baseString := commonQuery + ` AND branch = @BaseRelease`
+	baseQuery := f.client.BQ.Query(baseString + groupByQuery)
+
+	baseQuery.Parameters = append(baseQuery.Parameters, queryParameters...)
+	baseQuery.Parameters = append(baseQuery.Parameters, []bigquery.QueryParameter{
+		{
+			Name:  "From",
+			Value: f.BaseStart,
+		},
+		{
+			Name:  "To",
+			Value: f.BaseEnd,
+		},
+		{
+			Name:  "BaseRelease",
+			Value: f.BaseRelease,
+		},
+	}...)
+
+	baseStatus, baseErrs := query.FetchTestStatusResults(ctx, baseQuery)
+
+	if len(baseErrs) != 0 {
+		errs = append(errs, baseErrs...)
+	}
+
+	log.Infof("Fallback (%s) QueryTestStatus completed in %s with %d base results from db", f.BaseRelease, time.Since(before), len(baseStatus))
+
+	return crtype.ReportTestStatus{BaseStatus: baseStatus}, errs
+}
+
+func newFallbackReleases() crtype.FallbackReleases {
+	fb := crtype.FallbackReleases{
+		Releases: map[string]crtype.ReleaseTestMap{},
+	}
+	return fb
+}

--- a/pkg/api/componentreadiness/middleware/releasefallback/releasefallback_test.go
+++ b/pkg/api/componentreadiness/middleware/releasefallback/releasefallback_test.go
@@ -1,0 +1,171 @@
+package releasefallback
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	crtype "github.com/openshift/sippy/pkg/apis/api/componentreport"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Transform(t *testing.T) {
+	reqOpts419 := crtype.RequestOptions{
+		BaseRelease: crtype.RequestReleaseOptions{
+			Release: "4.19",
+		},
+		AdvancedOption: crtype.RequestAdvancedOptions{IncludeMultiReleaseAnalysis: true},
+	}
+	test1ID := "test1ID"
+	test1Variants := []string{"Arch:amd64", "Platform:aws"}
+	test1Key := crtype.TestWithVariantsKey{
+		TestID: test1ID,
+		Variants: map[string]string{
+			"Arch":     "amd64",
+			"Platform": "aws",
+		},
+	}
+	test1KeyBytes, err := json.Marshal(test1Key)
+	test1KeyStr := string(test1KeyBytes)
+	assert.NoError(t, err)
+
+	start418 := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+	end418 := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	release418 := crtype.Release{
+		Release: "4.18",
+		Start:   &start418,
+		End:     &end418,
+	}
+	fallbackMap418 := crtype.ReleaseTestMap{
+		Release: release418,
+		Tests: map[string]crtype.TestStatus{
+			test1KeyStr: buildTestStatus("test1", test1Variants, 100, 95, 0, nil),
+		},
+	}
+
+	start417 := time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC)
+	end417 := time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC)
+	release417 := crtype.Release{
+		Release: "4.17",
+		Start:   &start417,
+		End:     &end417,
+	}
+	fallbackMap417 := crtype.ReleaseTestMap{
+		Release: release417,
+		Tests: map[string]crtype.TestStatus{
+			test1KeyStr: buildTestStatus("test1", test1Variants, 100, 98, 0, nil),
+		},
+	}
+
+	tests := []struct {
+		name             string
+		reqOpts          crtype.RequestOptions
+		fallbackReleases crtype.FallbackReleases
+		baseStatus       map[string]crtype.TestStatus
+		expectedStatus   map[string]crtype.TestStatus
+	}{
+		{
+			name:    "fallback to prior release",
+			reqOpts: reqOpts419,
+			fallbackReleases: crtype.FallbackReleases{
+				Releases: map[string]crtype.ReleaseTestMap{
+					fallbackMap418.Release.Release: fallbackMap418,
+				},
+			},
+			baseStatus: map[string]crtype.TestStatus{
+				test1KeyStr: buildTestStatus("test1", test1Variants, 100, 93, 0, nil),
+			},
+			expectedStatus: map[string]crtype.TestStatus{
+				test1KeyStr: buildTestStatus("test1", test1Variants, 100, 95, 0, &release418),
+			},
+		},
+		{
+			name:    "fallback twice to prior release",
+			reqOpts: reqOpts419,
+			fallbackReleases: crtype.FallbackReleases{
+				Releases: map[string]crtype.ReleaseTestMap{
+					fallbackMap418.Release.Release: fallbackMap418,
+					fallbackMap417.Release.Release: fallbackMap417, // 4.17 improves even further
+				},
+			},
+			baseStatus: map[string]crtype.TestStatus{
+				test1KeyStr: buildTestStatus("test1", test1Variants, 100, 93, 0, nil),
+			},
+			expectedStatus: map[string]crtype.TestStatus{
+				test1KeyStr: buildTestStatus("test1", test1Variants, 100, 98, 0, &release417),
+			},
+		},
+		{
+			name:    "fallback once to two releases ago",
+			reqOpts: reqOpts419,
+			fallbackReleases: crtype.FallbackReleases{
+				Releases: map[string]crtype.ReleaseTestMap{
+					fallbackMap418.Release.Release: fallbackMap418,
+					fallbackMap417.Release.Release: fallbackMap417, // 4.17 improves even further
+				},
+			},
+			baseStatus: map[string]crtype.TestStatus{
+				test1KeyStr: buildTestStatus("test1", test1Variants, 100, 97, 0, nil),
+			},
+			expectedStatus: map[string]crtype.TestStatus{
+				test1KeyStr: buildTestStatus("test1", test1Variants, 100, 98, 0, &release417),
+			},
+		},
+		{
+			name:    "don't fallback to prior release",
+			reqOpts: reqOpts419,
+			fallbackReleases: crtype.FallbackReleases{
+				Releases: map[string]crtype.ReleaseTestMap{
+					fallbackMap418.Release.Release: fallbackMap418,
+				},
+			},
+			baseStatus: map[string]crtype.TestStatus{
+				test1KeyStr: buildTestStatus("test1", test1Variants, 100, 100, 0, nil),
+			},
+			expectedStatus: map[string]crtype.TestStatus{
+				test1KeyStr: buildTestStatus("test1", test1Variants, 100, 100, 0, nil),
+			},
+		},
+		{
+			name:    "don't fallback to prior release with insufficient runs",
+			reqOpts: reqOpts419,
+			fallbackReleases: crtype.FallbackReleases{
+				Releases: map[string]crtype.ReleaseTestMap{
+					fallbackMap418.Release.Release: fallbackMap418,
+					fallbackMap417.Release.Release: fallbackMap417,
+				},
+			},
+			baseStatus: map[string]crtype.TestStatus{
+				test1KeyStr: buildTestStatus("test1", test1Variants, 10000, 9700, 0, nil),
+			},
+			expectedStatus: map[string]crtype.TestStatus{
+				// No fallback release had at least 60% of our run count
+				test1KeyStr: buildTestStatus("test1", test1Variants, 10000, 9700, 0, nil),
+			},
+		},
+	}
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rfb := NewReleaseFallbackMiddleware(nil, test.reqOpts)
+			rfb.cachedFallbackTestStatuses = &tests[i].fallbackReleases
+			baseStatus, _, err := rfb.Transform(test.baseStatus, map[string]crtype.TestStatus{})
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedStatus, baseStatus)
+		})
+	}
+}
+
+//nolint:unparam
+func buildTestStatus(testName string, variants []string, total, success, flake int, release *crtype.Release) crtype.TestStatus {
+	return crtype.TestStatus{
+		TestName:     testName,
+		TestSuite:    "conformance",
+		Component:    "foo",
+		Capabilities: nil,
+		Variants:     variants,
+		TotalCount:   total,
+		SuccessCount: success,
+		FlakeCount:   flake,
+		Release:      release,
+	}
+}

--- a/pkg/api/componentreadiness/query/releasedates.go
+++ b/pkg/api/componentreadiness/query/releasedates.go
@@ -1,0 +1,43 @@
+package query
+
+import (
+	"context"
+
+	"github.com/openshift/sippy/pkg/api"
+	crtype "github.com/openshift/sippy/pkg/apis/api/componentreport"
+	"github.com/openshift/sippy/pkg/apis/cache"
+	"github.com/openshift/sippy/pkg/bigquery"
+	"github.com/openshift/sippy/pkg/util"
+)
+
+func GetReleaseDatesFromBigQuery(ctx context.Context, client *bigquery.Client, reqOptions crtype.RequestOptions) ([]crtype.Release, []error) {
+	queries := &releaseDateQuerier{client: client, reqOptions: reqOptions}
+	return api.GetDataFromCacheOrGenerate[[]crtype.Release](ctx,
+		client.Cache,
+		cache.RequestOptions{},
+		api.GetPrefixedCacheKey("CRReleaseDates~", reqOptions),
+		queries.QueryReleaseDates, []crtype.Release{})
+}
+
+type releaseDateQuerier struct {
+	client     *bigquery.Client
+	reqOptions crtype.RequestOptions
+}
+
+func (c *releaseDateQuerier) QueryReleaseDates(ctx context.Context) ([]crtype.Release, []error) {
+	releases, err := api.GetReleasesFromBigQuery(ctx, c.client)
+	if err != nil {
+		return nil, []error{err}
+	}
+	crReleases := []crtype.Release{}
+	for _, release := range releases {
+		crRelease := crtype.Release{Release: release.Release}
+		if release.GADate != nil {
+			prior := util.AdjustReleaseTime(*release.GADate, true, "30", c.reqOptions.CacheOption.CRTimeRoundingFactor)
+			crRelease.Start = &prior
+			crRelease.End = release.GADate
+		}
+		crReleases = append(crReleases, crRelease)
+	}
+	return crReleases, nil
+}

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -8,8 +8,9 @@ import (
 	"sync"
 	"time"
 
-	bigquery2 "cloud.google.com/go/bigquery"
 	fet "github.com/glycerine/golang-fisher-exact"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/query"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
 	configv1 "github.com/openshift/sippy/pkg/apis/config/v1"
 	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 	"github.com/openshift/sippy/pkg/util"
@@ -19,40 +20,33 @@ import (
 	crtype "github.com/openshift/sippy/pkg/apis/api/componentreport"
 	"github.com/openshift/sippy/pkg/bigquery"
 	"github.com/openshift/sippy/pkg/regressionallowances"
-	"github.com/openshift/sippy/pkg/util/param"
 )
 
 func GetTestDetails(ctx context.Context, client *bigquery.Client, prowURL, gcsBucket string, reqOptions crtype.RequestOptions,
 ) (crtype.ReportTestDetails, []error) {
-	generator := componentReportGenerator{
-		client:                           client,
-		prowURL:                          prowURL,
-		gcsBucket:                        gcsBucket,
-		cacheOption:                      reqOptions.CacheOption,
-		BaseRelease:                      reqOptions.BaseRelease,
-		BaseOverrideRelease:              reqOptions.BaseOverrideRelease,
-		SampleRelease:                    reqOptions.SampleRelease,
-		RequestTestIdentificationOptions: reqOptions.TestIDOption,
-		RequestVariantOptions:            reqOptions.VariantOption,
-		RequestAdvancedOptions:           reqOptions.AdvancedOption,
+	generator := ComponentReportGenerator{
+		client:     client,
+		prowURL:    prowURL,
+		gcsBucket:  gcsBucket,
+		ReqOptions: reqOptions,
 	}
 
 	return api.GetDataFromCacheOrGenerate[crtype.ReportTestDetails](
 		ctx,
 		generator.client.Cache,
-		generator.cacheOption,
+		generator.ReqOptions.CacheOption,
 		generator.GetComponentReportCacheKey(ctx, "TestDetailsReport~"),
 		generator.GenerateTestDetailsReport,
 		crtype.ReportTestDetails{})
 }
 
-func (c *componentReportGenerator) GenerateTestDetailsReport(ctx context.Context) (crtype.ReportTestDetails, []error) {
-	if c.TestID == "" {
+func (c *ComponentReportGenerator) GenerateTestDetailsReport(ctx context.Context) (crtype.ReportTestDetails, []error) {
+	if c.ReqOptions.TestIDOption.TestID == "" {
 		return crtype.ReportTestDetails{}, []error{fmt.Errorf("test_id has to be defined for test details")}
 	}
-	for _, v := range c.DBGroupBy.List() {
-		if _, ok := c.RequestedVariants[v]; !ok {
-			return crtype.ReportTestDetails{}, []error{fmt.Errorf("all dbGroupBy variants have to be defined for test details: %s is missing in %v", v, c.RequestedVariants)}
+	for _, v := range c.ReqOptions.VariantOption.DBGroupBy.List() {
+		if _, ok := c.ReqOptions.VariantOption.RequestedVariants[v]; !ok {
+			return crtype.ReportTestDetails{}, []error{fmt.Errorf("all dbGroupBy variants have to be defined for test details: %s is missing in %v", v, c.ReqOptions.VariantOption.RequestedVariants)}
 		}
 	}
 
@@ -69,21 +63,21 @@ func (c *componentReportGenerator) GenerateTestDetailsReport(ctx context.Context
 	}
 
 	var baseOverrideReport *crtype.ReportTestDetails
-	if c.BaseOverrideRelease.Release != "" && c.BaseOverrideRelease.Release != c.BaseRelease.Release {
+	if c.ReqOptions.BaseOverrideRelease.Release != "" && c.ReqOptions.BaseOverrideRelease.Release != c.ReqOptions.BaseRelease.Release {
 		// because internalGenerateTestDetailsReport modifies SampleStatus we need to copy it here
 		overrideSampleStatus := map[string][]crtype.JobRunTestStatusRow{}
 		for k, v := range componentJobRunTestReportStatus.SampleStatus {
 			overrideSampleStatus[k] = v
 		}
 
-		overrideReport := c.internalGenerateTestDetailsReport(ctx, componentJobRunTestReportStatus.BaseOverrideStatus, c.BaseOverrideRelease.Release, &c.BaseOverrideRelease.Start, &c.BaseOverrideRelease.End, overrideSampleStatus)
+		overrideReport := c.internalGenerateTestDetailsReport(ctx, componentJobRunTestReportStatus.BaseOverrideStatus, c.ReqOptions.BaseOverrideRelease.Release, &c.ReqOptions.BaseOverrideRelease.Start, &c.ReqOptions.BaseOverrideRelease.End, overrideSampleStatus)
 		// swap out the base dates for the override
 		overrideReport.GeneratedAt = componentJobRunTestReportStatus.GeneratedAt
 		baseOverrideReport = &overrideReport
 	}
 
-	c.openRegressions = FilterRegressionsForRelease(allRegressions, c.SampleRelease.Release)
-	report := c.internalGenerateTestDetailsReport(ctx, componentJobRunTestReportStatus.BaseStatus, c.BaseRelease.Release, &c.BaseRelease.Start, &c.BaseRelease.End, componentJobRunTestReportStatus.SampleStatus)
+	c.openRegressions = FilterRegressionsForRelease(allRegressions, c.ReqOptions.SampleRelease.Release)
+	report := c.internalGenerateTestDetailsReport(ctx, componentJobRunTestReportStatus.BaseStatus, c.ReqOptions.BaseRelease.Release, &c.ReqOptions.BaseRelease.Start, &c.ReqOptions.BaseRelease.End, componentJobRunTestReportStatus.SampleStatus)
 	report.GeneratedAt = componentJobRunTestReportStatus.GeneratedAt
 
 	if baseOverrideReport != nil {
@@ -98,7 +92,7 @@ func (c *componentReportGenerator) GenerateTestDetailsReport(ctx context.Context
 	return report, nil
 }
 
-func (c *componentReportGenerator) GenerateJobRunTestReportStatus(ctx context.Context) (crtype.JobRunTestReportStatus, []error) {
+func (c *ComponentReportGenerator) GenerateJobRunTestReportStatus(ctx context.Context) (crtype.JobRunTestReportStatus, []error) {
 	before := time.Now()
 	componentJobRunTestReportStatus, errs := c.getJobRunTestStatusFromBigQuery(ctx)
 	if len(errs) > 0 {
@@ -110,36 +104,16 @@ func (c *componentReportGenerator) GenerateJobRunTestReportStatus(ctx context.Co
 	return componentJobRunTestReportStatus, nil
 }
 
-// filterByCrossCompareVariants adds the where clause for any variants being cross-compared (which are not included in RequestedVariants).
-// As a side effect, it also appends any necessary parameters for the clause.
-func filterByCrossCompareVariants(crossCompare []string, variantGroups map[string][]string, params *[]bigquery2.QueryParameter) (whereClause string) {
-	if len(variantGroups) == 0 {
-		return // avoid possible nil pointer dereference
-	}
-	sort.StringSlice(crossCompare).Sort()
-	for _, group := range crossCompare {
-		if variants := variantGroups[group]; len(variants) > 0 {
-			group = param.Cleanse(group)
-			paramName := "CrossVariants" + group
-			whereClause += fmt.Sprintf(` AND jv_%s.variant_value IN UNNEST(@%s)`, group, paramName)
-			*params = append(*params, bigquery2.QueryParameter{
-				Name:  paramName,
-				Value: variants,
-			})
-		}
-	}
-	return
-}
-
-func (c *componentReportGenerator) getBaseJobRunTestStatus(
+func (c *ComponentReportGenerator) getBaseJobRunTestStatus(
 	ctx context.Context,
 	allJobVariants crtype.JobVariants,
 	baseRelease string,
 	baseStart time.Time,
 	baseEnd time.Time) (map[string][]crtype.JobRunTestStatusRow, []error) {
 
-	generator := newBaseTestDetailsQueryGenerator(
-		c,
+	generator := query.NewBaseTestDetailsQueryGenerator(
+		c.client,
+		c.ReqOptions,
 		allJobVariants,
 		baseRelease,
 		baseStart,
@@ -148,9 +122,9 @@ func (c *componentReportGenerator) getBaseJobRunTestStatus(
 
 	jobRunTestStatus, errs := api.GetDataFromCacheOrGenerate[crtype.JobRunTestReportStatus](
 		ctx,
-		generator.ComponentReportGenerator.client.Cache, generator.cacheOption,
+		c.client.Cache, c.ReqOptions.CacheOption,
 		api.GetPrefixedCacheKey("BaseJobRunTestStatus~", generator),
-		generator.queryTestStatus,
+		generator.QueryTestStatus,
 		crtype.JobRunTestReportStatus{})
 
 	if len(errs) > 0 {
@@ -160,20 +134,22 @@ func (c *componentReportGenerator) getBaseJobRunTestStatus(
 	return jobRunTestStatus.BaseStatus, nil
 }
 
-func (c *componentReportGenerator) getSampleJobRunTestStatus(
+func (c *ComponentReportGenerator) getSampleJobRunTestStatus(
 	ctx context.Context,
 	allJobVariants crtype.JobVariants,
 	includeVariants map[string][]string,
 	start, end time.Time,
 	junitTable string) (map[string][]crtype.JobRunTestStatusRow, []error) {
 
-	generator := newSampleTestDetailsQueryGenerator(c, allJobVariants, includeVariants, start, end, junitTable)
+	generator := query.NewSampleTestDetailsQueryGenerator(
+		c.client, c.ReqOptions,
+		allJobVariants, includeVariants, start, end, junitTable)
 
 	jobRunTestStatus, errs := api.GetDataFromCacheOrGenerate[crtype.JobRunTestReportStatus](
 		ctx,
-		c.client.Cache, c.cacheOption,
+		c.client.Cache, c.ReqOptions.CacheOption,
 		api.GetPrefixedCacheKey("SampleJobRunTestStatus~", generator),
-		generator.queryTestStatus,
+		generator.QueryTestStatus,
 		crtype.JobRunTestReportStatus{})
 
 	if len(errs) > 0 {
@@ -183,7 +159,7 @@ func (c *componentReportGenerator) getSampleJobRunTestStatus(
 	return jobRunTestStatus.SampleStatus, nil
 }
 
-func (c *componentReportGenerator) getJobRunTestStatusFromBigQuery(ctx context.Context) (crtype.JobRunTestReportStatus, []error) {
+func (c *ComponentReportGenerator) getJobRunTestStatusFromBigQuery(ctx context.Context) (crtype.JobRunTestReportStatus, []error) {
 	fLog := logrus.WithField("func", "getJobRunTestStatusFromBigQuery")
 	allJobVariants, errs := GetJobVariantsFromBigQuery(ctx, c.client, c.gcsBucket)
 	if len(errs) > 0 {
@@ -200,7 +176,7 @@ func (c *componentReportGenerator) getJobRunTestStatusFromBigQuery(ctx context.C
 	statusDoneCh := make(chan struct{})     // To signal when all processing is done
 	statusErrsDoneCh := make(chan struct{}) // To signal when all processing is done
 
-	if c.BaseOverrideRelease.Release != "" && c.BaseOverrideRelease.Release != c.BaseRelease.Release {
+	if c.ReqOptions.BaseOverrideRelease.Release != "" && c.ReqOptions.BaseOverrideRelease.Release != c.ReqOptions.BaseRelease.Release {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -209,7 +185,7 @@ func (c *componentReportGenerator) getJobRunTestStatusFromBigQuery(ctx context.C
 				logrus.Infof("Context canceled while fetching base job run test status")
 				return
 			default:
-				baseOverrideStatus, baseOverrideErrs = c.getBaseJobRunTestStatus(ctx, allJobVariants, c.BaseOverrideRelease.Release, c.BaseOverrideRelease.Start, c.BaseOverrideRelease.End)
+				baseOverrideStatus, baseOverrideErrs = c.getBaseJobRunTestStatus(ctx, allJobVariants, c.ReqOptions.BaseOverrideRelease.Release, c.ReqOptions.BaseOverrideRelease.Start, c.ReqOptions.BaseOverrideRelease.End)
 			}
 		}()
 	}
@@ -222,7 +198,7 @@ func (c *componentReportGenerator) getJobRunTestStatusFromBigQuery(ctx context.C
 			logrus.Infof("Context canceled while fetching base job run test status")
 			return
 		default:
-			baseStatus, baseErrs = c.getBaseJobRunTestStatus(ctx, allJobVariants, c.BaseRelease.Release, c.BaseRelease.Start, c.BaseRelease.End)
+			baseStatus, baseErrs = c.getBaseJobRunTestStatus(ctx, allJobVariants, c.ReqOptions.BaseRelease.Release, c.ReqOptions.BaseRelease.Start, c.ReqOptions.BaseRelease.End)
 		}
 
 	}()
@@ -235,14 +211,14 @@ func (c *componentReportGenerator) getJobRunTestStatusFromBigQuery(ctx context.C
 			logrus.Infof("Context canceled while fetching sample job run test status")
 			return
 		default:
-			includeVariants, skipQuery := copyIncludeVariantsAndRemoveOverrides(c.variantJunitTableOverrides, -1, c.IncludeVariants)
+			includeVariants, skipQuery := copyIncludeVariantsAndRemoveOverrides(c.variantJunitTableOverrides, -1, c.ReqOptions.VariantOption.IncludeVariants)
 			if skipQuery {
 				fLog.Infof("skipping default status query as all values for a variant were overridden")
 				return
 			}
 			fLog.Infof("running default status query with includeVariants: %+v", includeVariants)
 			status, errs := c.getSampleJobRunTestStatus(ctx, allJobVariants, includeVariants,
-				c.SampleRelease.Start, c.SampleRelease.End, defaultJunitTable)
+				c.ReqOptions.SampleRelease.Start, c.ReqOptions.SampleRelease.End, query.DefaultJunitTable)
 			fLog.Infof("received %d test statuses and %d errors from default query", len(status), len(errs))
 			statusCh <- status
 			for _, err := range errs {
@@ -254,7 +230,7 @@ func (c *componentReportGenerator) getJobRunTestStatusFromBigQuery(ctx context.C
 
 	// fork additional sample queries for the overrides
 	for i, or := range c.variantJunitTableOverrides {
-		if !containsOverriddenVariant(c.IncludeVariants, or.VariantName, or.VariantValue) {
+		if !containsOverriddenVariant(c.ReqOptions.VariantOption.IncludeVariants, or.VariantName, or.VariantValue) {
 			continue
 		}
 		// only do this additional query if the specified override variant is actually included in this request
@@ -265,16 +241,16 @@ func (c *componentReportGenerator) getJobRunTestStatusFromBigQuery(ctx context.C
 			case <-ctx.Done():
 				return
 			default:
-				includeVariants, skipQuery := copyIncludeVariantsAndRemoveOverrides(c.variantJunitTableOverrides, i, c.IncludeVariants)
+				includeVariants, skipQuery := copyIncludeVariantsAndRemoveOverrides(c.variantJunitTableOverrides, i, c.ReqOptions.VariantOption.IncludeVariants)
 				if skipQuery {
 					fLog.Infof("skipping override status query as all values for a variant were overridden")
 					return
 				}
 				fLog.Infof("running override status query for %+v with includeVariants: %+v", or, includeVariants)
 				// Calculate a start time relative to the requested end time: (i.e. for rarely run jobs)
-				end := c.SampleRelease.End
+				end := c.ReqOptions.SampleRelease.End
 				start, err := util.ParseCRReleaseTime([]v1.Release{}, "", or.RelativeStart,
-					true, &c.SampleRelease.End, c.cacheOption.CRTimeRoundingFactor)
+					true, &c.ReqOptions.SampleRelease.End, c.ReqOptions.CacheOption.CRTimeRoundingFactor)
 				if err != nil {
 					statusErrCh <- err
 					return
@@ -337,7 +313,7 @@ func (c *componentReportGenerator) getJobRunTestStatusFromBigQuery(ctx context.C
 
 // internalGenerateTestDetailsReport handles the report generation for the lowest level test report including
 // breakdown by job as well as overall stats.
-func (c *componentReportGenerator) internalGenerateTestDetailsReport(ctx context.Context,
+func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(ctx context.Context,
 	baseStatus map[string][]crtype.JobRunTestStatusRow,
 	baseRelease string,
 	baseStart,
@@ -346,22 +322,22 @@ func (c *componentReportGenerator) internalGenerateTestDetailsReport(ctx context
 	result := crtype.ReportTestDetails{
 		ReportTestIdentification: crtype.ReportTestIdentification{
 			RowIdentification: crtype.RowIdentification{
-				Component:  c.Component,
-				Capability: c.Capability,
-				TestID:     c.TestID,
+				Component:  c.ReqOptions.TestIDOption.Component,
+				Capability: c.ReqOptions.TestIDOption.Capability,
+				TestID:     c.ReqOptions.TestIDOption.TestID,
 			},
 			ColumnIdentification: crtype.ColumnIdentification{
-				Variants: c.RequestedVariants,
+				Variants: c.ReqOptions.VariantOption.RequestedVariants,
 			},
 		},
 	}
 	var resolvedIssueCompensation int
-	approvedRegression := regressionallowances.IntentionalRegressionFor(c.SampleRelease.Release, result.ColumnIdentification, c.TestID)
+	approvedRegression := regressionallowances.IntentionalRegressionFor(c.ReqOptions.SampleRelease.Release, result.ColumnIdentification, c.ReqOptions.TestIDOption.TestID)
 	var baseRegression *regressionallowances.IntentionalRegression
 	// if we are ignoring fallback then honor the settings for the baseRegression
 	// otherwise let fallback determine the threshold
-	if !c.IncludeMultiReleaseAnalysis {
-		baseRegression = regressionallowances.IntentionalRegressionFor(baseRelease, result.ColumnIdentification, c.TestID)
+	if !c.ReqOptions.AdvancedOption.IncludeMultiReleaseAnalysis {
+		baseRegression = regressionallowances.IntentionalRegressionFor(baseRelease, result.ColumnIdentification, c.ReqOptions.TestIDOption.TestID)
 	}
 	// ignore triage if we have an intentional regression
 	if approvedRegression == nil {
@@ -422,7 +398,7 @@ func (c *componentReportGenerator) internalGenerateTestDetailsReport(ctx context
 		perceivedBaseFailure := perJobBaseFailure
 		perceivedSampleSuccess := perJobSampleSuccess + perJobSampleFlake
 		perceivedBaseSuccess := perJobBaseSuccess + perJobBaseFlake
-		if c.FlakeAsFailure {
+		if c.ReqOptions.AdvancedOption.FlakeAsFailure {
 			perceivedSampleFailure = perJobSampleFailure + perJobSampleFlake
 			perceivedBaseFailure = perJobBaseFailure + perJobBaseFlake
 			perceivedSampleSuccess = perJobSampleSuccess
@@ -432,7 +408,7 @@ func (c *componentReportGenerator) internalGenerateTestDetailsReport(ctx context
 			perceivedSampleSuccess,
 			perceivedBaseFailure,
 			perceivedBaseSuccess)
-		jobStats.Significant = r < 1-float64(c.Confidence)/100
+		jobStats.Significant = r < 1-float64(c.ReqOptions.AdvancedOption.Confidence)/100
 
 		result.JobStats = append(result.JobStats, jobStats)
 
@@ -463,7 +439,7 @@ func (c *componentReportGenerator) internalGenerateTestDetailsReport(ctx context
 		result.JobStats = append(result.JobStats, jobStats)
 		perceivedSampleFailure := perJobSampleFailure
 		perceivedSampleSuccess := perJobSampleSuccess + perJobSampleFlake
-		if c.FlakeAsFailure {
+		if c.ReqOptions.AdvancedOption.FlakeAsFailure {
 			perceivedSampleFailure = perJobSampleFailure + perJobSampleFlake
 			perceivedSampleSuccess = perJobSampleSuccess
 		}
@@ -471,7 +447,7 @@ func (c *componentReportGenerator) internalGenerateTestDetailsReport(ctx context
 			perceivedSampleSuccess,
 			0,
 			0)
-		jobStats.Significant = r < 1-float64(c.Confidence)/100
+		jobStats.Significant = r < 1-float64(c.ReqOptions.AdvancedOption.Confidence)/100
 
 		totalSampleFailure += perJobSampleFailure
 		totalSampleSuccess += perJobSampleSuccess
@@ -483,10 +459,10 @@ func (c *componentReportGenerator) internalGenerateTestDetailsReport(ctx context
 
 	// The hope is that this goes away
 	// once we agree we don't need to honor a higher intentional regression pass percentage
-	if baseRegression != nil && baseRegression.PreviousPassPercentage(c.FlakeAsFailure) > c.getPassRate(totalBaseSuccess, totalBaseFailure, totalBaseFlake) {
+	if baseRegression != nil && baseRegression.PreviousPassPercentage(c.ReqOptions.AdvancedOption.FlakeAsFailure) > c.getPassRate(totalBaseSuccess, totalBaseFailure, totalBaseFlake) {
 		// override with  the basis regression previous values
 		// testStats will reflect the expected threshold, not the computed values from the release with the allowed regression
-		baseRegressionPreviousRelease, err := previousRelease(baseRelease)
+		baseRegressionPreviousRelease, err := utils.PreviousRelease(baseRelease)
 		if err != nil {
 			logrus.WithError(err).Error("Failed to determine the previous release for baseRegression")
 		} else {
@@ -498,7 +474,7 @@ func (c *componentReportGenerator) internalGenerateTestDetailsReport(ctx context
 		}
 	}
 
-	requiredConfidence := c.getRequiredConfidence(c.TestID, c.RequestedVariants)
+	requiredConfidence := c.getRequiredConfidence(c.ReqOptions.TestIDOption.TestID, c.ReqOptions.VariantOption.RequestedVariants)
 
 	result.ReportTestStats = c.assessComponentStatus(
 		requiredConfidence,
@@ -518,7 +494,7 @@ func (c *componentReportGenerator) internalGenerateTestDetailsReport(ctx context
 	return result
 }
 
-func (c *componentReportGenerator) getJobRunStats(stats crtype.JobRunTestStatusRow, prowURL, gcsBucket string) crtype.TestDetailsJobRunStats {
+func (c *ComponentReportGenerator) getJobRunStats(stats crtype.JobRunTestStatusRow, prowURL, gcsBucket string) crtype.TestDetailsJobRunStats {
 	failure := getFailureCount(stats)
 	url := fmt.Sprintf("%s/view/gs/%s/", prowURL, gcsBucket)
 	subs := strings.Split(stats.FilePath, "/artifacts/")

--- a/pkg/api/componentreadiness/utils/utils.go
+++ b/pkg/api/componentreadiness/utils/utils.go
@@ -1,0 +1,107 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/openshift/sippy/pkg/apis/api/componentreport"
+	"github.com/sirupsen/logrus"
+)
+
+func PreviousRelease(release string) (string, error) {
+	prev := release
+	var err error
+	var major, minor int
+	if major, err = getMajor(release); err == nil {
+		if minor, err = getMinor(release); err == nil && minor > 0 {
+			prev = fmt.Sprintf("%d.%d", major, minor-1)
+		}
+	}
+
+	return prev, err
+}
+
+func getMajor(in string) (int, error) {
+	major, err := strconv.ParseInt(strings.Split(in, ".")[0], 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return int(major), err
+}
+
+func getMinor(in string) (int, error) {
+	minor, err := strconv.ParseInt(strings.Split(in, ".")[1], 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return int(minor), err
+}
+
+func NormalizeProwJobName(prowName string, reqOptions componentreport.RequestOptions) string {
+	name := prowName
+	if reqOptions.BaseRelease.Release != "" {
+		name = strings.ReplaceAll(name, reqOptions.BaseRelease.Release, "X.X")
+		if prev, err := PreviousRelease(reqOptions.BaseRelease.Release); err == nil {
+			name = strings.ReplaceAll(name, prev, "X.X")
+		}
+	}
+	if reqOptions.BaseOverrideRelease.Release != "" {
+		name = strings.ReplaceAll(name, reqOptions.BaseOverrideRelease.Release, "X.X")
+		if prev, err := PreviousRelease(reqOptions.BaseOverrideRelease.Release); err == nil {
+			name = strings.ReplaceAll(name, prev, "X.X")
+		}
+	}
+	if reqOptions.SampleRelease.Release != "" {
+		name = strings.ReplaceAll(name, reqOptions.SampleRelease.Release, "X.X")
+		if prev, err := PreviousRelease(reqOptions.SampleRelease.Release); err == nil {
+			name = strings.ReplaceAll(name, prev, "X.X")
+		}
+	}
+	// Some jobs encode frequency in their name, which can change
+	re := regexp.MustCompile(`-f\d+`)
+	name = re.ReplaceAllString(name, "-fXX")
+
+	return name
+}
+
+// DeserializeTestKey helps us workaround the limitations of a struct as a map key, where
+// we instead serialize a very small struct to json for a unit test key that includes test
+// ID and a specific set of variants. This function deserializes back to a struct.
+func DeserializeTestKey(stats componentreport.TestStatus, testKeyStr string) (componentreport.ReportTestIdentification, error) {
+	var testKey componentreport.TestWithVariantsKey
+	err := json.Unmarshal([]byte(testKeyStr), &testKey)
+	if err != nil {
+		logrus.WithError(err).Errorf("trying to unmarshel %s", testKeyStr)
+		return componentreport.ReportTestIdentification{}, err
+	}
+	testID := componentreport.ReportTestIdentification{
+		RowIdentification: componentreport.RowIdentification{
+			Component: stats.Component,
+			TestName:  stats.TestName,
+			TestSuite: stats.TestSuite,
+			TestID:    testKey.TestID,
+		},
+		ColumnIdentification: componentreport.ColumnIdentification{
+			Variants: testKey.Variants,
+		},
+	}
+	// Take the first cap for now. When we reach to a cell with specific capability, we will override the value.
+	if len(stats.Capabilities) > 0 {
+		testID.Capability = stats.Capabilities[0]
+	}
+	return testID, nil
+}
+
+func CalculatePassRate(reqOptions componentreport.RequestOptions, success, failure, flake int) float64 {
+	total := success + failure + flake
+	if total == 0 {
+		return 0.0
+	}
+	if reqOptions.AdvancedOption.FlakeAsFailure {
+		return float64(success) / float64(total)
+	}
+	return float64(success+flake) / float64(total)
+}

--- a/pkg/componentreadiness/jiraautomator/jiraautomator_test.go
+++ b/pkg/componentreadiness/jiraautomator/jiraautomator_test.go
@@ -31,7 +31,7 @@ func TestGetComponentRegressedTestsFromReport(t *testing.T) {
 			"Network":      "ovn",
 		},
 	}
-	awsAMD64OVNTest := crtype.TestIdentification{
+	awsAMD64OVNTest := crtype.TestWithVariantsKey{
 		TestID: "1",
 		Variants: map[string]string{
 			"Platform":     "aws",


### PR DESCRIPTION
- **Reapply "[TRT-1982](https://issues.redhat.com//browse/TRT-1982): Introduce middleware starting with ReleaseFallback impl"**
- **Fix cache key bug with base/sample test details queries**

Found the bug, the private reqOptions on the base/sample query generators meant cache keys were serializing as: time="2025-02-26T14:05:46.953-04:00" level=info msg="cache hit" key="BaseJobRunTestStatus~{\"BaseRelease\":\"4.18\",\"BaseStart\":\"2025-01-27T00:00:00Z\",\"BaseEnd\":\"2025-02-26T16:00:00Z\"}" type=componentreport.JobRunTestReportStatus

Causing all kinds of weird and horrifying wires to be crossed when you loaded the test details pages for subsequent tests. Fix is to make the field public and thus serialized as it was intended, but I missed.
