### PR TITLE
TRT-2089: fully wire up regression tracking middleware on test_details

### DIFF
--- a/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
+++ b/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
@@ -38,6 +38,14 @@ type RegressionTracker struct {
 }
 
 func (r *RegressionTracker) Query(ctx context.Context, wg *sync.WaitGroup, allJobVariants crtype.JobVariants, baseStatusCh, sampleStatusCh chan map[string]crtype.TestStatus, errCh chan error) {
+	r.internalQuery(errCh)
+}
+
+func (r *RegressionTracker) QueryTestDetails(ctx context.Context, wg *sync.WaitGroup, errCh chan error, allJobVariants crtype.JobVariants) {
+	r.internalQuery(errCh)
+}
+
+func (r *RegressionTracker) internalQuery(errCh chan error) {
 	// Load all known regressions for this release:
 	r.openRegressions = make([]*models.TestRegression, 0)
 	q := r.dbc.DB.Table("test_regressions").
@@ -49,9 +57,6 @@ func (r *RegressionTracker) Query(ctx context.Context, wg *sync.WaitGroup, allJo
 		return
 	}
 	r.log.Infof("Found %d open regressions", len(r.openRegressions))
-}
-
-func (r *RegressionTracker) QueryTestDetails(ctx context.Context, wg *sync.WaitGroup, errCh chan error, allJobVariants crtype.JobVariants) {
 }
 
 func (r *RegressionTracker) PreAnalysis(testKey crtype.ReportTestIdentification, testStats *crtype.ReportTestStats) error {

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	fet "github.com/glycerine/golang-fisher-exact"
+	"github.com/openshift/sippy/pkg/db"
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/sippy/pkg/api"
@@ -22,10 +23,11 @@ import (
 	"github.com/openshift/sippy/pkg/util"
 )
 
-func GetTestDetails(ctx context.Context, client *bigquery.Client, reqOptions crtype.RequestOptions,
+func GetTestDetails(ctx context.Context, client *bigquery.Client, dbc *db.DB, reqOptions crtype.RequestOptions,
 ) (crtype.ReportTestDetails, []error) {
 	generator := ComponentReportGenerator{
 		client:     client,
+		dbc:        dbc,
 		ReqOptions: reqOptions,
 	}
 	if os.Getenv("DEV_MODE") == "1" {

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -731,7 +731,7 @@ func (s *Server) jsonComponentReportTestDetailsFromBigQuery(w http.ResponseWrite
 		failureResponse(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	outputs, errs := componentreadiness.GetTestDetails(req.Context(), s.bigQueryClient, reqOptions)
+	outputs, errs := componentreadiness.GetTestDetails(req.Context(), s.bigQueryClient, s.db, reqOptions)
 	if len(errs) > 0 {
 		log.Warningf("%d errors were encountered while querying component test details from big query:", len(errs))
 		for _, err := range errs {


### PR DESCRIPTION
Follows up on https://github.com/openshift/sippy/pull/2559 to make the middleware work on the test details report 