### PR TITLE
MCO-1652: Add MCO suite tracking

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -704,6 +704,7 @@ func setProcedure(_ logrus.FieldLogger, variants map[string]string, jobName stri
 		{"-cert-rotation-shutdown-", "cert-rotation-shutdown"},
 		{"-console-operator-", "console-operator"},
 		{"-ipsec", "ipsec"},
+		{"-machine-config-operator", "machine-config-operator"},
 	}
 
 	for _, entry := range procedurePatterns {


### PR DESCRIPTION
Follow up to https://github.com/openshift/release/pull/64752 and https://github.com/openshift/origin/pull/29776

Just a draft for now, but since the original tests were added to serial directly and have reached the necessary pass rates before, I went ahead and added it to the views as well for 4.20.