### PR TITLE
NO-JIRA: allow for triage's resolution date to be cleared

### DIFF
--- a/sippy-ng/src/component_readiness/TriageFields.js
+++ b/sippy-ng/src/component_readiness/TriageFields.js
@@ -165,7 +165,7 @@ export default function TriageFields({
             onChange={(date) =>
               setTriageEntryData((prevData) => ({
                 ...prevData,
-                resolved: { Time: date, Valid: true },
+                resolved: { Time: date, Valid: date !== null },
               }))
             }
             renderInput={(props) => <TextField variant="standard" {...props} />}


### PR DESCRIPTION
We can't set `Valid: true` when sending a null date