### PR TITLE
Hypershift should be blocking in CR for 4.20+

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -33,6 +33,7 @@ component_readiness:
         Installer:
           - ipi
           - upi
+          - hypershift
         JobTier:
           - blocking
           - informing
@@ -55,6 +56,7 @@ component_readiness:
         Topology:
           - ha
           - microshift
+          - external
         CGroupMode:
           - v2
         ContainerRuntime:


### PR DESCRIPTION
I noticed in 4.19, we're not monitoring for regressions in hypershift in CR.  This adds it to the main view for 4.20+