### PR TITLE
Add network access to sidebar

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyMainInputs.js
+++ b/sippy-ng/src/component_readiness/CompReadyMainInputs.js
@@ -42,7 +42,6 @@ export default function CompReadyMainInputs(props) {
     'FromRelease',
     'FromReleaseMajor',
     'FromReleaseMinor',
-    'NetworkAccess',
     'NetworkStack',
     'Release',
     'ReleaseMajor',


### PR DESCRIPTION
We want to be able to compare nat-instance to default network access modes.