### PR TITLE
API to enable querying job artifacts

### DIFF
--- a/pkg/api/jobartifacts/apitypes.go
+++ b/pkg/api/jobartifacts/apitypes.go
@@ -2,29 +2,29 @@ package jobartifacts
 
 type QueryResponse struct {
 	Errors  []JobRunError `json:"errors,omitempty"`
-	JobRuns []JobRun      `json:"jobRuns,omitempty"`
+	JobRuns []JobRun      `json:"job_runs,omitempty"`
 }
 
 type JobRun struct {
 	// ID is string because some parsers translate long ints into scientific notation
 	ID      string `json:"id"`
 	URL     string `json:"url"`
-	JobName string `json:"jobName"`
+	JobName string `json:"job_name"`
 	// NOTE: limited per maxJobFilesToScan, sets Truncated if more files match
 	Artifacts             []JobRunArtifact `json:"artifacts"`
-	ArtifactListTruncated bool             `json:"artifactListTruncated"`
+	ArtifactListTruncated bool             `json:"artifact_list_truncated"`
 }
 
 type JobRunError struct {
-	ID    string `json:"jobRunId,omitempty"`
+	ID    string `json:"job_run_id,omitempty"`
 	Error string `json:"error"`
 }
 
 type JobRunArtifact struct {
-	JobRunID    string `json:"jobRunId"`
-	ArtifactURL string `json:"artifactUrl"`
+	JobRunID    string `json:"job_run_id"`
+	ArtifactURL string `json:"artifact_url"`
 	// NOTE: limited per maxFileMatches, sets Truncated if file has more matches
-	MatchedContent   []string `json:"matchedContents,omitempty"`
-	MatchesTruncated bool     `json:"matchesTruncated"`
+	MatchedContent   []string `json:"matched_contents,omitempty"`
+	MatchesTruncated bool     `json:"matches_truncated"`
 	Error            string   `json:"error,omitempty"`
 }

--- a/pkg/api/jobartifacts/apitypes.go
+++ b/pkg/api/jobartifacts/apitypes.go
@@ -1,0 +1,30 @@
+package jobartifacts
+
+type QueryResponse struct {
+	Errors  []JobRunError `json:"errors,omitempty"`
+	JobRuns []JobRun      `json:"jobRuns,omitempty"`
+}
+
+type JobRun struct {
+	// ID is string because some parsers translate long ints into scientific notation
+	ID      string `json:"id"`
+	URL     string `json:"url"`
+	JobName string `json:"jobName"`
+	// NOTE: limited per maxJobFilesToScan, sets Truncated if more files match
+	Artifacts             []JobRunArtifact `json:"artifacts"`
+	ArtifactListTruncated bool             `json:"artifactListTruncated"`
+}
+
+type JobRunError struct {
+	ID    string `json:"jobRunId,omitempty"`
+	Error string `json:"error"`
+}
+
+type JobRunArtifact struct {
+	JobRunID    string `json:"jobRunId"`
+	ArtifactURL string `json:"artifactUrl"`
+	// NOTE: limited per maxFileMatches, sets Truncated if file has more matches
+	MatchedContent   []string `json:"matchedContents,omitempty"`
+	MatchesTruncated bool     `json:"matchesTruncated"`
+	Error            string   `json:"error,omitempty"`
+}

