### PR TITLE
TRT-2045: display triages on test-details page

### DIFF
--- a/pkg/api/componentreadiness/triage.go
+++ b/pkg/api/componentreadiness/triage.go
@@ -22,8 +22,14 @@ func GetTriage(dbc *db.DB, id int) (models.Triage, error) {
 	return existingTriage, res.Error
 }
 
-func ListTriages(dbc *db.DB) ([]models.Triage, error) {
-	triages, err := query.ListTriages(dbc)
+func ListTriages(dbc *db.DB, testID, release string) ([]models.Triage, error) {
+	var triages []models.Triage
+	var err error
+	if testID != "" || release != "" {
+		triages, err = query.TriagesForTestIDRelease(dbc, testID, release)
+	} else {
+		triages, err = query.ListTriages(dbc)
+	}
 	for i := range triages {
 		injectHATEOASLinks(&triages[i])
 	}

--- a/pkg/db/query/triage_queries.go
+++ b/pkg/db/query/triage_queries.go
@@ -7,10 +7,33 @@ import (
 )
 
 func ListTriages(dbc *db.DB) ([]models.Triage, error) {
-	triages := []models.Triage{}
+	var triages []models.Triage
 	res := dbc.DB.Preload("Bug").Preload("Regressions").Find(&triages)
 	if res.Error != nil {
 		log.WithError(res.Error).Error("error listing all triages")
+	}
+	return triages, res.Error
+}
+
+func TriagesForTestIDRelease(dbc *db.DB, testID, release string) ([]models.Triage, error) {
+	var triages []models.Triage
+	query := dbc.DB.
+		Joins("JOIN triage_regressions trr ON trr.triage_id = triages.id").
+		Joins("JOIN test_regressions tr ON tr.id = trr.test_regression_id")
+
+	if testID != "" {
+		query.Where("tr.test_id = ?", testID)
+	}
+	if release != "" {
+		query.Where("tr.release = ?", release)
+	}
+
+	res := query.
+		Preload("Bug").
+		Preload("Regressions").
+		Find(&triages)
+	if res.Error != nil {
+		log.WithError(res.Error).Error("error finding triages")
 	}
 	return triages, res.Error
 }

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1253,9 +1253,9 @@ func (s *Server) jsonTriages(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		// Otherwise list all:
-		// TODO: support release filtering
-		triages, err := componentreadiness.ListTriages(s.db)
+		testID := param.SafeRead(req, "test")
+		release := param.SafeRead(req, "sampleRelease")
+		triages, err := componentreadiness.ListTriages(s.db, testID, release)
 		if err != nil {
 			failureResponse(w, http.StatusInternalServerError, err.Error())
 			return


### PR DESCRIPTION
If `triage` entries are present for the displayed `test_id` and `sampleRelease` they will show on the test-details page instead of the `TriagedIncidentsPanel`. Eventually, the latter will be removed entirely.