### PR TITLE
TRT-2122: Fix last failure time picking up flakes

### DIFF
--- a/pkg/api/componentreadiness/query/querygenerators.go
+++ b/pkg/api/componentreadiness/query/querygenerators.go
@@ -54,6 +54,7 @@ const (
 						ELSE 2
 					END) AS row_num,
 %s
+				jobs.prowjob_start as prowjob_start,
 				jobs.org,
 				jobs.repo,
 				jobs.pr_number,
@@ -283,6 +284,9 @@ func BuildCommonTestStatusQuery(
 
 	// WARNING: returning additional columns from this query will require explicit parsing in deserializeRowToTestStatus
 	// TODO: jira_component and jira_component_id appear to not be used? Could save bigquery costs if we remove them.
+	// TODO: last_failure here explicitly uses success_val not adjusted_success_val, this ensures we
+	// show the last time the test failed, not flaked. if you enable the flakes as failures feature (which is
+	// non default today), the last failure time will be wrong which can impact things like failed fix detection.
 	queryString := fmt.Sprintf(`WITH latest_component_mapping AS (
 						SELECT *
 						FROM %s.component_mapping cm
@@ -297,7 +301,7 @@ func BuildCommonTestStatusQuery(
 						COUNT(cm.id) AS total_count,
 						SUM(adjusted_success_val) AS success_count,
 						SUM(adjusted_flake_count) AS flake_count,
-						MAX(CASE WHEN adjusted_success_val = 0 THEN modified_time ELSE NULL END) AS last_failure,
+						MAX(CASE WHEN success_val = 0 THEN prowjob_start ELSE NULL END) AS last_failure,
 						ANY_VALUE(cm.component) AS component,
 						ANY_VALUE(cm.capabilities) AS capabilities,
 					FROM (%s)


### PR DESCRIPTION
This looks to have come in with the non-enabled treat flakes as failures
feature, but we mistakenly assumed to do that all the time in the query
for calculating last failure time. As a result, we show tests that have
flaked since their triage resolution as pants on fire when we didn't
actually count a test failure.

Last failure will now be correct for the main use case, but not for
flakes as failures, we'll need to revisit if that feature ever takes off
in a default view.

I've also switched to using prowjob start time for the last failure, not
modified time which I believe is ingestion time. This was confusing as
the test details page shows job runs and their start times.