--- a/pkg/api/jobartifacts/manager.go
+++ b/pkg/api/jobartifacts/manager.go
@@ -1,0 +1,293 @@
+package jobartifacts
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openshift/sippy/pkg/util"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// these limits are rather arbitrary, can be expanded for performance until we run into GCS limitations
+const jobRunWorkerPoolSize = 12   // number of concurrent processors of one job run each
+const artifactWorkerPoolSize = 12 // number of concurrent processors of one artifact each
+const jobRunQueryTimeout = 30 * time.Second
+const artifactQueryTimeout = 28 * time.Second // give artifact scans a little time before the job timeout to return (possibly incomplete) results
+// these limits are also arbitrary, can be expanded if scenarios arise that justify it.
+const maxJobFilesToScan = 12 // limit the number of files inspected under each job
+const maxFileMatches = 12    // limit the number of content matches returned for each file
+
+type Manager struct {
+	ctxCancelFunc   context.CancelFunc
+	jobRunChan      chan jobRunRequest
+	jobRunWorkers   *sync.WaitGroup
+	artifactChan    chan artifactRequest
+	artifactWorkers *sync.WaitGroup
+}
+
+// NewManager creates a new Manager with a pool of workers to process job run artifact queries
+func NewManager(ctx context.Context) *Manager {
+	ctx, cancelFunc := context.WithCancel(ctx)
+	manager := &Manager{
+		ctxCancelFunc:   cancelFunc,
+		jobRunChan:      make(chan jobRunRequest),
+		jobRunWorkers:   &sync.WaitGroup{},
+		artifactChan:    make(chan artifactRequest),
+		artifactWorkers: &sync.WaitGroup{},
+	}
+	for i := jobRunWorkerPoolSize; i > 0; i-- {
+		manager.jobRunWorkers.Add(1)
+		go manager.jobRunWorker(ctx)
+	}
+	for i := artifactWorkerPoolSize; i > 0; i-- {
+		manager.artifactWorkers.Add(1)
+		go manager.artifactWorker(ctx)
+	}
+	return manager
+}
+
+// Close is the manager's way of closing up show and releasing all its workers
+func (m *Manager) Close() {
+	log.Info("Shutting down jobartifacts workers")
+	m.ctxCancelFunc()
+	m.artifactWorkers.Wait()
+	m.jobRunWorkers.Wait()
+	log.Info("Shutdown complete for jobartifacts workers")
+}
+
+// Query executes a top-level job artifacts query with concurrency and timeouts/cancellation
+func (m *Manager) Query(ctx context.Context, query *JobArtifactQuery) (result QueryResponse) {
+	artifactCtx, cancelArtifact := context.WithTimeout(ctx, artifactQueryTimeout)
+	defer cancelArtifact()
+	jobCtx, cancelJob := context.WithTimeout(ctx, jobRunQueryTimeout)
+	defer cancelJob()
+
+	// set up the request/response workflow
+	jobRunResponseChan := make(chan jobRunResponse) // for responses from the workers
+	remaining := sets.NewInt64(query.JobRunIDs...)  // keep track of responses still missing
+	finished := make(chan bool)                     // indicate we will not receive any more responses
+
+	// start a listener to wait for the responses and collect them; important to prepare
+	// the listener before dumping requests to the request channel, since that will block.
+	go func() {
+	responseLoop:
+		for {
+			select {
+			case <-jobCtx.Done(): // timed out or cancelled
+				break responseLoop
+			case res := <-jobRunResponseChan:
+				remaining.Delete(res.jobRun) // we have seen it, it is no longer remaining
+				if res.error != nil {
+					result.Errors = append(result.Errors, JobRunError{
+						ID:    strconv.FormatInt(res.jobRun, 10),
+						Error: res.error.Error(),
+					})
+				} else {
+					result.JobRuns = append(result.JobRuns, res.response)
+				}
+				if len(remaining) == 0 {
+					break responseLoop // we have received a response for every request
+				}
+			}
+		}
+		finished <- true
+	}()
+
+	// send all the requests along with our return channel
+	for _, id := range query.JobRunIDs {
+		request := jobRunRequest{
+			jobRun:      id,
+			query:       query,
+			jobRunsChan: jobRunResponseChan,
+			jobCtx:      jobCtx,
+			artifactCtx: artifactCtx,
+		}
+		select {
+		case <-jobCtx.Done(): // cancelled, give up on sending
+		case m.jobRunChan <- request:
+		}
+	}
+	<-finished // wait for all responses to be processed
+
+	// fill in errors for any that went missing
+	for it := range remaining {
+		result.Errors = append(result.Errors, JobRunError{
+			ID:    strconv.FormatInt(it, 10),
+			Error: fmt.Sprintf("request did not complete within %s", jobRunQueryTimeout),
+		})
+	}
+
+	// sort things for consistency
+	slices.SortFunc(result.JobRuns, func(a, b JobRun) int { // sort runs by ID ascending
+		return strings.Compare(a.ID, b.ID)
+	})
+	slices.SortFunc(result.Errors, func(a, b JobRunError) int { // sort errors by ID ascending
+		return strings.Compare(a.ID, b.ID)
+	})
+	return
+}
+
+// a jobRunRequest channels a single job run to be processed and returned with matching file paths
+type jobRunRequest struct {
+	jobRun      int64
+	query       *JobArtifactQuery
+	jobRunsChan chan jobRunResponse // when processing is done, send response to this channel
+	// putting a context in a struct is normally discouraged; but think of this entire struct as just parameters for a function call
+	// and then it is clear the usage is in the same spirit of passing a context to a function (just via a channel).
+	jobCtx      context.Context // enable cancellation/timeout of query
+	artifactCtx context.Context // earlier timeout for artifact queries so they tend to finish before the job query deadline
+}
+
+// jobRunReponse channels the response for a single job run that was processed
+type jobRunResponse struct {
+	jobRun   int64
+	response JobRun
+	error    error
+}
+
+func (m *Manager) jobRunWorker(managerCtx context.Context) {
+	defer m.jobRunWorkers.Done()
+	logger := log.WithField("func", "Manager.jobRunWorker")
+	for {
+		select {
+		case <-managerCtx.Done(): // shutting down the workers
+			logger.WithError(managerCtx.Err()).Debug("Shutting down per context")
+			return
+		case req := <-m.jobRunChan:
+			jobLog := logger.WithField("jobRunId", req.jobRun).WithContext(req.jobCtx)
+			jobLog.Debug("Received request from jobRunChan")
+			select {
+			case <-req.jobCtx.Done(): // query is starting too late, request already cancelled
+				jobLog.WithError(req.jobCtx.Err()).Warn("Aborted request for job run")
+			default: // execute the query and respond
+				jobRunRes, err := req.query.queryJobArtifacts(req.artifactCtx, req.jobRun, m, jobLog)
+				response := jobRunResponse{
+					jobRun:   req.jobRun,
+					error:    err,
+					response: jobRunRes,
+				}
+				select {
+				case <-req.jobCtx.Done(): // cancelled, don't try to respond
+					jobLog.WithError(req.jobCtx.Err()).Debug("jobRunResponse cancelled")
+				case req.jobRunsChan <- response:
+					jobLog.Debug("Wrote jobRunResponse to jobRunsChan")
+				}
+			}
+		}
+	}
+}
+
+// QueryJobRunArtifacts scans the content of all matched artifacts for one job, with concurrency and timeouts/cancellation
+func (m *Manager) QueryJobRunArtifacts(ctx context.Context, query *JobArtifactQuery, jobRunID int64, paths []string) (artifacts []JobRunArtifact) {
+	if len(paths) == 0 {
+		return // otherwise the listener below times out waiting for a first response
+	}
+
+	// set up the request/response workflow
+	artifactResponseChan := make(chan artifactResponse) // for responses from the workers
+	remaining := sets.NewString(paths...)               // keep track of responses still missing
+	finished := make(chan bool)                         // indicate we will not receive any more responses
+
+	// start a listener to wait for the responses and collect them; important to prepare
+	// the listener before dumping requests to the request channel, since that will block.
+	go func() {
+	responseLoop:
+		for {
+			select {
+			case <-ctx.Done(): // timed out or cancelled
+				break responseLoop
+			case res := <-artifactResponseChan:
+				remaining.Delete(res.artifactPath) // we have seen it, so it is no longer remaining
+				artifacts = append(artifacts, res.artifact)
+				if len(remaining) == 0 {
+					break responseLoop // we have received a response for every request
+				}
+			}
+		}
+		finished <- true
+	}()
+
+	// send all the requests along with our return channel
+	for _, path := range paths {
+		request := artifactRequest{
+			artifactPath:  path,
+			query:         query,
+			artifactsChan: artifactResponseChan,
+			ctx:           ctx,
+			jobRunID:      jobRunID,
+		}
+		select {
+		case <-ctx.Done(): // cancelled, give up on sending
+		case m.artifactChan <- request:
+		}
+	}
+	<-finished // wait for all responses to be processed
+
+	// fill in errors for any that went missing
+	for path := range remaining {
+		artifacts = append(artifacts, JobRunArtifact{
+			JobRunID:    strconv.FormatInt(jobRunID, 10),
+			ArtifactURL: fmt.Sprintf(artifactURLFmt, util.GcsBucketRoot, path),
+			Error:       fmt.Sprintf("request did not complete within %s", artifactQueryTimeout),
+		})
+	}
+
+	// sort artifacts by path ascending
+	slices.SortFunc(artifacts, func(a, b JobRunArtifact) int {
+		return strings.Compare(a.ArtifactURL, b.ArtifactURL)
+	})
+	return
+}
+
+// artifactRequest channels a single artifact to be processed and returned with matching contents
+type artifactRequest struct {
+	artifactPath  string
+	query         *JobArtifactQuery
+	artifactsChan chan artifactResponse // when processing is done, send response to this channel
+	// putting a context in a struct is normally discouraged; but think of this entire struct as just parameters for a function call
+	// and then it is clear the usage is in the same spirit of passing a context to a function (just via a channel).
+	ctx      context.Context // enable cancellation/timeout of query
+	jobRunID int64
+}
+
+// artifactReponse channels the response for a single artifact that was processed
+type artifactResponse struct {
+	artifactPath string
+	artifact     JobRunArtifact
+}
+
+func (m *Manager) artifactWorker(managerCtx context.Context) {
+	defer m.artifactWorkers.Done()
+	logger := log.WithField("func", "Manager.artifactWorker")
+	for {
+		select {
+		case <-managerCtx.Done(): // shutting down the workers
+			logger.WithError(managerCtx.Err()).Debug("Shutting down per context")
+			return
+		case req := <-m.artifactChan:
+			artLog := logger.WithField("artifactPath", req.artifactPath).WithContext(req.ctx)
+			artLog.Debug("Received request from artifactChan")
+			select {
+			case <-req.ctx.Done(): // query is starting too late, request already cancelled
+				artLog.WithError(req.ctx.Err()).Warn("Aborted request for job run artifacts")
+			default: // execute the query and respond
+				response := artifactResponse{
+					artifactPath: req.artifactPath,
+					artifact:     req.query.getFileContentMatches(req.jobRunID, req.artifactPath),
+				}
+				select {
+				case <-req.ctx.Done(): // cancelled, don't send response
+					artLog.WithError(req.ctx.Err()).Debug("artifactResponse cancelled")
+				case req.artifactsChan <- response:
+					artLog.Debug("Wrote artifactResponse to artifactsChan")
+				}
+			}
+		}
+	}
+}

