### PR TITLE
Remove RHCOS version mismatch warnings

### DIFF
--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -141,7 +141,11 @@ func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release 
 	}
 	currStats, prevStats := calculateJobResultStatistics(jobReports)
 
-	warnings := ScanForReleaseWarnings(dbc, release, reportEnd)
+	// Warnings used to report CoreOS version mismatches, but it is no longer tied to the OCP
+	// release. These warnings are shown as a banner on the release overview page.  I left it here
+	// in case we ever want to show these banners again for something else.
+	// TODO: use or remove this logic
+	var warnings []string
 
 	RespondWithJSON(http.StatusOK, w, apitype.Health{
 		Indicators:  indicators,

--- a/pkg/api/releases_test.go
+++ b/pkg/api/releases_test.go
@@ -6,6 +6,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
+
 	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -13,59 +14,6 @@ import (
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/db/models"
 )
-
-func TestScanReleaseHealthForRHCOSVersionMisMatches(t *testing.T) {
-	tests := []struct {
-		name             string
-		releaseHealth    []apitype.ReleaseHealthReport
-		expectedWarnings []string
-	}{
-		{
-			name: "single stream os version match",
-			releaseHealth: []apitype.ReleaseHealthReport{
-				buildFakeReleaseHealthReport("411.85.202203212232-0"),
-			},
-		},
-		{
-			name: "single stream os version mismatch",
-			releaseHealth: []apitype.ReleaseHealthReport{
-				buildFakeReleaseHealthReport("410.85.202203212232-0"),
-			},
-			expectedWarnings: []string{
-				"OS version 410.85.202203212232-0 does not match OpenShift release 4.11",
-			},
-		},
-		{
-			name: "single stream os version parse error",
-			releaseHealth: []apitype.ReleaseHealthReport{
-				buildFakeReleaseHealthReport("foobar"),
-			},
-			expectedWarnings: []string{
-				"unable to parse OpenShift version from OS version foobar",
-			},
-		},
-		{
-			name: "multi stream os version mismatch",
-			releaseHealth: []apitype.ReleaseHealthReport{
-				buildFakeReleaseHealthReport("411.85.202203212232-0"), // one good
-				buildFakeReleaseHealthReport("410.85.202203212232-0"),
-				buildFakeReleaseHealthReport("412.85.202203212232-0"),
-				buildFakeReleaseHealthReport("413.85.202203212232-0"),
-			},
-			expectedWarnings: []string{
-				"OS version 410.85.202203212232-0 does not match OpenShift release 4.11",
-				"OS version 412.85.202203212232-0 does not match OpenShift release 4.11",
-				"OS version 413.85.202203212232-0 does not match OpenShift release 4.11",
-			},
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			warnings := ScanReleaseHealthForRHCOSVersionMisMatches(tc.releaseHealth)
-			assert.ElementsMatch(t, tc.expectedWarnings, warnings, "unexpected warnings")
-		})
-	}
-}
 
 func TestTransformRelease(t *testing.T) {
 


### PR DESCRIPTION
RHCOS is no longer tied to the OCP release.