### PR TITLE
Only enable checks for gocritic we already enabled

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters-settings:
   gofmt:
     simplify: false # do not require the -s flag
   gocritic:
+    disable-all: true # let's only enable ones we opt in to, not random new ones
     enabled-checks:
       # Diagnostic
       - argOrder


### PR DESCRIPTION
Some new rules are failing, like converting 3+ if statements to switch.