### PR TITLE
TRT-1540: add alert when no accepted or rejected results are found for the payload calendar

### DIFF
--- a/sippy-ng/src/releases/PayloadCalendar.js
+++ b/sippy-ng/src/releases/PayloadCalendar.js
@@ -1,16 +1,46 @@
 import FullCalendar from '@fullcalendar/react'
 
+import { Alert, Grid } from '@mui/material'
 import { filterFor } from '../helpers'
 import { useHistory } from 'react-router-dom'
 import { useTheme } from '@mui/material/styles'
 import dayGridPlugin from '@fullcalendar/daygrid'
 import PayloadCalendarLegend from './PayloadCalendarLegend'
 import PropTypes from 'prop-types'
-import React, { Fragment } from 'react'
+import React, { Fragment, useState } from 'react'
 
 export default function PayloadCalendar(props) {
   const theme = useTheme()
   const history = useHistory()
+
+  const [acceptedFound, setAcceptedFound] = useState(true)
+
+  const acceptedSourceSuccess = (info) => {
+    setAcceptedFound(info.length > 0)
+    displayAlertIfNecessary()
+  }
+
+  const [rejectedFound, setRejectedFound] = useState(true)
+
+  const rejectedSourceSuccess = (info) => {
+    setRejectedFound(info.length > 0)
+    displayAlertIfNecessary()
+  }
+
+  const [alertMessage, setAlertMessage] = useState('')
+
+  const displayAlertIfNecessary = () => {
+    if (!acceptedFound && !rejectedFound) {
+      setAlertMessage('Warning: no results found for payload')
+    } else {
+      setAlertMessage('')
+    }
+  }
+
+  const failedRetrieval = (error) => {
+    console.error(error)
+    setAlertMessage('Warning: error retrieving results for payload')
+  }
 
   const eventSources = [
     {
@@ -30,6 +60,7 @@ export default function PayloadCalendar(props) {
       },
       color: theme.palette.success.light,
       textColor: theme.palette.success.contrastText,
+      success: acceptedSourceSuccess,
     },
     {
       url:
@@ -48,6 +79,7 @@ export default function PayloadCalendar(props) {
       },
       color: theme.palette.error.light,
       textColor: theme.palette.error.contrastText,
+      success: rejectedSourceSuccess,
     },
     {
       url: process.env.REACT_APP_API_URL + '/api/incidents',
@@ -70,6 +102,11 @@ export default function PayloadCalendar(props) {
 
   return (
     <Fragment>
+      {alertMessage && (
+        <Grid container justifyContent="center" width="100%">
+          <Alert severity="error">{alertMessage}</Alert>
+        </Grid>
+      )}
       <PayloadCalendarLegend />
       <FullCalendar
         timeZone="UTC"
@@ -82,6 +119,7 @@ export default function PayloadCalendar(props) {
         initialView="dayGridMonth"
         eventClick={eventClick}
         eventSources={eventSources}
+        eventSourceFailure={failedRetrieval}
       />
     </Fragment>
   )


### PR DESCRIPTION
The alert will display if the current view of the payload calendar didn't return any results for `accepted` or `rejected` payloads; to warn the user that there might be something wrong. It will also display (with a different message) when there is actually an error returned from any of the event sources.

<img width="1191" alt="Screenshot 2025-03-12 at 7 52 10 AM" src="https://github.com/user-attachments/assets/bfad0d30-8d49-401a-9b10-d457697e8db7" />
