### PR TITLE
Add sippy version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ DEPS = npm go
 CHECK := $(foreach dep,$(DEPS),\
         $(if $(shell which $(dep)),"$(dep) found",$(error "Missing $(dep) in PATH")))
 
+GIT_COMMIT := $(shell git rev-parse --short HEAD)
+BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+GIT_TREE_STATE := $(if $(shell git status --porcelain),dirty,clean)
+LDFLAGS := -ldflags "-X github.com/openshift/sippy/pkg/version.commitFromGit=$(GIT_COMMIT) -X github.com/openshift/sippy/pkg/version.buildDate=$(BUILD_DATE) -X github.com/openshift/sippy/pkg/version.gitTreeState=$(GIT_TREE_STATE)"
+
 all: test build
 
 build: builddir clean npm frontend sippy sippy-daemon
@@ -19,10 +24,10 @@ frontend:
 	cd sippy-ng; npm run build
 
 sippy: builddir
-	go build -mod=vendor ./cmd/sippy/...
+	go build $(LDFLAGS) -mod=vendor ./cmd/sippy/...
 
 sippy-daemon: builddir
-	go build -mod=vendor ./cmd/sippy-daemon/...
+	go build $(LDFLAGS) -mod=vendor ./cmd/sippy-daemon/...
 
 test: builddir npm
 ifeq ($(ARTIFACT_DIR),)

--- a/cmd/sippy-daemon/main.go
+++ b/cmd/sippy-daemon/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -15,6 +17,7 @@ import (
 	"github.com/openshift/sippy/pkg/flags"
 	"github.com/openshift/sippy/pkg/github/commenter"
 	"github.com/openshift/sippy/pkg/sippyserver"
+	"github.com/openshift/sippy/pkg/version"
 )
 
 var logLevel = "info"
@@ -50,6 +53,9 @@ func NewSippyDaemonCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sippy-daemon",
 		Short: "Sippy daemon is used for on-going tasks like monitoring git repos for reporting risk analysis.",
+		PersistentPreRun: func(c *cobra.Command, args []string) {
+			fmt.Fprintf(os.Stdout, "sippy built from %s\n", version.Get().GitCommit)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			processes := make([]sippyserver.DaemonProcess, 0)

--- a/cmd/sippy/main.go
+++ b/cmd/sippy/main.go
@@ -15,6 +15,7 @@ var rootCmd = &cobra.Command{
 including name, suite, or NURP+ variants (network, upgrade, release,
 platform, etc).`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PrintVersion(cmd, args)
 		level, err := log.ParseLevel(logLevel)
 		if err != nil {
 			log.WithError(err).Fatal("cannot parse log-level")
@@ -42,6 +43,7 @@ func main() {
 		NewAutomateJiraCommand(),
 		NewTrackRegressionsCommand(),
 		NewVariantsCommand(),
+		NewVersionCommand(),
 	)
 
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info",

--- a/cmd/sippy/version.go
+++ b/cmd/sippy/version.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/openshift/sippy/pkg/version"
+)
+
+// NewVersionCommand prints out sippy version information, in a similar style to other kube tools,
+// e.g. https://github.com/openshift/kubernetes/blob/6892b57d65d25fb0588693bce3d338d8b8b1d2b4/cmd/kubeadm/app/cmd/version.go#L67
+func NewVersionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Report version information for sippy",
+		// Set persistent pre run to empty so we don't double print version info
+		PersistentPreRun: NoPrintVersion,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := version.Get()
+			const flag = "output"
+			of, err := cmd.Flags().GetString(flag)
+			if err != nil {
+				return errors.Wrapf(err, "error accessing flag %s for command %s", flag, cmd.Name())
+			}
+			switch of {
+			case "":
+				fmt.Fprintf(os.Stdout, "sippy built from %s\n", v.GitCommit)
+			case "short":
+				fmt.Fprintf(os.Stdout, "%s\n", v.GitCommit)
+			case "yaml":
+				y, err := yaml.Marshal(&v)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(os.Stdout, string(y))
+			case "json":
+				y, err := json.MarshalIndent(&v, "", "  ")
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(os.Stdout, string(y))
+			default:
+				return errors.Errorf("invalid output format: %s", of)
+			}
+
+			return nil
+		},
+	}
+	cmd.Flags().StringP("output", "o", "", "Output format; available options are 'yaml', 'json' and 'short'")
+	return cmd
+}
+
+// PrintVersion is used as a PersistentPreRun function to ensure we always print the version.
+var PrintVersion = func(cmd *cobra.Command, args []string) {
+	fmt.Fprintf(os.Stdout, "sippy built from %s\n", version.Get().GitCommit)
+}
+
+// NoPrintVersion is used as an empty PersistentPreRun function so we don't print version info
+// for some commands.
+var NoPrintVersion = func(cmd *cobra.Command, args []string) {
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,31 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	"k8s.io/apimachinery/pkg/version"
+)
+
+var (
+	// commitFromGit is a constant representing the source version that
+	// generated this build. It should be set during build via -ldflags.
+	commitFromGit string
+	// build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	buildDate string
+	// state of git tree, either "clean" or "dirty"
+	gitTreeState string
+)
+
+// Get returns the overall codebase version. It's for detecting
+// what code a binary was built from.
+func Get() version.Info {
+	return version.Info{
+		GitCommit:    commitFromGit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
I'd like to know when looking at cron jobs or other sippy logs which
commit it was built from. This adds a version command, ported from
origin, which was based on how other kube tools report versions.

<img width="838" alt="image" src="https://github.com/user-attachments/assets/24e115a9-fabf-4afd-a9ab-bfed03e2f15d" />