--- a/pkg/api/jobartifacts/query.go
+++ b/pkg/api/jobartifacts/query.go
@@ -1,0 +1,152 @@
+package jobartifacts
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/openshift/sippy/pkg/util"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/api/iterator"
+)
+
+const artifactURLFmt = "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/%s/%s"
+
+type JobArtifactQuery struct {
+	GcsBucket        *storage.BucketHandle
+	DbClient         *db.DB
+	JobRunIDs        []int64
+	PathGlob         string // A simple glob to match files in the artifact bucket for each queried run
+	ArtifactContains string // A string to match in the content of the files
+	// TODO: regex, jq, xpath support for matching content; requesting match context lines; etc.
+}
+
+func (q *JobArtifactQuery) queryJobArtifacts(ctx context.Context, jobRunID int64, mgr *Manager, logger *log.Entry) (JobRun, error) {
+	logger = logger.WithField("func", "queryJobArtifacts").WithField("job_run_id", jobRunID)
+
+	jobRunPath, jobRunResponse, err := q.getJobRun(jobRunID)
+	if err != nil {
+		logger.WithError(err).Error("could not query job's bucket path")
+		return jobRunResponse, err
+	}
+
+	filePaths, truncated, err := q.getJobRunFiles(jobRunPath)
+	if err != nil {
+		logger.WithError(err).Error("could not find job artifact files")
+		return jobRunResponse, err
+	}
+	jobRunResponse.ArtifactListTruncated = truncated
+	jobRunResponse.Artifacts = mgr.QueryJobRunArtifacts(ctx, q, jobRunID, filePaths)
+	return jobRunResponse, nil
+}
+
+func (q *JobArtifactQuery) getJobRun(jobRunID int64) (string, JobRun, error) {
+	jobRunResponse := JobRun{ID: strconv.FormatInt(jobRunID, 10)}
+	jobRunModel := new(models.ProwJobRun)
+	res := q.DbClient.DB.Preload("ProwJob").First(jobRunModel, jobRunID)
+	if res.Error != nil {
+		return "", jobRunResponse, res.Error
+	}
+	jobRunResponse.JobName = jobRunModel.ProwJob.Name
+
+	url := jobRunModel.URL
+	if url == "" {
+		return "", jobRunResponse, fmt.Errorf("DB entry for job run %d has no URL", jobRunID)
+	}
+	jobRunResponse.URL = url
+
+	const marker = "/" + util.GcsBucketRoot + "/"
+	pathStart := strings.Index(url, marker)
+	if pathStart == -1 {
+		return "", jobRunResponse, fmt.Errorf("job run %d URL %s does not include bucket root %q", jobRunID, url, util.GcsBucketRoot)
+	}
+
+	jobRunPath := url[pathStart+len(marker):]
+	if !strings.HasSuffix(jobRunPath, "/") {
+		jobRunPath += "/" // ensure the path looks like a bucket "object prefix"
+	}
+	return jobRunPath, jobRunResponse, nil
+}
+
+func (q *JobArtifactQuery) getJobRunFiles(jobRunPath string) ([]string, bool, error) {
+	files := []string{}
+	truncated := false
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+	query := &storage.Query{
+		Prefix:     jobRunPath,
+		Projection: storage.ProjectionNoACL,
+	}
+	if q.PathGlob != "" {
+		query.MatchGlob = jobRunPath + q.PathGlob
+	}
+	iter := q.GcsBucket.Objects(ctx, query)
+	for {
+		attrs, err := iter.Next()
+		if err != nil {
+			if errors.Is(err, iterator.Done) {
+				break
+			}
+			return nil, false, err
+		}
+		if len(files) >= maxJobFilesToScan {
+			truncated = true
+			break
+		}
+		files = append(files, attrs.Name)
+	}
+
+	return files, truncated, nil
+}
+
+func (q *JobArtifactQuery) getFileContentMatches(jobRunID int64, filePath string) (artifact JobRunArtifact) {
+	artifact.JobRunID = strconv.FormatInt(jobRunID, 10)
+	artifact.ArtifactURL = fmt.Sprintf(artifactURLFmt, util.GcsBucketRoot, filePath)
+	if q.ArtifactContains == "" { // no snippets requested
+		return
+	}
+
+	gcsReader, err := q.GcsBucket.Object(filePath).NewReader(context.Background())
+	if err != nil {
+		artifact.Error = err.Error()
+		return
+	}
+	defer gcsReader.Close()
+
+	reader := bufio.NewReader(gcsReader)
+	for {
+		// scan the file line by line; however, if lines are too long, ReadString
+		// breaks them up instead of failing, so these may not be complete lines.
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			artifact.Error = err.Error()
+			return
+		}
+
+		if q.lineMatchesQuery(line) {
+			if len(artifact.MatchedContent) >= maxFileMatches {
+				artifact.MatchesTruncated = true
+				break
+			}
+			artifact.MatchedContent = append(artifact.MatchedContent, line)
+		}
+	}
+
+	return
+}
+
+func (q *JobArtifactQuery) lineMatchesQuery(content string) bool {
+	// this can become more interesting when we want.
+	return strings.Contains(content, q.ArtifactContains)
+}

