### PR TITLE
NO-JIRA: use new function name to restore functionality

### DIFF
--- a/sippy-ng/src/component_readiness/RegressedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsPanel.js
@@ -152,7 +152,7 @@ export default function RegressedTestsPanel(props) {
       renderCell: (params) => {
         return (
           <IconButton
-            onClick={(event) => copyTestID(event, params.value)}
+            onClick={(event) => copyTestToClipboard(event, params.value)}
             size="small"
             aria-label="Copy test ID"
             color="inherit"


### PR DESCRIPTION
The function name was changed in https://github.com/openshift/sippy/commit/93cc9d230e45b2237b98bd32296c6d4eaf927e84#diff-10893e44787a52095576ae3ffa73c55ba0c42a28ba33682ebb4e7978ed4514af, and this usage was missed