### PR TITLE
enrich test details results

### DIFF
--- a/pkg/api/componentreadiness/component_report_test.go
+++ b/pkg/api/componentreadiness/component_report_test.go
@@ -1353,10 +1353,10 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 						},
 						JobStats: []crtype.TestDetailsJobStats{
 							{
-								JobName:     prowJob1,
-								SampleStats: sampleTestStatsHigh,
-								BaseStats:   baseTestStatsHigh,
-								Significant: false,
+								NormalizedJobName: prowJob1,
+								SampleStats:       sampleTestStatsHigh,
+								BaseStats:         baseTestStatsHigh,
+								Significant:       false,
 							},
 						},
 					},
@@ -1400,10 +1400,10 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 						},
 						JobStats: []crtype.TestDetailsJobStats{
 							{
-								JobName:     prowJob1,
-								SampleStats: sampleTestStatsLow,
-								BaseStats:   baseTestStatsHigh,
-								Significant: true,
+								NormalizedJobName: prowJob1,
+								SampleStats:       sampleTestStatsLow,
+								BaseStats:         baseTestStatsHigh,
+								Significant:       true,
 							},
 						},
 					},
@@ -1447,10 +1447,10 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 						},
 						JobStats: []crtype.TestDetailsJobStats{
 							{
-								JobName:     prowJob1,
-								SampleStats: sampleTestStatsHigh,
-								BaseStats:   baseTestStatsLow,
-								Significant: false,
+								NormalizedJobName: prowJob1,
+								SampleStats:       sampleTestStatsHigh,
+								BaseStats:         baseTestStatsLow,
+								Significant:       false,
 							},
 						},
 					},
@@ -1502,16 +1502,16 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 						},
 						JobStats: []crtype.TestDetailsJobStats{
 							{
-								JobName:     prowJob1,
-								SampleStats: sampleTestStatsHigh,
-								BaseStats:   baseTestStatsHigh,
-								Significant: false,
+								NormalizedJobName: prowJob1,
+								SampleStats:       sampleTestStatsHigh,
+								BaseStats:         baseTestStatsHigh,
+								Significant:       false,
 							},
 							{
-								JobName:     prowJob2,
-								SampleStats: sampleTestStatsHigh,
-								BaseStats:   baseTestStatsHigh,
-								Significant: false,
+								NormalizedJobName: prowJob2,
+								SampleStats:       sampleTestStatsHigh,
+								BaseStats:         baseTestStatsHigh,
+								Significant:       false,
 							},
 						},
 					},
