### PR TITLE
don't delete bugs anymore

### DIFF
--- a/pkg/db/query/job_queries.go
+++ b/pkg/db/query/job_queries.go
@@ -170,10 +170,11 @@ func LoadBugsForJobs(dbc *db.DB,
 
 	job := models.ProwJob{}
 	q := dbc.DB.Where("id IN ?", jobIDs)
+	timeLimit := "NOW() - last_change_time < interval '14 days'" // filter bugs since we no longer delete them
 	if filterClosed {
-		q = q.Preload("Bugs", "UPPER(status) != 'CLOSED' and UPPER(status) != 'VERIFIED'")
+		q = q.Preload("Bugs", timeLimit+" and UPPER(status) != 'CLOSED' and UPPER(status) != 'VERIFIED'")
 	} else {
-		q = q.Preload("Bugs")
+		q = q.Preload("Bugs", timeLimit)
 	}
 	// TODO: possible bug here, we took an array of job IDs and queried for it, but we only read
 	// the first, and one caller seems to be passing multiple.

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -209,10 +209,11 @@ func LoadBugsForTest(dbc *db.DB, testName string, filterClosed bool) ([]models.B
 
 	test := models.Test{}
 	q := dbc.DB.Where("name = ?", testName)
+	timeLimit := "NOW() - last_change_time < interval '14 days'" // filter bugs since we no longer delete them
 	if filterClosed {
-		q = q.Preload("Bugs", "UPPER(status) != 'CLOSED' and UPPER(status) != 'VERIFIED'")
+		q = q.Preload("Bugs", timeLimit+" and UPPER(status) != 'CLOSED' and UPPER(status) != 'VERIFIED'")
 	} else {
-		q = q.Preload("Bugs")
+		q = q.Preload("Bugs", timeLimit)
 	}
 	res := q.First(&test)
 	if res.Error != nil {


### PR DESCRIPTION
triage records reference bugs and we don't want to remove those. there's no real reason to remove stale bugs, just filter them out of our queries.