### PR TITLE
Fix missing regressed since values

### DIFF
--- a/cmd/sippy/component_readiness.go
+++ b/cmd/sippy/component_readiness.go
@@ -194,7 +194,7 @@ func (f *ComponentReadinessFlags) runServerMode() error {
 		// Do an immediate metrics update
 		err = metrics.RefreshMetricsDB(
 			context.Background(),
-			nil,
+			dbc,
 			bigQueryClient,
 			time.Time{},
 			cache.RequestOptions{CRTimeRoundingFactor: f.ComponentReadinessFlags.CRTimeRoundingFactor},
@@ -214,7 +214,7 @@ func (f *ComponentReadinessFlags) runServerMode() error {
 					log.Info("tick")
 					err := metrics.RefreshMetricsDB(
 						context.Background(),
-						nil,
+						dbc,
 						bigQueryClient,
 						time.Time{},
 						cache.RequestOptions{CRTimeRoundingFactor: f.ComponentReadinessFlags.CRTimeRoundingFactor},

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -281,6 +281,8 @@ func (c *ComponentReportGenerator) GenerateReport(ctx context.Context) (crtype.C
 			errs = append(errs, err)
 			return crtype.ComponentReport{}, errs
 		}
+	} else {
+		log.Warnf("no postgres connection for ComponentReportGenerator, regression tracking data will not be included")
 	}
 
 	// perform analysis and generate report:

--- a/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
+++ b/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
@@ -142,7 +142,7 @@ func (r *ReleaseFallback) matchBestBaseStats(
 				// this back to the core report generator so it can include the adjusted release/start/end dates in
 				// the report, and ultimately the UI.
 				baseStats.Release = &cachedReleaseTestStatuses.Release
-				r.log.Infof("Overrode base stats (%.4f) using release %s (%.4f) for test: %s - %s",
+				r.log.Debugf("Overrode base stats (%.4f) using release %s (%.4f) for test: %s - %s",
 					basePassRate, baseStats.Release.Release, cPassRate, baseStats.TestName, testKeyStr)
 			}
 		}


### PR DESCRIPTION
Missed passing the db connection through to the metrics loop here. If the
auth sippy which runs the component-readiness entrypoint command
happened to be the one which found the cache expired, it would populate
it without regressed since values. This would happen roughly half the
time.
