### PR TITLE
TRT-2105: intervals for payload-job runs

### DIFF
--- a/cmd/sippy-daemon/main.go
+++ b/cmd/sippy-daemon/main.go
@@ -25,11 +25,10 @@ import (
 var logLevel = "info"
 
 type SippyDaemonFlags struct {
-	BigQueryFlags       *flags.BigQueryFlags
-	CacheFlags          *flags.CacheFlags
-	DBFlags             *flags.PostgresFlags
-	GoogleCloudFlags    *flags.GoogleCloudFlags
-	GoogleStorageBucket string
+	BigQueryFlags    *flags.BigQueryFlags
+	CacheFlags       *flags.CacheFlags
+	DBFlags          *flags.PostgresFlags
+	GoogleCloudFlags *flags.GoogleCloudFlags
 
 	GithubCommenterFlags *flags.GithubCommenterFlags
 	MetricsAddr          string
@@ -42,7 +41,6 @@ func NewSippyDaemonFlags() *SippyDaemonFlags {
 		CacheFlags:           flags.NewCacheFlags(),
 		GithubCommenterFlags: flags.NewGithubCommenterFlags(),
 		GoogleCloudFlags:     flags.NewGoogleCloudFlags(),
-		GoogleStorageBucket:  "test-platform-results",
 	}
 }
 
@@ -53,7 +51,6 @@ func (f *SippyDaemonFlags) BindFlags(fs *pflag.FlagSet) {
 	f.GithubCommenterFlags.BindFlags(fs)
 	f.GoogleCloudFlags.BindFlags(fs)
 
-	fs.StringVar(&f.GoogleStorageBucket, "google-storage-bucket", f.GoogleStorageBucket, "GCS bucket to pull artifacts from")
 	fs.StringVar(&f.MetricsAddr, "listen-metrics", f.MetricsAddr, "The address to serve prometheus metrics on (default :2112)")
 }
 
@@ -118,7 +115,7 @@ func NewSippyDaemonCommand() *cobra.Command {
 				// get comment data, get existing comments, possible delete existing, and adding the comment
 				// could  lower to 3 seconds if we need, most writes likely won't have to delete
 				processes = append(processes, sippyserver.NewWorkProcessor(dbc,
-					gcsClient.Bucket(f.GoogleStorageBucket),
+					gcsClient.Bucket(f.GoogleCloudFlags.StorageBucket),
 					10, bigQueryClient, 5*time.Minute, 5*time.Second, ghCommenter, f.GithubCommenterFlags.CommentProcessingDryRun))
 			}
 

--- a/cmd/sippy/component_readiness.go
+++ b/cmd/sippy/component_readiness.go
@@ -178,6 +178,7 @@ func (f *ComponentReadinessFlags) runServerMode() error {
 		&resources.Static,
 		dbc,
 		gcsClient,
+		f.GoogleCloudFlags.StorageBucket,
 		bigQueryClient,
 		nil,
 		cacheClient,

--- a/cmd/sippy/serve.go
+++ b/cmd/sippy/serve.go
@@ -151,6 +151,7 @@ func NewServeCommand() *cobra.Command {
 				&resources.Static,
 				dbc,
 				gcsClient,
+				f.GoogleCloudFlags.StorageBucket,
 				bigQueryClient,
 				pinnedDateTime,
 				cacheClient,

--- a/pkg/api/jobrunintervals/job_run_intervals.go
+++ b/pkg/api/jobrunintervals/job_run_intervals.go
@@ -21,8 +21,7 @@ import (
 // 1) using a GCS path that was calculated and passed in (we can retrieve intervals immediately)
 // 2) looking up the url given the jobRunID and extracting the prow job name (we need to wait until the sippyDB is populated)
 // If the GCS path could not be calculated, it will be empty.
-func JobRunIntervals(gcsClient *storage.Client, dbc *db.DB, jobRunID int64, gcsPath string,
-	intervalFile string, logger *log.Entry) (*apitype.EventIntervalList, error) {
+func JobRunIntervals(gcsClient *storage.Client, dbc *db.DB, jobRunID int64, gcsPath string, intervalFile string, logger *log.Entry) (*apitype.EventIntervalList, error) {
 
 	jobRun, err := api.FetchJobRun(dbc, jobRunID, false, nil, logger)
 	if err != nil {

--- a/pkg/apis/api/interval.go
+++ b/pkg/apis/api/interval.go
@@ -32,6 +32,7 @@ type EventInterval struct {
 type EventIntervalList struct {
 	Items                  []EventInterval `json:"items"`
 	IntervalFilesAvailable []string        `json:"intervalFilesAvailable"`
+	JobRunURL              string          `json:"jobRunURL"`
 }
 
 // LegacyEventInterval is the previous temporary schema we used before we completed the port to the new API.

--- a/pkg/flags/google.go
+++ b/pkg/flags/google.go
@@ -11,11 +11,13 @@ import (
 type GoogleCloudFlags struct {
 	ServiceAccountCredentialFile string
 	OAuthClientCredentialFile    string
+	StorageBucket                string
 }
 
 func NewGoogleCloudFlags() *GoogleCloudFlags {
 	return &GoogleCloudFlags{
 		ServiceAccountCredentialFile: os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"),
+		StorageBucket:                DefaultGoogleStorageBucket,
 	}
 }
 
@@ -29,6 +31,11 @@ func (f *GoogleCloudFlags) BindFlags(fs *pflag.FlagSet) {
 		"google-oauth-credential-file",
 		f.OAuthClientCredentialFile,
 		"location of a credential file described by https://developers.google.com/people/quickstart/go, setup from https://cloud.google.com/bigquery/docs/authentication/end-user-installed#client-credentials")
+
+	fs.StringVar(&f.StorageBucket,
+		"google-storage-bucket",
+		f.StorageBucket,
+		"default storage bucket in Google Cloud Storage to use for job results")
 }
 
 func (f *GoogleCloudFlags) Validate() error {
@@ -38,3 +45,5 @@ func (f *GoogleCloudFlags) Validate() error {
 
 	return nil
 }
+
+const DefaultGoogleStorageBucket = "test-platform-results"

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -64,6 +64,7 @@ func NewServer(
 	static fs.FS,
 	dbClient *db.DB,
 	gcsClient *storage.Client,
+	gcsBucket string,
 	bigQueryClient *bigquery.Client,
 	pinnedDateTime *time.Time,
 	cacheClient cache.Cache,
@@ -86,6 +87,7 @@ func NewServer(
 		bigQueryClient:       bigQueryClient,
 		pinnedDateTime:       pinnedDateTime,
 		gcsClient:            gcsClient,
+		gcsBucket:            gcsBucket,
 		cache:                cacheClient,
 		crTimeRoundingFactor: crTimeRoundingFactor,
 		views:                views,
@@ -126,6 +128,7 @@ type Server struct {
 	bigQueryClient       *bigquery.Client
 	pinnedDateTime       *time.Time
 	gcsClient            *storage.Client
+	gcsBucket            string
 	cache                cache.Cache
 	crTimeRoundingFactor time.Duration
 	capabilities         []string
@@ -1166,7 +1169,7 @@ func (s *Server) jsonJobRunIntervals(w http.ResponseWriter, req *http.Request) {
 		// JobName was not passed.
 		gcsPath = ""
 	}
-	result, err := jobrunintervals.JobRunIntervals(s.gcsClient, s.db, jobRunID, gcsPath,
+	result, err := jobrunintervals.JobRunIntervals(s.gcsClient, s.db, jobRunID, s.gcsBucket, gcsPath,
 		intervalFile, logger.WithField("func", "JobRunIntervals"))
 	if err != nil {
 		failureResponse(w, http.StatusBadRequest, err.Error())

--- a/sippy-ng/src/prow_job_runs/IntervalsChart.js
+++ b/sippy-ng/src/prow_job_runs/IntervalsChart.js
@@ -10,6 +10,7 @@ import {
   Box,
   Button,
   Checkbox,
+  Link,
   MenuItem,
   Select,
   TextField,
@@ -189,6 +190,7 @@ export default function IntervalsChart(props) {
   const [isLoaded, setLoaded] = React.useState(false)
   const [eventIntervals, setEventIntervals] = React.useState([])
   const [filteredIntervals, setFilteredIntervals] = React.useState([])
+  const [jobRunUrl, setJobRunUrl] = React.useState('')
 
   // Interval colors will hold the colors calculated by invoking intervalColorizers functions
   // against each interval. Anything that matches will get added to this map and passed to the
@@ -275,6 +277,7 @@ export default function IntervalsChart(props) {
       })
       .then((json) => {
         if (json != null) {
+          setJobRunUrl(json.jobRunURL)
           // Process and filter our intervals
           let tmpIntervals = json.items
           mutateIntervals(tmpIntervals)
@@ -541,8 +544,14 @@ export default function IntervalsChart(props) {
   return (
     <Fragment>
       <p>
-        Loaded {eventIntervals.length} intervals from GCS, filtered down to{' '}
-        {filteredIntervals.length}.
+        Loaded {eventIntervals.length} intervals from{' '}
+        <Link
+          onClick={() => window.open(jobRunUrl)}
+          style={{ cursor: 'pointer' }}
+        >
+          GCS job run
+        </Link>
+        , filtered down to {filteredIntervals.length}.
       </p>
       <div className={classes.filterRow}>
         Categories:


### PR DESCRIPTION
the intervals page insisted on finding a job run in the DB even though it has what it needs in most cases from the parameters. rather than break for jobs that don't have entries in the DB (like when invoked with `/payload-job`), the DB lookup is now optional (but authoritative if present).

i think this covers all of the cases we will actually see. we could futher fall back to looking up the job in BQ `jobs` table, but it looks unnecessary.

also there's now a link to the job run.