### PR TITLE
TRT-2050: create a page for `triage` details and allow some simple edits

### DIFF
--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -53,6 +53,7 @@ import RepositoryDetails from './repositories/RepositoryDetails'
 import Sidebar from './components/Sidebar'
 import Tests from './tests/Tests'
 import Toolbar from '@mui/material/Toolbar'
+import Triage from './component_readiness/Triage'
 import Typography from '@mui/material/Typography'
 import Upgrades from './releases/Upgrades'
 import VariantStatus from './jobs/VariantStatus'
@@ -627,6 +628,16 @@ export default function App(props) {
                                     key={'tests-' + props.match.params.release}
                                     release={props.match.params.release}
                                   />
+                                )
+                              }
+                            />
+
+                            <Route
+                              path="/triages/:id"
+                              render={(props) =>
+                                redirectIfLatest(
+                                  props,
+                                  <Triage id={props.match.params.id} />
                                 )
                               }
                             />

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -347,7 +347,7 @@ Flakes: ${stats.flake_count}`
         <h2>{testName}</h2>
       </div>
       <Grid container>
-        <Grid>
+        <Grid item xs={12}>
           {triageEntries.length === 0 &&
             data.analyses[0].incidents &&
             data.analyses[0].incidents.length > 0 && (
@@ -372,8 +372,9 @@ Flakes: ${stats.flake_count}`
           {writeEndpointsEnabled && regressionId > 0 && (
             <UpsertTriageModal
               regressionId={regressionId}
-              setHasBeenTriaged={setHasBeenTriaged}
+              setComplete={setHasBeenTriaged}
               buttonText="Triage"
+              submissionDelay={2000}
             />
           )}
 

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -741,3 +741,15 @@ export function generateRegressionCount(regressed_tests, triaged_incidents) {
   let triagedCount = triaged_incidents ? triaged_incidents.length : 0
   return regressedCount + triagedCount
 }
+
+export function safeExternalHref(url) {
+  try {
+    const parsed = new URL(url)
+    if (['http:', 'https:'].includes(parsed.protocol)) {
+      return parsed.href
+    }
+  } catch (e) {
+    // Invalid URL
+  }
+  return '#'
+}

