### PR TITLE
TRT-2089: allow the ability to triage a test from the test_details report

### DIFF
--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1306,6 +1306,11 @@ func (s *Server) jsonTriages(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 		api.RespondWithJSON(http.StatusOK, w, triage)
+	case http.MethodOptions:
+		// TODO(sgoeddel): should we enable CORS? If so, we will have to do some special logic to allow localhost as well until gorilla is utilized
+		// w.Header().Set("Access-Control-Allow-Origin", "https://sippy-auth.dptools.openshift.org")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS")
+		api.RespondWithJSON(http.StatusOK, w, nil)
 	default:
 		failureResponse(w, http.StatusBadRequest, "Unsupported method")
 	}

--- a/sippy-ng/src/component_readiness/TriageFields.js
+++ b/sippy-ng/src/component_readiness/TriageFields.js
@@ -1,0 +1,163 @@
+import { FormHelperText, MenuItem, Select, TextField } from '@mui/material'
+import { getTriagesAPIUrl, jiraUrlPrefix } from './CompReadyUtils'
+import { makeStyles } from '@mui/styles'
+import Button from '@mui/material/Button'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+const useStyles = makeStyles({
+  triageForm: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+    padding: '10px 0',
+  },
+  validationErrors: {
+    color: 'red',
+  },
+})
+
+export default function TriageFields({
+  regressionId,
+  setAlertText,
+  setAlertSeverity,
+  triageEntryData,
+  setTriageEntryData,
+  handleFormCompletion,
+}) {
+  const classes = useStyles()
+
+  const [triageValidationErrors, setTriageValidationErrors] = React.useState([])
+
+  const handleTriageChange = (e) => {
+    const { name, value } = e.target
+
+    setTriageEntryData((prevData) => ({
+      ...prevData,
+      [name]: value,
+    }))
+  }
+
+  const handleTriageEntrySubmit = () => {
+    const managingIds = triageEntryData.hasOwnProperty('ids')
+    const validationErrors = []
+    if (triageEntryData.type === 'type') {
+      validationErrors.push('invalid type, please make a selection')
+    }
+    if (!triageEntryData.url.startsWith(jiraUrlPrefix)) {
+      validationErrors.push('invalid url, should begin with ' + jiraUrlPrefix)
+    }
+    if (triageEntryData.description.length < 1) {
+      validationErrors.push('invalid description, cannot be blank')
+    }
+    if (managingIds && triageEntryData.ids.length < 1) {
+      validationErrors.push('no tests selected, please select at least one')
+    }
+    setTriageValidationErrors(validationErrors)
+
+    if (validationErrors.length === 0) {
+      const data = {
+        url: triageEntryData.url,
+        type: triageEntryData.type,
+        description: triageEntryData.description,
+      }
+      if (managingIds) {
+        data.regressions = triageEntryData.ids.map((id) => {
+          return { id: Number(id) }
+        })
+      } else if (regressionId > 0) {
+        data.regressions = [{ id: regressionId }]
+      }
+
+      fetch(getTriagesAPIUrl(), {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }).then((response) => {
+        if (!response.ok) {
+          response.json().then((data) => {
+            let errorMessage = 'invalid response returned from server'
+            if (data?.code) {
+              errorMessage =
+                'error creating triage entry: ' +
+                data.code +
+                ': ' +
+                data.message
+            }
+            console.error(errorMessage)
+            setAlertText(errorMessage)
+            setAlertSeverity('error')
+          })
+          return
+        }
+
+        setAlertText('successfully created triage entry')
+        setAlertSeverity('success')
+        handleFormCompletion()
+      })
+    }
+  }
+
+  const triageTypeOptions = [
+    'type',
+    'ci-infra',
+    'product-infra',
+    'product',
+    'test',
+  ]
+
+  return (
+    <div className={classes.triageForm}>
+      <TextField
+        name="url"
+        label="Jira URL"
+        value={triageEntryData.url}
+        onChange={handleTriageChange}
+      />
+      <TextField
+        name="description"
+        label="Description"
+        value={triageEntryData.description}
+        onChange={handleTriageChange}
+      />
+      <Select
+        name="type"
+        label="Type"
+        value={triageEntryData.type}
+        onChange={handleTriageChange}
+      >
+        {triageTypeOptions.map((option, index) => (
+          <MenuItem key={index} value={option}>
+            {option}
+          </MenuItem>
+        ))}
+      </Select>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={handleTriageEntrySubmit}
+      >
+        Create Entry
+      </Button>
+      {triageValidationErrors && (
+        <FormHelperText className={classes.validationErrors}>
+          {triageValidationErrors.map((text, index) => (
+            <span key={index}>
+              {text}
+              <br />
+            </span>
+          ))}
+        </FormHelperText>
+      )}
+    </div>
+  )
+}
+
+TriageFields.propTypes = {
+  regressionId: PropTypes.number,
+  setAlertText: PropTypes.func.isRequired,
+  setAlertSeverity: PropTypes.func.isRequired,
+  triageEntryData: PropTypes.object.isRequired,
+  setTriageEntryData: PropTypes.func.isRequired,
+  handleFormCompletion: PropTypes.func.isRequired,
+}

