### PR TITLE
TRT-2109: hide regressed tests from list of those associated with the triage when they have rolled off

### DIFF
--- a/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
+++ b/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
@@ -81,15 +81,17 @@ export default function ComponentReadinessToolBar(props) {
       const activeRegressionIds = allRegressed?.map(
         (test) => test.regression?.id
       )
-      const triagesAssociatedWithActiveRegressions = triages.filter(
-        (triage) => {
-          return (
-            triage.regressions.find((regression) =>
-              activeRegressionIds.includes(regression.id)
-            ) !== undefined
-          )
+      let triagesAssociatedWithActiveRegressions = []
+      triages.forEach((triage) => {
+        // Filter out any included regressions that are no longer active
+        triage.regressions = triage.regressions.filter((regression) =>
+          activeRegressionIds.includes(regression.id)
+        )
+        // If there are no regressions left, the triage record will be hidden
+        if (triage.regressions.length > 0) {
+          triagesAssociatedWithActiveRegressions.push(triage)
         }
-      )
+      })
       setTriageEntries(triagesAssociatedWithActiveRegressions)
       setTriageEntryCreated(false)
       setIsLoaded(true)


### PR DESCRIPTION
This follows up on https://github.com/openshift/sippy/pull/2662 to hide the individual tests from the list associated with the triage if they have rolled off. Note that these tests will still show on the triage details page.