### PR TITLE
TRT-2080: Include dev start date with Release

### DIFF
--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -508,7 +508,7 @@ func GetReleasesFromBigQuery(ctx context.Context, client *bqcachedclient.Client)
 	return releases, nil
 }
 
-// transformRelease converts the BQ release row to v1.Relesae type
+// transformRelease converts the BQ release row to v1.Release type
 func transformRelease(r apitype.ReleaseRow) v1.Release {
 	release := v1.Release{Release: r.Release, Status: r.ReleaseStatus.String()}
 	if r.GADate.Valid {
@@ -517,7 +517,7 @@ func transformRelease(r apitype.ReleaseRow) v1.Release {
 	}
 	if r.DevelStartDate.IsValid() {
 		develStartDate := r.DevelStartDate.In(time.UTC)
-		release.DevelStartDate = &develStartDate
+		release.DevelopmentStartDate = &develStartDate
 	}
 	return release
 }

--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -503,12 +503,21 @@ func GetReleasesFromBigQuery(ctx context.Context, client *bqcachedclient.Client)
 			log.WithError(err).Error("error parsing release row from bigquery")
 			return releases, err
 		}
-		release := v1.Release{Release: r.Release, Status: r.ReleaseStatus.String()}
-		if r.GADate.Valid {
-			gaDate := r.GADate.Date.In(time.UTC)
-			release.GADate = &gaDate
-		}
-		releases = append(releases, release)
+		releases = append(releases, transformRelease(r))
 	}
 	return releases, nil
+}
+
+// transformRelease converts the BQ release row to v1.Relesae type
+func transformRelease(r apitype.ReleaseRow) v1.Release {
+	release := v1.Release{Release: r.Release, Status: r.ReleaseStatus.String()}
+	if r.GADate.Valid {
+		gaDate := r.GADate.Date.In(time.UTC)
+		release.GADate = &gaDate
+	}
+	if r.DevelStartDate.IsValid() {
+		develStartDate := r.DevelStartDate.In(time.UTC)
+		release.DevelStartDate = &develStartDate
+	}
+	return release
 }

--- a/pkg/api/releases_test.go
+++ b/pkg/api/releases_test.go
@@ -2,6 +2,11 @@ package api
 
 import (
 	"testing"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
+	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 
 	"github.com/stretchr/testify/assert"
 
@@ -58,6 +63,59 @@ func TestScanReleaseHealthForRHCOSVersionMisMatches(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			warnings := ScanReleaseHealthForRHCOSVersionMisMatches(tc.releaseHealth)
 			assert.ElementsMatch(t, tc.expectedWarnings, warnings, "unexpected warnings")
+		})
+	}
+}
+
+func TestTransformRelease(t *testing.T) {
+
+	devStart420, _ := time.Parse(time.RFC3339, "2025-04-18T00:00:00.00Z")
+	devStart419, _ := time.Parse(time.RFC3339, "2024-11-25T00:00:00.00Z")
+	gaDate419, _ := time.Parse(time.RFC3339, "2025-05-09T00:00:00.00Z")
+
+	tests := []struct {
+		name            string
+		releaseRow      apitype.ReleaseRow
+		expectedRelease v1.Release
+	}{
+		{
+			name:            "release without devel start",
+			releaseRow:      apitype.ReleaseRow{Release: "4.20", ReleaseStatus: bigquery.NullString{Valid: true, StringVal: "Development"}},
+			expectedRelease: v1.Release{Release: "4.20", Status: "Development"},
+		},
+		{
+			name: "release with devel start",
+			releaseRow: apitype.ReleaseRow{Release: "4.20", ReleaseStatus: bigquery.NullString{Valid: true, StringVal: "Development"}, DevelStartDate: civil.Date{
+				Year:  2025,
+				Month: 4,
+				Day:   18,
+			}},
+			expectedRelease: v1.Release{Release: "4.20", Status: "Development", DevelStartDate: &devStart420},
+		},
+		{
+			name: "release with ga date",
+			releaseRow: apitype.ReleaseRow{Release: "4.19", ReleaseStatus: bigquery.NullString{Valid: true, StringVal: "Development"}, DevelStartDate: civil.Date{
+				Year:  2024,
+				Month: 11,
+				Day:   25,
+			}, GADate: bigquery.NullDate{
+				Date: civil.Date{
+					Year:  2025,
+					Month: 5,
+					Day:   9},
+				Valid: true,
+			}},
+			expectedRelease: v1.Release{Release: "4.19", Status: "Development", DevelStartDate: &devStart419, GADate: &gaDate419},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			release := transformRelease(tc.releaseRow)
+			assert.Equal(t, tc.expectedRelease.Release, release.Release, "unexpected release")
+			assert.Equal(t, tc.expectedRelease.Status, release.Status, "unexpected status")
+			assert.Equal(t, tc.expectedRelease.GADate, release.GADate, "unexpected status")
+			assert.Equal(t, tc.expectedRelease.DevelStartDate, release.DevelStartDate, "unexpected devel start")
 		})
 	}
 }

