### PR TITLE
Ensure we handle any google error

### DIFF
--- a/pkg/api/jobrunintervals/job_run_intervals.go
+++ b/pkg/api/jobrunintervals/job_run_intervals.go
@@ -31,12 +31,15 @@ func JobRunIntervals(gcsClient *storage.Client, dbc *db.DB, jobRunID int64, gcsP
 
 	bkt := gcsClient.Bucket(jobRun.GCSBucket)
 	gcsJobRun := gcs.NewGCSJobRun(bkt, gcsPath)
-	intervalFiles := gcsJobRun.FindAllMatches([]*regexp.Regexp{gcs.GetIntervalFile()})
+	intervals := &apitype.EventIntervalList{}
+	intervalFiles, err := gcsJobRun.FindAllMatches([]*regexp.Regexp{gcs.GetIntervalFile()})
+	if err != nil {
+		return intervals, err
+	}
 
 	// We will often match multiple files here, one for upgrade phase, one for conformance
 	// testing phase. For now, we return them all, and each interval has a filename it
 	// originated from.
-	intervals := &apitype.EventIntervalList{}
 	if len(intervalFiles) == 0 {
 		logger.Info("no interval files found")
 		return intervals, nil

--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -827,7 +827,11 @@ func (pl *ProwLoader) prowJobToJobRun(ctx context.Context, pj *prow.ProwJob, rel
 	}
 	bkt := pl.gcsClient.Bucket(pj.Spec.DecorationConfig.GCSConfiguration.Bucket)
 	gcsJobRun := gcs.NewGCSJobRun(bkt, path)
-	allMatches := gcsJobRun.FindAllMatches([]*regexp.Regexp{gcs.GetDefaultJunitFile()})
+	allMatches, err := gcsJobRun.FindAllMatches([]*regexp.Regexp{gcs.GetDefaultJunitFile()})
+	if err != nil {
+		return errors.Wrap(err, "error finding junit file")
+	}
+
 	var junitMatches []string
 	if len(allMatches) > 0 {
 		junitMatches = allMatches[0]

--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -148,7 +148,11 @@ ORDER BY j.prowjob_job_name;
 			}
 			bkt := v.gcsClient.Bucket(jlr.GCSBucket.StringVal)
 			gcsJobRun := gcs.NewGCSJobRun(bkt, path)
-			allMatches := gcsJobRun.FindAllMatches([]*regexp.Regexp{gcs.GetDefaultClusterDataFile()})
+			allMatches, err := gcsJobRun.FindAllMatches([]*regexp.Regexp{gcs.GetDefaultClusterDataFile()})
+			if err != nil {
+				jLog.WithError(err).Error("error finding cluster data file, proceeding without")
+				allMatches = [][]string{}
+			}
 			var clusterMatches []string
 			if len(allMatches) > 0 {
 				clusterMatches = allMatches[0]
@@ -171,7 +175,7 @@ ORDER BY j.prowjob_job_name;
 				}
 			}
 		} else {
-			jLog.WithField("gcs_bucket", jlr.GCSBucket).WithField("url", jlr.URL.StringVal).Warning("job had no gcs bucket or prow job url")
+			jLog.WithField("gcs_bucket", jlr.GCSBucket).WithField("url", jlr.URL.StringVal).Error("job had no gcs bucket or prow job url, proceeding without")
 		}
 
 		variants := v.CalculateVariantsForJob(jLog, jlr.JobName, clusterData)


### PR DESCRIPTION
In the GCS code, we're ignoring non-iterator errors, and hitting this in our cron jobs for QE. Looks like maybe the variant registry job doesn't have access to the QE GCS bucket.  This was failing silently before.