### PR TITLE
TRT-2120: Enable sippy e2e db tests and prevent port collisions

### DIFF
--- a/e2e-scripts/sippy-e2e-sippy-e2e-test-commands.sh
+++ b/e2e-scripts/sippy-e2e-sippy-e2e-test-commands.sh
@@ -135,4 +135,5 @@ ${KUBECTL_CMD} -n sippy-e2e get svc,ep
 
 ${KUBECTL_CMD} -n sippy-e2e delete secret regcred
 
-go test ./test/e2e/... -v
+# only 1 in parallel, some tests will clash if run at the same time
+go test ./test/e2e/... -v -p 1

--- a/pkg/api/componentreadiness/regressiontracker.go
+++ b/pkg/api/componentreadiness/regressiontracker.go
@@ -72,7 +72,9 @@ func (prs *PostgresRegressionStore) OpenRegression(view crtype.View, newRegresse
 		Opened:      time.Now(),
 		Variants:    variants,
 		MaxFailures: newRegressedTest.SampleStats.FailureCount,
-		LastFailure: sql.NullTime{Valid: true, Time: *newRegressedTest.LastFailure},
+	}
+	if newRegressedTest.LastFailure != nil {
+		newRegression.LastFailure = sql.NullTime{Valid: true, Time: *newRegressedTest.LastFailure}
 	}
 	res := prs.dbc.DB.Create(newRegression)
 	if res.Error != nil {


### PR DESCRIPTION
I saw failures intermittently on the port 8080 which makes me think two pods on the same CI node both running sippy e2e at once may conflict? Trying random ports.

Also opening up psql access again with a random port, so we can enable some of the tests that use direct psql.