### PR TITLE
change layout of `test_details` results

### DIFF
--- a/pkg/api/componentreadiness/component_report_test.go
+++ b/pkg/api/componentreadiness/component_report_test.go
@@ -1353,10 +1353,10 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 						},
 						JobStats: []crtype.TestDetailsJobStats{
 							{
-								NormalizedJobName: prowJob1,
-								SampleStats:       sampleTestStatsHigh,
-								BaseStats:         baseTestStatsHigh,
-								Significant:       false,
+								SampleJobName: prowJob1,
+								SampleStats:   sampleTestStatsHigh,
+								BaseStats:     baseTestStatsHigh,
+								Significant:   false,
 							},
 						},
 					},
@@ -1400,10 +1400,11 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 						},
 						JobStats: []crtype.TestDetailsJobStats{
 							{
-								NormalizedJobName: prowJob1,
-								SampleStats:       sampleTestStatsLow,
-								BaseStats:         baseTestStatsHigh,
-								Significant:       true,
+								SampleJobName: prowJob1,
+								BaseJobName:   prowJob2,
+								SampleStats:   sampleTestStatsLow,
+								BaseStats:     baseTestStatsHigh,
+								Significant:   true,
 							},
 						},
 					},
@@ -1447,10 +1448,11 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 						},
 						JobStats: []crtype.TestDetailsJobStats{
 							{
-								NormalizedJobName: prowJob1,
-								SampleStats:       sampleTestStatsHigh,
-								BaseStats:         baseTestStatsLow,
-								Significant:       false,
+								SampleJobName: prowJob1,
+								BaseJobName:   prowJob2,
+								SampleStats:   sampleTestStatsHigh,
+								BaseStats:     baseTestStatsLow,
+								Significant:   false,
 							},
 						},
 					},
@@ -1502,16 +1504,16 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 						},
 						JobStats: []crtype.TestDetailsJobStats{
 							{
-								NormalizedJobName: prowJob1,
-								SampleStats:       sampleTestStatsHigh,
-								BaseStats:         baseTestStatsHigh,
-								Significant:       false,
+								SampleJobName: prowJob1,
+								SampleStats:   sampleTestStatsHigh,
+								BaseStats:     baseTestStatsHigh,
+								Significant:   false,
 							},
 							{
-								NormalizedJobName: prowJob2,
-								SampleStats:       sampleTestStatsHigh,
-								BaseStats:         baseTestStatsHigh,
-								Significant:       false,
+								SampleJobName: prowJob2,
+								SampleStats:   sampleTestStatsHigh,
+								BaseStats:     baseTestStatsHigh,
+								Significant:   false,
 							},
 						},
 					},
