### PR TITLE
NO-JIRA: fix the test checkbox by updating the location of the regression_id in the JSON

### DIFF
--- a/sippy-ng/src/component_readiness/RegressedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsPanel.js
@@ -218,7 +218,11 @@ export default function RegressedTestsPanel(props) {
             headerName: 'Triage',
             flex: 4,
             valueGetter: (params) => {
-              return String(params.row.regression_id)
+              if (!params.row.regression?.opened) {
+                // For a regression we haven't yet detected:
+                return '0'
+              }
+              return String(params.row.regression.id)
             },
             renderCell: (param) => (
               <input


### PR DESCRIPTION
The API return value changed in https://github.com/openshift/sippy/commit/64b4c66791c10dbc025de8264a08c5ca9653c3a0