@@ -1586,11 +1586,11 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 			assert.Equal(t, tc.expectedReport.Analyses[0].ReportStatus, report.Analyses[0].ReportStatus, "expected report status %+v, got %+v", tc.expectedReport.Analyses[0].ReportStatus, report.Analyses[0].ReportStatus)
 			assert.Equal(t, len(tc.expectedReport.Analyses[0].JobStats), len(report.Analyses[0].JobStats), "expected len of job stats %+v, got %+v", len(tc.expectedReport.Analyses[0].JobStats), report.Analyses[0].JobStats)
 			for i := range tc.expectedReport.Analyses[0].JobStats {
-				jobName := report.Analyses[0].JobStats[i].JobName
-				assert.Equal(t, tc.expectedReport.Analyses[0].JobStats[i].JobName, jobName, "expected job name %+v, got %+v", tc.expectedReport.Analyses[0].JobStats[i].JobName, jobName)
+				jobName := report.Analyses[0].JobStats[i].NormalizedJobName
+				assert.Equal(t, tc.expectedReport.Analyses[0].JobStats[i].NormalizedJobName, jobName, "expected job name %+v, got %+v", tc.expectedReport.Analyses[0].JobStats[i].NormalizedJobName, jobName)
 				assert.Equal(t, tc.expectedReport.Analyses[0].JobStats[i].Significant, report.Analyses[0].JobStats[i].Significant, "expected per job significant %+v, got %+v", tc.expectedReport.Analyses[0].JobStats[i].Significant, report.Analyses[0].JobStats[i].Significant)
-				assert.Equal(t, tc.expectedReport.Analyses[0].JobStats[i].BaseStats, report.Analyses[0].JobStats[i].BaseStats, "expected per job base stats for %s to be %+v, got %+v", tc.expectedReport.Analyses[0].JobStats[i].JobName, tc.expectedReport.Analyses[0].JobStats[i].BaseStats, report.Analyses[0].JobStats[i].BaseStats)
-				assert.Equal(t, tc.expectedReport.Analyses[0].JobStats[i].SampleStats, report.Analyses[0].JobStats[i].SampleStats, "expected per job sample stats for %s to be %+v, got %+v", tc.expectedReport.Analyses[0].JobStats[i].JobName, tc.expectedReport.Analyses[0].JobStats[i].SampleStats, report.Analyses[0].JobStats[i].SampleStats)
+				assert.Equal(t, tc.expectedReport.Analyses[0].JobStats[i].BaseStats, report.Analyses[0].JobStats[i].BaseStats, "expected per job base stats for %s to be %+v, got %+v", tc.expectedReport.Analyses[0].JobStats[i].NormalizedJobName, tc.expectedReport.Analyses[0].JobStats[i].BaseStats, report.Analyses[0].JobStats[i].BaseStats)
+				assert.Equal(t, tc.expectedReport.Analyses[0].JobStats[i].SampleStats, report.Analyses[0].JobStats[i].SampleStats, "expected per job sample stats for %s to be %+v, got %+v", tc.expectedReport.Analyses[0].JobStats[i].NormalizedJobName, tc.expectedReport.Analyses[0].JobStats[i].SampleStats, report.Analyses[0].JobStats[i].SampleStats)
 				assert.Equal(t, tc.expectedSampleJobRunLen[jobName], len(report.Analyses[0].JobStats[i].SampleJobRunStats), "expected sample job run counts %+v, got %+v", tc.expectedSampleJobRunLen[jobName], len(report.Analyses[0].JobStats[i].SampleJobRunStats))
 				assert.Equal(t, tc.expectedBaseJobRunLen[jobName], len(report.Analyses[0].JobStats[i].BaseJobRunStats), "expected base job run counts %+v, got %+v", tc.expectedBaseJobRunLen[jobName], len(report.Analyses[0].JobStats[i].BaseJobRunStats))
 			}

--- a/pkg/api/componentreadiness/query/querygenerators.go
+++ b/pkg/api/componentreadiness/query/querygenerators.go
@@ -789,13 +789,7 @@ func fetchJobRunTestStatusResults(ctx context.Context,
 			continue
 		}
 		prowName := utils.NormalizeProwJobName(testStatus.ProwJob, reqOptions)
-		rows, ok := status[prowName]
-		if !ok {
-			status[prowName] = []crtype.JobRunTestStatusRow{testStatus}
-		} else {
-			rows = append(rows, testStatus)
-			status[prowName] = rows
-		}
+		status[prowName] = append(status[prowName], testStatus)
 	}
 	return status, errs
 }

