### PR TITLE
TRT-2056: Track more regression data and show last failure in triaged table

### DIFF
--- a/pkg/api/componentreadiness/regressiontracker.go
+++ b/pkg/api/componentreadiness/regressiontracker.go
@@ -90,10 +90,6 @@ func (prs *PostgresRegressionStore) UpdateRegression(reg *models.TestRegression)
 	return res.Error
 }
 
-func (prs *PostgresRegressionStore) CloseRegression(reg *models.TestRegression, closedAt time.Time) error {
-	return prs.UpdateRegression(reg)
-}
-
 func NewRegressionTracker(
 	bigqueryClient *sippybigquery.Client,
 	dbc *db.DB,

--- a/pkg/api/componentreadiness/regressiontracker.go
+++ b/pkg/api/componentreadiness/regressiontracker.go
@@ -4,22 +4,19 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
 	"github.com/openshift/sippy/pkg/api/componentreadiness/middleware/regressiontracker"
-	"github.com/openshift/sippy/pkg/db/models"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
-	"google.golang.org/api/iterator"
-
 	crtype "github.com/openshift/sippy/pkg/apis/api/componentreport"
 	"github.com/openshift/sippy/pkg/apis/cache"
 	configv1 "github.com/openshift/sippy/pkg/apis/config/v1"
 	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 	sippybigquery "github.com/openshift/sippy/pkg/bigquery"
 	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -39,46 +36,7 @@ type RegressionStore interface {
 	// a regressed test, so people using custom reporting can see what is regressed in main as well.
 	ListCurrentRegressionsForRelease(release string) ([]*models.TestRegression, error)
 	OpenRegression(view crtype.View, newRegressedTest crtype.ReportTestSummary) (*models.TestRegression, error)
-	ReOpenRegression(reg *models.TestRegression) error
-	CloseRegression(reg *models.TestRegression, closedAt time.Time) error
-}
-
-// TODO: temporary, just being used for migration code on initial rollout, can be deleted as soon as postgres imports
-// the current regressions.
-//
-// ListCurrentRegressionsForRelease returns *all* regressions for all releases. We operate on the assumption that
-// only one view is allowed to have regression tracking enabled (i.e. 4.18-main) per release, which is validated
-// when the views file is loaded. This is because we want to display regression tracking data on any report that shows
-// a regressed test, so users using custom reporting can see what is regressed in main as well.
-func ListCurrentRegressions(ctx context.Context, client *sippybigquery.Client) ([]*crtype.TestRegressionBigQuery, error) {
-	// Use max snapshot date to get the most recently appended view of the regressions.
-	queryString := fmt.Sprintf("SELECT * FROM %s.test_regressions_append WHERE snapshot = (SELECT MAX(snapshot) FROM %s.test_regressions_append)",
-		client.Dataset, client.Dataset)
-
-	sampleQuery := client.BQ.Query(queryString)
-
-	regressions := make([]*crtype.TestRegressionBigQuery, 0)
-	log.Infof("Fetching current test regressions with: %s", sampleQuery.Q)
-
-	it, err := sampleQuery.Read(ctx)
-	if err != nil {
-		log.WithError(err).Error("error querying triaged incidents from bigquery")
-		return regressions, err
-	}
-
-	for {
-		var regression crtype.TestRegressionBigQuery
-		err := it.Next(&regression)
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			log.WithError(err).Error("error parsing triaged incident from bigquery")
-			return nil, errors.Wrap(err, "error parsing triaged incident from bigquery")
-		}
-		regressions = append(regressions, &regression)
-	}
-	return regressions, nil
+	UpdateRegression(reg *models.TestRegression) error
 }
 
 type PostgresRegressionStore struct {
@@ -98,8 +56,8 @@ func (prs *PostgresRegressionStore) ListCurrentRegressionsForRelease(release str
 		Where("closed IS NULL OR closed > ?", time.Now().Add(-regressionHysteresisDays*24*time.Hour))
 	res := q.Scan(&regressions)
 	return regressions, res.Error
-
 }
+
 func (prs *PostgresRegressionStore) OpenRegression(view crtype.View, newRegressedTest crtype.ReportTestSummary) (*models.TestRegression, error) {
 
 	variants := []string{}
@@ -109,12 +67,13 @@ func (prs *PostgresRegressionStore) OpenRegression(view crtype.View, newRegresse
 	log.Infof("variants: %s", strings.Join(variants, ","))
 
 	newRegression := &models.TestRegression{
-		View:     view.Name,
-		Release:  view.SampleRelease.Release,
-		TestID:   newRegressedTest.TestID,
-		TestName: newRegressedTest.TestName,
-		Opened:   time.Now(),
-		Variants: variants,
+		View:        view.Name,
+		Release:     view.SampleRelease.Release,
+		TestID:      newRegressedTest.TestID,
+		TestName:    newRegressedTest.TestName,
+		Opened:      time.Now(),
+		Variants:    variants,
+		MaxFailures: newRegressedTest.SampleStats.FailureCount,
 	}
 	res := prs.dbc.DB.Create(newRegression)
 	if res.Error != nil {
@@ -125,16 +84,13 @@ func (prs *PostgresRegressionStore) OpenRegression(view crtype.View, newRegresse
 
 }
 
-func (prs *PostgresRegressionStore) ReOpenRegression(reg *models.TestRegression) error {
-	reg.Closed = sql.NullTime{Valid: false}
+func (prs *PostgresRegressionStore) UpdateRegression(reg *models.TestRegression) error {
 	res := prs.dbc.DB.Save(&reg)
 	return res.Error
 }
 
 func (prs *PostgresRegressionStore) CloseRegression(reg *models.TestRegression, closedAt time.Time) error {
-	reg.Closed = sql.NullTime{Valid: true, Time: closedAt}
-	res := prs.dbc.DB.Save(&reg)
-	return res.Error
+	return prs.UpdateRegression(reg)
 }
 
 func NewRegressionTracker(
@@ -176,48 +132,6 @@ type RegressionTracker struct {
 // Run iterates all views with regression tracking enabled and syncs the results of its
 // component report to the regression tables.
 func (rt *RegressionTracker) Run(ctx context.Context) error {
-
-	// TODO: remove this temporary migration code for initial rollout
-	var totalRegressions int64
-	rt.dbc.DB.Model(&models.TestRegression{}).Count(&totalRegressions)
-	if totalRegressions == 0 {
-		rt.logger.Warn("no test regressions found in postgres, migrating bigquery regressions over")
-		allBigQueryRegressions, err := ListCurrentRegressions(ctx, rt.bigqueryClient)
-		if err != nil {
-			rt.logger.WithError(err).Error("error listing bigquery regressions")
-			return err
-		}
-		rt.logger.Infof("loaded %d test regressions from bigquery", len(allBigQueryRegressions))
-		for _, reg := range allBigQueryRegressions {
-			newRegression := &models.TestRegression{
-				View:     reg.View,
-				Release:  reg.Release,
-				TestID:   reg.TestID,
-				TestName: reg.TestName,
-				Opened:   reg.Opened,
-			}
-			if !reg.Closed.Valid {
-				newRegression.Closed = sql.NullTime{
-					Valid: false,
-				}
-			} else {
-				newRegression.Closed = sql.NullTime{
-					Valid: true,
-					Time:  reg.Closed.Timestamp,
-				}
-			}
-			variants := []string{}
-			for _, v := range reg.Variants {
-				variants = append(variants, fmt.Sprintf("%s:%s", v.Key, v.Value))
-			}
-			newRegression.Variants = variants
-
-			res := rt.dbc.DB.Create(newRegression)
-			if res.Error != nil {
-				return res.Error
-			}
-		}
-	}
 
 	// Run the existing logic
 	var err error
@@ -307,20 +221,32 @@ func (rt *RegressionTracker) SyncRegressionsForReport(ctx context.Context, view 
 				// regression for this test. We'll re-use it to limit churn as sometimes tests may drop
 				// in / out of the report depending on the data available in the sample/basis.
 				rLog.Infof("re-opening existing regression: %v", openReg)
+				if regTest.SampleStats.FailureCount > openReg.MaxFailures {
+					openReg.MaxFailures = regTest.SampleStats.FailureCount
+				}
 				if !rt.dryRun {
 					reopenedRegs++
-					err := rt.backend.ReOpenRegression(openReg)
+					openReg.Closed = sql.NullTime{Valid: false}
+					err := rt.backend.UpdateRegression(openReg)
 					if err != nil {
 						rLog.WithError(err).Errorf("error re-opening regression: %v", openReg)
 						return errors.Wrapf(err, "error re-opening regression: %v", openReg)
 					}
 				}
 			} else {
+				if regTest.SampleStats.FailureCount > openReg.MaxFailures {
+					openReg.MaxFailures = regTest.SampleStats.FailureCount
+					err := rt.backend.UpdateRegression(openReg)
+					if err != nil {
+						rLog.WithError(err).Errorf("error updating MaxFailures for regression: %v", openReg)
+						return errors.Wrapf(err, "error updating MaxFailures for regression: %v", openReg)
+					}
+				}
+				// Still consider untouched even if we bumped the max failures count
 				untouchedRegs++
 				rLog.WithFields(log.Fields{
 					"test": regTest.TestName,
 				}).Debugf("reusing already opened regression: %v", openReg)
-
 			}
 			matchedOpenRegressions = append(matchedOpenRegressions, openReg)
 		} else {
@@ -342,8 +268,10 @@ func (rt *RegressionTracker) SyncRegressionsForReport(ctx context.Context, view 
 	now := time.Now()
 	for _, regression := range regressions {
 		var matched bool
+		// We don't want to reject a regression as unmatched because it's max failures count is different.
+		// We also do not want to wipe out the max failures value when closing.
 		for _, m := range matchedOpenRegressions {
-			if reflect.DeepEqual(m, regression) {
+			if m.ID == regression.ID {
 				matched = true
 				break
 			}
@@ -353,7 +281,8 @@ func (rt *RegressionTracker) SyncRegressionsForReport(ctx context.Context, view 
 			rLog.Infof("found a regression no longer appearing in the report which should be closedRegs: %v", regression)
 			closedRegs++
 			if !rt.dryRun {
-				err := rt.backend.CloseRegression(regression, now)
+				regression.Closed = sql.NullTime{Valid: true, Time: now}
+				err := rt.backend.UpdateRegression(regression)
 				if err != nil {
 					rLog.WithError(err).Errorf("error closing regression: %v", regression)
 					return errors.Wrap(err, "error closing regression")

--- a/pkg/db/models/triage.go
+++ b/pkg/db/models/triage.go
@@ -84,6 +84,8 @@ type TestRegression struct {
 	Opened   time.Time      `json:"opened" gorm:"not null"`
 	Closed   sql.NullTime   `json:"closed"`
 	Triages  []Triage       `json:"-" gorm:"many2many:triage_regressions;"`
+	// LastFailure is the last failure in the sample we saw while this regression was open.
+	LastFailure sql.NullTime `json:"last_failure"`
 	// MaxFailures is the maximum number of failures we found in the reporting window while this regression was open.
 	// This is intended to help inform the min fail thresholds we should be using, and what kind of regressions
 	// disappear on their own.

--- a/pkg/db/models/triage.go
+++ b/pkg/db/models/triage.go
@@ -84,4 +84,8 @@ type TestRegression struct {
 	Opened   time.Time      `json:"opened" gorm:"not null"`
 	Closed   sql.NullTime   `json:"closed"`
 	Triages  []Triage       `json:"-" gorm:"many2many:triage_regressions;"`
+	// MaxFailures is the maximum number of failures we found in the reporting window while this regression was open.
+	// This is intended to help inform the min fail thresholds we should be using, and what kind of regressions
+	// disappear on their own.
+	MaxFailures int `json:"max_failures"`
 }

--- a/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
@@ -72,6 +72,26 @@ export default function TriagedRegressionTestList(props) {
         </Tooltip>
       ),
     },
+    {
+      field: 'last_failure',
+      headerName: 'Last Failure',
+      flex: 12,
+      valueGetter: (params) => {
+        if (!params.row.last_failure.Valid) {
+          return null
+        }
+        return new Date(params.row.last_failure.Time).getTime()
+      },
+      renderCell: (params) => {
+        if (!params.value) return ''
+        const lastFailureDate = new Date(params.value)
+        return (
+          <div className="last-failure">
+            {relativeTime(lastFailureDate, new Date())}
+          </div>
+        )
+      },
+    },
   ]
 
   return (

--- a/test/e2e/componentreadiness/regressiontracker/regressiontracker_test.go
+++ b/test/e2e/componentreadiness/regressiontracker/regressiontracker_test.go
@@ -78,14 +78,16 @@ func Test_RegressionTracker(t *testing.T) {
 
 		// Now close it:
 		assert.False(t, lookup.Closed.Valid)
-		err = tracker.CloseRegression(lookup, time.Now())
+		lookup.Closed = sql.NullTime{Valid: true, Time: time.Now()}
+		err = tracker.UpdateRegression(lookup)
 		assert.NoError(t, err)
 		// look it up again because we're being ridiculous:
 		dbc.DB.First(&lookup)
 
 		assert.True(t, lookup.Closed.Valid)
 
-		err = tracker.ReOpenRegression(lookup)
+		lookup.Closed = sql.NullTime{Valid: false}
+		err = tracker.UpdateRegression(lookup)
 		assert.NoError(t, err)
 		dbc.DB.First(&lookup)
 		assert.False(t, lookup.Closed.Valid)


### PR DESCRIPTION
For the duration a regression is open, track the max number of failures we saw in the sample window. This will be helpful for determining what minFail we should use, and provide insights related to regressions that go away on their own.

Doesn't work great with triage right now for the same reason we see 100% passing on a triaged test details page, we decrement traiged runs today and don't return any info on them. This will be better in the new traige where job runs only get decremented when the regression is considered closed.

Also removed temp bigquery migration code for the postgres rollout that
I forgot to come back for.



Also tracks the last failure time for the regression. 

And finally displays that in the triaged portion of the regressed tests modal. This will allow us to better see if a triaged regression is on-going, without having to go to the other tabs and find a specific row.
