### PR TITLE
trt-2058: Show Triaged Issues in TestDetails

### DIFF
--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -351,6 +351,7 @@ func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(ctx context
 		},
 	}
 	var resolvedIssueCompensation int
+	var incidents []crtype.TriagedIncident
 	approvedRegression := regressionallowances.IntentionalRegressionFor(c.ReqOptions.SampleRelease.Release, result.ColumnIdentification, c.ReqOptions.TestIDOption.TestID)
 	var baseRegression *regressionallowances.IntentionalRegression
 	activeProductRegression := false
@@ -361,13 +362,13 @@ func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(ctx context
 	}
 	// ignore triage if we have an intentional regression
 	if approvedRegression == nil {
-		resolvedIssueCompensation, activeProductRegression, _ = c.triagedIncidentsFor(ctx, result.ReportTestIdentification)
+		resolvedIssueCompensation, activeProductRegression, incidents = c.triagedIncidentsFor(ctx, result.ReportTestIdentification)
 	}
 
 	var totalBaseFailure, totalBaseSuccess, totalBaseFlake, totalSampleFailure, totalSampleSuccess, totalSampleFlake int
 	var perJobBaseFailure, perJobBaseSuccess, perJobBaseFlake, perJobSampleFailure, perJobSampleSuccess, perJobSampleFlake int
 
