### PR TITLE
OCPERT-33 add/refine qe view for releases 4.14+

### DIFF
--- a/config/qe-views.yaml
+++ b/config/qe-views.yaml
@@ -1,10 +1,169 @@
 ---
 component_readiness:
-  - name: 4.17-qe-main
+  - name: 4.14-qe-main
+    base_release:
+      release: "4.14"
+      relative_start: "2024-10-16T00:00:00Z"
+      relative_end: "2024-11-16T23:59:59Z"
+    sample_release:
+      release: "4.14"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: {}
+        Network: {}
+        Platform: {}
+      db_group_by:
+        Architecture: {}
+        FeatureSet: {}
+        Installer: {}
+        Network: {}
+        Platform: {}
+        Suite: {}
+        Topology: {}
+        Upgrade: {}
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        Network:
+          - ovn
+        Owner:
+          - qe
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - rosa
+          - vsphere
+        Topology:
+          - ha
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+    metrics:
+      enabled: true
+    regression_tracking:
+      enabled: false
+  - name: 4.15-qe-main
+    base_release:
+      release: "4.15"
+      relative_start: "2024-11-07T00:00:00Z"
+      relative_end: "2024-12-07T23:59:59Z"
+    sample_release:
+      release: "4.15"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: {}
+        Network: {}
+        Platform: {}
+      db_group_by:
+        Architecture: {}
+        FeatureSet: {}
+        Installer: {}
+        Network: {}
+        Platform: {}
+        Suite: {}
+        Topology: {}
+        Upgrade: {}
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        Network:
+          - ovn
+        Owner:
+          - qe
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - rosa
+          - vsphere
+        Topology:
+          - ha
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+    metrics:
+      enabled: true
+    regression_tracking:
+      enabled: false
+  - name: 4.16-qe-main
     base_release:
       release: "4.16"
-      relative_start: ga-30d
+      relative_start: "2024-11-27T00:00:00Z"
+      relative_end: "2024-12-27T23:59:59Z"
+    sample_release:
+      release: "4.16"
+      relative_start: now-7d
       relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: {}
+        Network: {}
+        Platform: {}
+      db_group_by:
+        Architecture: {}
+        FeatureSet: {}
+        Installer: {}
+        Network: {}
+        Platform: {}
+        Suite: {}
+        Topology: {}
+        Upgrade: {}
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        Network:
+          - ovn
+        Owner:
+          - qe
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - rosa
+          - vsphere
+        Topology:
+          - ha
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+    metrics:
+      enabled: true
+    regression_tracking:
+      enabled: false
+  - name: 4.17-qe-main
+    base_release:
+      release: "4.17"
+      relative_start: "2025-01-06T00:00:00Z"
+      relative_end: "2025-02-06T23:59:59Z"
     sample_release:
       release: "4.17"
       relative_start: now-7d
@@ -35,7 +194,6 @@ component_readiness:
           - ovn
         Owner:
           - qe
-          - service-delivery
         Platform:
           - aws
           - azure
@@ -56,9 +214,9 @@ component_readiness:
       enabled: false
   - name: 4.18-qe-main
     base_release:
-      release: "4.17"
-      relative_start: ga-30d
-      relative_end: ga
+      release: "4.18"
+      relative_start: "2025-02-06T00:00:00Z"
+      relative_end: "2025-03-06T23:59:59Z"
     sample_release:
       release: "4.18"
       relative_start: now-7d
@@ -89,7 +247,6 @@ component_readiness:
           - ovn
         Owner:
           - qe
-          - service-delivery
         Platform:
           - aws
           - azure

--- a/config/qe-views.yaml
+++ b/config/qe-views.yaml
@@ -55,6 +55,59 @@ component_readiness:
       enabled: true
     regression_tracking:
       enabled: false
+  - name: 4.14-qe-main
+    base_release:
+      release: "4.14"
+      relative_start: "2024-10-16T00:00:00Z"
+      relative_end: "2024-11-16T23:59:59Z"
+    sample_release:
+      release: "4.14"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: {}
+        Network: {}
+        Platform: {}
+      db_group_by:
+        Architecture: {}
+        FeatureSet: {}
+        Installer: {}
+        Network: {}
+        Platform: {}
+        Suite: {}
+        Topology: {}
+        Upgrade: {}
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        Network:
+          - ovn
+        Owner:
+          - qe
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - rosa
+          - vsphere
+        Topology:
+          - ha
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+    metrics:
+      enabled: true
+    regression_tracking:
+      enabled: false
   - name: 4.15-qe-auto-release
     base_release:
       release: "4.15"
@@ -81,6 +134,59 @@ component_readiness:
       include_variants:
         Procedure:
           - automated-release
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        Network:
+          - ovn
+        Owner:
+          - qe
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - rosa
+          - vsphere
+        Topology:
+          - ha
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+    metrics:
+      enabled: true
+    regression_tracking:
+      enabled: false
+  - name: 4.15-qe-main
+    base_release:
+      release: "4.15"
+      relative_start: "2024-11-07T00:00:00Z"
+      relative_end: "2024-12-07T23:59:59Z"
+    sample_release:
+      release: "4.15"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: {}
+        Network: {}
+        Platform: {}
+      db_group_by:
+        Architecture: {}
+        FeatureSet: {}
+        Installer: {}
+        Network: {}
+        Platform: {}
+        Suite: {}
+        Topology: {}
+        Upgrade: {}
+      include_variants:
         Architecture:
           - amd64
         FeatureSet:
