### PR TITLE
trt-2093: Move virt to main view

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -39,6 +39,7 @@ component_readiness:
           - standard
         LayeredProduct:
           - none
+          - virt
         Network:
           - ovn
         Owner:
@@ -109,6 +110,7 @@ component_readiness:
           - standard
         LayeredProduct:
           - none
+          - virt
         Owner:
           - eng
         Platform:
@@ -174,6 +176,7 @@ component_readiness:
           - standard
         LayeredProduct:
           - none
+          - virt
         Owner:
           - eng
         Platform:
@@ -243,6 +246,7 @@ component_readiness:
           - upi
         LayeredProduct:
           - none
+          - virt
         Network:
           - ovn
         Owner:
@@ -269,75 +273,6 @@ component_readiness:
       enabled: false
     regression_tracking:
       enabled: false
-  - name: 4.20-virt
-    base_release:
-      release: "4.19"
-      relative_start: now-30d
-      relative_end: now
-    sample_release:
-      release: "4.20"
-      relative_start: now-7d
-      relative_end: now
-    variant_options:
-      column_group_by:
-        Architecture: {}
-        Network: {}
-        Platform: {}
-        Topology: {}
-        LayeredProduct: {}
-      db_group_by:
-        Architecture: {}
-        FeatureSet: {}
-        Installer: {}
-        Network: {}
-        Platform: {}
-        Suite: {}
-        LayeredProduct: {}
-        Topology: {}
-        Upgrade: {}
-      include_variants:
-        Architecture:
-          - amd64
-        FeatureSet:
-          - default
-          - techpreview
-        Installer:
-          - ipi
-          - upi
-        JobTier:
-          - blocking
-          - informing
-          - standard
-        LayeredProduct:
-          - virt
-        Network:
-          - ovn
-        Owner:
-          - eng
-          - service-delivery
-        Platform:
-          - aws
-          - azure
-          - gcp
-          - metal
-          - rosa
-          - vsphere
-        Topology:
-          - ha
-          - microshift
-        CGroupMode:
-          - v2
-        ContainerRuntime:
-          - runc
-          - crun
-    advanced_options:
-      minimum_failure: 3
-      confidence: 95
-      pity_factor: 5
-      ignore_missing: false
-      ignore_disruption: true
-      flake_as_failure: false
-      pass_rate_required_new_tests: 95
   - name: 4.19-main
     base_release:
       release: "4.18"


### PR DESCRIPTION
[CR 4.20 virt](https://sippy.dptools.openshift.org/sippy-ng/component_readiness/main?view=4.20-virt) looks to have no active regressions.  [TRT-2093](https://issues.redhat.com/browse/TRT-2093) is requesting we move them back into the main view.