### PR TITLE
Time filtering for intervals charts

### DIFF
--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -37,12 +37,12 @@ import Drawer from '@mui/material/Drawer'
 import FeatureGates from './tests/FeatureGates'
 import IconButton from '@mui/material/IconButton'
 import Install from './releases/Install'
+import IntervalsChart from './prow_job_runs/IntervalsChart'
 import Jobs from './jobs/Jobs'
 import MenuIcon from '@mui/icons-material/Menu'
 import MuiAppBar from '@mui/material/AppBar'
 import PayloadStream from './releases/PayloadStream'
 import PayloadStreams from './releases/PayloadStreams'
-import ProwJobRun from './prow_job_runs/ProwJobRun'
 import PullRequests from './pull_requests/PullRequests'
 import React, { Fragment, useContext, useEffect, useState } from 'react'
 import ReleaseOverview from './releases/ReleaseOverview'
@@ -688,7 +688,7 @@ export default function App(props) {
                             <Route
                               path="/job_runs/:jobrunid/:jobname?/:repoinfo?/:pullnumber?/intervals"
                               render={(props) => (
-                                <ProwJobRun
+                                <IntervalsChart
                                   jobRunID={props.match.params.jobrunid}
                                   jobName={props.match.params.jobname}
                                   repoInfo={props.match.params.repoinfo}

--- a/sippy-ng/src/prow_job_runs/IntervalsChart.js
+++ b/sippy-ng/src/prow_job_runs/IntervalsChart.js
@@ -493,6 +493,12 @@ export default function IntervalsChart(props) {
     setEnd(event.target.value)
   }
 
+  const resetTimeFilters = (event) => {
+    console.log('reset time filters')
+    setStart(eventIntervals[0].from)
+    setEnd(eventIntervals[eventIntervals.length - 1].to)
+  }
+
   // handleSegmentClicked is called whenever an individual interval in the chart is clicked.
   // Used to display details on the interval and locator in a way that a user can copy if needed.
   function handleSegmentClicked(segment) {
@@ -571,7 +577,7 @@ export default function IntervalsChart(props) {
           label="Start"
           variant="outlined"
           onChange={handleStartTimeFilterChange}
-          defaultValue={start}
+          value={start}
         />
         -
         <TextField
@@ -579,8 +585,11 @@ export default function IntervalsChart(props) {
           label="End"
           variant="outlined"
           onChange={handleEndTimeFilterChange}
-          defaultValue={end}
+          value={end}
         />
+        <Button key="resetTimeFilters" onClick={() => resetTimeFilters()}>
+          Reset
+        </Button>
       </div>
       <div>
         <Tooltip

--- a/sippy-ng/src/prow_job_runs/IntervalsChart.js
+++ b/sippy-ng/src/prow_job_runs/IntervalsChart.js
@@ -17,6 +17,7 @@ import {
 } from '@mui/material'
 import { CircularProgress } from '@mui/material'
 import { escapeRegex } from '../helpers'
+import { makeStyles } from '@mui/styles'
 import { stringify } from 'query-string'
 import { useHistory } from 'react-router-dom'
 import Alert from '@mui/material/Alert'
@@ -38,6 +39,13 @@ const sourceOrder = [
   'EtcdLog',
   'EtcdLeadership',
 ]
+
+const useStyles = makeStyles({
+  filterRow: {
+    padding: '10px 0',
+    paddingBottom: '1rem',
+  },
+})
 
 // These Sources should be sorted on their locator to group lines together by node, pod, etc.
 const sortOnLocatorSources = ['NodeState']
@@ -175,6 +183,7 @@ const intervalColorizers = {
 
 export default function IntervalsChart(props) {
   const history = useHistory()
+  const classes = useStyles()
 
   const [fetchError, setFetchError] = React.useState('')
   const [isLoaded, setLoaded] = React.useState(false)
@@ -334,7 +343,6 @@ export default function IntervalsChart(props) {
       overrideDisplayFlag != null // adjust this check as needed
 
     if (isReady) {
-      console.log('useEffect on intervals/sources')
       updateFiltering()
     }
   }, [selectedSources, history, eventIntervals, overrideDisplayFlag])
@@ -346,7 +354,6 @@ export default function IntervalsChart(props) {
       const isReady = eventIntervals != null && eventIntervals.length > 0
 
       if (isReady) {
-        console.log('Filter text updated:', filterText)
         updateFiltering()
       }
     }, 800)
@@ -532,7 +539,7 @@ export default function IntervalsChart(props) {
         Loaded {eventIntervals.length} intervals from GCS, filtered down to{' '}
         {filteredIntervals.length}.
       </p>
-      <div style={{ paddingBottom: '1rem' }}>
+      <div className={classes.filterRow}>
         Categories:
         <Box
           display="flex"
@@ -554,7 +561,7 @@ export default function IntervalsChart(props) {
           ))}
         </Box>
       </div>
-      <div style={{ paddingBottom: '1rem' }}>
+      <div className={classes.filterRow}>
         Files:
         <Select
           labelId="interval-file-label"
@@ -577,7 +584,7 @@ export default function IntervalsChart(props) {
           defaultValue={filterText}
         />
       </div>
-      <div style={{ paddingBottom: '1rem' }}>
+      <div className={classes.filterRow}>
         Time Filter:
         <TextField
           id="start"

--- a/sippy-ng/src/prow_job_runs/IntervalsChart.js
+++ b/sippy-ng/src/prow_job_runs/IntervalsChart.js
@@ -7,8 +7,8 @@ import {
   useQueryParam,
 } from 'use-query-params'
 import {
+  Box,
   Button,
-  ButtonGroup,
   Checkbox,
   MenuItem,
   Select,
@@ -285,6 +285,7 @@ export default function IntervalsChart(props) {
               allSources.push(eventInterval.source)
             }
           })
+          allSources.sort()
           console.log('allSources = ' + allSources)
           setAllSources(allSources)
           // This is a little tricky, we do a query first without specifying a filename, as we don't know what
@@ -533,7 +534,12 @@ export default function IntervalsChart(props) {
       </p>
       <div>
         Categories:
-        <ButtonGroup size="small" aria-label="Categories">
+        <Box
+          display="flex"
+          flexWrap="wrap"
+          gap={1} // optional spacing between buttons
+          mt={1}
+        >
           {allSources.map((source) => (
             <Button
               key={source}
@@ -541,11 +547,12 @@ export default function IntervalsChart(props) {
               variant={
                 selectedSources.includes(source) ? 'contained' : 'outlined'
               }
+              size="small"
             >
               {source}
             </Button>
           ))}
-        </ButtonGroup>
+        </Box>
       </div>
       <div>
         Files:

--- a/sippy-ng/src/prow_job_runs/IntervalsChart.js
+++ b/sippy-ng/src/prow_job_runs/IntervalsChart.js
@@ -532,7 +532,7 @@ export default function IntervalsChart(props) {
         Loaded {eventIntervals.length} intervals from GCS, filtered down to{' '}
         {filteredIntervals.length}.
       </p>
-      <div>
+      <div style={{ paddingBottom: '1rem' }}>
         Categories:
         <Box
           display="flex"
@@ -554,7 +554,7 @@ export default function IntervalsChart(props) {
           ))}
         </Box>
       </div>
-      <div>
+      <div style={{ paddingBottom: '1rem' }}>
         Files:
         <Select
           labelId="interval-file-label"
@@ -577,7 +577,7 @@ export default function IntervalsChart(props) {
           defaultValue={filterText}
         />
       </div>
-      <div>
+      <div style={{ paddingBottom: '1rem' }}>
         Time Filter:
         <TextField
           id="start"

--- a/sippy-ng/src/prow_job_runs/IntervalsChart.js
+++ b/sippy-ng/src/prow_job_runs/IntervalsChart.js
@@ -173,7 +173,7 @@ const intervalColorizers = {
   },
 }
 
-export default function ProwJobRun(props) {
+export default function IntervalsChart(props) {
   const history = useHistory()
 
   const [fetchError, setFetchError] = React.useState('')
@@ -217,6 +217,21 @@ export default function ProwJobRun(props) {
     return ''
   })
 
+  const [start, setStart] = useState(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('start')) {
+      return params.get('start')
+    }
+    return ''
+  })
+  const [end, setEnd] = useState(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('end')) {
+      return params.get('end')
+    }
+    return ''
+  })
+
   const fetchData = () => {
     let queryString = ''
     console.log(
@@ -254,6 +269,12 @@ export default function ProwJobRun(props) {
           let tmpIntervals = json.items
           mutateIntervals(tmpIntervals)
           setEventIntervals(tmpIntervals)
+
+          // if the query params did not already define a start/end filter, use the first/last interval to set it up
+          if (!start && !end) {
+            setStart(tmpIntervals[0].from)
+            setEnd(tmpIntervals[tmpIntervals.length - 1].to)
+          }
 
           let intervalFilesAvailable = json.intervalFilesAvailable
           intervalFilesAvailable.sort()
@@ -305,19 +326,31 @@ export default function ProwJobRun(props) {
   }, [intervalFile])
 
   useEffect(() => {
-    updateFiltering()
+    const isReady =
+      selectedSources != null &&
+      eventIntervals != null &&
+      eventIntervals.length > 0 &&
+      overrideDisplayFlag != null // adjust this check as needed
+
+    if (isReady) {
+      console.log('useEffect on intervals/sources')
+      updateFiltering()
+    }
   }, [selectedSources, history, eventIntervals, overrideDisplayFlag])
 
   useEffect(() => {
     // Delayed processing of the filter text input to allow the user to finish typing before
     // we update our filtering:
     const timer = setTimeout(() => {
-      console.log('Filter text updated:', filterText)
-      updateFiltering()
-    }, 800)
+      const isReady = eventIntervals != null && eventIntervals.length > 0
 
+      if (isReady) {
+        console.log('Filter text updated:', filterText)
+        updateFiltering()
+      }
+    }, 800)
     return () => clearTimeout(timer)
-  }, [filterText])
+  }, [filterText, start, end])
 
   function updateFiltering() {
     console.log('updating filtering')
@@ -328,8 +361,17 @@ export default function ProwJobRun(props) {
         intervalFile: StringParam,
         filter: StringParam,
         overrideDisplayFlag: BooleanParam,
+        start: StringParam,
+        end: StringParam,
       },
-      { selectedSources, intervalFile, filterText, overrideDisplayFlag }
+      {
+        selectedSources,
+        intervalFile,
+        filterText,
+        start,
+        end,
+        overrideDisplayFlag,
+      }
     )
 
     history.replace({
@@ -340,7 +382,16 @@ export default function ProwJobRun(props) {
       eventIntervals,
       selectedSources,
       filterText,
-      overrideDisplayFlag
+      overrideDisplayFlag,
+      start,
+      end
+    )
+    console.log(
+      'now we have ' +
+        filteredIntervals.length +
+        '/' +
+        eventIntervals.length +
+        ' intervals'
     )
     setFilteredIntervals(filteredIntervals)
   }
@@ -403,8 +454,6 @@ export default function ProwJobRun(props) {
       }
     })
 
