### PR TITLE
TRT-1474: log the user making a mutating triage request in preparation for auditing

### DIFF
--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1272,6 +1272,13 @@ func (s *Server) jsonTriages(w http.ResponseWriter, req *http.Request) {
 		log.Infof("Extracted triage ID: %d", triageID)
 	}
 
+	if req.Method == http.MethodPost || req.Method == http.MethodPut {
+		user := req.Header.Get("X-Forwarded-User")
+		email := req.Header.Get("X-Forwarded-Email")
+
+		log.Infof("triage %s being made by user: %s, email: %s", req.Method, user, email)
+	}
+
 	switch req.Method {
 	case http.MethodGet:
 		// Was a specific record requested?


### PR DESCRIPTION
I want to verify that we have access to this info without making changes to our oauth proxy pod