### PR TITLE
refactor of `test_details` analysis

### DIFF
--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -793,7 +793,7 @@ func initTestAnalysisStruct(
 		Start:   &reqOptions.SampleRelease.Start,
 		End:     &reqOptions.SampleRelease.End,
 		TestDetailsTestStats: crtype.TestDetailsTestStats{
-			SuccessRate:  utils.CalculatePassRate(sampleStats.SuccessCount, successFailCount, sampleStats.FlakeCount, reqOptions.AdvancedOption.FlakeAsFailure),
+			SuccessRate:  crtype.CalculatePassRate(sampleStats.SuccessCount, successFailCount, sampleStats.FlakeCount, reqOptions.AdvancedOption.FlakeAsFailure),
 			SuccessCount: sampleStats.SuccessCount,
 			FlakeCount:   sampleStats.FlakeCount,
 			FailureCount: successFailCount,
@@ -810,7 +810,7 @@ func initTestAnalysisStruct(
 			Start:   &baseStart,
 			End:     &baseEnd,
 			TestDetailsTestStats: crtype.TestDetailsTestStats{
-				SuccessRate:  utils.CalculatePassRate(baseStats.SuccessCount, failCount, baseStats.FlakeCount, reqOptions.AdvancedOption.FlakeAsFailure),
+				SuccessRate:  crtype.CalculatePassRate(baseStats.SuccessCount, failCount, baseStats.FlakeCount, reqOptions.AdvancedOption.FlakeAsFailure),
 				SuccessCount: baseStats.SuccessCount,
 				FlakeCount:   baseStats.FlakeCount,
 				FailureCount: failCount,
@@ -1012,7 +1012,7 @@ func (c *ComponentReportGenerator) getTestStatusPassRate(testStatus crtype.TestS
 }
 
 func (c *ComponentReportGenerator) getPassRate(success, failure, flake int) float64 {
-	return utils.CalculatePassRate(success, failure, flake, c.ReqOptions.AdvancedOption.FlakeAsFailure)
+	return crtype.CalculatePassRate(success, failure, flake, c.ReqOptions.AdvancedOption.FlakeAsFailure)
 }
 
 func getRegressionStatus(basisPassPercentage, samplePassPercentage float64) crtype.Status {

--- a/pkg/api/componentreadiness/component_report_test.go
+++ b/pkg/api/componentreadiness/component_report_test.go
@@ -1585,7 +1585,7 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
-			report := tc.generator.internalGenerateTestDetailsReport(baseStats, "", nil, nil, sampleStats, tc.generator.ReqOptions.TestIDOptions[0])
+			report := tc.generator.internalGenerateTestDetailsReport("", nil, nil, baseStats, sampleStats, tc.generator.ReqOptions.TestIDOptions[0])
 			assert.Equal(t, tc.expectedReport.RowIdentification, report.RowIdentification, "expected report row identification %+v, got %+v", tc.expectedReport.RowIdentification, report.RowIdentification)
 			assert.Equal(t, tc.expectedReport.ColumnIdentification, report.ColumnIdentification, "expected report column identification %+v, got %+v", tc.expectedReport.ColumnIdentification, report.ColumnIdentification)
 			assert.Equal(t, tc.expectedReport.Analyses[0].BaseStats, report.Analyses[0].BaseStats, "expected report base stats %+v, got %+v", tc.expectedReport.Analyses[0].BaseStats, report.Analyses[0].BaseStats)

--- a/pkg/api/componentreadiness/component_report_test.go
+++ b/pkg/api/componentreadiness/component_report_test.go
@@ -247,95 +247,121 @@ func TestGenerateComponentReport(t *testing.T) {
 		assert.NoError(t, err, "error marshalling awsAMD64OVNInstallerIPITest")
 	}
 	awsAMD64OVNBaseTestStats90Percent := crtype.TestStatus{
-		TestName:     "test 1",
-		Variants:     []string{"standard"},
-		TotalCount:   1000,
-		FlakeCount:   10,
-		SuccessCount: 900,
+		TestName: "test 1",
+		Variants: []string{"standard"},
+		TestCount: crtype.TestCount{
+			TotalCount:   1000,
+			FlakeCount:   10,
+			SuccessCount: 900,
+		},
 	}
 	awsAMD64OVNBaseTestStats50Percent := crtype.TestStatus{
-		TestName:     "test 1",
-		Variants:     []string{"standard"},
-		TotalCount:   1000,
-		FlakeCount:   10,
-		SuccessCount: 500,
+		TestName: "test 1",
+		Variants: []string{"standard"},
+		TestCount: crtype.TestCount{
+			TotalCount:   1000,
+			FlakeCount:   10,
+			SuccessCount: 500,
+		},
 	}
 	awsAMD64OVNBaseTestStatsVariants90Percent := crtype.TestStatus{
-		TestName:     "test 1",
-		Variants:     []string{"standard", "fips"},
-		TotalCount:   1000,
-		FlakeCount:   10,
-		SuccessCount: 900,
+		TestName: "test 1",
+		Variants: []string{"standard", "fips"},
+		TestCount: crtype.TestCount{
+			TotalCount:   1000,
+			FlakeCount:   10,
+			SuccessCount: 900,
+		},
 	}
 	awsAMD64OVNSampleTestStats90Percent := crtype.TestStatus{
-		TestName:     "test 1",
-		Variants:     []string{"standard"},
-		TotalCount:   100,
-		FlakeCount:   1,
-		SuccessCount: 90,
+		TestName: "test 1",
+		Variants: []string{"standard"},
+		TestCount: crtype.TestCount{
+			TotalCount:   100,
+			FlakeCount:   1,
+			SuccessCount: 90,
+		},
 	}
 	awsAMD64OVNSampleTestStats85Percent := crtype.TestStatus{
-		TestName:     "test 1",
-		Variants:     []string{"standard"},
-		TotalCount:   100,
-		FlakeCount:   1,
-		SuccessCount: 85,
+		TestName: "test 1",
+		Variants: []string{"standard"},
+		TestCount: crtype.TestCount{
+			TotalCount:   100,
+			FlakeCount:   1,
+			SuccessCount: 85,
+		},
 	}
 	awsAMD64OVNSampleTestStats50Percent := crtype.TestStatus{
-		TestName:     "test 1",
-		Variants:     []string{"standard"},
-		TotalCount:   100,
-		FlakeCount:   1,
-		SuccessCount: 50,
+		TestName: "test 1",
+		Variants: []string{"standard"},
+		TestCount: crtype.TestCount{
+			TotalCount:   100,
+			FlakeCount:   1,
+			SuccessCount: 50,
+		},
 	}
 	awsAMD64OVNSampleTestStatsTiny := crtype.TestStatus{
-		TestName:     "test 1",
-		Variants:     []string{"standard"},
-		TotalCount:   3,
-		FlakeCount:   0,
-		SuccessCount: 1,
+		TestName: "test 1",
+		Variants: []string{"standard"},
+		TestCount: crtype.TestCount{
+			TotalCount:   3,
+			FlakeCount:   0,
+			SuccessCount: 1,
+		},
 	}
 	awsAMD64OVNSampleTestStatsVariants90Percent := crtype.TestStatus{
-		TestName:     "test 1",
-		Variants:     []string{"standard", "fips"},
-		TotalCount:   100,
-		FlakeCount:   1,
-		SuccessCount: 90,
+		TestName: "test 1",
+		Variants: []string{"standard", "fips"},
+		TestCount: crtype.TestCount{
+			TotalCount:   100,
+			FlakeCount:   1,
+			SuccessCount: 90,
+		},
 	}
 	awsAMD64SDNBaseTestStats90Percent := crtype.TestStatus{
-		TestName:     "test 2",
-		Variants:     []string{"standard"},
-		TotalCount:   1000,
-		FlakeCount:   10,
-		SuccessCount: 900,
+		TestName: "test 2",
+		Variants: []string{"standard"},
+		TestCount: crtype.TestCount{
+			TotalCount:   1000,
+			FlakeCount:   10,
+			SuccessCount: 900,
+		},
 	}
 	awsAMD64SDNBaseTestStats50Percent := crtype.TestStatus{
-		TestName:     "test 2",
-		Variants:     []string{"standard"},
-		TotalCount:   1000,
-		FlakeCount:   10,
-		SuccessCount: 500,
+		TestName: "test 2",
+		Variants: []string{"standard"},
+		TestCount: crtype.TestCount{
+			TotalCount:   1000,
+			FlakeCount:   10,
+			SuccessCount: 500,
+		},
 	}
 	awsAMD64SDNSampleTestStats90Percent := crtype.TestStatus{
-		TestName:     "test 2",
-		Variants:     []string{"standard"},
-		TotalCount:   100,
-		FlakeCount:   1,
-		SuccessCount: 90,
+		TestName: "test 2",
+		Variants: []string{"standard"},
+		TestCount: crtype.TestCount{
+			TotalCount:   100,
+			FlakeCount:   1,
+			SuccessCount: 90,
+		},
 	}
 	awsAMD64OVN2BaseTestStats90Percent := crtype.TestStatus{
-		TestName:     "test 3",
-		Variants:     []string{"standard"},
-		TotalCount:   1000,
-		FlakeCount:   10,
-		SuccessCount: 900,
+		TestName: "test 3",
+		Variants: []string{"standard"},
+		TestCount: crtype.TestCount{
+			TotalCount:   1000,
+			FlakeCount:   10,
+			SuccessCount: 900,
+		},
 	}
 	awsAMD64OVN2SampleTestStats80Percent := crtype.TestStatus{
-		TestName:     "test 3",
-		Variants:     []string{"standard"},
-		TotalCount:   100,
-		FlakeCount:   1,
-		SuccessCount: 80,
+		TestName: "test 3",
+		Variants: []string{"standard"},
+		TestCount: crtype.TestCount{
+			TotalCount:   100,
+			FlakeCount:   1,
+			SuccessCount: 80,
+		},
 	}
 	columnAWSAMD64OVN := crtype.ColumnIdentification{
 		Variants: map[string]string{
@@ -1542,44 +1568,52 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		for _, testStats := range tc.baseRequiredJobStats {
 			for i := 0; i < testStats.Success; i++ {
 				baseStats[testStats.job] = append(baseStats[testStats.job], crtype.TestJobRunRows{
-					ProwJob:      testStats.job,
-					TotalCount:   1,
-					SuccessCount: 1,
+					ProwJob: testStats.job,
+					TestCount: crtype.TestCount{
+						TotalCount:   1,
+						SuccessCount: 1,
+					},
 				})
 			}
 			for i := 0; i < testStats.Failure; i++ {
 				baseStats[testStats.job] = append(baseStats[testStats.job], crtype.TestJobRunRows{
-					ProwJob:    testStats.job,
-					TotalCount: 1,
+					ProwJob:   testStats.job,
+					TestCount: crtype.TestCount{TotalCount: 1},
 				})
 			}
 			for i := 0; i < testStats.Flake; i++ {
 				baseStats[testStats.job] = append(baseStats[testStats.job], crtype.TestJobRunRows{
-					ProwJob:    testStats.job,
-					TotalCount: 1,
-					FlakeCount: 1,
+					ProwJob: testStats.job,
+					TestCount: crtype.TestCount{
+						TotalCount: 1,
+						FlakeCount: 1,
+					},
 				})
 			}
 		}
 		for _, testStats := range tc.sampleRequiredJobStats {
 			for i := 0; i < testStats.Success; i++ {
 				sampleStats[testStats.job] = append(sampleStats[testStats.job], crtype.TestJobRunRows{
-					ProwJob:      testStats.job,
-					TotalCount:   1,
-					SuccessCount: 1,
+					ProwJob: testStats.job,
+					TestCount: crtype.TestCount{
+						TotalCount:   1,
+						SuccessCount: 1,
+					},
 				})
 			}
 			for i := 0; i < testStats.Failure; i++ {
 				sampleStats[testStats.job] = append(sampleStats[testStats.job], crtype.TestJobRunRows{
-					ProwJob:    testStats.job,
-					TotalCount: 1,
+					ProwJob:   testStats.job,
+					TestCount: crtype.TestCount{TotalCount: 1},
 				})
 			}
 			for i := 0; i < testStats.Flake; i++ {
 				sampleStats[testStats.job] = append(sampleStats[testStats.job], crtype.TestJobRunRows{
-					ProwJob:    testStats.job,
-					TotalCount: 1,
-					FlakeCount: 1,
+					ProwJob: testStats.job,
+					TestCount: crtype.TestCount{
+						TotalCount: 1,
+						FlakeCount: 1,
+					},
 				})
 			}
 		}

--- a/pkg/api/componentreadiness/middleware/regressionallowances/regressionallowances.go
+++ b/pkg/api/componentreadiness/middleware/regressionallowances/regressionallowances.go
@@ -92,7 +92,7 @@ func (r *RegressionAllowances) matchBaseRegression(testID crtype.ReportTestIdent
 	success := baseStats.SuccessCount
 	fail := baseStats.FailureCount
 	flake := baseStats.FlakeCount
-	basePassRate := utils.CalculatePassRate(success, fail, flake, r.reqOptions.AdvancedOption.FlakeAsFailure)
+	basePassRate := crtype.CalculatePassRate(success, fail, flake, r.reqOptions.AdvancedOption.FlakeAsFailure)
 	if baseRegression.PreviousPassPercentage(r.reqOptions.AdvancedOption.FlakeAsFailure) > basePassRate {
 		// override with  the basis regression previous values
 		// testStats will reflect the expected threshold, not the computed values from the release with the allowed regression
@@ -100,7 +100,7 @@ func (r *RegressionAllowances) matchBaseRegression(testID crtype.ReportTestIdent
 			SuccessCount: baseRegression.PreviousSuccesses,
 			FailureCount: baseRegression.PreviousFailures,
 			FlakeCount:   baseRegression.PreviousFlakes,
-			SuccessRate: utils.CalculatePassRate(baseRegression.PreviousSuccesses, baseRegression.PreviousFailures,
+			SuccessRate: crtype.CalculatePassRate(baseRegression.PreviousSuccesses, baseRegression.PreviousFailures,
 				baseRegression.PreviousFlakes, r.reqOptions.AdvancedOption.FlakeAsFailure),
 		}
 		baseRegressionPreviousRelease, err := utils.PreviousRelease(r.reqOptions.BaseRelease.Release)

--- a/pkg/api/componentreadiness/middleware/regressionallowances/regressionallowances_test.go
+++ b/pkg/api/componentreadiness/middleware/regressionallowances/regressionallowances_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
 	crtype "github.com/openshift/sippy/pkg/apis/api/componentreport"
 	"github.com/openshift/sippy/pkg/regressionallowances"
 	"github.com/stretchr/testify/assert"
@@ -168,7 +167,7 @@ func buildTestStatus(total, success, flake int, baseRelease string) *crtype.Repo
 				FailureCount: fails,
 				SuccessCount: success,
 				FlakeCount:   flake,
-				SuccessRate:  utils.CalculatePassRate(success, fails, flake, false),
+				SuccessRate:  crtype.CalculatePassRate(success, fails, flake, false),
 			},
 		},
 	}
@@ -188,7 +187,7 @@ func buildTestStatus2(total, success, flake int, baseRelease, sampleRelease stri
 			FailureCount: fails,
 			SuccessCount: success,
 			FlakeCount:   flake,
-			SuccessRate:  utils.CalculatePassRate(success, fails, flake, false),
+			SuccessRate:  crtype.CalculatePassRate(success, fails, flake, false),
 		},
 	}
 	ts.PityAdjustment = pityAdjust

--- a/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
+++ b/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
@@ -141,10 +141,10 @@ func (r *ReleaseFallback) PreAnalysis(testKey crtype.ReportTestIdentification, t
 			success := testStats.BaseStats.SuccessCount
 			fail := testStats.BaseStats.FailureCount
 			flake := testStats.BaseStats.FlakeCount
-			basePassRate := utils.CalculatePassRate(success, fail, flake, r.reqOptions.AdvancedOption.FlakeAsFailure)
+			basePassRate := crtype.CalculatePassRate(success, fail, flake, r.reqOptions.AdvancedOption.FlakeAsFailure)
 
 			_, success, fail, flake = cTestStats.GetTotalSuccessFailFlakeCounts()
-			cPassRate := utils.CalculatePassRate(success, fail, flake, r.reqOptions.AdvancedOption.FlakeAsFailure)
+			cPassRate := crtype.CalculatePassRate(success, fail, flake, r.reqOptions.AdvancedOption.FlakeAsFailure)
 			if cPassRate > basePassRate {
 				// We've found a better pass rate in a prior release with enough runs to qualify.
 				// Adjust the stats and keep looking for an even better one.

--- a/pkg/api/componentreadiness/middleware/releasefallback/releasefallback_test.go
+++ b/pkg/api/componentreadiness/middleware/releasefallback/releasefallback_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
 	crtype "github.com/openshift/sippy/pkg/apis/api/componentreport"
 	"github.com/stretchr/testify/assert"
 )
@@ -215,9 +214,11 @@ func buildTestStatus(testName string, variants []string, total, success, flake i
 		Component:    "foo",
 		Capabilities: nil,
 		Variants:     variants,
-		TotalCount:   total,
-		SuccessCount: success,
-		FlakeCount:   flake,
+		TestCount: crtype.TestCount{
+			TotalCount:   total,
+			SuccessCount: success,
+			FlakeCount:   flake,
+		},
 	}
 }
 
@@ -232,7 +233,7 @@ func buildTestStats(total, success int, baseRelease crtype.Release, explanations
 				FailureCount: fails,
 				SuccessCount: success,
 				FlakeCount:   0,
-				SuccessRate:  utils.CalculatePassRate(success, fails, 0, false),
+				SuccessRate:  crtype.CalculatePassRate(success, fails, 0, false),
 			},
 		},
 	}

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -202,7 +202,11 @@ func (c *ComponentReportGenerator) GenerateDetailsReportForTest(ctx context.Cont
 	componentJobRunTestReportStatus.GeneratedAt = &now
 
 	// Generate the report for the main release that was originally requested:
-	report := c.internalGenerateTestDetailsReport(componentJobRunTestReportStatus.BaseStatus, c.ReqOptions.BaseRelease.Release, &c.ReqOptions.BaseRelease.Start, &c.ReqOptions.BaseRelease.End, componentJobRunTestReportStatus.SampleStatus, testIDOption)
+	report := c.internalGenerateTestDetailsReport(
+		c.ReqOptions.BaseRelease.Release,
+		&c.ReqOptions.BaseRelease.Start, &c.ReqOptions.BaseRelease.End,
+		componentJobRunTestReportStatus.BaseStatus, componentJobRunTestReportStatus.SampleStatus,
+		testIDOption)
 	report.GeneratedAt = componentJobRunTestReportStatus.GeneratedAt
 
 	// Generate the report for the fallback release if one was found:
@@ -232,7 +236,11 @@ func (c *ComponentReportGenerator) GenerateDetailsReportForTest(ctx context.Cont
 			return crtype.ReportTestDetails{}, []error{err}
 		}
 
-		overrideReport := c.internalGenerateTestDetailsReport(componentJobRunTestReportStatus.BaseOverrideStatus, testIDOption.BaseOverrideRelease, start, end, componentJobRunTestReportStatus.SampleStatus, testIDOption)
+		overrideReport := c.internalGenerateTestDetailsReport(
+			testIDOption.BaseOverrideRelease,
+			start, end,
+			componentJobRunTestReportStatus.BaseOverrideStatus, componentJobRunTestReportStatus.SampleStatus,
+			testIDOption)
 		// swap out the base dates for the override
 		overrideReport.GeneratedAt = componentJobRunTestReportStatus.GeneratedAt
 		baseOverrideReport = &overrideReport
@@ -449,7 +457,12 @@ func (c *ComponentReportGenerator) getJobRunTestStatusFromBigQuery(ctx context.C
 // breakdown by job as well as overall stats.
 //
 //nolint:gocyclo
-func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(baseStatus map[string][]crtype.TestJobRunRows, baseRelease string, baseStart, baseEnd *time.Time, sampleStatus map[string][]crtype.TestJobRunRows, testIDOption crtype.RequestTestIdentificationOptions) crtype.ReportTestDetails {
+func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(
+	baseRelease string,
+	baseStart, baseEnd *time.Time,
+	baseStatus, sampleStatus map[string][]crtype.TestJobRunRows,
+	testIDOption crtype.RequestTestIdentificationOptions,
+) crtype.ReportTestDetails {
 
 	// make a copy of sampleStatus because it's passed by ref, and we're going to modify it.
 	sampleStatusCopy := map[string][]crtype.TestJobRunRows{}

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -626,14 +626,13 @@ func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(
 }
 
 func (c *ComponentReportGenerator) getJobRunStats(stats crtype.TestJobRunRows) crtype.TestDetailsJobRunStats {
-	failure := getFailureCount(stats)
 	jobRunStats := crtype.TestDetailsJobRunStats{
-		TestStats: crtype.TestDetailsTestStats{
-			SuccessRate:  c.getPassRate(stats.SuccessCount, failure, stats.FlakeCount),
-			SuccessCount: stats.SuccessCount,
-			FailureCount: failure,
-			FlakeCount:   stats.FlakeCount,
-		},
+		TestStats: crtype.NewTestStats(
+			stats.SuccessCount,
+			stats.Failures(),
+			stats.FlakeCount,
+			c.ReqOptions.AdvancedOption.FlakeAsFailure,
+		),
 		JobURL:    stats.ProwJobURL,
 		JobRunID:  stats.ProwJobRunID,
 		StartTime: stats.StartTime,

--- a/pkg/api/componentreadiness/utils/utils.go
+++ b/pkg/api/componentreadiness/utils/utils.go
@@ -108,17 +108,6 @@ func DeserializeTestKey(stats componentreport.TestStatus, testKeyStr string) (co
 	return testID, nil
 }
 
-func CalculatePassRate(success, failure, flake int, treatFlakeAsFailure bool) float64 {
-	total := success + failure + flake
-	if total == 0 {
-		return 0.0
-	}
-	if treatFlakeAsFailure {
-		return float64(success) / float64(total)
-	}
-	return float64(success+flake) / float64(total)
-}
-
 // VariantsMapToStringSlice converts the map form of variants to a string slice
 // where each variant is formatted key:value.
 func VariantsMapToStringSlice(variants map[string]string) []string {


### PR DESCRIPTION
I set out to refactor `test_details.internalGenerateTestDetailsReport` for readability and along the way discovered a few bugs to fix. The bug fixes are isolated to their own commits; otherwise no functionality should be changing. Those (relatively simple) commits:

* two `respect FlakeAsFailure` commits
* `bugfix: also assessTestStats on sample-only tests`
* `baseRegression tweaking now handled in middleware` - at least I think? If anyone has a testcase handy it would be good to check.

I'd especially appreciate a review of my "fixes" to make sure they really are fixes. That should be much less work than a total review -- the actual refactoring is less suspicious; I got some good test failures along the way to make sure there was some coverage, and the results seem OK locally.