-	report := crtype.TestDetailsAnalysis{}
+	report := crtype.TestDetailsAnalysis{TriagedIncidents: incidents}
 	for prowJob, baseStatsList := range baseStatus {
 		jobStats := crtype.TestDetailsJobStats{
 			JobName: prowJob,

--- a/pkg/apis/api/componentreport/types.go
+++ b/pkg/apis/api/componentreport/types.go
@@ -256,7 +256,8 @@ func (r ReportTestStats) IsTriaged() bool {
 // multiple different analyses run.
 type TestDetailsAnalysis struct {
 	ReportTestStats
-	JobStats []TestDetailsJobStats `json:"job_stats,omitempty"`
+	JobStats         []TestDetailsJobStats `json:"job_stats,omitempty"`
+	TriagedIncidents []TriagedIncident     `json:"incidents,omitempty"`
 }
 
 // ReportTestDetails is the top level API response for test details reports.

--- a/sippy-ng/src/component_readiness/CompReadyTestDetailRow.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestDetailRow.js
@@ -24,7 +24,7 @@ export default function CompReadyTestDetailRow(props) {
   // element: a test detail element
   // idx: array index of test detail element
   // showOnlyFailures: says to focus on job failures
-  const { element, idx, showOnlyFailures } = props
+  const { element, idx, showOnlyFailures, triagedURLs } = props
 
   const infoCell = (stats) => {
     return (
@@ -89,7 +89,11 @@ export default function CompReadyTestDetailRow(props) {
                     }}
                   >
                     <Typography className={classes.crCellName}>
-                      {jobRun.test_stats.failure_count > 0 ? 'F' : 'S'}
+                      {jobRun.test_stats.failure_count > 0
+                        ? triagedURLs[jobRun.job_url] !== undefined
+                          ? 'T'
+                          : 'F'
+                        : 'S'}
                     </Typography>
                   </a>
                 )
@@ -129,4 +133,5 @@ CompReadyTestDetailRow.propTypes = {
   element: PropTypes.object.isRequired,
   idx: PropTypes.number.isRequired,
   showOnlyFailures: PropTypes.bool.isRequired,
+  triagedURLs: PropTypes.array.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompReadyTestPanel.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestPanel.js
@@ -167,6 +167,21 @@ export default function CompReadyTestPanel(props) {
     return null
   }
 
+  let urls = []
+  if (data && data.incidents && data.incidents.length > 0) {
+    for (let i = 0; i < data.incidents.length; i++) {
+      let incident = data.incidents[i]
+      if (incident && incident.job_runs && incident.job_runs.length > 0) {
+        for (let z = 0; z < incident.job_runs.length; z++) {
+          let job_run = incident.job_runs[z]
+          if (job_run.url !== undefined && urls[job_run.url] === undefined) {
+            urls[job_run.url] = true
+          }
+        }
+      }
+    }
+  }
+
   return (
     <Fragment>
       <Grid container spacing={2} style={{ marginTop: '10px' }}>
@@ -242,6 +257,7 @@ export default function CompReadyTestPanel(props) {
                       element={element}
                       idx={idx}
                       showOnlyFailures={showOnlyFailures}
+                      triagedURLs={urls}
                     ></CompReadyTestDetailRow>
                   )
                 })

--- a/sippy-ng/src/component_readiness/CompReadyTestPanel.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestPanel.js
@@ -168,18 +168,14 @@ export default function CompReadyTestPanel(props) {
   }
 
   let urls = []
-  if (data && data.incidents && data.incidents.length > 0) {
-    for (let i = 0; i < data.incidents.length; i++) {
-      let incident = data.incidents[i]
-      if (incident && incident.job_runs && incident.job_runs.length > 0) {
-        for (let z = 0; z < incident.job_runs.length; z++) {
-          let job_run = incident.job_runs[z]
-          if (job_run.url !== undefined && urls[job_run.url] === undefined) {
-            urls[job_run.url] = true
-          }
+  if (data?.incidents?.length) {
+    data.incidents.forEach((incident) => {
+      incident?.job_runs?.forEach((job_run) => {
+        if (job_run.url !== undefined) {
+          urls[job_run.url] = true
         }
-      }
-    }
+      })
+    })
   }
 
   return (

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -17,6 +17,7 @@ import {
   gotFetchError,
   makePageTitle,
   makeRFC3339Time,
+  mergeIncidents,
   noDataTable,
 } from './CompReadyUtils'
 import { ComponentReadinessStyleContext } from './ComponentReadiness'
@@ -43,6 +44,7 @@ import Table from '@mui/material/Table'
 import TableBody from '@mui/material/TableBody'
 import TableCell from '@mui/material/TableCell'
 import TableRow from '@mui/material/TableRow'
+import TriagedIncidentsPanel from './TriagedIncidentsPanel'
 
 // Big query requests take a while so give the user the option to
 // abort in case they inadvertently requested a huge dataset.
@@ -234,14 +236,10 @@ export default function CompReadyTestReport(props) {
   }
 
   const columnNames = getColumns(data)
-  if (columnNames[0] === 'Cancelled' || columnNames[0] == 'None') {
+  if (columnNames[0] === 'Cancelled' || columnNames[0] === 'None') {
     return (
       <CompReadyCancelled message={columnNames[0]} apiCallStr={apiCallStr} />
     )
-  }
-
-  const handleFailuresOnlyChange = (event) => {
-    setShowOnlyFailures(event.target.checked)
   }
 
   const [statusStr, assessmentIcon] = getStatusAndIcon(
@@ -397,6 +395,18 @@ View the [test details report|${document.location.href}] for additional context.
           </Box>
         </Grid>
       </Grid>
+
+      {data.analyses[0].incidents && data.analyses[0].incidents.length > 0 ? (
+        <Fragment>
+          <h2>Triaged Tests</h2>
+          <TriagedIncidentsPanel
+            triagedIncidents={mergeIncidents(data.analyses[0].incidents, data)}
+          />
+        </Fragment>
+      ) : (
+        // no incidents
+        <Fragment />
+      )}
 
       <h2>Regression Report</h2>
 

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -501,6 +501,8 @@ export function validateData(data) {
   return ['']
 }
 
+// groupIncidentIncidents expects data from CR api call and passes the
+// incident as the details portion for the grouped incident
 export function groupIncidentIncidents(incidents, groupedIncidents) {
   incidents.forEach((incident) => {
     if (incident.incidents && incident.incidents.length > 0) {
@@ -509,6 +511,7 @@ export function groupIncidentIncidents(incidents, groupedIncidents) {
   })
 }
 
+// groupIncidents uses the incident_group_id to create a logical grouping of triaged incidents
 export function groupIncidents(incidents, groupedIncidents, detailsIncident) {
   incidents.forEach((i) => {
     if (!groupedIncidents.has(i.incident_group_id)) {
@@ -523,6 +526,7 @@ export function groupIncidents(incidents, groupedIncidents, detailsIncident) {
   })
 }
 
+// createGroupedIncidentArray converts the map into an array of grouped incidents
 export function createGroupedIncidentArray(groupedIncidents) {
   return Array.from(groupedIncidents, ([group_id, grouped_incidents]) => ({
     group_id,
@@ -530,12 +534,17 @@ export function createGroupedIncidentArray(groupedIncidents) {
   }))
 }
 
+// mergeIncidents expects a data object from TestDetails and passes it as
+// the details portion of the grouped incident
 export function mergeIncidents(incidents, detailsIncident) {
   let groupedIncidents = new Map()
   groupIncidents(incidents, groupedIncidents, detailsIncident)
   return createGroupedIncidentArray(groupedIncidents)
 }
 
+// mergeRegressionData takes the data from CR api and organizes the data
+// for groupedIncidents, regressedTests (untriaged) and combined list of untriaged and triaged tests
+// all used in the RegressedTestsModal dialog
 export function mergeRegressionData(data) {
   let ret = validateData(data)
   if (ret[0] !== '') {

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -61,7 +61,7 @@ export default function RegressedTestsModal(props) {
           >
             <Tab label="Untriaged Regressions" {...tabProps(0)} />
             <Tab label="Regressed Tests" {...tabProps(1)} />
-            <Tab label="Triaged Incidents" {...tabProps(2)} />
+            <Tab label="Triaged Tests" {...tabProps(2)} />
           </Tabs>
           <RegressedTestsTabPanel activeIndex={activeTabIndex} index={0}>
             <RegressedTestsPanel

--- a/sippy-ng/src/component_readiness/TriagedTestJobRuns.js
+++ b/sippy-ng/src/component_readiness/TriagedTestJobRuns.js
@@ -55,5 +55,5 @@ export default function TriagedTestJobRuns(props) {
 }
 
 TriagedTestJobRuns.propTypes = {
-  jobRuns: PropTypes.object.isRequired,
+  jobRuns: PropTypes.array.isRequired,
 }


### PR DESCRIPTION
- Adds the Triaged Tests view used in the Regressed Tests Modal Dialog to Test Details when there is 1 or more associated Triage records
- Marks Triaged JobRuns with `T` instead of `F`

![image](https://github.com/user-attachments/assets/abb344a5-0817-496f-ab7f-b226dc840ee9)
