### PR TITLE
TRT-2045: don't show triaged tests list if there are none

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -456,7 +456,7 @@ View the [test details report|${document.location.href}] for additional context.
           </Fragment>
         )}
 
-      {triageEntries.length >= 0 && (
+      {triageEntries.length > 0 && (
         <Fragment>
           <h2>Triaged Tests</h2>
           <TriagedTestsPanel triageEntries={triageEntries} />


### PR DESCRIPTION
Accidentally displayed them when there were no results. The check should be `> 0`, rather than `>= 0`