@@ -1586,11 +1588,11 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 			assert.Equal(t, tc.expectedReport.Analyses[0].ReportStatus, report.Analyses[0].ReportStatus, "expected report status %+v, got %+v", tc.expectedReport.Analyses[0].ReportStatus, report.Analyses[0].ReportStatus)
 			assert.Equal(t, len(tc.expectedReport.Analyses[0].JobStats), len(report.Analyses[0].JobStats), "expected len of job stats %+v, got %+v", len(tc.expectedReport.Analyses[0].JobStats), report.Analyses[0].JobStats)
 			for i := range tc.expectedReport.Analyses[0].JobStats {
-				jobName := report.Analyses[0].JobStats[i].NormalizedJobName
-				assert.Equal(t, tc.expectedReport.Analyses[0].JobStats[i].NormalizedJobName, jobName, "expected job name %+v, got %+v", tc.expectedReport.Analyses[0].JobStats[i].NormalizedJobName, jobName)
+				jobName := report.Analyses[0].JobStats[i].SampleJobName
+				assert.Equal(t, tc.expectedReport.Analyses[0].JobStats[i].SampleJobName, jobName, "expected job name %+v, got %+v", tc.expectedReport.Analyses[0].JobStats[i].SampleJobName, jobName)
 				assert.Equal(t, tc.expectedReport.Analyses[0].JobStats[i].Significant, report.Analyses[0].JobStats[i].Significant, "expected per job significant %+v, got %+v", tc.expectedReport.Analyses[0].JobStats[i].Significant, report.Analyses[0].JobStats[i].Significant)
-				assert.Equal(t, tc.expectedReport.Analyses[0].JobStats[i].BaseStats, report.Analyses[0].JobStats[i].BaseStats, "expected per job base stats for %s to be %+v, got %+v", tc.expectedReport.Analyses[0].JobStats[i].NormalizedJobName, tc.expectedReport.Analyses[0].JobStats[i].BaseStats, report.Analyses[0].JobStats[i].BaseStats)
-				assert.Equal(t, tc.expectedReport.Analyses[0].JobStats[i].SampleStats, report.Analyses[0].JobStats[i].SampleStats, "expected per job sample stats for %s to be %+v, got %+v", tc.expectedReport.Analyses[0].JobStats[i].NormalizedJobName, tc.expectedReport.Analyses[0].JobStats[i].SampleStats, report.Analyses[0].JobStats[i].SampleStats)
+				assert.Equal(t, tc.expectedReport.Analyses[0].JobStats[i].BaseStats, report.Analyses[0].JobStats[i].BaseStats, "expected per job base stats for %s to be %+v, got %+v", tc.expectedReport.Analyses[0].JobStats[i].SampleJobName, tc.expectedReport.Analyses[0].JobStats[i].BaseStats, report.Analyses[0].JobStats[i].BaseStats)
+				assert.Equal(t, tc.expectedReport.Analyses[0].JobStats[i].SampleStats, report.Analyses[0].JobStats[i].SampleStats, "expected per job sample stats for %s to be %+v, got %+v", tc.expectedReport.Analyses[0].JobStats[i].SampleJobName, tc.expectedReport.Analyses[0].JobStats[i].SampleStats, report.Analyses[0].JobStats[i].SampleStats)
 				assert.Equal(t, tc.expectedSampleJobRunLen[jobName], len(report.Analyses[0].JobStats[i].SampleJobRunStats), "expected sample job run counts %+v, got %+v", tc.expectedSampleJobRunLen[jobName], len(report.Analyses[0].JobStats[i].SampleJobRunStats))
 				assert.Equal(t, tc.expectedBaseJobRunLen[jobName], len(report.Analyses[0].JobStats[i].BaseJobRunStats), "expected base job run counts %+v, got %+v", tc.expectedBaseJobRunLen[jobName], len(report.Analyses[0].JobStats[i].BaseJobRunStats))
 			}

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -370,9 +370,7 @@ func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(ctx context
 
 	report := crtype.TestDetailsAnalysis{TriagedIncidents: incidents}
 	for prowJob, baseStatsList := range baseStatus {
-		jobStats := crtype.TestDetailsJobStats{
-			NormalizedJobName: prowJob,
-		}
+		jobStats := crtype.TestDetailsJobStats{}
 		perJobBaseFailure = 0
 		perJobBaseSuccess = 0
 		perJobBaseFlake = 0
@@ -449,10 +447,8 @@ func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(ctx context
 		totalSampleSuccess += perJobSampleSuccess
 		totalSampleFlake += perJobSampleFlake
 	}
-	for prowJob, sampleStatsList := range sampleStatusCopy {
-		jobStats := crtype.TestDetailsJobStats{
-			NormalizedJobName: prowJob,
-		}
+	for _, sampleStatsList := range sampleStatusCopy {
+		jobStats := crtype.TestDetailsJobStats{}
 		perJobSampleFailure = 0
 		perJobSampleSuccess = 0
 		perJobSampleFlake = 0
@@ -485,7 +481,8 @@ func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(ctx context
 		totalSampleFlake += perJobSampleFlake
 	}
 	sort.Slice(report.JobStats, func(i, j int) bool {
-		return report.JobStats[i].NormalizedJobName < report.JobStats[j].NormalizedJobName
+		return report.JobStats[i].SampleJobName+":"+report.JobStats[i].BaseJobName <
+			report.JobStats[j].SampleJobName+":"+report.JobStats[j].BaseJobName
 	})
 
 	// The hope is that this goes away

--- a/pkg/apis/api/componentreport/types.go
+++ b/pkg/apis/api/componentreport/types.go
@@ -290,9 +290,9 @@ type TestDetailsTestStats struct {
 }
 
 type TestDetailsJobStats struct {
-	NormalizedJobName string                   `json:"job_name"`
-	SampleJobName     string                   `json:"sample_job_name"`
-	BaseJobName       string                   `json:"base_job_name"`
+	// one of sample/base job name could be missing if jobs change between releases
+	SampleJobName     string                   `json:"sample_job_name,omitempty"`
+	BaseJobName       string                   `json:"base_job_name,omitempty"`
 	SampleStats       TestDetailsTestStats     `json:"sample_stats"`
 	BaseStats         TestDetailsTestStats     `json:"base_stats"`
 	SampleJobRunStats []TestDetailsJobRunStats `json:"sample_job_run_stats,omitempty"`

--- a/sippy-ng/src/component_readiness/CompReadyTestDetailRow.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestDetailRow.js
@@ -105,18 +105,34 @@ export default function CompReadyTestDetailRow(props) {
 
   return (
     <Fragment>
-      <TableRow key={idx}>
-        <TableCell className={classes.crColResult} key={'column' + '-' + idx}>
+      <TableRow key={'jobheader-' + idx}>
+        <TableCell
+          className={classes.crColJobName}
+          key={'basisJob-' + idx}
+          colSpan={3}
+        >
           <Typography className={classes.crCellName}>
-            {element.job_name}
+            {element.base_job_name || '(No basis equivalent)'}
           </Typography>
         </TableCell>
+        <TableCell
+          className={classes.crColJobName}
+          key={'sampleJob-' + idx}
+          colSpan={3}
+        >
+          <Typography className={classes.crCellName}>
+            {element.sample_job_name || '(No sample equivalent)'}
+          </Typography>
+        </TableCell>
+      </TableRow>
+      <TableRow key={idx}>
         <TableCell style={{ verticalAlign: 'top' }}>
-          {infoCell(element.base_stats)}
+          {element.base_job_name ? infoCell(element.base_stats) : ''}
         </TableCell>
         {testJobDetailCell(element, 'base')}
+        <TableCell></TableCell>
         <TableCell style={{ verticalAlign: 'top' }}>
-          {infoCell(element.sample_stats)}
+          {element.sample_job_name ? infoCell(element.sample_stats) : ''}
         </TableCell>
         {testJobDetailCell(element, 'sample')}
         <TableCell style={{ verticalAlign: 'top' }}>

--- a/sippy-ng/src/component_readiness/CompReadyTestPanel.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestPanel.js
@@ -220,10 +220,10 @@ export default function CompReadyTestPanel(props) {
         <Table className="cr-comp-read-table">
           <TableHead>
             <TableRow>
-              {tableCell('ProwJob Name', 0)}
-              {tableCell('Basis Info', 1)}
-              {tableCell('Basis Runs', 2)}
-              {tableCell('Sample Info', 3)}
+              {tableCell('Basis Job', 0)}
+              {tableCell('Basis Runs', 1)}
+              {tableCell('', 2)}
+              {tableCell('Sample Job', 3)}
               {tableCell('Sample Runs', 4)}
               {tableTooltipCell(
                 'Statistically Significant',

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -127,6 +127,10 @@ const useStyles = makeStyles((theme) => ({
     left: 0,
     zIndex: 1,
   },
+  crColJobName: {
+    verticalAlign: 'bottom',
+    backgroundColor: theme.palette.mode === 'dark' ? grey[900] : grey['A200'],
+  },
   componentName: {
     width: 175,
     minWidth: 175,


### PR DESCRIPTION
Rather than a "normalized" job name taking up an oversized column on the left, the real job names are interleaved with their results. Also if a sample or basis job is not present, name and zeroed stats are omitted. I think this is clearer, and it compacts better than the previous layout (where the long job name would become many lines).

![image](https://github.com/user-attachments/assets/a5853907-d5cf-45a3-a86e-7d2b0aee679e)

The normalized name no longer has a use in the UI so omit it.