### PR TITLE
Exclude osde2e jobs in component readiness

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -634,6 +634,7 @@ func (v *OCPVariantLoader) setJobTier(_ logrus.FieldLogger, variants map[string]
 		{"-okd", "excluded"},
 		{"-recovery", "excluded"},
 		{"alibaba", "excluded"},
+		{"-osde2e-", "excluded"},
 
 		// Experimental new jobs using nested vsphere lvl 2 environment,
 		// not ready to make release blocking yet.

--- a/pkg/variantregistry/ocp_test.go
+++ b/pkg/variantregistry/ocp_test.go
@@ -67,7 +67,7 @@ func TestVariantSyncer(t *testing.T) {
 				VariantSuite:            "parallel",
 				VariantUpgrade:          VariantNoValue,
 				VariantProcedure:        "none",
-				VariantJobTier:          "candidate",
+				VariantJobTier:          "excluded",
 				VariantAggregation:      VariantNoValue,
 				VariantSecurityMode:     VariantDefaultValue,
 				VariantFeatureSet:       VariantDefaultValue,


### PR DESCRIPTION
These were not intended to be blocking signal yet and should not be causing red cells.
