### PR TITLE
Fix triaged and resolved regressions staying open forever

### DIFF
--- a/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
+++ b/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
@@ -85,6 +85,10 @@ func (r *RegressionTracker) PreAnalysis(testKey crtype.ReportTestIdentification,
 
 // PostAnalysis adjusts status code (and thus icons) based on the triaged state of open regressions.
 func (r *RegressionTracker) PostAnalysis(testKey crtype.ReportTestIdentification, testStats *crtype.ReportTestStats) error {
+	if testStats.ReportStatus > crtype.SignificantTriagedRegression {
+		// no need to adjust status for triage if this is no longer a regression
+		return nil
+	}
 	if len(r.openRegressions) > 0 {
 		view := r.openRegressions[0].View // grab view from first regression, they were queried only for sample release
 		or := FindOpenRegression(view, testKey.TestID, testKey.Variants, r.openRegressions)


### PR DESCRIPTION
The new middleware did not account for regressions actually clearing the
sample. (oops) If the sample is no longer regressed, we should not be
adjusting status based on whether or not it's triaged and resolved, it's
just gone.

This was causing things to never leave the report.
