### PR TITLE
TRT-2114: add component to list ALL triages and link to it from the toolbar

### DIFF
--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -54,6 +54,7 @@ import Sidebar from './components/Sidebar'
 import Tests from './tests/Tests'
 import Toolbar from '@mui/material/Toolbar'
 import Triage from './component_readiness/Triage'
+import TriageList from './component_readiness/TriageList'
 import Typography from '@mui/material/Typography'
 import Upgrades from './releases/Upgrades'
 import VariantStatus from './jobs/VariantStatus'
@@ -637,6 +638,15 @@ export default function App(props) {
                               render={(props) => (
                                 <CompReadyVarsProvider>
                                   <Triage id={props.match.params.id} />
+                                </CompReadyVarsProvider>
+                              )}
+                            />
+
+                            <Route
+                              path="/triages"
+                              render={() => (
+                                <CompReadyVarsProvider>
+                                  <TriageList />
                                 </CompReadyVarsProvider>
                               )}
                             />

--- a/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
+++ b/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
@@ -14,6 +14,7 @@ import {
   GridView,
   HelpCenter,
   InsertLink,
+  LocalHospital,
   Refresh,
   ViewColumn,
   Widgets,
@@ -54,9 +55,9 @@ export default function ComponentReadinessToolBar(props) {
   const [triageEntries, setTriageEntries] = React.useState([])
   const [isLoaded, setIsLoaded] = React.useState(false)
   const capabilitiesContext = React.useContext(CapabilitiesContext)
+  const localDBEnabled = capabilitiesContext.includes('local_db')
 
   React.useEffect(() => {
-    const localDBEnabled = capabilitiesContext.includes('local_db')
     // triage entries will only be available when there is a postgres connection
     let triageFetch
     if (localDBEnabled) {
@@ -252,6 +253,21 @@ export default function ComponentReadinessToolBar(props) {
                 </Tooltip>
               </IconButton>
             </Box>
+
+            {localDBEnabled && (
+              <Box sx={{ display: { md: 'flex' } }}>
+                <IconButton
+                  size="large"
+                  aria-label="Show all triage records"
+                  color="inherit"
+                  href="/sippy-ng/triages/"
+                >
+                  <Tooltip title="Show all triage records">
+                    <LocalHospital />
+                  </Tooltip>
+                </IconButton>
+              </Box>
+            )}
 
             <Box sx={{ display: { md: 'flex' } }}>
               <IconButton

--- a/sippy-ng/src/component_readiness/Triage.js
+++ b/sippy-ng/src/component_readiness/Triage.js
@@ -41,6 +41,7 @@ export default function Triage({ id }) {
       .then((t) => {
         setTriage(t)
         setIsLoaded(true)
+        document.title = 'Triage: ' + t.id
       })
       .catch((error) => {
         setMessage(error.toString())

--- a/sippy-ng/src/component_readiness/TriageList.js
+++ b/sippy-ng/src/component_readiness/TriageList.js
@@ -1,0 +1,56 @@
+import { CapabilitiesContext } from '../App'
+import { getTriagesAPIUrl } from './CompReadyUtils'
+import React, { Fragment } from 'react'
+import TriagedTestsPanel from './TriagedTestsPanel'
+
+export default function TriageList() {
+  const [isLoaded, setIsLoaded] = React.useState(false)
+  const [triages, setTriages] = React.useState([])
+  const [message, setMessage] = React.useState('')
+
+  const capabilitiesContext = React.useContext(CapabilitiesContext)
+  const localDBEnabled = capabilitiesContext.includes('local_db')
+
+  React.useEffect(() => {
+    setIsLoaded(false)
+    let triageFetch
+    // triage entries will only be available when there is a postgres connection
+    if (localDBEnabled) {
+      triageFetch = fetch(getTriagesAPIUrl()).then((response) => {
+        if (response.status !== 200) {
+          throw new Error('API server returned ' + response.status)
+        }
+        return response.json()
+      })
+    } else {
+      triageFetch = Promise.resolve({})
+    }
+
+    triageFetch
+      .then((t) => {
+        setTriages(t)
+        setIsLoaded(true)
+        document.title = 'All Triages'
+      })
+      .catch((error) => {
+        setMessage(error.toString())
+      })
+  }, [])
+
+  if (message !== '') {
+    return <h2>{message}</h2>
+  }
+
+  if (!isLoaded) {
+    return <p>Loading...</p>
+  }
+
+  return (
+    <Fragment>
+      <h2>All Triage Records</h2>
+      <TriagedTestsPanel triageEntries={triages} triageEntriesPerPage={50} />
+    </Fragment>
+  )
+}
+
+TriageList.propTypes = {}

--- a/sippy-ng/src/component_readiness/TriagedRegressions.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressions.js
@@ -5,14 +5,18 @@ import InfoIcon from '@mui/icons-material/Info'
 import PropTypes from 'prop-types'
 import React, { Fragment } from 'react'
 
-export default function TriagedRegressions(props) {
+export default function TriagedRegressions({
+  triageEntries,
+  eventEmitter,
+  entriesPerPage = 10,
+}) {
   const [sortModel, setSortModel] = React.useState([
     { field: 'component', sort: 'asc' },
   ])
 
   const handleSetSelectionModel = (event) => {
     let selectedTriagedEntry = {}
-    props.triageEntries.forEach((entry) => {
+    triageEntries.forEach((entry) => {
       if (event[0] === entry.id) selectedTriagedEntry = entry
     })
 
@@ -20,7 +24,7 @@ export default function TriagedRegressions(props) {
       selectedTriagedEntry.regressions !== null &&
       selectedTriagedEntry.regressions.length > 0
     ) {
-      props.eventEmitter.emit(
+      eventEmitter.emit(
         'triagedEntrySelectionChanged',
         selectedTriagedEntry.regressions
       )
@@ -134,10 +138,10 @@ export default function TriagedRegressions(props) {
         onSortModelChange={setSortModel}
         onSelectionModelChange={handleSetSelectionModel}
         components={{ Toolbar: GridToolbar }}
-        rows={props.triageEntries}
+        rows={triageEntries}
         columns={columns}
         getRowId={(row) => row.id}
-        pageSize={10}
+        pageSize={entriesPerPage}
         rowHeight={60}
         autoHeight={true}
         checkboxSelection={false}
@@ -154,4 +158,5 @@ export default function TriagedRegressions(props) {
 TriagedRegressions.propTypes = {
   eventEmitter: PropTypes.object,
   triageEntries: PropTypes.array,
+  entriesPerPage: PropTypes.number,
 }

--- a/sippy-ng/src/component_readiness/TriagedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/TriagedTestsPanel.js
@@ -14,6 +14,7 @@ export default function TriagedTestsPanel(props) {
         <TriagedRegressions
           eventEmitter={eventEmitter}
           triageEntries={props.triageEntries}
+          entriesPerPage={props.triageEntriesPerPage}
         />
         <TriagedRegressionTestList
           eventEmitter={eventEmitter}
@@ -27,6 +28,7 @@ export default function TriagedTestsPanel(props) {
 
 TriagedTestsPanel.propTypes = {
   triageEntries: PropTypes.array.isRequired,
+  triageEntriesPerPage: PropTypes.number,
   allRegressedTests: PropTypes.array,
   filterVals: PropTypes.string,
 }


### PR DESCRIPTION
This is mostly achieved by reusing the `TriagedTestsPanel`, and handing it all triage entries using a default listing of more records per page. There are opportunities here to add additional custom filtering as the number of records grows larger, but this will meet our needs for awhile.

The link won't show if the `local_db` capability isn't enabled.