--- a/pkg/api/jobartifacts/query_test.go
+++ b/pkg/api/jobartifacts/query_test.go
@@ -1,0 +1,85 @@
+package jobartifacts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openshift/sippy/pkg/util"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFunctional_JobRunPathFound(t *testing.T) {
+	dbClient := util.GetDbHandle(t)
+	query := JobArtifactQuery{DbClient: dbClient}
+	path, jobRun, err := query.getJobRun(1898704060324777984)
+	assert.NoError(t, err)
+	assert.Equal(t, "logs/periodic-ci-openshift-release-master-ci-4.19-e2e-azure-ovn/1898704060324777984/", path)
+	assert.Equal(t, "periodic-ci-openshift-release-master-ci-4.19-e2e-azure-ovn", jobRun.JobName)
+}
+
+func TestFunctional_ListFiles(t *testing.T) {
+	gcsClient := util.GetGcsBucket(t)
+	query := JobArtifactQuery{GcsBucket: gcsClient}
+	files, truncated, err := query.getJobRunFiles("logs/periodic-ci-openshift-release-master-ci-4.19-e2e-azure-ovn/1898704060324777984/")
+	assert.NoError(t, err)
+	assert.True(t, truncated, "expected a lot of files under the job")
+	assert.Equal(t, maxJobFilesToScan, len(files), "expected to receive the max number of files")
+}
+
+func TestFunctional_FilterFiles(t *testing.T) {
+	gcsClient := util.GetGcsBucket(t)
+	query := JobArtifactQuery{GcsBucket: gcsClient, PathGlob: "artifacts/*e2e*/gather-extra/build-log.txt"}
+	files, truncated, err := query.getJobRunFiles("logs/periodic-ci-openshift-release-master-ci-4.19-e2e-azure-ovn/1898704060324777984/")
+	assert.NoError(t, err)
+	assert.False(t, truncated, "expected no need for truncating the file list")
+	assert.Equal(t, 1, len(files), "expected glob to match one file")
+}
+
+func TestFunctional_FilterContent(t *testing.T) {
+	gcsClient := util.GetGcsBucket(t)
+	const filePath = "logs/periodic-ci-openshift-release-master-ci-4.19-e2e-azure-ovn/1898704060324777984/artifacts/e2e-azure-ovn/gather-extra/build-log.txt"
+
+	query := JobArtifactQuery{GcsBucket: gcsClient, ArtifactContains: "ClusterVersion:"}
+	artifact := query.getFileContentMatches(1898704060324777984, filePath)
+	assert.Empty(t, artifact.Error)
+	assert.False(t, artifact.MatchesTruncated, "expected no need for truncating the file list")
+	assert.Equal(t, 2, len(artifact.MatchedContent), "expected content to match with two lines")
+
+	query.ArtifactContains = "error:"
+	artifact = query.getFileContentMatches(1898704060324777984, filePath)
+	assert.Empty(t, artifact.Error)
+	assert.True(t, artifact.MatchesTruncated, "expected to truncate content matches")
+	assert.Equal(t, maxFileMatches, len(artifact.MatchedContent), "expected content to match with many lines")
+}
+
+func TestFunctional_QueryJobArtifacts(t *testing.T) {
+	mgr := NewManager(context.Background())
+	query := JobArtifactQuery{
+		DbClient:         util.GetDbHandle(t),
+		GcsBucket:        util.GetGcsBucket(t),
+		PathGlob:         "artifacts/*e2e*/gather-extra/build-log.txt",
+		ArtifactContains: "ClusterVersion:",
+	}
+	jobRun, err := query.queryJobArtifacts(context.Background(), 1898704060324777984, mgr, log.WithField("test", "queryJobArtifacts"))
+	assert.NoError(t, err)
+	assert.NotEmpty(t, jobRun.Artifacts, "expected to find some artifacts")
+	mgr.Close()
+}
+
+func TestFunctional_Query(t *testing.T) {
+	mgr := NewManager(context.Background())
+	query := JobArtifactQuery{
+		DbClient:         util.GetDbHandle(t),
+		GcsBucket:        util.GetGcsBucket(t),
+		JobRunIDs:        []int64{1898704060324777984, 42},
+		PathGlob:         "artifacts/*e2e*/gather-extra/build-log.txt",
+		ArtifactContains: "ClusterVersion:",
+	}
+	res := mgr.Query(context.Background(), &query)
+	assert.NotEmpty(t, res.Errors)
+	assert.Equal(t, "42", res.Errors[0].ID, "expected not to find the answer to everything")
+	assert.NotEmpty(t, res.JobRuns, "expected to find the job")
+	assert.NotEmpty(t, res.JobRuns[0].Artifacts, "expected to find some artifacts")
+	mgr.Close()
+}

