### PR TITLE
Increase timeout for golangci-lint

### DIFF
--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -9,7 +9,7 @@ if [ "$CI" = "true" ];
 then
   go version
   golangci-lint version -v
-  golangci-lint "${@}"
+  golangci-lint --timeout 10m "${@}"
 else
   DOCKER=${DOCKER:-podman}
 
@@ -29,5 +29,5 @@ else
     --volume "${PWD}:/go/src/github.com/openshift/sippy${VOLUME_OPTION}" \
     --workdir /go/src/github.com/openshift/sippy \
     docker.io/golangci/golangci-lint:v1.57.0 \
-    golangci-lint "${@}"
+    golangci-lint --timeout 10m "${@}"
 fi


### PR DESCRIPTION
New version seems too slow for our CI system
