### PR TITLE
NO-JIRA: refactor accessibility mode to use context

### DIFF
--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -1,5 +1,4 @@
-import { Accessibility, DarkMode, LightMode } from '@mui/icons-material'
-import { AccessibilityModeProvider } from './AccessibilityModeProvider'
+import { AccessibilityModeProvider } from './components/AccessibilityModeProvider'
 import { CompReadyVarsProvider } from './component_readiness/CompReadyVars'
 import { createTheme, useTheme } from '@mui/material/styles'
 import {
@@ -10,6 +9,7 @@ import {
   Tooltip,
 } from '@mui/material'
 import { cyan, green, orange, red } from '@mui/material/colors'
+import { DarkMode, LightMode } from '@mui/icons-material'
 import {
   findFirstNonGARelease,
   getReportStartDate,
@@ -25,7 +25,7 @@ import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5'
 import { Redirect, Route, Switch } from 'react-router-dom'
 import { TestAnalysis } from './tests/TestAnalysis'
 import { useCookies } from 'react-cookie'
-import AccessibilityToggle from './component_readiness/AccessibilityToggle'
+import AccessibilityToggle from './components/AccessibilityToggle'
 import Alert from '@mui/material/Alert'
 import BuildClusterDetails from './build_clusters/BuildClusterDetails'
 import BuildClusterOverview from './build_clusters/BuildClusterOverview'
@@ -110,9 +110,6 @@ export const CapabilitiesContext = React.createContext([])
 export const ReportEndContext = React.createContext('')
 const ColorModeContext = React.createContext({
   toggleColorMode: () => {},
-})
-export const AccessibilityModeContext = React.createContext({
-  toggleAccessibilityMode: () => {},
 })
 
 const useStyles = makeStyles(() => ({

--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -194,8 +194,6 @@ export default function App(props) {
     [setCookie]
   )
 
-  // const accessibilityMode = useContext(AccessibilityModeContext)
-
   const [lastUpdated, setLastUpdated] = React.useState(null)
   const [drawerOpen, setDrawerOpen] = React.useState(true)
   const [isLoaded, setLoaded] = React.useState(false)

--- a/sippy-ng/src/component_readiness/CompCapRow.js
+++ b/sippy-ng/src/component_readiness/CompCapRow.js
@@ -31,13 +31,7 @@ export default function CompCapRow(props) {
   // results is an array of columns and contains the status value per columnName
   // columnNames is the calculated array of columns
   // filterVals: the parts of the url containing input values
-  const {
-    capabilityName,
-    results,
-    columnNames,
-    filterVals,
-    accessibilityMode,
-  } = props
+  const { capabilityName, results, columnNames, filterVals } = props
 
   const [capabilityParam, setCapabilityParam] = useQueryParam(
     'capability',
@@ -73,7 +67,6 @@ export default function CompCapRow(props) {
               columnVal.regressed_tests,
               columnVal.triaged_incidents
             )}
-            accessibilityMode={accessibilityMode}
           />
         ))}
       </TableRow>
@@ -86,5 +79,4 @@ CompCapRow.propTypes = {
   results: PropTypes.array.isRequired,
   columnNames: PropTypes.array.isRequired,
   filterVals: PropTypes.string.isRequired,
-  accessibilityMode: PropTypes.bool.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompCapTestRow.js
+++ b/sippy-ng/src/component_readiness/CompCapTestRow.js
@@ -30,7 +30,6 @@ export default function CompCapTestRow(props) {
     filterVals,
     component,
     capability,
-    accessibilityMode,
   } = props
 
   // Put the testName on the left side with no link.
@@ -59,7 +58,6 @@ export default function CompCapTestRow(props) {
             capability={capability}
             testName={testName}
             regressedTests={columnVal.regressed_tests}
-            accessibilityMode={accessibilityMode}
           />
         ))}
       </TableRow>
@@ -76,5 +74,4 @@ CompCapTestRow.propTypes = {
   filterVals: PropTypes.string.isRequired,
   component: PropTypes.string.isRequired,
   capability: PropTypes.string.isRequired,
-  accessibilityMode: PropTypes.bool.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompReadyCapsCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCapsCell.js
@@ -14,14 +14,8 @@ import React, { useContext } from 'react'
 import TableCell from '@mui/material/TableCell'
 
 export default function CompReadyCapsCell(props) {
-  const {
-    status,
-    environment,
-    capabilityName,
-    filterVals,
-    regressedCount,
-    accessibilityMode,
-  } = props
+  const { status, environment, capabilityName, filterVals, regressedCount } =
+    props
   const theme = useTheme()
   const classes = useContext(ComponentReadinessStyleContext)
 
@@ -72,11 +66,7 @@ export default function CompReadyCapsCell(props) {
         }}
       >
         <Link to={capabilityReport(capabilityName, environment, filterVals)}>
-          <CompSeverityIcon
-            status={status}
-            count={regressedCount}
-            accessibilityMode={accessibilityMode}
-          />
+          <CompSeverityIcon status={status} count={regressedCount} />
         </Link>
       </TableCell>
     )
@@ -89,5 +79,4 @@ CompReadyCapsCell.propTypes = {
   capabilityName: PropTypes.string.isRequired,
   filterVals: PropTypes.string.isRequired,
   regressedCount: PropTypes.number,
-  accessibilityMode: PropTypes.bool.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilities.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilities.js
@@ -44,7 +44,7 @@ const cancelFetch = () => {
 // This is page 2 or 2a which runs when you click a component cell on the left or under an environment of page 1.
 export default function CompReadyEnvCapabilities(props) {
   const classes = useContext(ComponentReadinessStyleContext)
-  const { filterVals, component, environment, theme, accessibilityMode } = props
+  const { filterVals, component, environment, theme } = props
 
   const [fetchError, setFetchError] = React.useState('')
   const [isLoaded, setIsLoaded] = React.useState(false)
@@ -211,7 +211,6 @@ export default function CompReadyEnvCapabilities(props) {
         data={data}
         filterVals={filterVals}
         forceRefresh={forceRefresh}
-        accessibilityMode={accessibilityMode}
       />
       <br></br>
       <TableContainer component="div" className="cr-table-wrapper">
@@ -277,7 +276,6 @@ export default function CompReadyEnvCapabilities(props) {
                       )}
                       columnNames={columnNames}
                       filterVals={newFilterVals}
-                      accessibilityMode={accessibilityMode}
                     />
                   )
                 })
@@ -301,5 +299,4 @@ CompReadyEnvCapabilities.propTypes = {
   component: PropTypes.string.isRequired,
   environment: PropTypes.string,
   theme: PropTypes.object.isRequired,
-  accessibilityMode: PropTypes.bool.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapability.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapability.js
@@ -45,14 +45,7 @@ const cancelFetch = () => {
 // a cell under an environment on the right in page 2 or 2a
 export default function CompReadyEnvCapability(props) {
   const classes = useContext(ComponentReadinessStyleContext)
-  const {
-    filterVals,
-    component,
-    capability,
-    environment,
-    theme,
-    accessibilityMode,
-  } = props
+  const { filterVals, component, capability, environment, theme } = props
 
   const [fetchError, setFetchError] = React.useState('')
   const [isLoaded, setIsLoaded] = React.useState(false)
@@ -217,7 +210,6 @@ export default function CompReadyEnvCapability(props) {
         data={data}
         filterVals={filterVals}
         forceRefresh={forceRefresh}
-        accessibilityMode={accessibilityMode}
       />
       <br></br>
       <TableContainer component="div" className="cr-table-wrapper">
@@ -311,5 +303,4 @@ CompReadyEnvCapability.propTypes = {
   capability: PropTypes.string.isRequired,
   environment: PropTypes.string,
   theme: PropTypes.object.isRequired,
-  accessibilityMode: PropTypes.bool.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
@@ -246,7 +246,6 @@ export default function CompReadyEnvCapabilityTest(props) {
                     filterVals={filterVals}
                     component={component}
                     capability={capability}
-                    accessibilityMode={props.accessibilityMode}
                   />
                 )
               })
@@ -271,5 +270,4 @@ CompReadyEnvCapabilityTest.propTypes = {
   capability: PropTypes.string.isRequired,
   testId: PropTypes.string.isRequired,
   environment: PropTypes.string,
-  accessibilityMode: PropTypes.bool.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompReadyRow.js
+++ b/sippy-ng/src/component_readiness/CompReadyRow.js
@@ -29,14 +29,7 @@ export default function CompReadyRow(props) {
   // results is an array of columns and contains the status value per columnName
   // columnNames is the calculated array of columns
   // filterVals: the parts of the url containing input values
-  const {
-    componentName,
-    results,
-    columnNames,
-    filterVals,
-    grayFactor,
-    accessibilityMode,
-  } = props
+  const { componentName, results, columnNames, filterVals, grayFactor } = props
 
   const [componentParam, setComponentParam] = useQueryParam(
     'component',
@@ -73,7 +66,6 @@ export default function CompReadyRow(props) {
               columnVal.regressed_tests,
               columnVal.triaged_incidents
             )}
-            accessibilityMode={accessibilityMode}
           />
         ))}
       </TableRow>
@@ -87,5 +79,4 @@ CompReadyRow.propTypes = {
   columnNames: PropTypes.array.isRequired,
   filterVals: PropTypes.string.isRequired,
   grayFactor: PropTypes.number.isRequired,
-  accessibilityMode: PropTypes.bool.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompReadyTestCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestCell.js
@@ -23,7 +23,6 @@ export default function CompReadyTestCell(props) {
     capability,
     testName,
     regressedTests,
-    accessibilityMode,
   } = props
   const theme = useTheme()
   const classes = useContext(ComponentReadinessStyleContext)
@@ -81,10 +80,7 @@ export default function CompReadyTestCell(props) {
             regressedTests
           )}
         >
-          <CompSeverityIcon
-            status={status}
-            accessibilityMode={accessibilityMode}
-          />
+          <CompSeverityIcon status={status} />
         </Link>
       </TableCell>
     )
@@ -100,5 +96,4 @@ CompReadyTestCell.propTypes = {
   capability: PropTypes.string.isRequired,
   testName: PropTypes.string.isRequired,
   regressedTests: PropTypes.object,
-  accessibilityMode: PropTypes.bool.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -1,5 +1,5 @@
 import './ComponentReadiness.css'
-import { AccessibilityModeContext } from '../App'
+import { AccessibilityModeContext } from '../components/AccessibilityModeProvider'
 import {
   Box,
   Button,

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -1,4 +1,5 @@
 import './ComponentReadiness.css'
+import { AccessibilityModeContext } from '../App'
 import {
   Box,
   Button,
@@ -89,6 +90,7 @@ function TestsReportTabPanel(props) {
 // This is page 5 which runs when you click a test cell on the right of page 4 or page 4a
 export default function CompReadyTestReport(props) {
   const classes = useContext(ComponentReadinessStyleContext)
+  const { accessibilityModeOn } = useContext(AccessibilityModeContext)
 
   const [activeTabIndex, setActiveTabIndex] = React.useState(0)
 
@@ -104,7 +106,6 @@ export default function CompReadyTestReport(props) {
     environment,
     testName,
     testBasisRelease,
-    accessibilityMode,
   } = props
 
   const [fetchError, setFetchError] = React.useState('')
@@ -247,7 +248,7 @@ export default function CompReadyTestReport(props) {
   const [statusStr, assessmentIcon] = getStatusAndIcon(
     data.analyses[0].status,
     0,
-    accessibilityMode
+    accessibilityModeOn
   )
   const significanceTitle = `Test results for individual Prow Jobs may not be statistically
   significant, but when taken in aggregate, there may be a statistically
@@ -506,5 +507,4 @@ CompReadyTestReport.propTypes = {
   environment: PropTypes.string.isRequired,
   testName: PropTypes.string.isRequired,
   testBasisRelease: PropTypes.string.isRequired,
-  accessibilityMode: PropTypes.bool.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompSeverityIcon.js
+++ b/sippy-ng/src/component_readiness/CompSeverityIcon.js
@@ -1,19 +1,21 @@
 import './ComponentReadiness.css'
+import { AccessibilityModeContext } from '../App'
 import { Badge, Tooltip } from '@mui/material'
 import { getStatusAndIcon } from './CompReadyUtils'
 import { useTheme } from '@mui/material/styles'
 import { withStyles } from '@mui/styles'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useContext } from 'react'
 
 export default function CompSeverityIcon(props) {
   const theme = useTheme()
-  const { explanations, status, grayFactor, count, accessibilityMode } = props
+  const { accessibilityModeOn } = useContext(AccessibilityModeContext)
+  const { explanations, status, grayFactor, count } = props
 
   const [statusStr, icon] = getStatusAndIcon(
     status,
     grayFactor,
-    accessibilityMode
+    accessibilityModeOn
   )
 
   let toolTip = ''
@@ -49,5 +51,4 @@ CompSeverityIcon.propTypes = {
   explanations: PropTypes.array,
   grayFactor: PropTypes.number,
   count: PropTypes.number,
-  accessibilityMode: PropTypes.bool.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompSeverityIcon.js
+++ b/sippy-ng/src/component_readiness/CompSeverityIcon.js
@@ -1,5 +1,5 @@
 import './ComponentReadiness.css'
-import { AccessibilityModeContext } from '../App'
+import { AccessibilityModeContext } from '../components/AccessibilityModeProvider'
 import { Badge, Tooltip } from '@mui/material'
 import { getStatusAndIcon } from './CompReadyUtils'
 import { useTheme } from '@mui/material/styles'

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -1,5 +1,4 @@
 import './ComponentReadiness.css'
-import { AccessibilityModeContext } from '../App'
 import { BooleanParam, StringParam, useQueryParam } from 'use-query-params'
 import {
   cancelledDataTable,
@@ -222,8 +221,6 @@ export default function ComponentReadiness(props) {
   const [copyPopoverEl, setCopyPopoverEl] = React.useState(null)
   const copyPopoverOpen = Boolean(copyPopoverEl)
 
-  const accessibilityMode = useContext(AccessibilityModeContext)
-
   const linkToReport = () => {
     const currentUrl = new URL(window.location.href)
     if (searchRowRegex && searchRowRegex !== '') {
@@ -425,7 +422,6 @@ export default function ComponentReadiness(props) {
                       testId={testId}
                       testName={testName}
                       testBasisRelease={testBasisRelease}
-                      accessibilityMode={accessibilityMode.accessibilityModeOn}
                     ></CompReadyTestReport>
                   )
                 }}
@@ -445,7 +441,6 @@ export default function ComponentReadiness(props) {
                       component={varsContext.component}
                       capability={varsContext.capability}
                       testId={testId}
-                      accessibilityMode={accessibilityMode.accessibilityModeOn}
                     ></CompReadyEnvCapabilityTest>
                   )
                 }}
@@ -468,7 +463,6 @@ export default function ComponentReadiness(props) {
                       testId={testId}
                       environment={varsContext.environment}
                       theme={theme}
-                      accessibilityMode={accessibilityMode.accessibilityModeOn}
                     ></CompReadyEnvCapabilityTest>
                   )
                 }}
@@ -487,7 +481,6 @@ export default function ComponentReadiness(props) {
                       component={varsContext.component}
                       capability={varsContext.capability}
                       theme={theme}
-                      accessibilityMode={accessibilityMode.accessibilityModeOn}
                     ></CompReadyEnvCapability>
                   )
                 }}
@@ -505,7 +498,6 @@ export default function ComponentReadiness(props) {
                       capability={varsContext.capability}
                       environment={varsContext.environment}
                       theme={theme}
-                      accessibilityMode={accessibilityMode.accessibilityModeOn}
                     ></CompReadyEnvCapability>
                   )
                 }}
@@ -519,7 +511,6 @@ export default function ComponentReadiness(props) {
                       filterVals={filterVals}
                       component={varsContext.component}
                       theme={theme}
-                      accessibilityMode={accessibilityMode.accessibilityModeOn}
                     ></CompReadyEnvCapabilities>
                   )
                 }}
@@ -537,7 +528,6 @@ export default function ComponentReadiness(props) {
                       component={varsContext.component}
                       environment={varsContext.environment}
                       theme={theme}
-                      accessibilityMode={accessibilityMode.accessibilityModeOn}
                     ></CompReadyEnvCapabilities>
                   )
                 }}
@@ -577,9 +567,6 @@ export default function ComponentReadiness(props) {
                             data={data}
                             filterVals={filterVals}
                             forceRefresh={forceRefresh}
-                            accessibilityMode={
-                              accessibilityMode.accessibilityModeOn
-                            }
                           />
                           <TableContainer
                             component="div"
@@ -689,9 +676,6 @@ export default function ComponentReadiness(props) {
                                       )}
                                       grayFactor={redOnlyChecked ? 100 : 0}
                                       filterVals={filterVals}
-                                      accessibilityMode={
-                                        accessibilityMode.accessibilityModeOn
-                                      }
                                     />
                                   ))}
                               </TableBody>

--- a/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
+++ b/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
@@ -43,7 +43,6 @@ export default function ComponentReadinessToolBar(props) {
     clearSearches,
     data,
     filterVals,
-    accessibilityMode,
   } = props
 
   let regressionData = mergeRegressionData(data)
@@ -259,7 +258,6 @@ export default function ComponentReadinessToolBar(props) {
         filterVals={filterVals}
         isOpen={regressedTestDialog}
         close={closeRegressedTestsDialog}
-        accessibilityMode={accessibilityMode}
       />
     </div>
   )
@@ -276,5 +274,4 @@ ComponentReadinessToolBar.propTypes = {
   data: PropTypes.object,
   forceRefresh: PropTypes.func,
   filterVals: PropTypes.string.isRequired,
-  accessibilityMode: PropTypes.bool.isRequired,
 }

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -67,14 +67,12 @@ export default function RegressedTestsModal(props) {
             <RegressedTestsPanel
               regressedTests={props.regressedTests}
               filterVals={props.filterVals}
-              accessibilityMode={props.accessibilityMode}
             />
           </RegressedTestsTabPanel>
           <RegressedTestsTabPanel activeIndex={activeTabIndex} index={1}>
             <RegressedTestsPanel
               regressedTests={props.allRegressedTests}
               filterVals={props.filterVals}
-              accessibilityMode={props.accessibilityMode}
             />
           </RegressedTestsTabPanel>
           <RegressedTestsTabPanel activeIndex={activeTabIndex} index={2}>
@@ -101,5 +99,4 @@ RegressedTestsModal.propTypes = {
   filterVals: PropTypes.string.isRequired,
   isOpen: PropTypes.bool,
   close: PropTypes.func,
-  accessibilityMode: PropTypes.bool.isRequired,
 }

--- a/sippy-ng/src/component_readiness/RegressedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsPanel.js
@@ -183,7 +183,6 @@ export default function RegressedTestsPanel(props) {
             <CompSeverityIcon
               status={params.row.status}
               explanations={params.row.explanations}
-              accessibilityMode={props.accessibilityMode}
             />
           </Link>
         </div>
@@ -242,5 +241,4 @@ export default function RegressedTestsPanel(props) {
 RegressedTestsPanel.propTypes = {
   regressedTests: PropTypes.array,
   filterVals: PropTypes.string.isRequired,
-  accessibilityMode: PropTypes.bool.isRequired,
 }

--- a/sippy-ng/src/component_readiness/Sidebar.js
+++ b/sippy-ng/src/component_readiness/Sidebar.js
@@ -1,7 +1,7 @@
 import { ComponentReadinessStyleContext } from './ComponentReadiness'
 import { Drawer } from '@mui/material'
 import { useTheme } from '@mui/styles'
-import AccessibilityToggle from './AccessibilityToggle'
+import AccessibilityToggle from '../components/AccessibilityToggle'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import clsx from 'clsx'

--- a/sippy-ng/src/component_readiness/Sidebar.js
+++ b/sippy-ng/src/component_readiness/Sidebar.js
@@ -63,5 +63,4 @@ export default function Sidebar(props) {
 
 Sidebar.propTypes = {
   isTestDetails: PropTypes.bool,
-  // accessibilityMode: PropTypes.bool.isRequired,
 }

--- a/sippy-ng/src/components/AccessibilityModeProvider.js
+++ b/sippy-ng/src/components/AccessibilityModeProvider.js
@@ -1,7 +1,10 @@
-import { AccessibilityModeContext } from './App'
 import { useCookies } from 'react-cookie'
 import PropTypes from 'prop-types'
 import React from 'react'
+
+export const AccessibilityModeContext = React.createContext({
+  toggleAccessibilityMode: () => {},
+})
 
 export const AccessibilityModeProvider = ({ children }) => {
   const [cookies, setCookie] = useCookies(['sippyAccessibilityMode'])

--- a/sippy-ng/src/components/AccessibilityToggle.js
+++ b/sippy-ng/src/components/AccessibilityToggle.js
@@ -1,5 +1,5 @@
 import { Accessibility } from '@mui/icons-material'
-import { AccessibilityModeContext } from '../App'
+import { AccessibilityModeContext } from './AccessibilityModeProvider'
 import { Tooltip } from '@mui/material'
 import IconButton from '@mui/material/IconButton'
 import React, { useContext } from 'react'


### PR DESCRIPTION
There are only 2 places that actually need the value of `accessibilityModeOn`: `CompReadyTestReport` and `CompSeverityIcon`. The rest of the usages were just prop drilling. We can use `useContext` to avoid that and make this much cleaner.