### PR TITLE
TRT-2045: add the ability to create a triage entry in the UI, and update modal accordingly

### DIFF
--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1254,6 +1254,10 @@ func (s *Server) jsonTriages(w http.ResponseWriter, req *http.Request) {
 		return
 
 	case http.MethodPost: // create
+		if !s.enableWriteAPIs {
+			failureResponse(w, http.StatusNotImplemented, "POST triages is not available on this server")
+			return
+		}
 		var triage models.Triage
 		if err := json.NewDecoder(req.Body).Decode(&triage); err != nil {
 			log.WithError(err).Error("error parsing new triage record")
@@ -1267,6 +1271,10 @@ func (s *Server) jsonTriages(w http.ResponseWriter, req *http.Request) {
 		}
 		api.RespondWithJSON(http.StatusOK, w, triage)
 	case http.MethodPut: // update
+		if !s.enableWriteAPIs {
+			failureResponse(w, http.StatusNotImplemented, "PUT triages is not available on this server")
+			return
+		}
 		if triageID == 0 {
 			failureResponse(w, http.StatusBadRequest, "no triage ID specified in URL")
 			return
@@ -1626,18 +1634,17 @@ func (s *Server) Serve() {
 		{
 			EndpointPath: "/api/component_readiness/triages",
 			Description:  "Manage component readiness regression triage records. (GET, POST, PUT)",
-			Capabilities: []string{LocalDBCapability, ComponentReadinessCapability, WriteEndpointsCapability},
+			Capabilities: []string{LocalDBCapability, ComponentReadinessCapability},
 			HandlerFunc:  s.jsonTriages,
 		},
 		{
 			// TODO: had to duplicate above for trailing slash for GET/PUT on specific records
-			// Switch to gorilla mux for cleaner handling of this, specific verbs, and extracting params from url
-			// Because we don't have control over verbs, we're also disabling GET if write endpoints are disabled, which
-			// means no triage apis available in non-auth sippy for now. Non urgent as we likely will just
-			// augment existing apis with triage data for the reading anyhow.
+			// Switch to gorilla mux for cleaner handling of this, specific verbs, and extracting params from url.
+			// Because we don't have control over verbs, we're also not listing the write endpoints capability here.
+			// Instead, we check it for specific verbs in the jsonTriages function.
 			EndpointPath: "/api/component_readiness/triages/",
 			Description:  "Manage component readiness regression triage records. (GET, POST, PUT)",
-			Capabilities: []string{LocalDBCapability, ComponentReadinessCapability, WriteEndpointsCapability},
+			Capabilities: []string{LocalDBCapability, ComponentReadinessCapability},
 			HandlerFunc:  s.jsonTriages,
 		},
 		{

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -90,6 +90,10 @@ export function getTestDetailsAPIUrl() {
   return process.env.REACT_APP_API_URL + '/api/component_readiness/test_details'
 }
 
+export function getTriagesAPIUrl() {
+  return process.env.REACT_APP_API_URL + '/api/component_readiness/triages'
+}
+
 export const gotoCompReadyMain = () => {
   window.location.href = '/sippy-ng/component_readiness/main'
   //window.history.back()
@@ -543,13 +547,22 @@ export function mergeIncidents(incidents, detailsIncident) {
 }
 
 // mergeRegressionData takes the data from CR api and organizes the data
-// for groupedIncidents, regressedTests (untriaged) and combined list of untriaged and triaged tests
+// for groupedIncidents, regressedTests (untriaged), combined list of untriaged and triaged tests
 // all used in the RegressedTestsModal dialog
-export function mergeRegressionData(data) {
+// if there is a triage entry with a matching regression_id, it computes the proper status for the triaged icon, and removes the corresponding explanations
+export function mergeRegressionData(data, triageEntries) {
   let ret = validateData(data)
   if (ret[0] !== '') {
     return ret
   }
+
+  // the set of regressionIds from the triageEntries will be used to determine if a test that has other not been triaged should be marked as such
+  const regressionIds = new Set()
+  triageEntries.forEach((tr) => {
+    tr.regressions.forEach((regression) => {
+      regressionIds.add(regression.id)
+    })
+  })
 
   let groupedIncidents = new Map()
   let regressedTests = []
@@ -557,9 +570,17 @@ export function mergeRegressionData(data) {
 
   data.rows.forEach((row) => {
     row.columns.forEach((column) => {
-      if (column.regressed_tests && column.regressed_tests.length > 0) {
-        regressedTests = regressedTests.concat(column.regressed_tests)
-        allRegressions = allRegressions.concat(column.regressed_tests)
+      const regressed = column.regressed_tests
+      if (column.regressed_tests && regressed.length > 0) {
+        regressed.forEach((r) => {
+          if (regressionIds.has(r.regression_id)) {
+            r.effective_status = r.status + 2 //setting effective_status to status + 2, for a regressed test, derives the correct triaged version
+            r.explanations = [] //explanations are not relevant when we have a matching triage entry
+          } else {
+            regressedTests.push(r)
+          }
+        })
+        allRegressions = allRegressions.concat(regressed)
       }
 
       if (column.triaged_incidents && column.triaged_incidents.length > 0) {

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -565,7 +565,7 @@ export function mergeRegressionData(data, triageEntries) {
   })
 
   let groupedIncidents = new Map()
-  let regressedTests = []
+  let untriagedRegressedTests = []
   let allRegressions = []
 
   data.rows.forEach((row) => {
@@ -577,7 +577,7 @@ export function mergeRegressionData(data, triageEntries) {
             r.effective_status = r.status + 2 //setting effective_status to status + 2, for a regressed test, derives the correct triaged version
             r.explanations = [] //explanations are not relevant when we have a matching triage entry
           } else {
-            regressedTests.push(r)
+            untriagedRegressedTests.push(r)
           }
         })
         allRegressions = allRegressions.concat(regressed)
@@ -591,13 +591,16 @@ export function mergeRegressionData(data, triageEntries) {
     })
   })
 
-  regressedTests.sort((a, b) => {
+  untriagedRegressedTests.sort((a, b) => {
     return (
       a.component.toLowerCase() < b.component.toLowerCase() ||
       a.capability.toLowerCase() < b.capability.toLowerCase()
     )
   })
-  regressedTests = regressedTests.map((item, index) => ({ ...item, id: index }))
+  untriagedRegressedTests = untriagedRegressedTests.map((item, index) => ({
+    ...item,
+    id: index,
+  }))
 
   allRegressions.sort((a, b) => {
     return (
@@ -608,7 +611,7 @@ export function mergeRegressionData(data, triageEntries) {
   allRegressions = allRegressions.map((item, index) => ({ ...item, id: index }))
 
   return [
-    regressedTests,
+    untriagedRegressedTests,
     allRegressions,
     createGroupedIncidentArray(groupedIncidents),
   ]

--- a/sippy-ng/src/component_readiness/CompReadyVars.js
+++ b/sippy-ng/src/component_readiness/CompReadyVars.js
@@ -37,7 +37,6 @@ function getDefaultIncludeMultiReleaseAnalysis() {
   return false
 }
 
-//TODO: here is an example of a provider, I should do something like this
 export const CompReadyVarsProvider = ({ children }) => {
   const [allJobVariants, setAllJobVariants] = useState([])
   const [views, setViews] = useState([])

--- a/sippy-ng/src/component_readiness/CompSeverityIcon.js
+++ b/sippy-ng/src/component_readiness/CompSeverityIcon.js
@@ -18,8 +18,8 @@ export default function CompSeverityIcon(props) {
     accessibilityModeOn
   )
 
-  let toolTip = ''
-  if (explanations !== undefined) {
+  let toolTip = statusStr
+  if (explanations !== undefined && explanations.length > 0) {
     toolTip = explanations.join(' ')
   }
 

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import React, { Fragment, useContext } from 'react'
 import RegressedTestsPanel from './RegressedTestsPanel'
 import TriagedIncidentsPanel from './TriagedIncidentsPanel'
+import TriagedTestsPanel from './TriagedTestsPanel'
 
 function tabProps(index) {
   return {
@@ -61,22 +62,30 @@ export default function RegressedTestsModal(props) {
           >
             <Tab label="Untriaged Regressions" {...tabProps(0)} />
             <Tab label="Regressed Tests" {...tabProps(1)} />
-            <Tab label="Triaged Tests" {...tabProps(2)} />
+            <Tab label="Triaged Incidents" {...tabProps(2)} />
+            {props.triageEntries.length > 0 && (
+              <Tab label="Triaged Tests" {...tabProps(3)} />
+            )}
           </Tabs>
           <RegressedTestsTabPanel activeIndex={activeTabIndex} index={0}>
             <RegressedTestsPanel
               regressedTests={props.regressedTests}
+              setTriageEntryCreated={props.setTriageEntryCreated}
               filterVals={props.filterVals}
             />
           </RegressedTestsTabPanel>
           <RegressedTestsTabPanel activeIndex={activeTabIndex} index={1}>
             <RegressedTestsPanel
               regressedTests={props.allRegressedTests}
+              setTriageEntryCreated={props.setTriageEntryCreated}
               filterVals={props.filterVals}
             />
           </RegressedTestsTabPanel>
           <RegressedTestsTabPanel activeIndex={activeTabIndex} index={2}>
             <TriagedIncidentsPanel triagedIncidents={props.triagedIncidents} />
+          </RegressedTestsTabPanel>
+          <RegressedTestsTabPanel activeIndex={activeTabIndex} index={3}>
+            <TriagedTestsPanel triageEntries={props.triageEntries} />
           </RegressedTestsTabPanel>
           <Button
             style={{ marginTop: 20, marginBottom: 20, marginLeft: 20 }}
@@ -96,6 +105,8 @@ RegressedTestsModal.propTypes = {
   regressedTests: PropTypes.array,
   allRegressedTests: PropTypes.array,
   triagedIncidents: PropTypes.array,
+  triageEntries: PropTypes.array,
+  setTriageEntryCreated: PropTypes.func,
   filterVals: PropTypes.string.isRequired,
   isOpen: PropTypes.bool,
   close: PropTypes.func,

--- a/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
@@ -1,0 +1,105 @@
+import { DataGrid, GridToolbar } from '@mui/x-data-grid'
+import { formColumnName } from './CompReadyUtils'
+import { relativeTime } from '../helpers'
+import { Tooltip, Typography } from '@mui/material'
+import PropTypes from 'prop-types'
+import React, { Fragment } from 'react'
+
+export default function TriagedRegressionTestList(props) {
+  const [sortModel, setSortModel] = React.useState([
+    { field: 'component', sort: 'asc' },
+  ])
+
+  const [triagedRegressions, setTriagedRegressions] = React.useState([])
+  const [showView, setShowView] = React.useState(false)
+
+  const handleTriagedRegressionGroupSelectionChanged = (data) => {
+    let displayView = false
+    if (data) {
+      displayView = true
+    }
+    setTriagedRegressions(data)
+    setShowView(displayView)
+  }
+  props.eventEmitter.on(
+    'triagedEntrySelectionChanged',
+    handleTriagedRegressionGroupSelectionChanged
+  )
+
+  const columns = [
+    {
+      field: 'test_name',
+      headerName: 'Test Name',
+      flex: 40,
+      valueGetter: (params) => {
+        return params.row.test_name
+      },
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'release',
+      headerName: 'Release',
+      flex: 20,
+      valueGetter: (params) => {
+        return params.row.release
+      },
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'variants',
+      headerName: 'Variants',
+      flex: 30,
+      valueGetter: (params) => {
+        return formColumnName({ variants: params.row.variants })
+      },
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'opened',
+      headerName: 'Regressed Since',
+      flex: 12,
+      valueGetter: (params) => {
+        if (!params.row.opened) {
+          // For a regression we haven't yet detected:
+          return ''
+        }
+        const regressedSinceDate = new Date(params.row.opened)
+        return relativeTime(regressedSinceDate, new Date())
+      },
+      renderCell: (param) => (
+        <Tooltip title="WARNING: This is the first time we detected this test regressed in the default query. This value is not relevant if you've altered query parameters from the default.">
+          <div className="regressed-since">{param.value}</div>
+        </Tooltip>
+      ),
+    },
+  ]
+
+  return (
+    <Fragment>
+      <div hidden={!showView} className="cr-triage-panel-element">
+        <Typography>Test Failures</Typography>
+        <DataGrid
+          sortModel={sortModel}
+          onSortModelChange={setSortModel}
+          components={{ Toolbar: GridToolbar }}
+          rows={triagedRegressions}
+          columns={columns}
+          getRowId={(row) => row.id}
+          pageSize={10}
+          rowHeight={60}
+          autoHeight={true}
+          checkboxSelection={false}
+          componentsProps={{
+            toolbar: {
+              columns: columns,
+            },
+          }}
+        />
+      </div>
+    </Fragment>
+  )
+}
+
+TriagedRegressionTestList.propTypes = {
+  eventEmitter: PropTypes.object,
+}

--- a/sippy-ng/src/component_readiness/TriagedRegressions.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressions.js
@@ -1,0 +1,85 @@
+import { DataGrid, GridToolbar } from '@mui/x-data-grid'
+import { Typography } from '@mui/material'
+import PropTypes from 'prop-types'
+import React, { Fragment } from 'react'
+
+export default function TriagedRegressions(props) {
+  const [sortModel, setSortModel] = React.useState([
+    { field: 'component', sort: 'asc' },
+  ])
+
+  const handleSetSelectionModel = (event) => {
+    let selectedTriagedEntry = {}
+    props.triageEntries.forEach((entry) => {
+      if (event[0] === entry.id) selectedTriagedEntry = entry
+    })
+
+    props.eventEmitter.emit(
+      'triagedEntrySelectionChanged',
+      selectedTriagedEntry.regressions
+    )
+  }
+
+  const columns = [
+    {
+      field: 'description',
+      valueGetter: (value) => {
+        return 'Description is not yet tracked'
+      },
+      headerName: 'Description',
+      flex: 20,
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'type',
+      valueGetter: (value) => {
+        return value.row.type
+      },
+      headerName: 'Type',
+      flex: 5,
+      renderCell: (param) => <div>{param.value}</div>,
+    },
+    {
+      field: 'url',
+      valueGetter: (value) => {
+        return value.row.url
+      },
+      headerName: 'Jira',
+      flex: 12,
+      renderCell: (param) => (
+        <a target="_blank" href={param.value} rel="noreferrer">
+          <div className="test-name">{param.value}</div>
+        </a>
+      ),
+    },
+  ]
+
+  return (
+    <Fragment>
+      <Typography>Triaged Test Regressions</Typography>
+      <DataGrid
+        sortModel={sortModel}
+        onSortModelChange={setSortModel}
+        onSelectionModelChange={handleSetSelectionModel}
+        components={{ Toolbar: GridToolbar }}
+        rows={props.triageEntries}
+        columns={columns}
+        getRowId={(row) => row.id}
+        pageSize={10}
+        rowHeight={60}
+        autoHeight={true}
+        checkboxSelection={false}
+        componentsProps={{
+          toolbar: {
+            columns: columns,
+          },
+        }}
+      />
+    </Fragment>
+  )
+}
+
+TriagedRegressions.propTypes = {
+  eventEmitter: PropTypes.object,
+  triageEntries: PropTypes.array,
+}

--- a/sippy-ng/src/component_readiness/TriagedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/TriagedTestsPanel.js
@@ -1,0 +1,26 @@
+import { Grid } from '@mui/material'
+import EventEmitter from 'eventemitter3'
+import PropTypes from 'prop-types'
+import React, { Fragment } from 'react'
+import TriagedRegressions from './TriagedRegressions'
+import TriagedRegressionTestList from './TriagedRegressionTestList'
+
+export default function TriagedTestsPanel(props) {
+  const eventEmitter = new EventEmitter()
+
+  return (
+    <Fragment>
+      <Grid>
+        <TriagedRegressions
+          eventEmitter={eventEmitter}
+          triageEntries={props.triageEntries}
+        />
+        <TriagedRegressionTestList eventEmitter={eventEmitter} />
+      </Grid>
+    </Fragment>
+  )
+}
+
+TriagedTestsPanel.propTypes = {
+  triageEntries: PropTypes.array,
+}


### PR DESCRIPTION
The option to add a new triage entry will only be available in auth sippy.

This also sets the corresponding tests to the applicable triaged status and icon. It adds a new panel to the regressed tests modal to display these entries and associated tests.

The new panel will eventually replace the current "Triaged Tests" panel, but for now it is in addition to it. With that in mind, I have mostly copied that panel into new components and made the necessary updates rather than adapting it to work with both use cases.

There will be a follow up to add a `Description` field to the backend, DB, and UI for triage entries.

Add a new entry:
![Screenshot 2025-04-22 at 3 36 00 PM](https://github.com/user-attachments/assets/c11e2b60-96dc-4696-b373-8f16ad6a1904)

View entries:
![Screenshot 2025-04-22 at 3 36 14 PM](https://github.com/user-attachments/assets/ba7ec277-bf84-43b7-8d10-58f948702bde)

