### PR TITLE
TRT-2094: add a link to the test_details report for each triage record

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -1,5 +1,4 @@
 import { alpha, InputBase, Typography } from '@mui/material'
-import { CompReadyVarsContext } from './CompReadyVars'
 import { formatInTimeZone } from 'date-fns-tz'
 import { safeEncodeURIComponent } from '../helpers'
 import { styled } from '@mui/styles'
@@ -19,7 +18,7 @@ import orange from './orange.svg'
 import orange_3d from './extreme-orange.svg'
 import orange_3d_triaged from './extreme-orange-triaged.svg'
 import orange_triaged from './orange-triaged.svg'
-import React, { useContext } from 'react'
+import React from 'react'
 import red from './regressed.svg'
 import red_3d from './extreme.svg'
 import red_3d_triaged from './extreme-triaged.svg'
@@ -744,9 +743,12 @@ export function generateTestReport(
 
 // Construct a URL with all existing filters utilizing the necessary info from the regressed test.
 // We pass these arguments to the component that generates the test details report.
-export function generateTestReportForRegressedTest(regressedTest, filterVals) {
+export function generateTestReportForRegressedTest(
+  regressedTest,
+  filterVals,
+  expandEnvironment
+) {
   const environmentVal = formColumnName({ variants: regressedTest.variants })
-  const { expandEnvironment } = useContext(CompReadyVarsContext)
   const safeComponentName = safeEncodeURIComponent(regressedTest.component)
   const safeTestId = safeEncodeURIComponent(regressedTest.test_id)
   const safeTestName = safeEncodeURIComponent(regressedTest.test_name)

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -85,7 +85,11 @@ export default function RegressedTestsModal(props) {
           )}
           {triageEntriesExist && (
             <RegressedTestsTabPanel activeIndex={activeTabIndex} index={1}>
-              <TriagedTestsPanel triageEntries={props.triageEntries} />
+              <TriagedTestsPanel
+                triageEntries={props.triageEntries}
+                allRegressedTests={props.allRegressedTests}
+                filterVals={props.filterVals}
+              />
             </RegressedTestsTabPanel>
           )}
           <RegressedTestsTabPanel activeIndex={activeTabIndex} index={2}>

--- a/sippy-ng/src/component_readiness/RegressedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsPanel.js
@@ -1,4 +1,5 @@
 import { CapabilitiesContext } from '../App'
+import { CompReadyVarsContext } from './CompReadyVars'
 import { DataGrid, GridToolbar } from '@mui/x-data-grid'
 import { FileCopy } from '@mui/icons-material'
 import {
@@ -13,10 +14,11 @@ import Button from '@mui/material/Button'
 import CompSeverityIcon from './CompSeverityIcon'
 import IconButton from '@mui/material/IconButton'
 import PropTypes from 'prop-types'
-import React, { Fragment } from 'react'
+import React, { Fragment, useContext } from 'react'
 import TriageFields from './TriageFields'
 
 export default function RegressedTestsPanel(props) {
+  const { expandEnvironment } = useContext(CompReadyVarsContext)
   const { filterVals, regressedTests, setTriageEntryCreated } = props
   const [sortModel, setSortModel] = React.useState([
     { field: 'component', sort: 'asc' },
@@ -218,7 +220,13 @@ export default function RegressedTestsPanel(props) {
           }}
           className="status"
         >
-          <Link to={generateTestReportForRegressedTest(params.row, filterVals)}>
+          <Link
+            to={generateTestReportForRegressedTest(
+              params.row,
+              filterVals,
+              expandEnvironment
+            )}
+          >
             <CompSeverityIcon
               status={
                 params.row.effective_status

--- a/sippy-ng/src/component_readiness/RegressedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsPanel.js
@@ -1,54 +1,20 @@
 import { CapabilitiesContext } from '../App'
-import { CompReadyVarsContext } from './CompReadyVars'
 import { DataGrid, GridToolbar } from '@mui/x-data-grid'
 import { FileCopy } from '@mui/icons-material'
-import { formColumnName, sortQueryParams } from './CompReadyUtils'
+import {
+  formColumnName,
+  generateTestReportForRegressedTest,
+} from './CompReadyUtils'
 import { Link } from 'react-router-dom'
 import { Popover, Snackbar, Tooltip } from '@mui/material'
-import { relativeTime, safeEncodeURIComponent } from '../helpers'
+import { relativeTime } from '../helpers'
 import Alert from '@mui/material/Alert'
 import Button from '@mui/material/Button'
 import CompSeverityIcon from './CompSeverityIcon'
 import IconButton from '@mui/material/IconButton'
 import PropTypes from 'prop-types'
-import React, { Fragment, useContext } from 'react'
+import React, { Fragment } from 'react'
 import TriageFields from './TriageFields'
-
-// Construct a URL with all existing filters plus testId, environment, and testName.
-// This is the url used when you click inside a TableCell on page4 on the right.
-// We pass these arguments to the component that generates the test details report.
-function generateTestReport(
-  testId,
-  variants,
-  filterVals,
-  componentName,
-  capabilityName,
-  testName,
-  testBasisRelease
-) {
-  const environmentVal = formColumnName({ variants: variants })
-  const { expandEnvironment } = useContext(CompReadyVarsContext)
-  const safeComponentName = safeEncodeURIComponent(componentName)
-  const safeTestId = safeEncodeURIComponent(testId)
-  const safeTestName = safeEncodeURIComponent(testName)
-  const safeTestBasisRelease = safeEncodeURIComponent(testBasisRelease)
-  let variantsUrl = ''
-  Object.entries(variants).forEach(([key, value]) => {
-    variantsUrl += '&' + key + '=' + safeEncodeURIComponent(value)
-  })
-  const retUrl =
-    '/component_readiness/test_details' +
-    filterVals +
-    `&testBasisRelease=${safeTestBasisRelease}` +
-    `&testId=${safeTestId}` +
-    expandEnvironment(environmentVal) +
-    `&component=${safeComponentName}` +
-    `&capability=${capabilityName}` +
-    variantsUrl +
-    `&testName=${safeTestName}`
-
-  return sortQueryParams(retUrl)
-}
 
 export default function RegressedTestsPanel(props) {
   const { filterVals, regressedTests, setTriageEntryCreated } = props
@@ -252,17 +218,7 @@ export default function RegressedTestsPanel(props) {
           }}
           className="status"
         >
-          <Link
-            to={generateTestReport(
-              params.row.test_id,
-              params.row.variants,
-              filterVals,
-              params.row.component,
-              params.row.capability,
-              params.row.test_name,
-              params.row.base_stats ? params.row.base_stats.release : ''
-            )}
-          >
+          <Link to={generateTestReportForRegressedTest(params.row, filterVals)}>
             <CompSeverityIcon
               status={
                 params.row.effective_status

--- a/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
@@ -1,7 +1,12 @@
 import { DataGrid, GridToolbar } from '@mui/x-data-grid'
-import { formColumnName } from './CompReadyUtils'
+import {
+  formColumnName,
+  generateTestReportForRegressedTest,
+} from './CompReadyUtils'
+import { Link } from 'react-router-dom'
 import { relativeTime } from '../helpers'
 import { Tooltip, Typography } from '@mui/material'
+import CompSeverityIcon from './CompSeverityIcon'
 import PropTypes from 'prop-types'
 import React, { Fragment } from 'react'
 
@@ -98,6 +103,46 @@ export default function TriagedRegressionTestList(props) {
         )
       },
     },
+    {
+      field: 'status',
+      headerName: 'Status',
+      valueGetter: (params) => {
+        const value = {
+          status: '',
+          explanations: '',
+          url: '',
+        }
+        const regressionId = params.row.id
+        const matchingRegression = props.allRegressedTests.find(
+          (rt) => rt.regression?.id === regressionId
+        )
+        if (matchingRegression) {
+          value.status = matchingRegression.status
+          value.explanations = matchingRegression.explanations
+          value.url = generateTestReportForRegressedTest(
+            matchingRegression,
+            props.filterVals
+          )
+        }
+        return value
+      },
+      renderCell: (params) => (
+        <div
+          style={{
+            textAlign: 'center',
+          }}
+          className="status"
+        >
+          <Link to={params.value.url}>
+            <CompSeverityIcon
+              status={params.value.status}
+              explanations={params.value.explanations}
+            />
+          </Link>
+        </div>
+      ),
+      flex: 6,
+    },
   ]
 
   return (
@@ -129,5 +174,7 @@ export default function TriagedRegressionTestList(props) {
 TriagedRegressionTestList.propTypes = {
   eventEmitter: PropTypes.object,
   regressions: PropTypes.array,
+  allRegressedTests: PropTypes.array.isRequired,
+  filterVals: PropTypes.string.isRequired,
   showOnLoad: PropTypes.bool,
 }

--- a/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
@@ -1,3 +1,4 @@
+import { CompReadyVarsContext } from './CompReadyVars'
 import { DataGrid, GridToolbar } from '@mui/x-data-grid'
 import {
   formColumnName,
@@ -8,9 +9,11 @@ import { relativeTime } from '../helpers'
 import { Tooltip, Typography } from '@mui/material'
 import CompSeverityIcon from './CompSeverityIcon'
 import PropTypes from 'prop-types'
-import React, { Fragment } from 'react'
+import React, { Fragment, useContext } from 'react'
 
 export default function TriagedRegressionTestList(props) {
+  const { expandEnvironment } = useContext(CompReadyVarsContext)
+
   const [sortModel, setSortModel] = React.useState([
     { field: 'component', sort: 'asc' },
   ])
@@ -126,7 +129,8 @@ export default function TriagedRegressionTestList(props) {
                 value.explanations = matchingRegression.explanations
                 value.url = generateTestReportForRegressedTest(
                   matchingRegression,
-                  props.filterVals
+                  props.filterVals,
+                  expandEnvironment
                 )
               }
               return value

--- a/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
@@ -37,6 +37,9 @@ export default function TriagedRegressionTestList(props) {
     )
   }
 
+  const showStatus =
+    props.allRegressedTests !== undefined && props.allRegressedTests.length > 0
+
   const columns = [
     {
       field: 'test_name',
@@ -103,46 +106,50 @@ export default function TriagedRegressionTestList(props) {
         )
       },
     },
-    {
-      field: 'status',
-      headerName: 'Status',
-      valueGetter: (params) => {
-        const value = {
-          status: '',
-          explanations: '',
-          url: '',
-        }
-        const regressionId = params.row.id
-        const matchingRegression = props.allRegressedTests.find(
-          (rt) => rt.regression?.id === regressionId
-        )
-        if (matchingRegression) {
-          value.status = matchingRegression.status
-          value.explanations = matchingRegression.explanations
-          value.url = generateTestReportForRegressedTest(
-            matchingRegression,
-            props.filterVals
-          )
-        }
-        return value
-      },
-      renderCell: (params) => (
-        <div
-          style={{
-            textAlign: 'center',
-          }}
-          className="status"
-        >
-          <Link to={params.value.url}>
-            <CompSeverityIcon
-              status={params.value.status}
-              explanations={params.value.explanations}
-            />
-          </Link>
-        </div>
-      ),
-      flex: 6,
-    },
+    ...(showStatus
+      ? [
+          {
+            field: 'status',
+            headerName: 'Status',
+            valueGetter: (params) => {
+              const value = {
+                status: '',
+                explanations: '',
+                url: '',
+              }
+              const regressionId = params.row.id
+              const matchingRegression = props.allRegressedTests.find(
+                (rt) => rt.regression?.id === regressionId
+              )
+              if (matchingRegression) {
+                value.status = matchingRegression.status
+                value.explanations = matchingRegression.explanations
+                value.url = generateTestReportForRegressedTest(
+                  matchingRegression,
+                  props.filterVals
+                )
+              }
+              return value
+            },
+            renderCell: (params) => (
+              <div
+                style={{
+                  textAlign: 'center',
+                }}
+                className="status"
+              >
+                <Link to={params.value.url}>
+                  <CompSeverityIcon
+                    status={params.value.status}
+                    explanations={params.value.explanations}
+                  />
+                </Link>
+              </div>
+            ),
+            flex: 6,
+          },
+        ]
+      : []),
   ]
 
   return (
@@ -174,7 +181,7 @@ export default function TriagedRegressionTestList(props) {
 TriagedRegressionTestList.propTypes = {
   eventEmitter: PropTypes.object,
   regressions: PropTypes.array,
-  allRegressedTests: PropTypes.array.isRequired,
-  filterVals: PropTypes.string.isRequired,
+  allRegressedTests: PropTypes.array,
+  filterVals: PropTypes.string,
   showOnLoad: PropTypes.bool,
 }

--- a/sippy-ng/src/component_readiness/TriagedRegressions.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressions.js
@@ -17,7 +17,7 @@ export default function TriagedRegressions(props) {
     })
 
     if (
-      selectedTriagedEntry.regressions !== 'undefined' &&
+      selectedTriagedEntry.regressions !== null &&
       selectedTriagedEntry.regressions.length > 0
     ) {
       props.eventEmitter.emit(

--- a/sippy-ng/src/component_readiness/TriagedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/TriagedTestsPanel.js
@@ -15,12 +15,18 @@ export default function TriagedTestsPanel(props) {
           eventEmitter={eventEmitter}
           triageEntries={props.triageEntries}
         />
-        <TriagedRegressionTestList eventEmitter={eventEmitter} />
+        <TriagedRegressionTestList
+          eventEmitter={eventEmitter}
+          allRegressedTests={props.allRegressedTests}
+          filterVals={props.filterVals}
+        />
       </Grid>
     </Fragment>
   )
 }
 
 TriagedTestsPanel.propTypes = {
-  triageEntries: PropTypes.array,
+  triageEntries: PropTypes.array.isRequired,
+  allRegressedTests: PropTypes.array.isRequired,
+  filterVals: PropTypes.string.isRequired,
 }

--- a/sippy-ng/src/component_readiness/TriagedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/TriagedTestsPanel.js
@@ -27,6 +27,6 @@ export default function TriagedTestsPanel(props) {
 
 TriagedTestsPanel.propTypes = {
   triageEntries: PropTypes.array.isRequired,
-  allRegressedTests: PropTypes.array.isRequired,
-  filterVals: PropTypes.string.isRequired,
+  allRegressedTests: PropTypes.array,
+  filterVals: PropTypes.string,
 }


### PR DESCRIPTION
This adapts functionality from the `RegressedTestsPanel` to utilize in the `TriagedRegressionTestList` on the modal as well. The adapted functionality now resides in `CompReadyUtils`.

This is not shown on the triage details page as we don't have the necessary info available there to determine the URL. This could be enhanced in the future if desired, but I don't think it is necessary.