### PR TITLE
TRT-2135: add `created_at` and `updated_at` fields to Triage UI and default sort

### DIFF
--- a/sippy-ng/src/component_readiness/Triage.js
+++ b/sippy-ng/src/component_readiness/Triage.js
@@ -119,6 +119,14 @@ export default function Triage({ id }) {
             <TableCell>Last Change</TableCell>
             <TableCell>{triage.bug?.last_change_time}</TableCell>
           </TableRow>
+          <TableRow>
+            <TableCell>Record Created</TableCell>
+            <TableCell>{triage.created_at}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Record Updated</TableCell>
+            <TableCell>{triage.updated_at}</TableCell>
+          </TableRow>
         </TableBody>
       </Table>
       <h2>Included Tests</h2>

--- a/sippy-ng/src/component_readiness/TriagedRegressions.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressions.js
@@ -7,7 +7,7 @@ import React, { Fragment } from 'react'
 
 export default function TriagedRegressions(props) {
   const [sortModel, setSortModel] = React.useState([
-    { field: 'component', sort: 'asc' },
+    { field: 'created_at', sort: 'desc' },
   ])
 
   const handleSetSelectionModel = (event) => {
@@ -104,6 +104,24 @@ export default function TriagedRegressions(props) {
         return value.row.bug?.last_change_time || ''
       },
       headerName: 'Last Change',
+      flex: 5,
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'created_at',
+      valueGetter: (value) => {
+        return value.row.created_at
+      },
+      headerName: 'Created',
+      flex: 5,
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'updated_at',
+      valueGetter: (value) => {
+        return value.row.updated_at
+      },
+      headerName: 'Updated',
       flex: 5,
       renderCell: (param) => <div className="test-name">{param.value}</div>,
     },


### PR DESCRIPTION
TRT-2135 originally also called for a way to search by description, but that functionality already exists in the filters.