### PR TITLE
TRT-2146: Add to existing Triage from RegressedTestsModal

### DIFF
--- a/sippy-ng/src/component_readiness/AddRegressionPanel.js
+++ b/sippy-ng/src/component_readiness/AddRegressionPanel.js
@@ -10,7 +10,7 @@ import TriageFields from './TriageFields'
 
 export default function AddRegressionPanel({
   triages,
-  regressionId,
+  regressionIds,
   setAlertText,
   setAlertSeverity,
   handleNewTriageFormCompletion,
@@ -33,7 +33,12 @@ export default function AddRegressionPanel({
     )
     const updatedTriage = {
       ...existingTriage,
-      regressions: [...existingTriage.regressions, { id: regressionId }],
+      regressions: [
+        ...existingTriage.regressions,
+        ...regressionIds.map((id) => {
+          return { id: Number(id) }
+        }),
+      ],
     }
 
     fetch(getTriagesAPIUrl(existingTriageId), {
@@ -86,7 +91,7 @@ export default function AddRegressionPanel({
 
   return (
     <Fragment>
-      <DialogTitle>Add Triage</DialogTitle>
+      <DialogTitle>Triage</DialogTitle>
       <DialogContent>
         <Tabs
           value={tabIndex}
@@ -128,7 +133,7 @@ export default function AddRegressionPanel({
         )}
         {addToNew && (
           <Fragment>
-            <h3>Add to new Triage</h3>
+            <h3>Create new Triage</h3>
             <TriageFields
               setAlertText={setAlertText}
               setAlertSeverity={setAlertSeverity}
@@ -146,7 +151,7 @@ export default function AddRegressionPanel({
 
 AddRegressionPanel.propTypes = {
   triages: PropTypes.array.isRequired,
-  regressionId: PropTypes.number.isRequired,
+  regressionIds: PropTypes.array.isRequired,
   triageEntryData: PropTypes.object.isRequired,
   setTriageEntryData: PropTypes.func.isRequired,
   setAlertText: PropTypes.func.isRequired,

--- a/sippy-ng/src/component_readiness/CompReadyTestReport.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestReport.js
@@ -371,7 +371,7 @@ Flakes: ${stats.flake_count}`
 
           {writeEndpointsEnabled && regressionId > 0 && (
             <UpsertTriageModal
-              regressionId={regressionId}
+              regressionIds={[regressionId]}
               setComplete={setHasBeenTriaged}
               buttonText="Triage"
               submissionDelay={2000}

--- a/sippy-ng/src/component_readiness/RegressedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsPanel.js
@@ -15,7 +15,7 @@ import CompSeverityIcon from './CompSeverityIcon'
 import IconButton from '@mui/material/IconButton'
 import PropTypes from 'prop-types'
 import React, { Fragment, useContext } from 'react'
-import TriageFields from './TriageFields'
+import UpsertTriageModal from './UpsertTriageModal'
 
 export default function RegressedTestsPanel(props) {
   const [activeRow, setActiveRow] = useQueryParam(
@@ -48,19 +48,10 @@ export default function RegressedTestsPanel(props) {
   const capabilitiesContext = React.useContext(CapabilitiesContext)
   const triageEnabled = capabilitiesContext.includes('write_endpoints')
   const [triaging, setTriaging] = React.useState(false)
-  const [triageEntryData, setTriageEntryData] = React.useState({
-    url: '',
-    type: 'type',
-    description: '',
-    ids: [],
-  })
+  const [regressionIds, setRegressionIds] = React.useState([])
+
   const handleTriageFormCompletion = () => {
-    setTriageEntryData({
-      url: '',
-      type: 'type',
-      description: '',
-      ids: [],
-    })
+    setRegressionIds([])
     setTriaging(false)
     setTriageActionTaken(true)
   }
@@ -68,15 +59,9 @@ export default function RegressedTestsPanel(props) {
   const handleTriageTestIdChange = (e) => {
     const { value, checked } = e.target
     if (checked) {
-      setTriageEntryData((prevData) => ({
-        ...prevData,
-        ids: [...prevData.ids, value],
-      }))
+      setRegressionIds((prevData) => [...prevData, value])
     } else {
-      setTriageEntryData((prevData) => ({
-        ...prevData,
-        ids: prevData.ids.filter((id) => id !== value),
-      }))
+      setRegressionIds((prevData) => prevData.filter((id) => id !== value))
     }
   }
 
@@ -111,7 +96,7 @@ export default function RegressedTestsPanel(props) {
                 name="triage-test-id"
                 value={param.value}
                 onChange={handleTriageTestIdChange}
-                checked={triageEntryData.ids.includes(param.value)}
+                checked={regressionIds.includes(param.value)}
                 disabled={param.value === '0'}
               />
             ),
@@ -302,23 +287,21 @@ export default function RegressedTestsPanel(props) {
         }}
       />
       {triaging && (
-        <TriageFields
-          setAlertText={setAlertText}
-          setAlertSeverity={setAlertSeverity}
-          setTriageEntryData={setTriageEntryData}
-          triageEntryData={triageEntryData}
-          handleFormCompletion={handleTriageFormCompletion}
-          submitButtonText={'Create Entry'}
+        <UpsertTriageModal
+          regressionIds={regressionIds}
+          buttonText="Set Triage Info"
+          setComplete={handleTriageFormCompletion}
+          submissionDelay={1500}
         />
       )}
       {triageEnabled ? (
         <Button
           variant="contained"
           color="secondary"
-          sx={'margin-top: 10px'}
+          sx={'margin: 10px'}
           onClick={() => setTriaging(!triaging)}
         >
-          {triaging ? 'Close' : 'Triage'}
+          {triaging ? 'Cancel' : 'Triage'}
         </Button>
       ) : null}
 


### PR DESCRIPTION
This modifies the logic so that the `UpsertTriageModal` is used when triaging regressions within the `RegressedTestsModal`. This has the effect of including the ability to add to an existing triage record. In order to support this, the upsert logic needed to be changed so that it could add multiple regressions to a triage at a time, which was previously not necessary.

We could actually follow up on this to edit the triage directly from the modal now fairly simply...