--- a/pkg/sippyserver/pr_commenting_processor_test.go
+++ b/pkg/sippyserver/pr_commenting_processor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/dataloader/prowloader/gcs"
 	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/openshift/sippy/pkg/util"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -94,8 +95,8 @@ func TestMatchPriorRiskAnalysisTest(t *testing.T) {
 
 func TestAnalysisWorker(t *testing.T) {
 	// initialize AnalysisWorker
-	dbc := getDbHandle(t)
-	gcsBucket := getGcsBucket(t)
+	dbc := util.GetDbHandle(t)
+	gcsBucket := util.GetGcsBucket(t)
 	logrus.SetLevel(logrus.InfoLevel)
 
 	preparedComments := make(chan PreparedComment, 5)
@@ -130,11 +131,11 @@ func TestRunCommentAnalysis(t *testing.T) {
 	pendingWork := make(chan models.PullRequestComment, 1)
 	defer close(pendingWork)
 
-	dbc := getDbHandle(t)
+	dbc := util.GetDbHandle(t)
 	analysisWorker := AnalysisWorker{
 		riskAnalysisLocator: gcs.GetDefaultRiskAnalysisSummaryFile(),
 		dbc:                 dbc,
-		gcsBucket:           getGcsBucket(t),
+		gcsBucket:           util.GetGcsBucket(t),
 		prCommentProspects:  pendingWork,
 		preparedComments:    preparedComments,
 		newTestsWorker:      StandardNewTestsWorker(dbc),

--- a/pkg/util/param/param.go
+++ b/pkg/util/param/param.go
@@ -49,6 +49,10 @@ var paramRegexp = map[string]*regexp.Regexp{
 	"samplePROrg":      nameRegexp,
 	"samplePRRepo":     nameRegexp,
 	"samplePRNumber":   numRegexp,
+	// jobartifacts params
+	"pathGlob":     regexp.MustCompile(`^.+$`),         // a glob can be anything
+	"textContains": regexp.MustCompile(`^.+$`),         // text search can be anything
+	"prowJobRuns":  regexp.MustCompile(`^\d+(,\d+)*$`), // comma-separated integers
 }
 
 // SafeRead returns the value of a query parameter only if it matches the given regexp.

--- a/pkg/util/testing.go
+++ b/pkg/util/testing.go
@@ -1,0 +1,58 @@
+package util
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/openshift/sippy/pkg/dataloader/prowloader/gcs"
+	"github.com/openshift/sippy/pkg/db"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm/logger"
+)
+
+/*
+	  Enable functional tests requiring a live database and/or GCS bucket with known data to run, but
+	  don't risk checking in credentials with code; supply them via environment variables.
+		TEST_GCS_CREDS_PATH: the path to a local GCS credentials file, e.g. /home/$USER/git/sippy/openshift-sippy-ro.creds.json
+		TEST_SIPPY_DATABASE_DSN: the DSN for the sippy postgres database e.g. postgresql://sippyro:...@sippy-postgresql...amazonaws.com/sippy_openshift
+		TEST_DB_LOG_LEVEL: "silent" or "info" or "warn" or "error" - the log level for gorm database methods
+	  We do not want these trying to run during CI; skip tests with required environment variables that are not set.
+*/
+
+const GcsBucketRoot = "test-platform-results"
+
+func GetDbHandle(t *testing.T) *db.DB {
+	dbLogLevel := os.Getenv("TEST_DB_LOG_LEVEL") // e.g. "info" or "silent"
+	if dbLogLevel == "" {
+		dbLogLevel = "silent"
+	}
+	gormLogLevel, err := db.ParseGormLogLevel(dbLogLevel)
+	if err != nil {
+		logrus.WithError(err).Errorf("Cannot parse TEST_DB_LOG_LEVEL %s", dbLogLevel)
+		gormLogLevel = logger.Silent
+	}
+
+	dsn := os.Getenv("TEST_SIPPY_DATABASE_DSN")
+	if dsn == "" {
+		t.Skip("TEST_SIPPY_DATABASE_DSN environment variable is not set; skipping database tests")
+	}
+	dbc, err := db.New(dsn, gormLogLevel)
+	if err != nil {
+		logrus.WithError(err).Fatal("Cannot connect to database")
+	}
+	return dbc
+}
+
+func GetGcsBucket(t *testing.T) *storage.BucketHandle {
+	pathToGcsCredentials := os.Getenv("TEST_GCS_CREDS_PATH")
+	if pathToGcsCredentials == "" {
+		t.Skip("TEST_GCS_CREDS_PATH environment variable is not set; skipping GCS tests")
+	}
+	gcsClient, err := gcs.NewGCSClient(context.TODO(), pathToGcsCredentials, "")
+	if err != nil {
+		logrus.WithError(err).Fatalf("CRITICAL error getting GCS client with credentials at %s", pathToGcsCredentials)
+	}
+	return gcsClient.Bucket(GcsBucketRoot)
+}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,22 +1,14 @@
 package util
 
 import (
-	"context"
 	"fmt"
 	"math"
 	gourl "net/url"
-	"os"
 	"regexp"
 	"strconv"
-	"testing"
 	"time"
 
-	"cloud.google.com/go/storage"
 	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
-	"github.com/openshift/sippy/pkg/dataloader/prowloader/gcs"
-	"github.com/openshift/sippy/pkg/db"
-	"github.com/sirupsen/logrus"
-	"gorm.io/gorm/logger"
 )
 
 type FailureGroupStats struct {
@@ -184,48 +176,4 @@ func AdjustReleaseTime(relTime time.Time, isStart bool, daysAdjustment string, c
 		}
 	}
 	return relTime
-}
-
-/*
-	  Enable functional tests requiring a live database and/or GCS bucket with known data to run,
-	  but we do not want them trying to run during CI, so skip tests whose required environment variables are not set.
-	  Don't risk checking in credentials with code; supply them with environment variables:
-		TEST_DB_LOG_LEVEL: "silent" or "info" or "warn" or "error" - the log level for gorm database methods
-		TEST_SIPPY_DATABASE_DSN: the DSN for the sippy postgres database e.g. postgresql://sippyro:...@sippy-postgresql...amazonaws.com/sippy_openshift
-		TEST_GCS_CREDS_PATH: the path to a local GCS credentials file, e.g. /home/$USER/git/sippy/openshift-sippy-ro.creds.json
-*/
-const GcsBucketRoot = "test-platform-results"
-
-func GetDbHandle(t *testing.T) *db.DB {
-	dbLogLevel := os.Getenv("TEST_DB_LOG_LEVEL") // e.g. "info" or "silent"
-	if dbLogLevel == "" {
-		dbLogLevel = "silent"
-	}
-	gormLogLevel, err := db.ParseGormLogLevel(dbLogLevel)
-	if err != nil {
-		logrus.WithError(err).Errorf("Cannot parse TEST_DB_LOG_LEVEL %s", dbLogLevel)
-		gormLogLevel = logger.Silent
-	}
-
-	dsn := os.Getenv("TEST_SIPPY_DATABASE_DSN")
-	if dsn == "" {
-		t.Skip("TEST_SIPPY_DATABASE_DSN environment variable is not set; skipping database tests")
-	}
-	dbc, err := db.New(dsn, gormLogLevel)
-	if err != nil {
-		logrus.WithError(err).Fatal("Cannot connect to database")
-	}
-	return dbc
-}
-
-func GetGcsBucket(t *testing.T) *storage.BucketHandle {
-	pathToGcsCredentials := os.Getenv("TEST_GCS_CREDS_PATH")
-	if pathToGcsCredentials == "" {
-		t.Skip("TEST_GCS_CREDS_PATH environment variable is not set; skipping GCS tests")
-	}
-	gcsClient, err := gcs.NewGCSClient(context.TODO(), pathToGcsCredentials, "")
-	if err != nil {
-		logrus.WithError(err).Fatalf("CRITICAL error getting GCS client with credentials at %s", pathToGcsCredentials)
-	}
-	return gcsClient.Bucket(GcsBucketRoot)
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,14 +1,22 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"math"
 	gourl "net/url"
+	"os"
 	"regexp"
 	"strconv"
+	"testing"
 	"time"
 
+	"cloud.google.com/go/storage"
 	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
+	"github.com/openshift/sippy/pkg/dataloader/prowloader/gcs"
+	"github.com/openshift/sippy/pkg/db"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm/logger"
 )
 
 type FailureGroupStats struct {
@@ -176,4 +184,48 @@ func AdjustReleaseTime(relTime time.Time, isStart bool, daysAdjustment string, c
 		}
 	}
 	return relTime
+}
+
+/*
+	  Enable functional tests requiring a live database and/or GCS bucket with known data to run,
+	  but we do not want them trying to run during CI, so skip tests whose required environment variables are not set.
+	  Don't risk checking in credentials with code; supply them with environment variables:
+		TEST_DB_LOG_LEVEL: "silent" or "info" or "warn" or "error" - the log level for gorm database methods
+		TEST_SIPPY_DATABASE_DSN: the DSN for the sippy postgres database e.g. postgresql://sippyro:...@sippy-postgresql...amazonaws.com/sippy_openshift
+		TEST_GCS_CREDS_PATH: the path to a local GCS credentials file, e.g. /home/$USER/git/sippy/openshift-sippy-ro.creds.json
+*/
+const GcsBucketRoot = "test-platform-results"
+
+func GetDbHandle(t *testing.T) *db.DB {
+	dbLogLevel := os.Getenv("TEST_DB_LOG_LEVEL") // e.g. "info" or "silent"
+	if dbLogLevel == "" {
+		dbLogLevel = "silent"
+	}
+	gormLogLevel, err := db.ParseGormLogLevel(dbLogLevel)
+	if err != nil {
+		logrus.WithError(err).Errorf("Cannot parse TEST_DB_LOG_LEVEL %s", dbLogLevel)
+		gormLogLevel = logger.Silent
+	}
+
+	dsn := os.Getenv("TEST_SIPPY_DATABASE_DSN")
+	if dsn == "" {
+		t.Skip("TEST_SIPPY_DATABASE_DSN environment variable is not set; skipping database tests")
+	}
+	dbc, err := db.New(dsn, gormLogLevel)
+	if err != nil {
+		logrus.WithError(err).Fatal("Cannot connect to database")
+	}
+	return dbc
+}
+
+func GetGcsBucket(t *testing.T) *storage.BucketHandle {
+	pathToGcsCredentials := os.Getenv("TEST_GCS_CREDS_PATH")
+	if pathToGcsCredentials == "" {
+		t.Skip("TEST_GCS_CREDS_PATH environment variable is not set; skipping GCS tests")
+	}
+	gcsClient, err := gcs.NewGCSClient(context.TODO(), pathToGcsCredentials, "")
+	if err != nil {
+		logrus.WithError(err).Fatalf("CRITICAL error getting GCS client with credentials at %s", pathToGcsCredentials)
+	}
+	return gcsClient.Bucket(GcsBucketRoot)
 }


### PR DESCRIPTION
Search a set of job runs for artifacts matching a glob and (optionally) content matching a string. API params are:

- `prowJobRuns`: a comma-separated list of prow job run IDs to query
- `pathGlob`: a glob pattern to match against the GCS path (ref. https://cloud.google.com/storage/docs/json_api/v1/objects/list#list-object-glob)
- `textContains` (optional): a string to search for in the contents of the artifacts, returning the containing line

Returns a JSON `jobartifacts.QueryResponse` object listing the job runs, the artifacts that matched the glob, and (optionally) lines within those artifacts that matched. Errors that occurred are also listed per job run. To prevent (accidental) DOS, the number of artifacts and matches returned are limited.

Example query: http://localhost:8080/api/jobs/artifacts?prowJobRuns=1905396175427604480,1905379393581092864,1905368974137233408,1905409701445636096,1905375855236878336,1905396953936564224&pathGlob=artifacts/*e2e*/gather-extra/build-log.txt&textContains=ClusterVersion: