### PR TITLE
Revert "TRT-2044: bugloader: associate mapped tests with bugs"

### DIFF
--- a/pkg/dataloader/bugloader/bugloader.go
+++ b/pkg/dataloader/bugloader/bugloader.go
@@ -15,7 +15,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
 	"gorm.io/gorm/clause"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/sippy/pkg/bigquery"
 	"github.com/openshift/sippy/pkg/db"
@@ -93,7 +92,7 @@ func (bl *BugLoader) Load() {
 	dbExpectedBugs := make([]*models.Bug, 0)
 
 	// Fetch bugs<->test mapping from bigquery
-	testCache, err := query.LoadTestCache(bl.dbc, []string{"TestOwnerships"})
+	testCache, err := query.LoadTestCache(bl.dbc, []string{})
 	if err != nil {
 		bl.errors = append(bl.errors, err)
 		return
@@ -225,15 +224,10 @@ func (bl *BugLoader) Load() {
 func (bl *BugLoader) getTestBugMappings(ctx context.Context, testCache map[string]*models.Test) (map[uint]*models.Bug, error) {
 	bugs := make(map[uint]*models.Bug)
 
-	// `WHERE j.name != upgrade` is because there's a test named just `upgrade` in some junits,
-	// and querying against Jira produces thousands of tickets that mention `upgrade`; so just ignore it.
+	// `WHERE j.name != upgrade` is because there's a test named just `upgrade` in some junits, which querying
+	// Jira for produces thousands of tickets
 	querySQL := fmt.Sprintf(
-		`%s
-		JOIN %s.%s.%s j
-		  ON STRPOS(t.summary, j.name) > 0
-		  OR STRPOS(t.description, j.name) > 0
-		  OR STRPOS(t.comment, j.name ) > 0
-        WHERE j.name != "upgrade"`,
+		`%s CROSS JOIN %s.%s.%s j WHERE j.name != "upgrade" AND (STRPOS(t.summary, j.name) > 0 OR STRPOS(t.description, j.name) > 0 OR STRPOS(t.comment, j.name) > 0)`,
 		TicketDataQuery, ComponentMappingProject, ComponentMappingDataset, ComponentMappingTable)
 	log.Debug(querySQL)
 	q := bl.bqc.BQ.Query(querySQL)
@@ -243,14 +237,9 @@ func (bl *BugLoader) getTestBugMappings(ctx context.Context, testCache map[strin
 		return nil, errors.WithMessage(err, "failed to execute query")
 	}
 
-	// create a lookup of all the tests that are mapped to the same test id
-	testsForUID := MapTestCacheByUniqueID(testCache)
-	// and keep track of the tests we've seen for each bug id so we don't add duplicates
-	testsSeenForBug := make(map[uint]sets.Set[string])
-
 	for {
-		var bqb bigQueryBug
-		err := it.Next(&bqb)
+		var bwt bigQueryBug
+		err := it.Next(&bwt)
 		if errors.Is(err, iterator.Done) {
 			break
 		}
@@ -259,67 +248,31 @@ func (bl *BugLoader) getTestBugMappings(ctx context.Context, testCache map[strin
 		}
 
 		// Make sure data in BQ is sane
-		if bqb.JiraID == "" || bqb.LinkName == "" {
+		if bwt.JiraID == "" || bwt.LinkName == "" {
 			continue
 		}
 
-		jiraID, err := strconv.ParseUint(bqb.JiraID, 10, 64)
+		intID, err := strconv.Atoi(bwt.JiraID)
 		if err != nil {
-			bl.errors = append(bl.errors, errors.WithMessagef(err, "failed to convert jira id %s", bqb.JiraID))
+			bl.errors = append(bl.errors, errors.WithMessagef(err, "failed to convert jira id %s", bwt.JiraID))
 			continue
 		}
-		bqb.ID = uint(jiraID)
+		bwt.ID = uint(intID)
 
-		// look up sippy DB's record for this test name
-		test, found := testCache[bqb.LinkName]
-		if !found {
+		if _, ok := testCache[bwt.LinkName]; !ok {
 			// This is probably common since we're using ci-test-mapping test names, and sippy may not know all of them
-			log.Debugf("test name was in jira issue but not known by sippy: %s", bqb.LinkName)
+			log.Debugf("test name was in jira issue but not known by sippy: %s", bwt.LinkName)
 			continue
 		}
 
-		tests := []models.Test{*test}
-		// if we found test ownership, include all tests from the same ownership
-		for _, mapping := range test.TestOwnerships {
-			if mappedTests, found := testsForUID[mapping.UniqueID]; found {
-				tests = append(tests, mappedTests...)
-			}
+		if _, ok := bugs[bwt.ID]; !ok {
+			bugs[bwt.ID] = bigQueryBugToModel(bwt)
 		}
 
-		// map a bug for this jira id if we haven't already
-		if _, found := bugs[bqb.ID]; !found {
-			bugs[bqb.ID] = bigQueryBugToModel(bqb)
-		}
-
-		// track the tests we've seen for this bug id and add non-duplicates
-		seen := testsSeenForBug[bqb.ID]
-		if seen == nil {
-			seen = sets.New[string]()
-			testsSeenForBug[bqb.ID] = seen
-		}
-		for _, test := range tests {
-			if !seen.Has(test.Name) {
-				seen.Insert(test.Name)
-				bugs[bqb.ID].Tests = append(bugs[bqb.ID].Tests, test)
-			}
-		}
+		bugs[bwt.ID].Tests = append(bugs[bwt.ID].Tests, *testCache[bwt.LinkName])
 	}
 
 	return bugs, nil
-}
-
-// MapTestCacheByUniqueID takes a map of tests by name, with the TestOwnership preloaded, and returns a map of
-// all the tests that share the same unique ID (same TestOwnership).
-func MapTestCacheByUniqueID(testForID map[string]*models.Test) map[string][]models.Test {
-	testForUniqueID := make(map[string][]models.Test, len(testForID))
-	for _, test := range testForID {
-		for _, mapping := range test.TestOwnerships {
-			if mapping.UniqueID != "" {
-				testForUniqueID[mapping.UniqueID] = append(testForUniqueID[mapping.UniqueID], *test)
-			}
-		}
-	}
-	return testForUniqueID
 }
 
 // getJobBugMappings looks for jira cards that contain a job name from the jobs table in bigquery.  We

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -64,9 +64,8 @@ type ProwJobRun struct {
 
 type Test struct {
 	gorm.Model
-	Name           string `gorm:"uniqueIndex"`
-	Bugs           []Bug  `gorm:"many2many:bug_tests;"`
-	TestOwnerships []TestOwnership
+	Name string `gorm:"uniqueIndex"`
+	Bugs []Bug  `gorm:"many2many:bug_tests;"`
 }
 
 // ProwJobRunTest defines a join table linking tests to the job runs they execute in, along with the status for


### PR DESCRIPTION
Not certain this is related but it's suspicious:
```
time="2025-05-21T13:30:57.329Z" level=warning msg="1 errors were encountered while loading database:"
time="2025-05-21T13:30:57.329Z" level=error msg="loader \"bugs\" returned error: error deleting stale bugs: ERROR: update or delete on table \"bugs\" violates foreign key constraint \"fk_triages_bug\" on table \"triages\" (SQLSTATE 23503)"
Error: errors were encountered while loading database, see logs for details
```

Reverts openshift/sippy#2619