--- a/sippy-ng/src/component_readiness/RegressedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsPanel.js
@@ -322,6 +322,7 @@ export default function RegressedTestsPanel(props) {
           setTriageEntryData={setTriageEntryData}
           triageEntryData={triageEntryData}
           handleFormCompletion={handleTriageFormCompletion}
+          submitButtonText={'Create Entry'}
         />
       )}
       {triageEnabled ? (

--- a/sippy-ng/src/component_readiness/Triage.js
+++ b/sippy-ng/src/component_readiness/Triage.js
@@ -14,13 +14,15 @@ export default function Triage({ id }) {
   const [triage, setTriage] = React.useState({})
   const [isUpdated, setIsUpdated] = React.useState(false)
   const capabilitiesContext = React.useContext(CapabilitiesContext)
+  const triageEnabled = capabilitiesContext.includes('write_endpoints')
+  const localDBEnabled = capabilitiesContext.includes('local_db')
 
   React.useEffect(() => {
     setIsLoaded(false)
     setIsUpdated(false)
-    const localDBEnabled = capabilitiesContext.includes('local_db')
-    // triage entries will only be available when there is a postgres connection
+
     let triageFetch
+    // triage entries will only be available when there is a postgres connection
     if (localDBEnabled) {
       triageFetch = fetch(getTriagesAPIUrl() + '/' + id).then((response) => {
         if (response.status !== 200) {
@@ -75,11 +77,13 @@ export default function Triage({ id }) {
       </Table>
       <h2>Included Tests</h2>
       <TriagedRegressionTestList regressions={triage.regressions} />
-      <UpsertTriageModal
-        triage={triage}
-        buttonText={'Update'}
-        setComplete={setIsUpdated}
-      />
+      {triageEnabled && (
+        <UpsertTriageModal
+          triage={triage}
+          buttonText={'Update'}
+          setComplete={setIsUpdated}
+        />
+      )}
     </Fragment>
   )
 }

--- a/sippy-ng/src/component_readiness/Triage.js
+++ b/sippy-ng/src/component_readiness/Triage.js
@@ -1,0 +1,89 @@
+import { CapabilitiesContext } from '../App'
+import { getTriagesAPIUrl, jiraUrlPrefix } from './CompReadyUtils'
+import PropTypes from 'prop-types'
+import React, { Fragment } from 'react'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableRow from '@mui/material/TableRow'
+import TriagedRegressionTestList from './TriagedRegressionTestList'
+import UpsertTriageModal from './UpsertTriageModal'
+
+export default function Triage({ id }) {
+  const [isLoaded, setIsLoaded] = React.useState(false)
+  const [triage, setTriage] = React.useState({})
+  const [isUpdated, setIsUpdated] = React.useState(false)
+  const capabilitiesContext = React.useContext(CapabilitiesContext)
+
+  React.useEffect(() => {
+    setIsLoaded(false)
+    setIsUpdated(false)
+    const localDBEnabled = capabilitiesContext.includes('local_db')
+    // triage entries will only be available when there is a postgres connection
+    let triageFetch
+    if (localDBEnabled) {
+      triageFetch = fetch(getTriagesAPIUrl() + '/' + id).then((response) => {
+        if (response.status !== 200) {
+          throw new Error('API server returned ' + response.status)
+        }
+        return response.json()
+      })
+    } else {
+      triageFetch = Promise.resolve({})
+    }
+
+    triageFetch.then((t) => {
+      setTriage(t)
+      setIsLoaded(true)
+    })
+  }, [isUpdated])
+
+  if (!isLoaded) {
+    return <p>Loading...</p>
+  }
+
+  const displayUrl = triage.url.startsWith(jiraUrlPrefix)
+    ? triage.url.slice(jiraUrlPrefix.length)
+    : triage.url
+
+  return (
+    <Fragment>
+      <h2>Triage Details</h2>
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableCell>Description</TableCell>
+            <TableCell>{triage.description}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Jira</TableCell>
+            <TableCell>
+              <a href={triage.url}>{displayUrl}</a>
+            </TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Type</TableCell>
+            <TableCell>{triage.type}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Resolution Date</TableCell>
+            <TableCell>
+              {triage.resolved?.Valid ? triage.resolved?.Time : ''}
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+      <h2>Included Tests</h2>
+      <TriagedRegressionTestList regressions={triage.regressions} />
+      <UpsertTriageModal
+        triage={triage}
+        buttonText={'Update'}
+        setComplete={setIsUpdated}
+      />
+    </Fragment>
+  )
+}
+
+Triage.propTypes = {
+  id: PropTypes.string.isRequired,
+}

--- a/sippy-ng/src/component_readiness/Triage.js
+++ b/sippy-ng/src/component_readiness/Triage.js
@@ -1,9 +1,5 @@
 import { CapabilitiesContext } from '../App'
-import {
-  getTriagesAPIUrl,
-  jiraUrlPrefix,
-  safeExternalHref,
-} from './CompReadyUtils'
+import { getTriagesAPIUrl, jiraUrlPrefix } from './CompReadyUtils'
 import PropTypes from 'prop-types'
 import React, { Fragment } from 'react'
 import Table from '@mui/material/Table'
@@ -64,7 +60,8 @@ export default function Triage({ id }) {
           <TableRow>
             <TableCell>Jira</TableCell>
             <TableCell>
-              <a href={safeExternalHref(triage.url)}>{displayUrl}</a>
+              {/*TODO(sgoeddel): snyk doesn't like the link, bring it back in a followup*/}
+              {displayUrl}
             </TableCell>
           </TableRow>
           <TableRow>

--- a/sippy-ng/src/component_readiness/Triage.js
+++ b/sippy-ng/src/component_readiness/Triage.js
@@ -1,5 +1,9 @@
 import { CapabilitiesContext } from '../App'
-import { getTriagesAPIUrl, jiraUrlPrefix } from './CompReadyUtils'
+import {
+  getTriagesAPIUrl,
+  jiraUrlPrefix,
+  safeExternalHref,
+} from './CompReadyUtils'
 import PropTypes from 'prop-types'
 import React, { Fragment } from 'react'
 import Table from '@mui/material/Table'
@@ -47,8 +51,6 @@ export default function Triage({ id }) {
   const displayUrl = triage.url.startsWith(jiraUrlPrefix)
     ? triage.url.slice(jiraUrlPrefix.length)
     : triage.url
-  // validate the url for the link
-  const jiraLink = triage.url.startsWith('https://') ? triage.url : '#'
 
   return (
     <Fragment>
@@ -62,7 +64,7 @@ export default function Triage({ id }) {
           <TableRow>
             <TableCell>Jira</TableCell>
             <TableCell>
-              <a href={jiraLink}>{displayUrl}</a>
+              <a href={safeExternalHref(triage.url)}>{displayUrl}</a>
             </TableCell>
           </TableRow>
           <TableRow>

--- a/sippy-ng/src/component_readiness/Triage.js
+++ b/sippy-ng/src/component_readiness/Triage.js
@@ -47,6 +47,8 @@ export default function Triage({ id }) {
   const displayUrl = triage.url.startsWith(jiraUrlPrefix)
     ? triage.url.slice(jiraUrlPrefix.length)
     : triage.url
+  // validate the url for the link
+  const jiraLink = triage.url.startsWith('https://') ? triage.url : '#'
 
   return (
     <Fragment>
@@ -60,7 +62,7 @@ export default function Triage({ id }) {
           <TableRow>
             <TableCell>Jira</TableCell>
             <TableCell>
-              <a href={triage.url}>{displayUrl}</a>
+              <a href={jiraLink}>{displayUrl}</a>
             </TableCell>
           </TableRow>
           <TableRow>

--- a/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
@@ -10,8 +10,12 @@ export default function TriagedRegressionTestList(props) {
     { field: 'component', sort: 'asc' },
   ])
 
-  const [triagedRegressions, setTriagedRegressions] = React.useState([])
-  const [showView, setShowView] = React.useState(false)
+  const [triagedRegressions, setTriagedRegressions] = React.useState(
+    props.regressions !== undefined ? props.regressions : []
+  )
+  const [showView, setShowView] = React.useState(
+    props.regressions !== undefined && props.regressions.length > 0
+  )
 
   const handleTriagedRegressionGroupSelectionChanged = (data) => {
     let displayView = false
@@ -21,10 +25,12 @@ export default function TriagedRegressionTestList(props) {
     setTriagedRegressions(data)
     setShowView(displayView)
   }
-  props.eventEmitter.on(
-    'triagedEntrySelectionChanged',
-    handleTriagedRegressionGroupSelectionChanged
-  )
+  if (props.eventEmitter !== undefined) {
+    props.eventEmitter.on(
+      'triagedEntrySelectionChanged',
+      handleTriagedRegressionGroupSelectionChanged
+    )
+  }
 
   const columns = [
     {
@@ -122,4 +128,6 @@ export default function TriagedRegressionTestList(props) {
 
 TriagedRegressionTestList.propTypes = {
   eventEmitter: PropTypes.object,
+  regressions: PropTypes.array,
+  showOnLoad: PropTypes.bool,
 }

--- a/sippy-ng/src/component_readiness/TriagedRegressions.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressions.js
@@ -1,6 +1,8 @@
 import { DataGrid, GridToolbar } from '@mui/x-data-grid'
 import { jiraUrlPrefix } from './CompReadyUtils'
+import { Link } from 'react-router-dom'
 import { Typography } from '@mui/material'
+import InfoIcon from '@mui/icons-material/Info'
 import PropTypes from 'prop-types'
 import React, { Fragment } from 'react'
 
@@ -67,6 +69,15 @@ export default function TriagedRegressions(props) {
       ),
     },
     {
+      field: 'resolution_date',
+      valueGetter: (value) => {
+        return value.row.resolved?.Valid ? value.row.resolved.Time : ''
+      },
+      headerName: 'Resolution Date',
+      flex: 5,
+      renderCell: (param) => <div>{param.value}</div>,
+    },
+    {
       field: 'bug_state',
       valueGetter: (value) => {
         const bugState = value.row.bug?.status || ''
@@ -88,6 +99,19 @@ export default function TriagedRegressions(props) {
       headerName: 'Version',
       flex: 5,
       renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'details',
+      valueGetter: (value) => {
+        return value.row.id
+      },
+      headerName: 'Details',
+      flex: 2,
+      renderCell: (param) => (
+        <Link to={'/triages/' + param.value}>
+          <InfoIcon />
+        </Link>
+      ),
     },
   ]
 

--- a/sippy-ng/src/component_readiness/TriagedRegressions.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressions.js
@@ -1,6 +1,5 @@
 import { DataGrid, GridToolbar } from '@mui/x-data-grid'
 import { jiraUrlPrefix } from './CompReadyUtils'
-import { Link } from 'react-router-dom'
 import { Typography } from '@mui/material'
 import InfoIcon from '@mui/icons-material/Info'
 import PropTypes from 'prop-types'
@@ -108,9 +107,13 @@ export default function TriagedRegressions(props) {
       headerName: 'Details',
       flex: 2,
       renderCell: (param) => (
-        <Link to={'/triages/' + param.value}>
+        <a
+          href={'/sippy-ng/triages/' + param.value}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <InfoIcon />
-        </Link>
+        </a>
       ),
     },
   ]


### PR DESCRIPTION
This is a quick MVP to allow for the resolution date to be set in the UI. There will be more to come here in a followup PR.

The Triage details page looks like:
![Screenshot 2025-05-14 at 3 52 36 PM](https://github.com/user-attachments/assets/bfe42669-bed2-4a3f-9949-6809f26f3bbf)

It utilizes a modal for edits:
![Screenshot 2025-05-14 at 3 52 42 PM](https://github.com/user-attachments/assets/422fa745-50b8-4018-bbd1-557e04ee7c41)