--- a/pkg/api/releases_test.go
+++ b/pkg/api/releases_test.go
@@ -90,7 +90,7 @@ func TestTransformRelease(t *testing.T) {
 				Month: 4,
 				Day:   18,
 			}},
-			expectedRelease: v1.Release{Release: "4.20", Status: "Development", DevelStartDate: &devStart420},
+			expectedRelease: v1.Release{Release: "4.20", Status: "Development", DevelopmentStartDate: &devStart420},
 		},
 		{
 			name: "release with ga date",
@@ -105,7 +105,7 @@ func TestTransformRelease(t *testing.T) {
 					Day:   9},
 				Valid: true,
 			}},
-			expectedRelease: v1.Release{Release: "4.19", Status: "Development", DevelStartDate: &devStart419, GADate: &gaDate419},
+			expectedRelease: v1.Release{Release: "4.19", Status: "Development", DevelopmentStartDate: &devStart419, GADate: &gaDate419},
 		},
 	}
 
@@ -115,7 +115,7 @@ func TestTransformRelease(t *testing.T) {
 			assert.Equal(t, tc.expectedRelease.Release, release.Release, "unexpected release")
 			assert.Equal(t, tc.expectedRelease.Status, release.Status, "unexpected status")
 			assert.Equal(t, tc.expectedRelease.GADate, release.GADate, "unexpected status")
-			assert.Equal(t, tc.expectedRelease.DevelStartDate, release.DevelStartDate, "unexpected devel start")
+			assert.Equal(t, tc.expectedRelease.DevelopmentStartDate, release.DevelopmentStartDate, "unexpected devel start")
 		})
 	}
 }

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -714,9 +714,10 @@ type TestOutput struct {
 }
 
 type Releases struct {
-	Releases    []string             `json:"releases"`
-	GADates     map[string]time.Time `json:"ga_dates"`
-	LastUpdated time.Time            `json:"last_updated"`
+	Releases        []string             `json:"releases"`
+	GADates         map[string]time.Time `json:"ga_dates"`
+	DevelStartDates map[string]time.Time `json:"devel_start_dates"`
+	LastUpdated     time.Time            `json:"last_updated"`
 }
 
 type Indicator struct {

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -713,11 +713,15 @@ type TestOutput struct {
 	Output string `json:"output"`
 }
 
+type ReleaseDates struct {
+	GA               *time.Time `json:"ga,omitempty"`
+	DevelopmentStart *time.Time `json:"development_start,omitempty"`
+}
 type Releases struct {
-	Releases        []string             `json:"releases"`
-	GADates         map[string]time.Time `json:"ga_dates"`
-	DevelStartDates map[string]time.Time `json:"devel_start_dates"`
-	LastUpdated     time.Time            `json:"last_updated"`
+	Releases          []string                `json:"releases"`
+	DeprecatedGADates map[string]time.Time    `json:"ga_dates"`
+	Dates             map[string]ReleaseDates `json:"dates"`
+	LastUpdated       time.Time               `json:"last_updated"`
 }
 
 type Indicator struct {

--- a/pkg/apis/sippy/v1/types.go
+++ b/pkg/apis/sippy/v1/types.go
@@ -70,10 +70,10 @@ type FailureGroup struct {
 }
 
 type Release struct {
-	Release        string
-	Status         string
-	GADate         *time.Time
-	DevelStartDate *time.Time
+	Release              string
+	Status               string
+	GADate               *time.Time
+	DevelopmentStartDate *time.Time
 }
 
 type VariantMapping struct {

--- a/pkg/apis/sippy/v1/types.go
+++ b/pkg/apis/sippy/v1/types.go
@@ -70,9 +70,10 @@ type FailureGroup struct {
 }
 
 type Release struct {
-	Release string
-	Status  string
-	GADate  *time.Time
+	Release        string
+	Status         string
+	GADate         *time.Time
+	DevelStartDate *time.Time
 }
 
 type VariantMapping struct {

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -794,8 +794,10 @@ func (s *Server) jsonTestDetailsReportFromDB(w http.ResponseWriter, req *http.Re
 
 func (s *Server) jsonReleasesReportFromDB(w http.ResponseWriter, req *http.Request) {
 	gaDateMap := make(map[string]time.Time)
+	develDateMap := make(map[string]time.Time)
 	response := apitype.Releases{
-		GADates: gaDateMap,
+		GADates:         gaDateMap,
+		DevelStartDates: develDateMap,
 	}
 	releases, err := api.GetReleases(req.Context(), s.bigQueryClient)
 	if err != nil {
@@ -808,6 +810,9 @@ func (s *Server) jsonReleasesReportFromDB(w http.ResponseWriter, req *http.Reque
 		response.Releases = append(response.Releases, release.Release)
 		if release.GADate != nil {
 			response.GADates[release.Release] = *release.GADate
+		}
+		if release.DevelStartDate != nil {
+			response.DevelStartDates[release.Release] = *release.DevelStartDate
 		}
 	}
 

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -808,18 +808,14 @@ func (s *Server) jsonReleasesReportFromDB(w http.ResponseWriter, req *http.Reque
 
 	for _, release := range releases {
 		response.Releases = append(response.Releases, release.Release)
-		addDate := false
 		releaseDate := apitype.ReleaseDates{}
 		if release.GADate != nil {
 			response.DeprecatedGADates[release.Release] = *release.GADate
 			releaseDate.GA = release.GADate
-			addDate = true
+			response.Dates[release.Release] = releaseDate
 		}
 		if release.DevelopmentStartDate != nil {
 			releaseDate.DevelopmentStart = release.DevelopmentStartDate
-			addDate = true
-		}
-		if addDate {
 			response.Dates[release.Release] = releaseDate
 		}
 	}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -794,10 +794,10 @@ func (s *Server) jsonTestDetailsReportFromDB(w http.ResponseWriter, req *http.Re
 
 func (s *Server) jsonReleasesReportFromDB(w http.ResponseWriter, req *http.Request) {
 	gaDateMap := make(map[string]time.Time)
-	develDateMap := make(map[string]time.Time)
+	dateMap := make(map[string]apitype.ReleaseDates)
 	response := apitype.Releases{
-		GADates:         gaDateMap,
-		DevelStartDates: develDateMap,
+		DeprecatedGADates: gaDateMap,
+		Dates:             dateMap,
 	}
 	releases, err := api.GetReleases(req.Context(), s.bigQueryClient)
 	if err != nil {
@@ -808,11 +808,19 @@ func (s *Server) jsonReleasesReportFromDB(w http.ResponseWriter, req *http.Reque
 
 	for _, release := range releases {
 		response.Releases = append(response.Releases, release.Release)
+		addDate := false
+		releaseDate := apitype.ReleaseDates{}
 		if release.GADate != nil {
-			response.GADates[release.Release] = *release.GADate
+			response.DeprecatedGADates[release.Release] = *release.GADate
+			releaseDate.GA = release.GADate
+			addDate = true
 		}
-		if release.DevelStartDate != nil {
-			response.DevelStartDates[release.Release] = *release.DevelStartDate
+		if release.DevelopmentStartDate != nil {
+			releaseDate.DevelopmentStart = release.DevelopmentStartDate
+			addDate = true
+		}
+		if addDate {
+			response.Dates[release.Release] = releaseDate
 		}
 	}
 


### PR DESCRIPTION
Pass along DevelStartDate so callers can determine if development has started on the release yet.  Allowing us to add releases prior to actual branch cut / dev start dates