### PR TITLE
NO-JIRA: specify required flag when running in `ocp` mode

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -64,6 +64,7 @@ available [here](config/README.md).
   --database-dsn="postgresql://postgres:password@localhost:5432/postgres" \
   --mode=ocp \
   --config ./config/openshift.yaml \
+  --load-openshift-ci-bigquery \
   --google-service-account-credential-file ~/Downloads/openshift-ci-data-analysis-1b68cb387203.json
 ```
 
@@ -82,6 +83,7 @@ or [configure GitHub in your gitconfig](https://stackoverflow.com/questions/8505
   --database-dsn="postgresql://postgres:password@localhost:5432/postgres" \
   --mode=ocp \
   --config ./config/openshift.yaml \
+  --load-openshift-ci-bigquery \
   --google-service-account-credential-file ~/Downloads/openshift-ci-data-analysis-1b68cb387203.json
 ```
 
@@ -100,6 +102,7 @@ releases and architectures like this:
   --database-dsn="postgresql://postgres:password@localhost:5432/postgres" \
   --google-service-account-credential-file ~/Downloads/openshift-ci-data-analysis-1b68cb387203.json \
   --mode=ocp \
+  --load-openshift-ci-bigquery \
   --config ./config/openshift.yaml
 ```
 


### PR DESCRIPTION
We will always need the `load-openshift-ci-bigquery` flag when running in `ocp` mode due to https://github.com/openshift/sippy/blob/531d36b8dd127678279b12706fccf126dda1b430/pkg/flags/mode.go#L43-L48