### PR TITLE
jobartifacts: readability, expand content matching

### DIFF
--- a/pkg/api/jobartifacts/apitypes.go
+++ b/pkg/api/jobartifacts/apitypes.go
@@ -21,10 +21,19 @@ type JobRunError struct {
 }
 
 type JobRunArtifact struct {
-	JobRunID    string `json:"job_run_id"`
-	ArtifactURL string `json:"artifact_url"`
+	JobRunID       string      `json:"job_run_id"`
+	ArtifactURL    string      `json:"artifact_url"`
+	MatchedContent interface{} `json:"matched_content,omitempty"` // will be one of the content types below
+	Error          string      `json:"error,omitempty"`
+}
+
+type ContentLineMatches struct {
 	// NOTE: limited per maxFileMatches, sets Truncated if file has more matches
-	MatchedContent   []string `json:"matched_contents,omitempty"`
-	MatchesTruncated bool     `json:"matches_truncated"`
-	Error            string   `json:"error,omitempty"`
+	Matches   []ContentLineMatch `json:"matches"`
+	Truncated bool               `json:"truncated,omitempty"`
+}
+type ContentLineMatch struct {
+	Before []string `json:"before,omitempty"`
+	Match  string   `json:"match"`
+	After  []string `json:"after,omitempty"`
 }

--- a/pkg/api/jobartifacts/content_line_matcher.go
+++ b/pkg/api/jobartifacts/content_line_matcher.go
@@ -1,0 +1,139 @@
+package jobartifacts
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/openshift/sippy/pkg/util/param"
+	"github.com/openshift/sippy/pkg/util/sets"
+)
+
+// ContentLineMatcher is an interface for matching lines in a text artifact file.
+type ContentLineMatcher interface {
+	MatchLine(line string) bool
+}
+
+type lineMatcher struct {
+	matcher        ContentLineMatcher
+	contextBefore  int
+	contextAfter   int
+	maxFileMatches int
+}
+
+// NewStringMatcher creates a ContentMatcher that matches lines containing the specified string
+// as well as (optionally) recording context lines for the match.
+func NewStringMatcher(matchString string, contextBefore, contextAfter, maxFileMatches int) ContentMatcher {
+	return &lineMatcher{
+		matcher:        stringLineMatcher{matchString: matchString},
+		contextBefore:  contextBefore,
+		contextAfter:   contextAfter,
+		maxFileMatches: maxFileMatches,
+	}
+}
+
+type stringLineMatcher struct {
+	matchString string
+}
+
+func (slm stringLineMatcher) MatchLine(line string) bool {
+	return strings.Contains(line, slm.matchString)
+}
+
+// NewRegexMatcher creates a ContentMatcher that matches lines against a regex
+// as well as (optionally) recording context lines for the match.
+func NewRegexMatcher(matchRegex *regexp.Regexp, contextBefore, contextAfter, maxMatches int) ContentMatcher {
+	return &lineMatcher{
+		matcher:        regexLineMatcher{matchRegex: matchRegex},
+		contextBefore:  contextBefore,
+		contextAfter:   contextAfter,
+		maxFileMatches: maxMatches,
+	}
+}
+
+type regexLineMatcher struct {
+	matchRegex *regexp.Regexp
+}
+
+func (rlm regexLineMatcher) MatchLine(line string) bool {
+	return rlm.matchRegex.MatchString(line)
+}
+
+// GetMatches reads lines from the provided reader and returns a ContentLineMatches and possibly an error
+func (m *lineMatcher) GetMatches(reader *bufio.Reader) (interface{}, error) {
+	matches := ContentLineMatches{
+		Matches:   []ContentLineMatch{},
+		Truncated: false,
+	}
+	beforeLines := make([]string, 0, m.contextBefore) // lines before the match for context
+	var pendingMatches []*ContentLineMatch            // matches waiting to record more "after" context lines
+	seenMaxLines := false
+
+	for !matches.Truncated || len(pendingMatches) > 0 {
+		// scan the file line by line; however, if lines are too long, ReadString
+		// breaks them up instead of failing, so these may not be complete lines.
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return matches, err
+		}
+
+		// record this line in previous matches' "after" context
+		for _, match := range pendingMatches {
+			match.After = append(match.After, line)
+		}
+		if len(pendingMatches) > 0 && len(pendingMatches[0].After) >= m.contextAfter {
+			pendingMatches = pendingMatches[1:] // remove from pending once "after" context is full
+		}
+
+		// record the match (or the truncation if we already have enough)
+		if m.matcher.MatchLine(line) {
+			if seenMaxLines {
+				matches.Truncated = true
+				continue
+			}
+			matches.Matches = append(matches.Matches, ContentLineMatch{
+				Before: beforeLines,
+				Match:  line,
+				After:  []string{},
+			})
+			if m.contextAfter > 0 { // if we want "after" context, track matches waiting for it
+				pendingMatches = append(pendingMatches, &matches.Matches[len(matches.Matches)-1])
+			}
+			if len(matches.Matches) >= m.maxFileMatches {
+				seenMaxLines = true
+			}
+		}
+
+		// record the line for later matches' "before" context
+		if beforeLines = append(beforeLines, line); len(beforeLines) > m.contextBefore {
+			beforeLines = beforeLines[1:] // remove lines outside the "before" window
+		}
+	}
+	return matches, nil
+}
+
+// ParseLineMatcherParams parses common request parameters used to construct a ContentLineMatcher.
+func ParseLineMatcherParams(req *http.Request) (beforeContext, afterContext, maxMatches int, errs map[string]error) {
+	errs = map[string]error{}
+	params := map[string]int{}
+	for name := range sets.NewString("beforeContext", "afterContext", "maxFileMatches") {
+		if value, err := param.ReadUint(req, name, maxFileMatches); err != nil {
+			errs[name] = err
+		} else {
+			params[name] = value
+		}
+	}
+	beforeContext = params["beforeContext"]
+	afterContext = params["afterContext"]
+	maxMatches = params["maxFileMatches"]
+	if maxMatches == 0 {
+		maxMatches = maxFileMatches
+	}
+	return
+}