--- a/sippy-ng/src/component_readiness/UpsertTriageModal.js
+++ b/sippy-ng/src/component_readiness/UpsertTriageModal.js
@@ -1,0 +1,254 @@
+import {
+  Button,
+  DialogActions,
+  MenuItem,
+  Select,
+  Snackbar,
+  Tab,
+  Tabs,
+} from '@mui/material'
+import { getTriagesAPIUrl, jiraUrlPrefix } from './CompReadyUtils'
+import Alert from '@mui/material/Alert'
+import Dialog from '@mui/material/Dialog'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import PropTypes from 'prop-types'
+import React, { Fragment } from 'react'
+import TriageFields from './TriageFields'
+
+export default function UpsertTriageModal({
+  regressionId,
+  setHasBeenTriaged,
+  buttonText,
+}) {
+  const [triages, setTriages] = React.useState([])
+  const [triageModalOpen, setTriageModalOpen] = React.useState(false)
+  const handleTriageModalOpen = () => {
+    // Only get all existing entries when actually adding/editing a triage
+    fetch(getTriagesAPIUrl())
+      .then((response) => {
+        if (response.status !== 200) {
+          throw new Error(
+            `API call failed ${getTriagesAPIUrl()} Returned + ${
+              response.status
+            }`
+          )
+        }
+        return response.json()
+      })
+      .then((triages) => {
+        const filtered = triages.filter(
+          (triage) =>
+            !triage.regressions.some(
+              (regression) => regression.id === regressionId
+            )
+        )
+        setTriages(filtered)
+        if (filtered.length > 0) {
+          setExistingTriageID(filtered[0].id)
+        }
+      })
+      .catch((error) => {
+        setAlertText('Error retrieving existing triage records')
+        setAlertSeverity('error')
+        console.error(error)
+      })
+    setTriageModalOpen(true)
+  }
+  const handleTriageModalClosed = () => {
+    setTriageModalOpen(false)
+  }
+
+  const [existingTriageID, setExistingTriageID] = React.useState(0)
+  const handleExistingTriageChange = (event) => {
+    setExistingTriageID(event.target.value)
+  }
+
+  const handleAddToExistingTriageSubmit = () => {
+    const existingTriage = triages.find((t) => t.id === existingTriageID)
+
+    const updatedTriage = {
+      ...existingTriage,
+      regressions: [...existingTriage.regressions, { id: regressionId }],
+    }
+
+    fetch(getTriagesAPIUrl() + '/' + existingTriage.id, {
+      method: 'PUT',
+      body: JSON.stringify(updatedTriage),
+    }).then((response) => {
+      if (!response.ok) {
+        response.json().then((data) => {
+          let errorMessage = 'invalid response returned from server'
+          if (data?.code) {
+            errorMessage =
+              'error adding test to triage entry: ' +
+              data.code +
+              ': ' +
+              data.message
+          }
+          console.error(errorMessage)
+          setAlertText(errorMessage)
+          setAlertSeverity('error')
+        })
+        return
+      }
+
+      setAlertText(
+        'successfully added test to triage record: ' +
+          formatTriageURLDescription(existingTriage)
+      )
+      setAlertSeverity('success')
+      if (triages.length > 0) {
+        setExistingTriageID(triages[0].id) //reset the form to the first element
+      }
+      completeTriageSubmission()
+    })
+  }
+
+  const [newTriageEntryData, setNewTriageEntryData] = React.useState({
+    url: '',
+    type: 'type',
+    description: '',
+  })
+
+  const handleNewTriageFormCompletion = () => {
+    setNewTriageEntryData({
+      url: '',
+      type: 'type',
+      description: '',
+    })
+    setTriageModalOpen(false)
+    completeTriageSubmission()
+  }
+
+  const completeTriageSubmission = () => {
+    setTriageModalOpen(false)
+    // allow a couple seconds to view the success message before the page gets reloaded
+    const timer = setTimeout(() => {
+      setHasBeenTriaged(true)
+    }, 2000)
+    return () => clearTimeout(timer)
+  }
+
+  const [tabIndex, setTabIndex] = React.useState(0)
+  const handleTabChange = (event, newValue) => {
+    setTabIndex(newValue)
+  }
+
+  const [alertText, setAlertText] = React.useState('')
+  const [alertSeverity, setAlertSeverity] = React.useState('success')
+  const handleAlertClose = (event, reason) => {
+    if (reason === 'clickaway') {
+      return
+    }
+    setAlertText('')
+    setAlertSeverity('success')
+  }
+
+  const formatTriageURLDescription = (triage) => {
+    let url = triage.url
+    if (url.startsWith(jiraUrlPrefix)) {
+      url = url.slice(jiraUrlPrefix.length)
+    }
+    return url + ' - ' + triage.description
+  }
+
+  const addToExisting = tabIndex === 0
+  const addToNew = tabIndex === 1
+
+  return (
+    <Fragment>
+      <Snackbar
+        open={alertText.length > 0}
+        autoHideDuration={10000}
+        onClose={handleAlertClose}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      >
+        <Alert onClose={handleAlertClose} severity={alertSeverity}>
+          {alertText}
+        </Alert>
+      </Snackbar>
+      <Button
+        sx={{ margin: '10px 0' }}
+        variant="contained"
+        onClick={handleTriageModalOpen}
+      >
+        {buttonText}
+      </Button>
+      <Dialog
+        fullWidth
+        maxWidth="md"
+        open={triageModalOpen}
+        onClose={handleTriageModalClosed}
+      >
+        <DialogTitle>Add Triage</DialogTitle>
+        <DialogContent>
+          <Tabs
+            value={tabIndex}
+            onChange={handleTabChange}
+            indicatorColor="secondary"
+            textColor="primary"
+            variant="fullWidth"
+          >
+            <Tab label="Existing Triage" />
+            <Tab label="New Triage" />
+          </Tabs>
+          {addToExisting && (
+            <Fragment>
+              <h3>Add to existing Triage</h3>
+              <Select
+                id="existing-triage"
+                name="existing-triage"
+                label="Existing Triage"
+                value={existingTriageID}
+                onChange={handleExistingTriageChange}
+              >
+                {triages.map((triageEntry, index) => (
+                  <MenuItem key={index} value={triageEntry.id}>
+                    {formatTriageURLDescription(triageEntry)}
+                  </MenuItem>
+                ))}
+              </Select>
+              <Button
+                variant="contained"
+                color="primary"
+                sx={{ margin: '0 10px' }}
+                onClick={handleAddToExistingTriageSubmit}
+              >
+                Add to Entry
+              </Button>
+            </Fragment>
+          )}
+          {addToNew && (
+            <Fragment>
+              <h3>Add to new Triage</h3>
+              <TriageFields
+                regressionId={regressionId}
+                setAlertText={setAlertText}
+                setAlertSeverity={setAlertSeverity}
+                triageEntryData={newTriageEntryData}
+                handleFormCompletion={handleNewTriageFormCompletion}
+                setTriageEntryData={setNewTriageEntryData}
+              />
+            </Fragment>
+          )}
+        </DialogContent>
+        <DialogActions sx={{ justifyContent: 'flex-start' }}>
+          <Button
+            variant="contained"
+            color="secondary"
+            onClick={handleTriageModalClosed}
+          >
+            CLOSE
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Fragment>
+  )
+}
+
+UpsertTriageModal.propTypes = {
+  regressionId: PropTypes.number,
+  setHasBeenTriaged: PropTypes.func.isRequired,
+  buttonText: PropTypes.string.isRequired,
+}


### PR DESCRIPTION
This refactors as much of the form logic from the `RegressedTestsModal` as I could into a new `TriageFields` component that is used in the original location, and in a new `UpsertTriageModal` from the `CompReadyTestReport`. It allows for the association of the test to either an existing, or new, triage entry. At that point, the page is reloaded, and the status icon is updated to reflect the triage. The new modal is named `Upsert` because I plan on reusing it to edit a triage in other ways from the, yet-to-be-created, triage page. 