### PR TITLE
Revert "Hide triaged resolved ci-infra regressions"

### DIFF
--- a/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
+++ b/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
@@ -99,12 +99,8 @@ func (r *RegressionTracker) PostAnalysis(testKey crtype.ReportTestIdentification
 		if len(or.Triages) > 0 {
 
 			allTriagesResolved := true
-			allTriagesInfra := true
 			var lastResolution time.Time
 			for _, t := range or.Triages {
-				if t.Type != models.TriageTypeCIInfra {
-					allTriagesInfra = false
-				}
 				if !t.Resolved.Valid {
 					allTriagesResolved = false
 				} else if t.Resolved.Time.After(lastResolution) {
@@ -120,10 +116,6 @@ func (r *RegressionTracker) PostAnalysis(testKey crtype.ReportTestIdentification
 				testStats.Explanations = append(testStats.Explanations, fmt.Sprintf(
 					"Regression is triaged, and believed fixed as of %s, but failures have been observed as recently as %s.",
 					lastResolution.Format(time.RFC3339), testStats.LastFailure.Format(time.RFC3339)))
-			case allTriagesResolved && allTriagesInfra:
-				// claimed fixed, triaged as CI infra problem, thus we can make this completely disappear,
-				// no significant regression unless the problem reappears after resolution date (the above case)
-				testStats.ReportStatus = crtype.NotSignificant
 			case allTriagesResolved:
 				// claimed fixed, no failures since resolution date
 				testStats.ReportStatus = crtype.FixedRegression

--- a/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker_test.go
+++ b/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker_test.go
@@ -93,43 +93,6 @@ func TestRegressionTracker_PostAnalysis(t *testing.T) {
 			expectedExplanationsCount: 1,
 		},
 		{
-			name: "ci-infra triage resolved",
-			testStats: crtype.ReportTestStats{
-				ReportStatus: crtype.ExtremeRegression,
-				Explanations: []string{},
-				LastFailure:  &daysAgo4,
-			},
-			openRegression: models.TestRegression{
-				ID:       0,
-				View:     "",
-				Release:  "",
-				TestID:   testKey.TestID,
-				TestName: testKey.TestName,
-				Variants: variantsStrSlice,
-				Opened:   daysAgo5,
-				Closed: sql.NullTime{
-					Time:  time.Time{},
-					Valid: false,
-				},
-				Triages: []models.Triage{
-					{
-						ID:          42,
-						CreatedAt:   daysAgo4,
-						UpdatedAt:   daysAgo4,
-						URL:         "https://example.com/foobar",
-						Description: "foobar",
-						Type:        "ci-infra",
-						Resolved: sql.NullTime{
-							Time:  daysAgo3,
-							Valid: true,
-						},
-					},
-				},
-			},
-			expectStatus:              crtype.NotSignificant,
-			expectedExplanationsCount: 0,
-		},
-		{
 			name: "triage resolved waiting to clear",
 			testStats: crtype.ReportTestStats{
 				ReportStatus: crtype.ExtremeRegression,


### PR DESCRIPTION
Reverts openshift/sippy#2669

Causing problems, the regressions are reappearing now with no tracking data, despite being triaged, then their test details page says no regression. Didn't happen in local testing so unclear why.