-    console.log('final intervalColors: ' + JSON.stringify(intervalColors))
-
     return timelineGroups
   }
 
@@ -434,6 +483,14 @@ export default function ProwJobRun(props) {
 
   const handleFilterChange = (event) => {
     setFilterText(event.target.value)
+  }
+
+  const handleStartTimeFilterChange = (event) => {
+    setStart(event.target.value)
+  }
+
+  const handleEndTimeFilterChange = (event) => {
+    setEnd(event.target.value)
   }
 
   // handleSegmentClicked is called whenever an individual interval in the chart is clicked.
@@ -508,6 +565,24 @@ export default function ProwJobRun(props) {
         />
       </div>
       <div>
+        Time Filter:
+        <TextField
+          id="start"
+          label="Start"
+          variant="outlined"
+          onChange={handleStartTimeFilterChange}
+          defaultValue={start}
+        />
+        -
+        <TextField
+          id="end"
+          label="End"
+          variant="outlined"
+          onChange={handleEndTimeFilterChange}
+          defaultValue={end}
+        />
+      </div>
+      <div>
         <Tooltip
           title={
             'Display ALL intervals, not just those that origin indicated were meant for display'
@@ -535,7 +610,7 @@ export default function ProwJobRun(props) {
   )
 }
 
-ProwJobRun.defaultProps = {
+IntervalsChart.defaultProps = {
   // default list of pre-selected sources:
   selectedSources: [
     'OperatorAvailable',
@@ -555,12 +630,14 @@ ProwJobRun.defaultProps = {
   overrideDisplayFlag: false,
 }
 
-ProwJobRun.propTypes = {
+IntervalsChart.propTypes = {
   jobRunID: PropTypes.string.isRequired,
   jobName: PropTypes.string,
   repoInfo: PropTypes.string,
   pullNumber: PropTypes.string,
   filterText: PropTypes.string,
+  start: PropTypes.string,
+  end: PropTypes.string,
   selectedSources: PropTypes.array,
   intervalFile: PropTypes.string,
   overrideDisplayFlag: PropTypes.bool,
@@ -570,19 +647,31 @@ function filterIntervals(
   eventIntervals,
   selectedSources,
   filterText,
-  overrideDisplayFlag
+  overrideDisplayFlag,
+  start,
+  end
 ) {
   let re = null
   if (filterText) {
     re = new RegExp(escapeRegex(filterText))
   }
 
+  let startFilter = new Date(start)
+  let endFilter = new Date(end)
+
   return _.filter(eventIntervals, function (eventInterval) {
     let shouldInclude = false
+    if (startFilter > new Date(eventInterval.from)) {
+      return shouldInclude
+    }
+    if (endFilter < new Date(eventInterval.to)) {
+      return shouldInclude
+    }
     if (!selectedSources.includes(eventInterval.source)) {
       return shouldInclude
     }
     if (!overrideDisplayFlag && !eventInterval.display) {
+      console.log('missed on override')
       return shouldInclude
     }
     // Hack for Disruption intervals, we don't ever want to show those without the display flag, they should have been
@@ -596,6 +685,8 @@ function filterIntervals(
         re.test(eventInterval.displayLocator)
       ) {
         shouldInclude = true
+      } else {
+        console.log('missed on regex')
       }
     } else {
       shouldInclude = true
@@ -791,7 +882,6 @@ function createTimelineData(
     if (intervalColorizers[item.source]) {
       let r = intervalColorizers[item.source](item)
       if (r) {
-        console.log('for ' + item.source + ' got result: ' + r)
         intervalColors[r[0]] = r[1]
         val = r[0]
       }


### PR DESCRIPTION
The existing time filtering worked poorly, it was impossible to get to precise times, often buggy, and would still include mass empty rows between intervals actually in the frame.

Add actual interval time filtering, prepopulated with the first/last intervals times. You can then adjust precisely if desired and see only intervals in that timeframe. A reset button is included, and these are working as query params so you can send someone a link to just what you see.

Also took the time to sort the Categories/Sources buttons, and wrap them so we no longer have to scroll to the right all the time.