--- a/pkg/api/componentreadiness/query/querygenerators.go
+++ b/pkg/api/componentreadiness/query/querygenerators.go
@@ -400,6 +400,7 @@ func getTestDetailsQuery(
 						ANY_VALUE(cm.jira_component_id) AS jira_component_id,
 						COUNT(*) AS total_count,
 						ANY_VALUE(jobs.prowjob_url) AS prowjob_url,
+						ANY_VALUE(jobs.prowjob_build_id) AS prowjob_run_id,
 						ANY_VALUE(cm.capabilities) as capabilities,
 						SUM(adjusted_success_val) AS success_count,
 						SUM(adjusted_flake_count) AS flake_count,

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -533,7 +533,8 @@ func (c *ComponentReportGenerator) getJobRunStats(stats crtype.JobRunTestStatusR
 			FailureCount: failure,
 			FlakeCount:   stats.FlakeCount,
 		},
-		JobURL: stats.ProwJobURL,
+		JobURL:   stats.ProwJobURL,
+		JobRunID: stats.ProwJobRunID,
 	}
 	return jobRunStats
 }

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -371,7 +371,7 @@ func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(ctx context
 	report := crtype.TestDetailsAnalysis{TriagedIncidents: incidents}
 	for prowJob, baseStatsList := range baseStatus {
 		jobStats := crtype.TestDetailsJobStats{
-			JobName: prowJob,
+			NormalizedJobName: prowJob,
 		}
 		perJobBaseFailure = 0
 		perJobBaseSuccess = 0
@@ -380,6 +380,7 @@ func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(ctx context
 		perJobSampleSuccess = 0
 		perJobSampleFlake = 0
 		for _, baseStats := range baseStatsList {
+			jobStats.BaseJobName = baseStats.ProwJob
 			if result.JiraComponent == "" && baseStats.JiraComponent != "" {
 				result.JiraComponent = baseStats.JiraComponent
 			}
@@ -397,6 +398,7 @@ func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(ctx context
 		}
 		if sampleStatsList, ok := sampleStatusCopy[prowJob]; ok {
 			for _, sampleStats := range sampleStatsList {
+				jobStats.SampleJobName = sampleStats.ProwJob
 				if result.JiraComponent == "" && sampleStats.JiraComponent != "" {
 					result.JiraComponent = sampleStats.JiraComponent
 				}
@@ -449,12 +451,13 @@ func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(ctx context
 	}
 	for prowJob, sampleStatsList := range sampleStatusCopy {
 		jobStats := crtype.TestDetailsJobStats{
-			JobName: prowJob,
+			NormalizedJobName: prowJob,
 		}
 		perJobSampleFailure = 0
 		perJobSampleSuccess = 0
 		perJobSampleFlake = 0
 		for _, sampleStats := range sampleStatsList {
+			jobStats.SampleJobName = sampleStats.ProwJob
 			jobStats.SampleJobRunStats = append(jobStats.SampleJobRunStats, c.getJobRunStats(sampleStats))
 			perJobSampleSuccess += sampleStats.SuccessCount
 			perJobSampleFlake += sampleStats.FlakeCount
@@ -482,7 +485,7 @@ func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(ctx context
 		totalSampleFlake += perJobSampleFlake
 	}
 	sort.Slice(report.JobStats, func(i, j int) bool {
-		return report.JobStats[i].JobName < report.JobStats[j].JobName
+		return report.JobStats[i].NormalizedJobName < report.JobStats[j].NormalizedJobName
 	})
 
 	// The hope is that this goes away

--- a/pkg/apis/api/componentreport/types.go
+++ b/pkg/apis/api/componentreport/types.go
@@ -299,7 +299,8 @@ type TestDetailsJobStats struct {
 }
 
 type TestDetailsJobRunStats struct {
-	JobURL string `json:"job_url"`
+	JobURL   string `json:"job_url"`
+	JobRunID string `json:"job_run_id"`
 	// TestStats is the test stats from one particular job run.
 	// For the majority of the tests, there is only one junit. But
 	// there are cases multiple junits are generated for the same test.
@@ -327,6 +328,7 @@ type JobRunTestIdentification struct {
 
 type JobRunTestStatusRow struct {
 	ProwJob         string   `bigquery:"prowjob_name"`
+	ProwJobRunID    string   `bigquery:"prowjob_run_id"`
 	ProwJobURL      string   `bigquery:"prowjob_url"`
 	TestID          string   `bigquery:"test_id"`
 	TestName        string   `bigquery:"test_name"`

--- a/pkg/apis/api/componentreport/types.go
+++ b/pkg/apis/api/componentreport/types.go
@@ -290,7 +290,9 @@ type TestDetailsTestStats struct {
 }
 
 type TestDetailsJobStats struct {
-	JobName           string                   `json:"job_name"`
+	NormalizedJobName string                   `json:"job_name"`
+	SampleJobName     string                   `json:"sample_job_name"`
+	BaseJobName       string                   `json:"base_job_name"`
 	SampleStats       TestDetailsTestStats     `json:"sample_stats"`
 	BaseStats         TestDetailsTestStats     `json:"base_stats"`
 	SampleJobRunStats []TestDetailsJobRunStats `json:"sample_job_run_stats,omitempty"`


### PR DESCRIPTION
test_details report data now includes the original sample/base job names (if relevant) and a new attr for job run ID. So it now looks like:

```
{
...
      "job_stats": [
        {
          "job_name": "periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-X.X-periodics-e2e-aws-techpreview",
          "sample_job_name": "periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.19-periodics-e2e-aws-techpreview",
          "base_job_name": "",
          "sample_stats": {...},
          "base_stats": {...},
          "sample_job_run_stats": [
            {
              "job_url": "https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.19-periodics-e2e-aws-techpreview/1906587761641525248",
              "job_run_id": "1906587761641525248",
              "test_stats": {
                "success_rate": 1,
                "success_count": 1,
                "failure_count": 0,
                "flake_count": 0
              }
            },
```