### PR TITLE
TRT-1787: use query params for selections within the regressed test modal 

### DIFF
--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -674,6 +674,11 @@ export default function App(props) {
                                     <ComponentReadiness
                                       key={getUrlWithoutParams([
                                         'regressedModal',
+                                        'regressedModalTab',
+                                        'regressedModalRow',
+                                        'regressedModalPage',
+                                        'regressedModalTestRow',
+                                        'regressedModalTestPage',
                                       ])}
                                     />
                                   </CompReadyVarsProvider>

--- a/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
+++ b/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
@@ -7,7 +7,13 @@ import {
   Popover,
   Tooltip,
 } from '@mui/material'
-import { BooleanParam, useQueryParam } from 'use-query-params'
+import {
+  BooleanParam,
+  NumberParam,
+  StringParam,
+  useQueryParam,
+  useQueryParams,
+} from 'use-query-params'
 import {
   BugReport,
   Clear,
@@ -131,8 +137,26 @@ export default function ComponentReadinessToolBar(props) {
     'regressedModal',
     BooleanParam
   )
+  const [, setQuery] = useQueryParams(
+    {
+      regressedModalTab: NumberParam,
+      regressedModalRow: StringParam,
+      regressedModalPage: NumberParam,
+      regressedModalTestRow: NumberParam,
+      regressedModalTestPage: NumberParam,
+    },
+    { updateType: 'replaceIn' }
+  )
+
   const closeRegressedTestsDialog = () => {
-    setRegressedTestDialog(false, 'replaceIn')
+    setRegressedTestDialog(undefined, 'replaceIn')
+    setQuery({
+      regressedModalTab: undefined,
+      regressedModalRow: undefined,
+      regressedModalPage: undefined,
+      regressedModalTestRow: undefined,
+      regressedModalTestPage: undefined,
+    })
   }
 
   if (!isLoaded) {

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -1,4 +1,10 @@
 import { Box, Button, Grid, Tab, Tabs, Typography } from '@mui/material'
+import {
+  NumberParam,
+  StringParam,
+  useQueryParam,
+  useQueryParams,
+} from 'use-query-params'
 import Dialog from '@mui/material/Dialog'
 import PropTypes from 'prop-types'
 import React, { Fragment } from 'react'
@@ -19,9 +25,7 @@ RegressedTestsTabPanel.propTypes = {
   activeIndex: PropTypes.number.isRequired,
 }
 
-function RegressedTestsTabPanel(props) {
-  const { children, activeIndex, index, ...other } = props
-
+function RegressedTestsTabPanel({ children, activeIndex, index, ...other }) {
   return (
     <div
       role="tabpanel"
@@ -39,26 +43,51 @@ function RegressedTestsTabPanel(props) {
   )
 }
 
-export default function RegressedTestsModal(props) {
-  const [activeTabIndex, setActiveTabIndex] = React.useState(0)
+export default function RegressedTestsModal({
+  regressedTests,
+  allRegressedTests,
+  unresolvedTests,
+  triagedIncidents,
+  triageEntries,
+  setTriageEntryCreated,
+  filterVals,
+  isOpen,
+  close,
+}) {
+  const [activeTab = 0, setActiveTab] = useQueryParam(
+    'regressedModalTab',
+    NumberParam,
+    { updateType: 'replaceIn' }
+  )
+  const [, setQuery] = useQueryParams(
+    {
+      regressedModalRow: StringParam,
+      regressedModalPage: NumberParam,
+      regressedModalTestRow: NumberParam,
+      regressedModalTestPage: NumberParam,
+    },
+    { updateType: 'replaceIn' }
+  )
 
   const handleTabChange = (event, newValue) => {
-    setActiveTabIndex(newValue)
+    setActiveTab(newValue)
+    // The active pages and rows in the DataGrid are most likely no longer relevant when switching tabs
+    setQuery({
+      regressedModalRow: undefined,
+      regressedModalPage: undefined,
+      regressedModalTestRow: undefined,
+      regressedModalTestPage: undefined,
+    })
   }
 
-  const triageEntriesExist = props.triageEntries.length > 0
+  const triageEntriesExist = triageEntries.length > 0
 
   return (
     <Fragment>
-      <Dialog
-        fullWidth={true}
-        maxWidth={false}
-        open={props.isOpen}
-        onClose={props.close}
-      >
+      <Dialog fullWidth={true} maxWidth={false} open={isOpen} onClose={close}>
         <Grid className="regressed-tests-dialog">
           <Tabs
-            value={activeTabIndex}
+            value={activeTab}
             onChange={handleTabChange}
             aria-label="Regressed Tests Tabs"
           >
@@ -70,48 +99,46 @@ export default function RegressedTestsModal(props) {
             )}
             <Tab label="All" {...tabProps(3)} />
           </Tabs>
-          <RegressedTestsTabPanel activeIndex={activeTabIndex} index={0}>
+          <RegressedTestsTabPanel activeIndex={activeTab} index={0}>
             <RegressedTestsPanel
-              regressedTests={props.unresolvedTests}
-              setTriageEntryCreated={props.setTriageEntryCreated}
-              filterVals={props.filterVals}
+              regressedTests={unresolvedTests}
+              setTriageEntryCreated={setTriageEntryCreated}
+              filterVals={filterVals}
             />
           </RegressedTestsTabPanel>
-          <RegressedTestsTabPanel activeIndex={activeTabIndex} index={1}>
+          <RegressedTestsTabPanel activeIndex={activeTab} index={1}>
             <RegressedTestsPanel
-              regressedTests={props.regressedTests}
-              setTriageEntryCreated={props.setTriageEntryCreated}
-              filterVals={props.filterVals}
+              regressedTests={regressedTests}
+              setTriageEntryCreated={setTriageEntryCreated}
+              filterVals={filterVals}
             />
           </RegressedTestsTabPanel>
           {!triageEntriesExist && (
-            <RegressedTestsTabPanel activeIndex={activeTabIndex} index={2}>
-              <TriagedIncidentsPanel
-                triagedIncidents={props.triagedIncidents}
-              />
+            <RegressedTestsTabPanel activeIndex={activeTab} index={2}>
+              <TriagedIncidentsPanel triagedIncidents={triagedIncidents} />
             </RegressedTestsTabPanel>
           )}
           {triageEntriesExist && (
-            <RegressedTestsTabPanel activeIndex={activeTabIndex} index={2}>
+            <RegressedTestsTabPanel activeIndex={activeTab} index={2}>
               <TriagedTestsPanel
-                triageEntries={props.triageEntries}
-                allRegressedTests={props.allRegressedTests}
-                filterVals={props.filterVals}
+                triageEntries={triageEntries}
+                allRegressedTests={allRegressedTests}
+                filterVals={filterVals}
               />
             </RegressedTestsTabPanel>
           )}
-          <RegressedTestsTabPanel activeIndex={activeTabIndex} index={3}>
+          <RegressedTestsTabPanel activeIndex={activeTab} index={3}>
             <RegressedTestsPanel
-              regressedTests={props.allRegressedTests}
-              setTriageEntryCreated={props.setTriageEntryCreated}
-              filterVals={props.filterVals}
+              regressedTests={allRegressedTests}
+              setTriageEntryCreated={setTriageEntryCreated}
+              filterVals={filterVals}
             />
           </RegressedTestsTabPanel>
           <Button
             style={{ marginTop: 20, marginBottom: 20, marginLeft: 20 }}
             variant="contained"
             color="primary"
-            onClick={props.close}
+            onClick={close}
           >
             CLOSE
           </Button>

--- a/sippy-ng/src/component_readiness/RegressedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsPanel.js
@@ -7,6 +7,7 @@ import {
   generateTestReportForRegressedTest,
 } from './CompReadyUtils'
 import { Link } from 'react-router-dom'
+import { NumberParam, StringParam, useQueryParam } from 'use-query-params'
 import { Popover, Snackbar, Tooltip } from '@mui/material'
 import { relativeTime } from '../helpers'
 import Alert from '@mui/material/Alert'
@@ -18,6 +19,16 @@ import React, { Fragment, useContext } from 'react'
 import TriageFields from './TriageFields'
 
 export default function RegressedTestsPanel(props) {
+  const [activeRow, setActiveRow] = useQueryParam(
+    'regressedModalRow',
+    StringParam,
+    { updateType: 'replaceIn' }
+  )
+  const [activePage, setActivePage] = useQueryParam(
+    'regressedModalPage',
+    NumberParam,
+    { updateType: 'replaceIn' }
+  )
   const { expandEnvironment } = useContext(CompReadyVarsContext)
   const { filterVals, regressedTests, setTriageEntryCreated } = props
   const [sortModel, setSortModel] = React.useState([
@@ -268,7 +279,15 @@ export default function RegressedTestsPanel(props) {
             .map((key) => row.variants[key])
             .join(' ')
         }
+        selectionModel={activeRow}
+        onSelectionModelChange={(newRow) => {
+          setActiveRow(newRow)
+        }}
         pageSize={10}
+        page={activePage}
+        onPageChange={(newPage) => {
+          setActivePage(newPage)
+        }}
         rowHeight={60}
         autoHeight={true}
         checkboxSelection={false}

--- a/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
@@ -5,6 +5,7 @@ import {
   generateTestReportForRegressedTest,
 } from './CompReadyUtils'
 import { Link } from 'react-router-dom'
+import { NumberParam, useQueryParam } from 'use-query-params'
 import { relativeTime } from '../helpers'
 import { Tooltip, Typography } from '@mui/material'
 import CompSeverityIcon from './CompSeverityIcon'
@@ -13,6 +14,17 @@ import React, { Fragment, useContext } from 'react'
 
 export default function TriagedRegressionTestList(props) {
   const { expandEnvironment } = useContext(CompReadyVarsContext)
+
+  const [activeRow, setActiveRow] = useQueryParam(
+    'regressedModalTestRow',
+    NumberParam,
+    { updateType: 'replaceIn' }
+  )
+  const [activePage, setActivePage] = useQueryParam(
+    'regressedModalTestPage',
+    NumberParam,
+    { updateType: 'replaceIn' }
+  )
 
   const [sortModel, setSortModel] = React.useState([
     { field: 'component', sort: 'asc' },
@@ -30,7 +42,9 @@ export default function TriagedRegressionTestList(props) {
     if (data) {
       displayView = true
     }
-    setTriagedRegressions(data)
+    setTriagedRegressions(data.regressions)
+    setActiveRow(data.activeId)
+
     setShowView(displayView)
   }
   if (props.eventEmitter !== undefined) {
@@ -167,6 +181,17 @@ export default function TriagedRegressionTestList(props) {
           rows={triagedRegressions}
           columns={columns}
           getRowId={(row) => row.id}
+          selectionModel={activeRow}
+          onSelectionModelChange={(newRow) => {
+            // Due to the usage of the eventEmitter, this can sometimes fire when we don't want it to actually de-select
+            if (newRow.length > 0) {
+              setActiveRow(Number(newRow))
+            }
+          }}
+          page={activePage}
+          onPageChange={(newPage) => {
+            setActivePage(newPage)
+          }}
           pageSize={10}
           rowHeight={60}
           autoHeight={true}

--- a/sippy-ng/src/component_readiness/TriagedRegressions.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressions.js
@@ -33,7 +33,7 @@ export default function TriagedRegressions({
 
   useEffect(() => {
     const triage = getSelectedTriage(activeRow)
-    if (triage != null) {
+    if (triage) {
       toggleAssociatedRegressions(triage)
     }
   }, [])
@@ -60,9 +60,10 @@ export default function TriagedRegressions({
 
   const handleSetSelectionModel = (event) => {
     const triage = getSelectedTriage(event[0])
-    setActiveRow(String(triage.id))
-
-    toggleAssociatedRegressions(triage)
+    if (triage) {
+      setActiveRow(String(triage.id))
+      toggleAssociatedRegressions(triage)
+    }
   }
 
   const columns = [


### PR DESCRIPTION
Params are cleared when switching tabs within the modal (as they may no longer be relevant), and also when closing the modal.

This also uses the query params for other usages of the panels, but that is nice functionality. The only downside there is the way they are named, but I think keeping `modal` in the name is worth it for clarity within the source code itself.