### PR TITLE
TRT-2094: fix triage details page by wrapping in the CompReadyVarsProvider

### DIFF
--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -634,12 +634,11 @@ export default function App(props) {
 
                             <Route
                               path="/triages/:id"
-                              render={(props) =>
-                                redirectIfLatest(
-                                  props,
+                              render={(props) => (
+                                <CompReadyVarsProvider>
                                   <Triage id={props.match.params.id} />
-                                )
-                              }
+                                </CompReadyVarsProvider>
+                              )}
                             />
 
                             <Route


### PR DESCRIPTION
https://github.com/openshift/sippy/pull/2649 broke the page as it now uses the `expandEnvironment` function