### PR TITLE
TRT-2089: utilize triages returned in the main test_details report

### DIFF
--- a/pkg/api/componentreadiness/triage.go
+++ b/pkg/api/componentreadiness/triage.go
@@ -22,14 +22,10 @@ func GetTriage(dbc *db.DB, id int) (models.Triage, error) {
 	return existingTriage, res.Error
 }
 
-func ListTriages(dbc *db.DB, regressionID string) ([]models.Triage, error) {
+func ListTriages(dbc *db.DB) ([]models.Triage, error) {
 	var triages []models.Triage
 	var err error
-	if regressionID != "" {
-		triages, err = query.TriagesForRegressionID(dbc, regressionID)
-	} else {
-		triages, err = query.ListTriages(dbc)
-	}
+	triages, err = query.ListTriages(dbc)
 	for i := range triages {
 		injectHATEOASLinks(&triages[i])
 	}

--- a/pkg/db/query/triage_queries.go
+++ b/pkg/db/query/triage_queries.go
@@ -15,20 +15,6 @@ func ListTriages(dbc *db.DB) ([]models.Triage, error) {
 	return triages, res.Error
 }
 
-func TriagesForRegressionID(dbc *db.DB, regressionID string) ([]models.Triage, error) {
-	var triages []models.Triage
-	res := dbc.DB.
-		Joins("JOIN triage_regressions trr ON trr.triage_id = triages.id").
-		Where("trr.test_regression_id = ?", regressionID).
-		Preload("Bug").
-		Preload("Regressions").
-		Find(&triages)
-	if res.Error != nil {
-		log.WithError(res.Error).Error("error finding triages")
-	}
-	return triages, res.Error
-}
-
 func ListOpenRegressions(dbc *db.DB, release string) ([]*models.TestRegression, error) {
 	var openRegressions []*models.TestRegression
 	res := dbc.DB.

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1253,8 +1253,7 @@ func (s *Server) jsonTriages(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		regressionID := param.SafeRead(req, "regressionId")
-		triages, err := componentreadiness.ListTriages(s.db, regressionID)
+		triages, err := componentreadiness.ListTriages(s.db)
 		if err != nil {
 			failureResponse(w, http.StatusInternalServerError, err.Error())
 			return

--- a/pkg/util/param/param.go
+++ b/pkg/util/param/param.go
@@ -52,7 +52,6 @@ var paramRegexp = map[string]*regexp.Regexp{
 	"samplePROrg":      nameRegexp,
 	"samplePRRepo":     nameRegexp,
 	"samplePRNumber":   uintRegexp,
-	"regressionId":     uintRegexp,
 	// jobartifacts params
 	"prowJobRuns":        regexp.MustCompile(`^\d+(,\d+)*$`), // comma-separated integers
 	"pathGlob":           nonEmptyRegex,                      // a glob can be anything

--- a/sippy-ng/src/component_readiness/TriagedRegressions.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressions.js
@@ -15,10 +15,15 @@ export default function TriagedRegressions(props) {
       if (event[0] === entry.id) selectedTriagedEntry = entry
     })
 
-    props.eventEmitter.emit(
-      'triagedEntrySelectionChanged',
-      selectedTriagedEntry.regressions
-    )
+    if (
+      selectedTriagedEntry.regressions !== 'undefined' &&
+      selectedTriagedEntry.regressions.length > 0
+    ) {
+      props.eventEmitter.emit(
+        'triagedEntrySelectionChanged',
+        selectedTriagedEntry.regressions
+      )
+    }
   }
 
   const columns = [


### PR DESCRIPTION
There is a caveat here, we don't have the regression data included in the response for tests other than the one we are displaying. This means that we cannot display other tests that are associated to this regression in the table. I believe this is fine, however.