--- a/pkg/api/jobartifacts/content_line_matcher_test.go
+++ b/pkg/api/jobartifacts/content_line_matcher_test.go
@@ -1,0 +1,62 @@
+package jobartifacts
+
+import (
+	"bufio"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchLineWithStringMatcher(t *testing.T) {
+	matcher := NewStringMatcher("test", 0, 0, maxFileMatches)
+	reader := bufio.NewReader(strings.NewReader("this is a test line\nanother line\n"))
+	matches, err := matcher.GetMatches(reader)
+	assert.NoError(t, err)
+	assert.Len(t, matches.(ContentLineMatches).Matches, 1)
+	assert.Equal(t, "this is a test line\n", matches.(ContentLineMatches).Matches[0].Match)
+}
+
+func TestMatchLineWithRegexMatcher(t *testing.T) {
+	regex := regexp.MustCompile(`test`)
+	matcher := NewRegexMatcher(regex, 0, 0, 0)
+	reader := bufio.NewReader(strings.NewReader("this is a test line\nanother line\n"))
+	matches, err := matcher.GetMatches(reader)
+	assert.NoError(t, err)
+	assert.Len(t, matches.(ContentLineMatches).Matches, 1)
+	assert.Equal(t, "this is a test line\n", matches.(ContentLineMatches).Matches[0].Match)
+}
+
+func TestMatchLineWithContext(t *testing.T) {
+	matcher := NewStringMatcher("test", 1, 1, maxFileMatches)
+	reader := bufio.NewReader(strings.NewReader("line before\nthis is a test line\nline after\nanother line\n"))
+	matches, err := matcher.GetMatches(reader)
+	assert.NoError(t, err)
+	assert.Len(t, matches.(ContentLineMatches).Matches, 1)
+	assert.Equal(t, "this is a test line\n", matches.(ContentLineMatches).Matches[0].Match)
+	assert.Equal(t, []string{"line before\n"}, matches.(ContentLineMatches).Matches[0].Before)
+	assert.Equal(t, []string{"line after\n"}, matches.(ContentLineMatches).Matches[0].After)
+}
+
+func TestMatchLineWithMultipleMatches(t *testing.T) {
+	matcher := NewStringMatcher("test", 1, 1, maxFileMatches)
+	reader := bufio.NewReader(strings.NewReader("this is a test line\nanother test line\n"))
+	matches, err := matcher.GetMatches(reader)
+	assert.NoError(t, err)
+	lineMatches := matches.(ContentLineMatches).Matches
+	assert.Len(t, lineMatches, 2)
+	assert.Equal(t, "this is a test line\n", lineMatches[0].Match)
+	assert.Equal(t, []string{"this is a test line\n"}, lineMatches[1].Before)
+	assert.Equal(t, "another test line\n", lineMatches[1].Match)
+	assert.Equal(t, []string{"another test line\n"}, lineMatches[0].After)
+}
+
+func TestMatchLineWithMaxFileMatches(t *testing.T) {
+	matcher := NewStringMatcher("test", 0, 0, 3)
+	reader := bufio.NewReader(strings.NewReader(strings.Repeat("this is a test line\n", 3+1)))
+	matches, err := matcher.GetMatches(reader)
+	assert.NoError(t, err)
+	assert.Len(t, matches.(ContentLineMatches).Matches, 3)
+	assert.True(t, matches.(ContentLineMatches).Truncated)
+}

--- a/pkg/util/param/param.go
+++ b/pkg/util/param/param.go
@@ -1,8 +1,10 @@
 package param
 
 import (
+	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -20,13 +22,14 @@ func Cleanse(name string) string {
 }
 
 // when requesting a param, also validate it against a regexp to ensure it is what we expect
-var wordRegexp = regexp.MustCompile(`^[\w]+$`)
-var numRegexp = regexp.MustCompile(`^[\d]+$`)
+var wordRegexp = regexp.MustCompile(`^\w+$`)
+var uintRegexp = regexp.MustCompile(`^\d+$`)
 var nameRegexp = regexp.MustCompile(`^[-.\w]+$`)
-var releaseRegexp = regexp.MustCompile(`^[\d]+\.[\d]+$`)
+var releaseRegexp = regexp.MustCompile(`^\d+\.\d+$`)
+var nonEmptyRegex = regexp.MustCompile(`^.+$`)
 var paramRegexp = map[string]*regexp.Regexp{
 	// sippy classic params
-	"release":         regexp.MustCompile(`^(Presubmits|[\d]+\.[\d]+)$`),
+	"release":         regexp.MustCompile(`^(Presubmits|\d+\.\d+)$`),
 	"period":          wordRegexp,
 	"stream":          wordRegexp,
 	"arch":            wordRegexp,
@@ -36,10 +39,10 @@ var paramRegexp = map[string]*regexp.Regexp{
 	"job":             nameRegexp,
 	"job_name":        nameRegexp,
 	"test":            regexp.MustCompile(`^.+$`), // tests can be anything, so always parameterize in sql
-	"prow_job_run_id": numRegexp,
+	"prow_job_run_id": uintRegexp,
 	"file":            nameRegexp,
 	"repo_info":       nameRegexp,
-	"pull_number":     numRegexp,
+	"pull_number":     uintRegexp,
 	"sort":            wordRegexp,
 	"sortField":       wordRegexp,
 	// component readiness params
@@ -48,11 +51,16 @@ var paramRegexp = map[string]*regexp.Regexp{
 	"testBasisRelease": releaseRegexp,
 	"samplePROrg":      nameRegexp,
 	"samplePRRepo":     nameRegexp,
-	"samplePRNumber":   numRegexp,
+	"samplePRNumber":   uintRegexp,
 	// jobartifacts params
-	"pathGlob":     regexp.MustCompile(`^.+$`),         // a glob can be anything
-	"textContains": regexp.MustCompile(`^.+$`),         // text search can be anything
-	"prowJobRuns":  regexp.MustCompile(`^\d+(,\d+)*$`), // comma-separated integers
+	"prowJobRuns":        regexp.MustCompile(`^\d+(,\d+)*$`), // comma-separated integers
+	"pathGlob":           nonEmptyRegex,                      // a glob can be anything
+	"maxJobFilesToScan ": uintRegexp,
+	"textContains":       nonEmptyRegex, // text search can look for anything
+	"textRegex":          nonEmptyRegex, // regex could be just about anything
+	"maxFileMatches":     uintRegexp,
+	"beforeContext":      uintRegexp,
+	"afterContext":       uintRegexp,
 }
 
 // SafeRead returns the value of a query parameter only if it matches the given regexp.
@@ -68,4 +76,35 @@ func SafeRead(req *http.Request, name string) string {
 	}
 	log.Warnf("invalid value for %s param: %q", name, value)
 	return ""
+}
+
+// ReadUint returns the value of a query parameter only if it is an unsigned int.
+// If the param is not present, it returns 0 and nil.
+// If limit is positive then values greater than the limit are considered invalid.
+// If the value is invalid, it returns 0 and an error.
+// If the param is present and valid, it returns the value and nil.
+func ReadUint(req *http.Request, name string, limit int) (int, error) {
+	intStr := req.URL.Query().Get(name)
+	if intStr == "" {
+		return 0, nil
+	}
+
+	if !uintRegexp.MatchString(intStr) {
+		err := fmt.Errorf("invalid value for %q param: %q", name, intStr)
+		log.Warn(err)
+		return 0, err
+	}
+
+	intValue, err := strconv.Atoi(intStr)
+	if err != nil {
+		log.WithError(err).Warnf("invalid value for %q param: %q", name, intStr)
+		return 0, err
+	}
+
+	if limit > 0 && intValue > limit {
+		err = fmt.Errorf("value %d for %q param exceeds limit %d", intValue, name, limit)
+		log.Warn(err)
+		return 0, err
+	}
+	return intValue, nil
 }


### PR DESCRIPTION
two commits:

* patterns/readability around select statements    
    
I found the select logic around channel actions jarring and repetitive; I think it's clearer if those patterns are named and implemented outside the main logic.

* expand content matching

introduces a more generic ContentMatcher type to handle any type of match we might like for an artifact file's content.
    
existing implementations can read files a line at a time and match strings like before, or match a regex. these can also return context lines around the match. the api is updated with parameters for constructing these.
    
future implementations can enable processing json, yaml, or xml.    

e.g. [regex match http://localhost:8080/api/jobs/artifacts?prowJobRuns=1905396175427604480,1905379393581092864,1905368974137233408,1905409701445636096&pathGlob=**/build-log.txt&textRegex=ClusterV.*on:&afterContext=2&maxFileMatches=2](http://localhost:8080/api/jobs/artifacts?prowJobRuns=1905396175427604480,1905379393581092864,1905368974137233408,1905409701445636096&pathGlob=**/build-log.txt&textRegex=ClusterV.*on:&afterContext=2&maxFileMatches=2) gets:
```
{
  "job_runs": [
    {
      "id": "1905368974137233408",
      "url": "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_kubernetes/2156/pull-ci-openshift-kubernetes-master-k8s-e2e-conformance-aws/1905368974137233408",
      "job_name": "pull-ci-openshift-kubernetes-master-k8s-e2e-conformance-aws",
      "artifacts": [
...
        {
          "job_run_id": "1905368974137233408",
          "artifact_url": "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_kubernetes/2156/pull-ci-openshift-kubernetes-master-k8s-e2e-conformance-aws/1905368974137233408/artifacts/k8s-e2e-conformance-aws/gather-audit-logs/build-log.txt",
          "matched_content": {
            "matches": [
              {
                "match": "ClusterVersion: Stable at \"4.19.0-0.ci.test-2025-03-27-233525-ci-op-l44pb7ir-latest\"\n",
                "after": [
                  "ClusterOperators:\n",
                  "\tAll healthy and stable\n"
                ]
              },
              {
                "match": "ClusterVersion: Stable at \"4.19.0-0.ci.test-2025-03-27-233525-ci-op-l44pb7ir-latest\"\n",
                "after": [
                  "ClusterOperators:\n",
                  "\tAll healthy and stable\n"
                ]
              }
            ]
          }
        },
...
```
