### PR TITLE
Classify console-operator jobs as candidate and give a procedure

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -642,6 +642,7 @@ func (v *OCPVariantLoader) setJobTier(_ logrus.FieldLogger, variants map[string]
 
 		// Konflux jobs aren't ready yet
 		{"-konflux", "candidate"},
+		{"-console-operator-", "candidate"}, // https://issues.redhat.com/browse/OCPBUGS-54873
 
 		// Hidden jobs
 		{"-disruptive", "hidden"},
@@ -695,6 +696,7 @@ func setProcedure(_ logrus.FieldLogger, variants map[string]string, jobName stri
 		{"-cpu-partitioning", "cpu-partitioning"},
 		{"-automated-release", "automated-release"},
 		{"-cert-rotation-shutdown-", "cert-rotation-shutdown"},
+		{"-console-operator-", "console-operator"},
 	}
 
 	for _, entry := range procedurePatterns {


### PR DESCRIPTION
Per discussion today we hope to eliminate suite, so we use Procedure now
for a job doing it's own thing.

Move to candidate as the job has a known problem that needs fixing and
should not be in CR as a new job.
