### PR TITLE
NO-JIRA: Adjust partial triage counts

### DIFF
--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -1387,9 +1387,9 @@ func (c *ComponentReportGenerator) assessComponentStatus(
 	initialSampleTotal := sampleTotal
 	adjustedSampleTotal := sampleTotal - numberOfIgnoredSampleJobRuns
 	if adjustedSampleTotal < sampleSuccess {
-		log.Errorf("adjustedSampleTotal is too small: sampleTotal=%d, numberOfIgnoredSampleJobRuns=%d, sampleSuccess=%d", sampleTotal, numberOfIgnoredSampleJobRuns, sampleSuccess)
+		log.Warnf("adjustedSampleTotal is too small: sampleTotal=%d, numberOfIgnoredSampleJobRuns=%d, sampleSuccess=%d", sampleTotal, numberOfIgnoredSampleJobRuns, sampleSuccess)
 		// due to differences in sample query times reflecting 'modified_time' and the use of job_run start / completion_time we can include
-		// some triaged job runs that are outside of our sample window resulting in removing too many runs
+		// some triaged job runs that are outside our sample window resulting in removing too many runs
 		// we see this often for triaged runs on the oldest day of the sample window
 		// this leads to us ignoring all triage runs and reporting a regression
 		// https://github.com/openshift/sippy/blob/eb5d6154c745c990c25dfca7d292da43cc1b38e5/pkg/api/componentreadiness/component_report.go#L943


### PR DESCRIPTION
Context is in the comments.

Note the current regressions without the fix:
![image](https://github.com/user-attachments/assets/22a3d24d-102b-4a6b-a7ef-d9697c8e1508)


And with:

![image](https://github.com/user-attachments/assets/4786db49-a4c9-4d5e-a13e-62dd2a38bef9)


There are 15 cases in the current sample (excluding aws) that are hitting this right now.