### PR TITLE
test_details: include start time in job run data

### DIFF
--- a/pkg/api/componentreadiness/query/querygenerators.go
+++ b/pkg/api/componentreadiness/query/querygenerators.go
@@ -401,6 +401,7 @@ func getTestDetailsQuery(
 						COUNT(*) AS total_count,
 						ANY_VALUE(jobs.prowjob_url) AS prowjob_url,
 						ANY_VALUE(jobs.prowjob_build_id) AS prowjob_run_id,
+						ANY_VALUE(jobs.prowjob_start) AS prowjob_start,
 						ANY_VALUE(cm.capabilities) as capabilities,
 						SUM(adjusted_success_val) AS success_count,
 						SUM(adjusted_flake_count) AS flake_count,

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -533,8 +533,9 @@ func (c *ComponentReportGenerator) getJobRunStats(stats crtype.JobRunTestStatusR
 			FailureCount: failure,
 			FlakeCount:   stats.FlakeCount,
 		},
-		JobURL:   stats.ProwJobURL,
-		JobRunID: stats.ProwJobRunID,
+		JobURL:    stats.ProwJobURL,
+		JobRunID:  stats.ProwJobRunID,
+		StartTime: stats.StartTime,
 	}
 	return jobRunStats
 }

--- a/pkg/apis/api/componentreport/types.go
+++ b/pkg/apis/api/componentreport/types.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
 	"github.com/openshift/sippy/pkg/apis/cache"
 	"github.com/openshift/sippy/pkg/util/sets"
 )
@@ -303,8 +304,9 @@ type TestDetailsJobStats struct {
 }
 
 type TestDetailsJobRunStats struct {
-	JobURL   string `json:"job_url"`
-	JobRunID string `json:"job_run_id"`
+	JobURL    string         `json:"job_url"`
+	JobRunID  string         `json:"job_run_id"`
+	StartTime civil.DateTime `json:"start_time"`
 	// TestStats is the test stats from one particular job run.
 	// For the majority of the tests, there is only one junit. But
 	// there are cases multiple junits are generated for the same test.
@@ -331,17 +333,18 @@ type JobRunTestIdentification struct {
 }
 
 type JobRunTestStatusRow struct {
-	ProwJob         string   `bigquery:"prowjob_name"`
-	ProwJobRunID    string   `bigquery:"prowjob_run_id"`
-	ProwJobURL      string   `bigquery:"prowjob_url"`
-	TestID          string   `bigquery:"test_id"`
-	TestName        string   `bigquery:"test_name"`
-	FilePath        string   `bigquery:"file_path"`
-	TotalCount      int      `bigquery:"total_count"`
-	SuccessCount    int      `bigquery:"success_count"`
-	FlakeCount      int      `bigquery:"flake_count"`
-	JiraComponent   string   `bigquery:"jira_component"`
-	JiraComponentID *big.Rat `bigquery:"jira_component_id"`
+	ProwJob         string         `bigquery:"prowjob_name"`
+	ProwJobRunID    string         `bigquery:"prowjob_run_id"`
+	ProwJobURL      string         `bigquery:"prowjob_url"`
+	StartTime       civil.DateTime `bigquery:"prowjob_start"`
+	TestID          string         `bigquery:"test_id"`
+	TestName        string         `bigquery:"test_name"`
+	FilePath        string         `bigquery:"file_path"`
+	TotalCount      int            `bigquery:"total_count"`
+	SuccessCount    int            `bigquery:"success_count"`
+	FlakeCount      int            `bigquery:"flake_count"`
+	JiraComponent   string         `bigquery:"jira_component"`
+	JiraComponentID *big.Rat       `bigquery:"jira_component_id"`
 }
 
 type JobRunTestReportStatus struct {


### PR DESCRIPTION
include job start time in the details so that it can be provided to the user for context. so results now look like
```
                    ...
                    "sample_job_run_stats": [
                        {
                            "job_url": "https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.19-periodics-e2e-aws-techpreview/1909849662261563392",
                            "job_run_id": "1909849662261563392",
                            "start_time": "2025-04-09T06:03:37",
                            "test_stats": {
                                "success_rate": 1,
                                "success_count": 1,
                                "failure_count": 0,
                                "flake_count": 0
                            }
                        }, ...
```