### PR TITLE
TRT-2152: data should be reloaded after triaging from modal

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilities.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilities.js
@@ -50,6 +50,8 @@ export default function CompReadyEnvCapabilities(props) {
   const [isLoaded, setIsLoaded] = React.useState(false)
   const [data, setData] = React.useState({})
 
+  const [triageActionTaken, setTriageActionTaken] = React.useState(false)
+
   // Set the browser tab title
   document.title =
     'Sippy > Component Readiness > Capabilities' +
@@ -70,7 +72,8 @@ export default function CompReadyEnvCapabilities(props) {
   useEffect(() => {
     setIsLoaded(false)
     fetchData()
-  }, [])
+    setTriageActionTaken(false)
+  }, [triageActionTaken])
 
   const fetchData = (fresh) => {
     if (fresh) {
@@ -210,6 +213,7 @@ export default function CompReadyEnvCapabilities(props) {
         clearSearches={clearSearches}
         data={data}
         filterVals={filterVals}
+        setTriageActionTaken={setTriageActionTaken}
         forceRefresh={forceRefresh}
       />
       <br></br>

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapability.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapability.js
@@ -51,6 +51,8 @@ export default function CompReadyEnvCapability(props) {
   const [isLoaded, setIsLoaded] = React.useState(false)
   const [data, setData] = React.useState({})
 
+  const [triageActionTaken, setTriageActionTaken] = React.useState(false)
+
   // Set the browser tab title
   document.title =
     'Sippy > Component Readiness > Capabilities > Tests' +
@@ -69,7 +71,8 @@ export default function CompReadyEnvCapability(props) {
   useEffect(() => {
     setIsLoaded(false)
     fetchData()
-  }, [])
+    setTriageActionTaken(false)
+  }, [triageActionTaken])
 
   const fetchData = (fresh) => {
     if (fresh) {
@@ -209,6 +212,7 @@ export default function CompReadyEnvCapability(props) {
         clearSearches={clearSearches}
         data={data}
         filterVals={filterVals}
+        setTriageActionTaken={setTriageActionTaken}
         forceRefresh={forceRefresh}
       />
       <br></br>

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
@@ -50,6 +50,8 @@ export default function CompReadyEnvCapabilityTest(props) {
   const [isLoaded, setIsLoaded] = React.useState(false)
   const [data, setData] = React.useState({})
 
+  const [triageActionTaken, setTriageActionTaken] = React.useState(false)
+
   const [searchRowRegexURL, setSearchRowRegexURL] = useQueryParam(
     'searchRow',
     StringParam
@@ -122,7 +124,8 @@ export default function CompReadyEnvCapabilityTest(props) {
   useEffect(() => {
     setIsLoaded(false)
     fetchData()
-  }, [])
+    setTriageActionTaken(false)
+  }, [triageActionTaken])
 
   const fetchData = (fresh) => {
     if (fresh) {
@@ -203,6 +206,7 @@ export default function CompReadyEnvCapabilityTest(props) {
       <ComponentReadinessToolBar
         data={data}
         filterVals={filterVals}
+        setTriageActionTaken={setTriageActionTaken}
         forceRefresh={forceRefresh}
       />
       <br></br>

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -231,6 +231,8 @@ export default function ComponentReadiness(props) {
   const [isLoaded, setIsLoaded] = React.useState(false)
   const [data, setData] = React.useState({})
 
+  const [triageActionTaken, setTriageActionTaken] = React.useState(false)
+
   const [copyPopoverEl, setCopyPopoverEl] = React.useState(null)
   const copyPopoverOpen = Boolean(copyPopoverEl)
 
@@ -368,12 +370,14 @@ export default function ComponentReadiness(props) {
   }
 
   useEffect(() => {
+    setIsLoaded(false)
     if (window.location.pathname.includes('/component_readiness/main')) {
       fetchData()
     } else {
       setIsLoaded(true)
     }
-  }, [])
+    setTriageActionTaken(false)
+  }, [triageActionTaken])
 
   if (!isLoaded) {
     return (
@@ -579,6 +583,7 @@ export default function ComponentReadiness(props) {
                             clearSearches={clearSearches}
                             data={data}
                             filterVals={filterVals}
+                            setTriageActionTaken={setTriageActionTaken}
                             forceRefresh={forceRefresh}
                           />
                           <TableContainer

--- a/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
+++ b/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
@@ -51,10 +51,10 @@ export default function ComponentReadinessToolBar(props) {
     handleRedOnlyCheckboxChange,
     clearSearches,
     data,
+    setTriageActionTaken,
     filterVals,
   } = props
 
-  const [triageEntryCreated, setTriageEntryCreated] = React.useState(false)
   const [regressedTests, setRegressedTests] = React.useState([])
   const [allRegressedTests, setAllRegressedTests] = React.useState([])
   const [unresolvedTests, setUnresolvedTests] = React.useState([])
@@ -101,10 +101,9 @@ export default function ComponentReadinessToolBar(props) {
         }
       })
       setTriageEntries(triagesAssociatedWithActiveRegressions)
-      setTriageEntryCreated(false)
       setIsLoaded(true)
     })
-  }, [triageEntryCreated])
+  }, [])
 
   const linkToReport = () => {
     const currentUrl = new URL(window.location.href)
@@ -352,7 +351,7 @@ export default function ComponentReadinessToolBar(props) {
         unresolvedTests={unresolvedTests}
         triagedIncidents={triagedIncidents}
         triageEntries={triageEntries}
-        setTriageEntryCreated={setTriageEntryCreated}
+        setTriageActionTaken={setTriageActionTaken}
         filterVals={filterVals}
         isOpen={regressedTestDialog}
         close={closeRegressedTestsDialog}
@@ -371,5 +370,6 @@ ComponentReadinessToolBar.propTypes = {
   clearSearches: PropTypes.func,
   data: PropTypes.object,
   forceRefresh: PropTypes.func,
+  setTriageActionTaken: PropTypes.func,
   filterVals: PropTypes.string.isRequired,
 }

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -49,7 +49,7 @@ export default function RegressedTestsModal({
   unresolvedTests,
   triagedIncidents,
   triageEntries,
-  setTriageEntryCreated,
+  setTriageActionTaken,
   filterVals,
   isOpen,
   close,
@@ -105,14 +105,14 @@ export default function RegressedTestsModal({
           <RegressedTestsTabPanel activeIndex={activeTab} index={0}>
             <RegressedTestsPanel
               regressedTests={unresolvedTests}
-              setTriageEntryCreated={setTriageEntryCreated}
+              setTriageActionTaken={setTriageActionTaken}
               filterVals={filterVals}
             />
           </RegressedTestsTabPanel>
           <RegressedTestsTabPanel activeIndex={activeTab} index={1}>
             <RegressedTestsPanel
               regressedTests={regressedTests}
-              setTriageEntryCreated={setTriageEntryCreated}
+              setTriageActionTaken={setTriageActionTaken}
               filterVals={filterVals}
             />
           </RegressedTestsTabPanel>
@@ -133,7 +133,7 @@ export default function RegressedTestsModal({
           <RegressedTestsTabPanel activeIndex={activeTab} index={3}>
             <RegressedTestsPanel
               regressedTests={allRegressedTests}
-              setTriageEntryCreated={setTriageEntryCreated}
+              setTriageActionTaken={setTriageActionTaken}
               filterVals={filterVals}
             />
           </RegressedTestsTabPanel>
@@ -157,7 +157,7 @@ RegressedTestsModal.propTypes = {
   unresolvedTests: PropTypes.array,
   triagedIncidents: PropTypes.array,
   triageEntries: PropTypes.array,
-  setTriageEntryCreated: PropTypes.func,
+  setTriageActionTaken: PropTypes.func,
   filterVals: PropTypes.string.isRequired,
   isOpen: PropTypes.bool,
   close: PropTypes.func,

--- a/sippy-ng/src/component_readiness/RegressedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsPanel.js
@@ -29,7 +29,7 @@ export default function RegressedTestsPanel(props) {
     { updateType: 'replaceIn' }
   )
   const { expandEnvironment } = useContext(CompReadyVarsContext)
-  const { filterVals, regressedTests, setTriageEntryCreated } = props
+  const { filterVals, regressedTests, setTriageActionTaken } = props
   const [sortModel, setSortModel] = React.useState([
     { field: 'component', sort: 'asc' },
   ])
@@ -62,7 +62,7 @@ export default function RegressedTestsPanel(props) {
       ids: [],
     })
     setTriaging(false)
-    setTriageEntryCreated(true)
+    setTriageActionTaken(true)
   }
 
   const handleTriageTestIdChange = (e) => {
@@ -344,6 +344,6 @@ export default function RegressedTestsPanel(props) {
 
 RegressedTestsPanel.propTypes = {
   regressedTests: PropTypes.array,
-  setTriageEntryCreated: PropTypes.func,
+  setTriageActionTaken: PropTypes.func,
   filterVals: PropTypes.string.isRequired,
 }


### PR DESCRIPTION
This fixes the following:

> When creating a new Triage record from the regressed test modal, the data in the modal is not fully updated until refreshing the page. The new record is present, and the proper regressions are added to it. However, the status for the regressions is not correct, and the regressions don't move to the proper tabs.