@@ -165,6 +271,59 @@ component_readiness:
       enabled: true
     regression_tracking:
       enabled: false
+  - name: 4.16-qe-main
+    base_release:
+      release: "4.16"
+      relative_start: "2024-11-27T00:00:00Z"
+      relative_end: "2024-12-27T23:59:59Z"
+    sample_release:
+      release: "4.16"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: {}
+        Network: {}
+        Platform: {}
+      db_group_by:
+        Architecture: {}
+        FeatureSet: {}
+        Installer: {}
+        Network: {}
+        Platform: {}
+        Suite: {}
+        Topology: {}
+        Upgrade: {}
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        Network:
+          - ovn
+        Owner:
+          - qe
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - rosa
+          - vsphere
+        Topology:
+          - ha
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+    metrics:
+      enabled: true
+    regression_tracking:
+      enabled: false
   - name: 4.17-qe-auto-release
     base_release:
       release: "4.17"
@@ -220,6 +379,59 @@ component_readiness:
       enabled: true
     regression_tracking:
       enabled: false
+  - name: 4.17-qe-main
+    base_release:
+      release: "4.17"
+      relative_start: "2025-01-06T00:00:00Z"
+      relative_end: "2025-02-06T23:59:59Z"
+    sample_release:
+      release: "4.17"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: {}
+        Network: {}
+        Platform: {}
+      db_group_by:
+        Architecture: {}
+        FeatureSet: {}
+        Installer: {}
+        Network: {}
+        Platform: {}
+        Suite: {}
+        Topology: {}
+        Upgrade: {}
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        Network:
+          - ovn
+        Owner:
+          - qe
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - rosa
+          - vsphere
+        Topology:
+          - ha
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+    metrics:
+      enabled: true
+    regression_tracking:
+      enabled: false
   - name: 4.18-qe-auto-release
     base_release:
       release: "4.18"
@@ -246,6 +458,59 @@ component_readiness:
       include_variants:
         Procedure:
           - automated-release
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        Network:
+          - ovn
+        Owner:
+          - qe
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - rosa
+          - vsphere
+        Topology:
+          - ha
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+    metrics:
+      enabled: true
+    regression_tracking:
+      enabled: false
+  - name: 4.18-qe-main
+    base_release:
+      release: "4.18"
+      relative_start: "2025-02-06T00:00:00Z"
+      relative_end: "2025-03-06T23:59:59Z"
+    sample_release:
+      release: "4.18"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: {}
+        Network: {}
+        Platform: {}
+      db_group_by:
+        Architecture: {}
+        FeatureSet: {}
+        Installer: {}
+        Network: {}
+        Platform: {}
+        Suite: {}
+        Topology: {}
+        Upgrade: {}
+      include_variants:
         Architecture:
           - amd64
         FeatureSet:

--- a/config/qe-views.yaml
+++ b/config/qe-views.yaml
@@ -1,6 +1,6 @@
 ---
 component_readiness:
-  - name: 4.14-qe-main
+  - name: 4.14-qe-auto-release
     base_release:
       release: "4.14"
       relative_start: "2024-10-16T00:00:00Z"
@@ -24,6 +24,8 @@ component_readiness:
         Topology: {}
         Upgrade: {}
       include_variants:
+        Procedure:
+          - automated-release
         Architecture:
           - amd64
         FeatureSet:
@@ -53,7 +55,7 @@ component_readiness:
       enabled: true
     regression_tracking:
       enabled: false
-  - name: 4.15-qe-main
+  - name: 4.15-qe-auto-release
     base_release:
       release: "4.15"
       relative_start: "2024-11-07T00:00:00Z"
@@ -77,6 +79,8 @@ component_readiness:
         Topology: {}
         Upgrade: {}
       include_variants:
+        Procedure:
+          - automated-release
         Architecture:
           - amd64
         FeatureSet:
@@ -106,7 +110,7 @@ component_readiness:
       enabled: true
     regression_tracking:
       enabled: false
-  - name: 4.16-qe-main
+  - name: 4.16-qe-auto-release
     base_release:
       release: "4.16"
       relative_start: "2024-11-27T00:00:00Z"
@@ -130,6 +134,8 @@ component_readiness:
         Topology: {}
         Upgrade: {}
       include_variants:
+        Procedure:
+          - automated-release
         Architecture:
           - amd64
         FeatureSet:
@@ -159,7 +165,7 @@ component_readiness:
       enabled: true
     regression_tracking:
       enabled: false
-  - name: 4.17-qe-main
+  - name: 4.17-qe-auto-release
     base_release:
       release: "4.17"
       relative_start: "2025-01-06T00:00:00Z"
@@ -183,6 +189,8 @@ component_readiness:
         Topology: {}
         Upgrade: {}
       include_variants:
+        Procedure:
+          - automated-release
         Architecture:
           - amd64
         FeatureSet:
@@ -212,7 +220,7 @@ component_readiness:
       enabled: true
     regression_tracking:
       enabled: false
-  - name: 4.18-qe-main
+  - name: 4.18-qe-auto-release
     base_release:
       release: "4.18"
       relative_start: "2025-02-06T00:00:00Z"
@@ -236,6 +244,8 @@ component_readiness:
         Topology: {}
         Upgrade: {}
       include_variants:
+        Procedure:
+          - automated-release
         Architecture:
           - amd64
         FeatureSet:


### PR DESCRIPTION
- use absolute datetime for base release
- time duration of base release is 30 days. queried earliest modified_time of auto release job from BigQuery
- only keep qe for variant owner, remove service-delivery
- base release version is same as sampel release
