### PR TITLE
TRT-1787: fix needless browser history updates

### DIFF
--- a/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
+++ b/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
@@ -150,13 +150,16 @@ export default function ComponentReadinessToolBar(props) {
 
   const closeRegressedTestsDialog = () => {
     setRegressedTestDialog(undefined, 'replaceIn')
-    setQuery({
-      regressedModalTab: undefined,
-      regressedModalRow: undefined,
-      regressedModalPage: undefined,
-      regressedModalTestRow: undefined,
-      regressedModalTestPage: undefined,
-    })
+    setQuery(
+      {
+        regressedModalTab: undefined,
+        regressedModalRow: undefined,
+        regressedModalPage: undefined,
+        regressedModalTestRow: undefined,
+        regressedModalTestPage: undefined,
+      },
+      'replaceIn'
+    )
   }
 
   if (!isLoaded) {

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -72,12 +72,15 @@ export default function RegressedTestsModal({
   const handleTabChange = (event, newValue) => {
     setActiveTab(newValue)
     // The active pages and rows in the DataGrid are most likely no longer relevant when switching tabs
-    setQuery({
-      regressedModalRow: undefined,
-      regressedModalPage: undefined,
-      regressedModalTestRow: undefined,
-      regressedModalTestPage: undefined,
-    })
+    setQuery(
+      {
+        regressedModalRow: undefined,
+        regressedModalPage: undefined,
+        regressedModalTestRow: undefined,
+        regressedModalTestPage: undefined,
+      },
+      'replaceIn'
+    )
   }
 
   const triageEntriesExist = triageEntries.length > 0

--- a/sippy-ng/src/component_readiness/RegressedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsPanel.js
@@ -281,12 +281,14 @@ export default function RegressedTestsPanel(props) {
         }
         selectionModel={activeRow}
         onSelectionModelChange={(newRow) => {
-          setActiveRow(newRow)
+          if (newRow) {
+            setActiveRow(newRow, 'replaceIn')
+          }
         }}
         pageSize={10}
         page={activePage}
         onPageChange={(newPage) => {
-          setActivePage(newPage)
+          setActivePage(newPage, 'replaceIn')
         }}
         rowHeight={60}
         autoHeight={true}

--- a/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
@@ -41,9 +41,9 @@ export default function TriagedRegressionTestList(props) {
     let displayView = false
     if (data) {
       displayView = true
+      setTriagedRegressions(data.regressions)
+      setActiveRow(data.activeId, 'replaceIn')
     }
-    setTriagedRegressions(data.regressions)
-    setActiveRow(data.activeId)
 
     setShowView(displayView)
   }
@@ -185,12 +185,12 @@ export default function TriagedRegressionTestList(props) {
           onSelectionModelChange={(newRow) => {
             // Due to the usage of the eventEmitter, this can sometimes fire when we don't want it to actually de-select
             if (newRow.length > 0) {
-              setActiveRow(Number(newRow))
+              setActiveRow(Number(newRow), 'replaceIn')
             }
           }}
           page={activePage}
           onPageChange={(newPage) => {
-            setActivePage(newPage)
+            setActivePage(newPage, 'replaceIn')
           }}
           pageSize={10}
           rowHeight={60}

--- a/sippy-ng/src/component_readiness/TriagedRegressions.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressions.js
@@ -32,9 +32,11 @@ export default function TriagedRegressions({
   )
 
   useEffect(() => {
-    const triage = getSelectedTriage(activeRow)
-    if (triage) {
-      toggleAssociatedRegressions(triage)
+    if (activeRow) {
+      const triage = getSelectedTriage(activeRow)
+      if (triage) {
+        toggleAssociatedRegressions(triage)
+      }
     }
   }, [])
 
@@ -61,7 +63,7 @@ export default function TriagedRegressions({
   const handleSetSelectionModel = (event) => {
     const triage = getSelectedTriage(event[0])
     if (triage) {
-      setActiveRow(String(triage.id))
+      setActiveRow(String(triage.id), 'replaceIn')
       toggleAssociatedRegressions(triage)
     }
   }
@@ -198,7 +200,7 @@ export default function TriagedRegressions({
         pageSize={entriesPerPage}
         page={activePage}
         onPageChange={(newPage) => {
-          setActivePage(newPage)
+          setActivePage(newPage, 'replaceIn')
         }}
         rowHeight={60}
         autoHeight={true}


### PR DESCRIPTION
explicitly use replace-in everywhere we are setting the modal query params and don't needlessly set them to improve UX

Follows up on https://github.com/openshift/sippy/pull/2675