### PR TITLE
TRT-2154: handle old test_details links

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyVars.js
+++ b/sippy-ng/src/component_readiness/CompReadyVars.js
@@ -570,7 +570,20 @@ export const CompReadyVarsProvider = ({ children }) => {
     const params = {}
     items.forEach((item) => {
       const variants = item.split(':')
-      params[variants[0]] = variants[1]
+      if (variants.length === 2) {
+        params[variants[0]] = variants[1]
+      } else {
+        // handle legacy links where env didn't specify variant name (TRT-2154)
+        Object.entries(allJobVariants).forEach(
+          ([variantName, variantValues]) => {
+            // the new env format started after platform 'none' was added.
+            // we only need to support 'none' in the legacy format for Upgrade=none
+            if (variantValues.includes(item))
+              if (variantName === 'Upgrade' || item !== 'none')
+                params[variantName] = item
+          }
+        )
+      }
     })
     const paramStrings = Object.entries(params).map(
       ([key, value]) => `${key}=${value}`


### PR DESCRIPTION
* [original broken link from the example jira](https://sippy-auth.dptools.openshift.org/sippy-ng/component_readiness/test_details?Aggregation=none&Architecture=amd64&Architecture=amd64&FeatureSet=default&FeatureSet=default&Installer=hypershift&Installer=hypershift&LayeredProduct=none&Network=ovn&Network=ovn&NetworkAccess=default&Platform=azure&Platform=azure&Procedure=none&Scheduler=default&SecurityMode=default&Suite=parallel&Suite=parallel&Topology=external&Topology=external&Upgrade=none&Upgrade=none&baseEndTime=2025-05-26%2023%3A59%3A59&baseRelease=4.19&baseStartTime=2025-04-26%2000%3A00%3A00&capability=OCPFeatureGate%3AGatewayAPIController&columnGroupBy=Architecture%2CNetwork%2CPlatform%2CTopology&component=Networking%20%2F%20router&confidence=95&dbGroupBy=Platform%2CArchitecture%2CNetwork%2CTopology%2CFeatureSet%2CUpgrade%2CSuite%2CInstaller&environment=amd64%20default%20hypershift%20ovn%20azure%20parallel%20external%20none&flakeAsFailure=false&ignoreDisruption=true&ignoreMissing=false&includeMultiReleaseAnalysis=true&includeVariant=Architecture%3Aamd64&includeVariant=CGroupMode%3Av2&includeVariant=ContainerRuntime%3Acrun&includeVariant=ContainerRuntime%3Arunc&includeVariant=FeatureSet%3Adefault&includeVariant=FeatureSet%3Atechpreview&includeVariant=Installer%3Ahypershift&includeVariant=Installer%3Aipi&includeVariant=Installer%3Aupi&includeVariant=JobTier%3Ablocking&includeVariant=JobTier%3Ainforming&includeVariant=JobTier%3Astandard&includeVariant=LayeredProduct%3Anone&includeVariant=LayeredProduct%3Avirt&includeVariant=Network%3Aovn&includeVariant=Owner%3Aeng&includeVariant=Owner%3Aservice-delivery&includeVariant=Platform%3Aaws&includeVariant=Platform%3Aazure&includeVariant=Platform%3Agcp&includeVariant=Platform%3Ametal&includeVariant=Platform%3Arosa&includeVariant=Platform%3Avsphere&includeVariant=Topology%3Aexternal&includeVariant=Topology%3Aha&includeVariant=Topology%3Amicroshift&minFail=3&passRateAllTests=0&passRateNewTests=95&pity=5&sampleEndTime=2025-05-26%2023%3A59%3A59&sampleRelease=4.20&sampleStartTime=2025-05-19%2000%3A00%3A00&testBasisRelease=4.19&testId=openshift-tests%3Afc5afb5bb15489ea838ed9afb8f2a0e3&testName=%5Bsig-network-edge%5D%5BOCPFeatureGate%3AGatewayAPIController%5D%5BFeature%3ARouter%5D%5Bapigroup%3Agateway.networking.k8s.io%5D%20Ensure%20HTTPRoute%20object%20is%20created%20%5BSuite%3Aopenshift%2Fconformance%2Fparallel%5D)
* [local link for same that now works](http://localhost:3000/sippy-ng/component_readiness/test_details?Aggregation=none&Architecture=amd64&Architecture=amd64&FeatureSet=default&FeatureSet=default&Installer=hypershift&Installer=hypershift&LayeredProduct=none&Network=ovn&Network=ovn&NetworkAccess=default&Platform=azure&Platform=azure&Procedure=none&Scheduler=default&SecurityMode=default&Suite=parallel&Suite=parallel&Topology=external&Topology=external&Upgrade=none&Upgrade=none&baseEndTime=2025-05-26%2023%3A59%3A59&baseRelease=4.19&baseStartTime=2025-04-26%2000%3A00%3A00&capability=OCPFeatureGate%3AGatewayAPIController&columnGroupBy=Architecture%2CNetwork%2CPlatform%2CTopology&component=Networking%20%2F%20router&confidence=95&dbGroupBy=Platform%2CArchitecture%2CNetwork%2CTopology%2CFeatureSet%2CUpgrade%2CSuite%2CInstaller&environment=amd64%20default%20hypershift%20ovn%20azure%20parallel%20external%20none&flakeAsFailure=false&ignoreDisruption=true&ignoreMissing=false&includeMultiReleaseAnalysis=true&includeVariant=Architecture%3Aamd64&includeVariant=CGroupMode%3Av2&includeVariant=ContainerRuntime%3Acrun&includeVariant=ContainerRuntime%3Arunc&includeVariant=FeatureSet%3Adefault&includeVariant=FeatureSet%3Atechpreview&includeVariant=Installer%3Ahypershift&includeVariant=Installer%3Aipi&includeVariant=Installer%3Aupi&includeVariant=JobTier%3Ablocking&includeVariant=JobTier%3Ainforming&includeVariant=JobTier%3Astandard&includeVariant=LayeredProduct%3Anone&includeVariant=LayeredProduct%3Avirt&includeVariant=Network%3Aovn&includeVariant=Owner%3Aeng&includeVariant=Owner%3Aservice-delivery&includeVariant=Platform%3Aaws&includeVariant=Platform%3Aazure&includeVariant=Platform%3Agcp&includeVariant=Platform%3Ametal&includeVariant=Platform%3Arosa&includeVariant=Platform%3Avsphere&includeVariant=Topology%3Aexternal&includeVariant=Topology%3Aha&includeVariant=Topology%3Amicroshift&minFail=3&passRateAllTests=0&passRateNewTests=95&pity=5&sampleEndTime=2025-05-26%2023%3A59%3A59&sampleRelease=4.20&sampleStartTime=2025-05-19%2000%3A00%3A00&testBasisRelease=4.19&testId=openshift-tests%3Afc5afb5bb15489ea838ed9afb8f2a0e3&testName=%5Bsig-network-edge%5D%5BOCPFeatureGate%3AGatewayAPIController%5D%5BFeature%3ARouter%5D%5Bapigroup%3Agateway.networking.k8s.io%5D%20Ensure%20HTTPRoute%20object%20is%20created%20%5BSuite%3Aopenshift%2Fconformance%2Fparallel%5D)

neither matches the current link which has newer dates...