### PR TITLE
Exclude konflux jobs from component readiness

### DIFF
--- a/pkg/api/componentreadiness/query/querygenerators.go
+++ b/pkg/api/componentreadiness/query/querygenerators.go
@@ -24,7 +24,7 @@ import (
 const (
 	DefaultJunitTable = "junit"
 
-	IgnoredJobsRegexp = `-okd|-recovery|aggregator-|alibaba|-disruptive|-rollback|-out-of-change|-sno-fips-recert|-bgp-`
+	IgnoredJobsRegexp = `-okd|-recovery|aggregator-|alibaba|-disruptive|-rollback|-out-of-change|-sno-fips-recert|-bgp-|-konflux`
 
 	// This query de-dupes the test results. There are multiple issues present in
 	// our data set:

--- a/pkg/api/componentreadiness/query/querygenerators.go
+++ b/pkg/api/componentreadiness/query/querygenerators.go
@@ -24,7 +24,7 @@ import (
 const (
 	DefaultJunitTable = "junit"
 
-	IgnoredJobsRegexp = `-okd|-recovery|aggregator-|alibaba|-disruptive|-rollback|-out-of-change|-sno-fips-recert|-bgp-|-konflux`
+	IgnoredJobsRegexp = `-okd|-recovery|aggregator-|alibaba|-disruptive|-rollback|-out-of-change|-sno-fips-recert|-bgp-|-konflux|-vsphere-host-groups`
 
 	// This query de-dupes the test results. There are multiple issues present in
 	// our data set:

--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -582,6 +582,9 @@ func (v *OCPVariantLoader) setJobTier(_ logrus.FieldLogger, variants map[string]
 		// not ready to make release blocking yet.
 		{"-vsphere-host-groups", "candidate"},
 
+		// Konflux jobs aren't ready yet
+		{"-konflux", "candidate"},
+
 		// Hidden jobs
 		{"-disruptive", "hidden"},
 		{"-rollback", "hidden"},


### PR DESCRIPTION
Also an update for https://github.com/openshift/sippy/pull/2402 