### PR TITLE
Add validation for gcs credentials and clarify the development readme

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -117,6 +117,7 @@ Then to launch the API server:
 ./sippy serve \
   --log-level=debug \
   --database-dsn="postgresql://postgres:password@localhost:5432/postgres" \
+  --google-service-account-credential-file ~/google-service-account-credential-file.json \
   --mode=ocp
 ````
 
@@ -128,7 +129,7 @@ If you'd like to launch just Component Readiness, you can run:
     --redis-url="redis://192.168.1.215:6379"
 ```
 
-When providing BigQuery credentials, your service account needs access to the project and datasets that are being used.
+When providing BigQuery credentials (`--google-service-account-credential-file`), your service account or personal token needs access to the project and datasets that are being used.
 The defaults are visible in `--help`. For component readiness, you need to have access to the storage API as well
 with the permission `bigquery.readsessions.create`.
 

--- a/cmd/sippy-daemon/main.go
+++ b/cmd/sippy-daemon/main.go
@@ -57,6 +57,10 @@ func (f *SippyDaemonFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&f.MetricsAddr, "listen-metrics", f.MetricsAddr, "The address to serve prometheus metrics on (default :2112)")
 }
 
+func (f *SippyDaemonFlags) Validate() error {
+	return f.GoogleCloudFlags.Validate()
+}
+
 func NewSippyDaemonCommand() *cobra.Command {
 	f := NewSippyDaemonFlags()
 
@@ -68,6 +72,9 @@ func NewSippyDaemonCommand() *cobra.Command {
 			fmt.Fprintf(os.Stdout, "sippy built from %s\n", version.Get().GitCommit)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := f.Validate(); err != nil {
+				return errors.WithMessage(err, "error validating options")
+			}
 
 			processes := make([]sippyserver.DaemonProcess, 0)
 

--- a/cmd/sippy/automatejira.go
+++ b/cmd/sippy/automatejira.go
@@ -116,6 +116,9 @@ func (f *AutomateJiraFlags) Validate(allVariants crtype.JobVariants) error {
 		}
 		f.ColumnThresholds[jiraautomator.Variant{Name: vt[0], Value: vt[1]}] = t
 	}
+	if err := f.GoogleCloudFlags.Validate(); err != nil {
+		return err
+	}
 	return f.JiraOptions.Validate(true)
 }
 

--- a/cmd/sippy/component_readiness.go
+++ b/cmd/sippy/component_readiness.go
@@ -90,7 +90,7 @@ func (f *ComponentReadinessFlags) BindFlags(flagSet *pflag.FlagSet) {
 }
 
 func (f *ComponentReadinessFlags) Validate() error {
-	return nil
+	return f.GoogleCloudFlags.Validate()
 }
 
 func (f *ComponentReadinessFlags) Run() error { //nolint:gocyclo

--- a/cmd/sippy/serve.go
+++ b/cmd/sippy/serve.go
@@ -66,7 +66,7 @@ func (f *ServerFlags) BindFlags(flagSet *pflag.FlagSet) {
 }
 
 func (f *ServerFlags) Validate() error {
-	return nil
+	return f.GoogleCloudFlags.Validate()
 }
 
 func NewServeCommand() *cobra.Command {

--- a/cmd/sippy/trackregressions.go
+++ b/cmd/sippy/trackregressions.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/sippy/pkg/apis/cache"
 	bqcachedclient "github.com/openshift/sippy/pkg/bigquery"
 	"github.com/openshift/sippy/pkg/flags/configflags"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -45,6 +46,10 @@ func (f *TrackRegressionFlags) BindFlags(fs *pflag.FlagSet) {
 	f.ConfigFlags.BindFlags(fs)
 }
 
+func (f *TrackRegressionFlags) Validate() error {
+	return f.GoogleCloudFlags.Validate()
+}
+
 func NewTrackRegressionsCommand() *cobra.Command {
 	f := NewTrackRegressionFlags()
 
@@ -53,6 +58,9 @@ func NewTrackRegressionsCommand() *cobra.Command {
 		Short: "Update tracked regressions for each view with tracking enabled",
 		Long:  "Check the component report for each view with regression tracking enabled. Maintains tables in bigquery with times we saw regressions appear/disappear.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := f.Validate(); err != nil {
+				return errors.WithMessage(err, "error validating options")
+			}
 			ctx, cancel := context.WithTimeout(context.Background(), time.Hour*1)
 			defer cancel()
 

--- a/pkg/flags/google.go
+++ b/pkg/flags/google.go
@@ -3,6 +3,7 @@ package flags
 import (
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
 
@@ -28,4 +29,12 @@ func (f *GoogleCloudFlags) BindFlags(fs *pflag.FlagSet) {
 		"google-oauth-credential-file",
 		f.OAuthClientCredentialFile,
 		"location of a credential file described by https://developers.google.com/people/quickstart/go, setup from https://cloud.google.com/bigquery/docs/authentication/end-user-installed#client-credentials")
+}
+
+func (f *GoogleCloudFlags) Validate() error {
+	if f.ServiceAccountCredentialFile == "" && f.OAuthClientCredentialFile == "" {
+		return errors.New("must specify one of 'google-service-account-credential-file' or 'google-oauth-credential-file'")
+	}
+
+	return nil
 }


### PR DESCRIPTION
The commands that utilize the GCS creds are:
`automatejira`, `component_readiness`, `load`, `serve`, `trackregressions`, `variants_generate`, and `sippy-daemon`. Of these, only `load` doesn't require it in all cases, so I have left validation off for it.