### PR TITLE
TRT-2147: Improvements to triage pages

### DIFF
--- a/sippy-ng/src/component_readiness/Triage.js
+++ b/sippy-ng/src/component_readiness/Triage.js
@@ -1,6 +1,9 @@
-import { Button } from '@mui/material'
+import { Button, Tooltip } from '@mui/material'
 import { CapabilitiesContext } from '../App'
+import { CheckCircle, Error as ErrorIcon } from '@mui/icons-material'
+import { formatDateToSeconds, relativeTime } from '../helpers'
 import { getTriagesAPIUrl, jiraUrlPrefix } from './CompReadyUtils'
+import { useTheme } from '@mui/material/styles'
 import PropTypes from 'prop-types'
 import React, { Fragment } from 'react'
 import SecureLink from '../components/SecureLink'
@@ -12,6 +15,7 @@ import TriagedRegressionTestList from './TriagedRegressionTestList'
 import UpsertTriageModal from './UpsertTriageModal'
 
 export default function Triage({ id }) {
+  const theme = useTheme()
   const [isLoaded, setIsLoaded] = React.useState(false)
   const [triage, setTriage] = React.useState({})
   const [message, setMessage] = React.useState('')
@@ -41,7 +45,7 @@ export default function Triage({ id }) {
       .then((t) => {
         setTriage(t)
         setIsLoaded(true)
-        document.title = 'Triage: ' + t.id
+        document.title = 'Triage "' + t.description + '" (' + t.id + ')'
       })
       .catch((error) => {
         setMessage(error.toString())
@@ -87,6 +91,25 @@ export default function Triage({ id }) {
       <Table>
         <TableBody>
           <TableRow>
+            <TableCell>Resolved</TableCell>
+            <TableCell>
+              {triage.resolved?.Valid ? (
+                <Tooltip
+                  title={`${relativeTime(
+                    new Date(triage.resolved.Time),
+                    new Date()
+                  )} (${formatDateToSeconds(triage.resolved.Time)})`}
+                >
+                  <CheckCircle style={{ color: theme.palette.success.light }} />
+                </Tooltip>
+              ) : (
+                <Tooltip title="Not resolved">
+                  <ErrorIcon style={{ color: theme.palette.error.light }} />
+                </Tooltip>
+              )}
+            </TableCell>
+          </TableRow>
+          <TableRow>
             <TableCell>Description</TableCell>
             <TableCell>{triage.description}</TableCell>
           </TableRow>
@@ -103,7 +126,18 @@ export default function Triage({ id }) {
           <TableRow>
             <TableCell>Resolution Date</TableCell>
             <TableCell>
-              {triage.resolved?.Valid ? triage.resolved?.Time : ''}
+              {triage.resolved?.Valid ? (
+                <Tooltip
+                  title={relativeTime(
+                    new Date(triage.resolved.Time),
+                    new Date()
+                  )}
+                >
+                  <span>{formatDateToSeconds(triage.resolved.Time)}</span>
+                </Tooltip>
+              ) : (
+                ''
+              )}
             </TableCell>
           </TableRow>
           <TableRow>
@@ -117,16 +151,51 @@ export default function Triage({ id }) {
             </TableCell>
           </TableRow>
           <TableRow>
-            <TableCell>Last Change</TableCell>
-            <TableCell>{triage.bug?.last_change_time}</TableCell>
+            <TableCell>Jira updated</TableCell>
+            <TableCell>
+              {triage.bug?.last_change_time ? (
+                <Tooltip
+                  title={relativeTime(
+                    new Date(triage.bug.last_change_time),
+                    new Date()
+                  )}
+                >
+                  <span>
+                    {formatDateToSeconds(triage.bug.last_change_time)}
+                  </span>
+                </Tooltip>
+              ) : (
+                ''
+              )}
+            </TableCell>
           </TableRow>
           <TableRow>
             <TableCell>Record Created</TableCell>
-            <TableCell>{triage.created_at}</TableCell>
+            <TableCell>
+              {triage.created_at ? (
+                <Tooltip
+                  title={relativeTime(new Date(triage.created_at), new Date())}
+                >
+                  <span>{formatDateToSeconds(triage.created_at)}</span>
+                </Tooltip>
+              ) : (
+                ''
+              )}
+            </TableCell>
           </TableRow>
           <TableRow>
             <TableCell>Record Updated</TableCell>
-            <TableCell>{triage.updated_at}</TableCell>
+            <TableCell>
+              {triage.updated_at ? (
+                <Tooltip
+                  title={relativeTime(new Date(triage.updated_at), new Date())}
+                >
+                  <span>{formatDateToSeconds(triage.updated_at)}</span>
+                </Tooltip>
+              ) : (
+                ''
+              )}
+            </TableCell>
           </TableRow>
         </TableBody>
       </Table>

--- a/sippy-ng/src/component_readiness/TriagedRegressions.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressions.js
@@ -1,7 +1,10 @@
+import { CheckCircle, Error as ErrorIcon } from '@mui/icons-material'
 import { DataGrid, GridToolbar } from '@mui/x-data-grid'
+import { formatDateToSeconds, relativeTime } from '../helpers'
 import { jiraUrlPrefix } from './CompReadyUtils'
 import { NumberParam, StringParam, useQueryParam } from 'use-query-params'
-import { Typography } from '@mui/material'
+import { Tooltip, Typography } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
 import InfoIcon from '@mui/icons-material/Info'
 import PropTypes from 'prop-types'
 import React, { Fragment, useEffect } from 'react'
@@ -11,6 +14,7 @@ export default function TriagedRegressions({
   eventEmitter,
   entriesPerPage = 10,
 }) {
+  const theme = useTheme()
   const [sortModel, setSortModel] = React.useState([
     { field: 'created_at', sort: 'desc' },
   ])
@@ -68,6 +72,30 @@ export default function TriagedRegressions({
 
   const columns = [
     {
+      field: 'resolution_date',
+      valueGetter: (value) => {
+        return value.row.resolved?.Valid ? value.row.resolved.Time : ''
+      },
+      headerName: 'Resolved',
+      flex: 4,
+      align: 'center',
+      renderCell: (param) =>
+        param.value ? (
+          <Tooltip
+            title={`${relativeTime(
+              new Date(param.value),
+              new Date()
+            )} (${formatDateToSeconds(param.value)})`}
+          >
+            <CheckCircle style={{ color: theme.palette.success.light }} />
+          </Tooltip>
+        ) : (
+          <Tooltip title="Not resolved">
+            <ErrorIcon style={{ color: theme.palette.error.light }} />
+          </Tooltip>
+        ),
+    },
+    {
       field: 'description',
       valueGetter: (value) => {
         return value.row.description
@@ -106,15 +134,7 @@ export default function TriagedRegressions({
         </a>
       ),
     },
-    {
-      field: 'resolution_date',
-      valueGetter: (value) => {
-        return value.row.resolved?.Valid ? value.row.resolved.Time : ''
-      },
-      headerName: 'Resolution Date',
-      flex: 5,
-      renderCell: (param) => <div>{param.value}</div>,
-    },
+
     {
       field: 'bug_state',
       valueGetter: (value) => {
@@ -142,27 +162,47 @@ export default function TriagedRegressions({
       valueGetter: (value) => {
         return value.row.bug?.last_change_time || ''
       },
-      headerName: 'Last Change',
+      headerName: 'Jira updated',
       flex: 5,
-      renderCell: (param) => <div className="test-name">{param.value}</div>,
+      renderCell: (param) => (
+        <Tooltip title={param.value}>
+          <div className="test-name">
+            {relativeTime(new Date(param.value), new Date())}
+          </div>
+        </Tooltip>
+      ),
     },
     {
       field: 'created_at',
+      hide: true,
       valueGetter: (value) => {
         return value.row.created_at
       },
-      headerName: 'Created',
+      headerName: 'Created at',
       flex: 5,
-      renderCell: (param) => <div className="test-name">{param.value}</div>,
+      renderCell: (param) => (
+        <Tooltip title={param.value}>
+          <div className="test-name">
+            {relativeTime(new Date(param.value), new Date())}
+          </div>
+        </Tooltip>
+      ),
     },
     {
       field: 'updated_at',
+      hide: true,
       valueGetter: (value) => {
         return value.row.updated_at
       },
-      headerName: 'Updated',
+      headerName: 'Updated At',
       flex: 5,
-      renderCell: (param) => <div className="test-name">{param.value}</div>,
+      renderCell: (param) => (
+        <div className="test-name">
+          <Tooltip title={param.value}>
+            <span>{relativeTime(new Date(param.value), new Date())}</span>
+          </Tooltip>
+        </div>
+      ),
     },
     {
       field: 'details',

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -38,6 +38,13 @@ export function safeEncodeURIComponent(value) {
     .replace('}', '%7D')
 }
 
+// Helper function to format dates to second precision
+export function formatDateToSeconds(dateString) {
+  if (!dateString) return ''
+  const date = new Date(dateString)
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z')
+}
+
 // relativeTime shows a plain English rendering of a time, e.g. "30 minutes ago".
 // This is because the ES6 Intl.RelativeTime isn't available in all environments yet,
 // e.g. Safari and NodeJS.


### PR DESCRIPTION
- Triage details page title to show description
- Table hides created and updated columns by default; only show jira updated
  column
- Show timestamps as relative 
- Show resolution as a glanceable status icon
- Format all timestamps to second precision for consistency

<img width="1106" alt="image" src="https://github.com/user-attachments/assets/24f681ca-9512-409e-86ed-e6aa086233bd" />


<img width="1098" alt="image" src="https://github.com/user-attachments/assets/987f399a-b1d6-495c-98f6-d88b3859333a" />
