### PR TITLE
more CR refactoring

### DIFF
--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -633,20 +633,12 @@ func (c *ComponentReportGenerator) getRowColumnIdentifications(testIDStr string,
 	testComponent, testCapabilities := componentAndCapabilityGetter(test, stats)
 	rows := []crtype.RowIdentification{}
 	// First Page with no component requested
-	requestedComponent := ""
-	requestedCapability := ""
-	requestedTestID := "" // component reports can filter on test if you drill down far enough
+	requestedComponent, requestedCapability, requestedTestID := "", "", ""
 	if len(c.ReqOptions.TestIDOptions) > 0 {
 		firstTIDOpts := c.ReqOptions.TestIDOptions[0]
-		if firstTIDOpts.Component != "" {
-			requestedComponent = firstTIDOpts.Component
-		}
-		if firstTIDOpts.Capability != "" {
-			requestedCapability = firstTIDOpts.Capability
-		}
-		if firstTIDOpts.TestID != "" {
-			requestedTestID = c.ReqOptions.TestIDOptions[0].TestID
-		}
+		requestedComponent = firstTIDOpts.Component
+		requestedCapability = firstTIDOpts.Capability
+		requestedTestID = firstTIDOpts.TestID // component reports can filter on test if you drill down far enough
 	}
 
 	if requestedComponent == "" {
@@ -655,14 +647,14 @@ func (c *ComponentReportGenerator) getRowColumnIdentifications(testIDStr string,
 	} else if requestedComponent == testComponent {
 		// A component filter was specified and this test matches that component:
 
+		row := crtype.RowIdentification{
+			Component: testComponent,
+			TestID:    test.TestID,
+			TestName:  stats.TestName,
+			TestSuite: stats.TestSuite,
+		}
 		// Exact test match
 		if requestedTestID != "" {
-			row := crtype.RowIdentification{
-				Component: testComponent,
-				TestID:    test.TestID,
-				TestName:  stats.TestName,
-				TestSuite: stats.TestSuite,
-			}
 			if requestedCapability != "" {
 				row.Capability = requestedCapability
 			}
@@ -672,13 +664,7 @@ func (c *ComponentReportGenerator) getRowColumnIdentifications(testIDStr string,
 				// Exact capability match only produces one row
 				if requestedCapability != "" {
 					if requestedCapability == capability {
-						row := crtype.RowIdentification{
-							Component:  testComponent,
-							TestID:     test.TestID,
-							TestName:   stats.TestName,
-							TestSuite:  stats.TestSuite,
-							Capability: capability,
-						}
+						row.Capability = capability
 						rows = append(rows, row)
 						break
 					}

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -1002,15 +1002,7 @@ func (c *ComponentReportGenerator) assessComponentStatus(testStats *crtype.Repor
 		testStats.RequiredConfidence = opts.Confidence
 	}
 
-	var baseSuccess, baseFailure, baseFlake, baseTotal int
-	if testStats.BaseStats != nil {
-		baseSuccess = testStats.BaseStats.SuccessCount
-		baseFailure = testStats.BaseStats.FailureCount
-		baseFlake = testStats.BaseStats.FlakeCount
-		baseTotal = baseSuccess + baseFailure + baseFlake
-	}
-
-	if baseTotal == 0 && opts.PassRateRequiredNewTests > 0 {
+	if (testStats.BaseStats == nil || testStats.BaseStats.Total() == 0) && opts.PassRateRequiredNewTests > 0 {
 		// If we have no base stats, fall back to a raw pass rate comparison for new or improperly renamed tests:
 		c.buildPassRateTestStats(testStats, float64(opts.PassRateRequiredNewTests))
 		// If a new test reports no regression, and we're not using pass rate mode for all tests, we alter

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -781,40 +781,24 @@ func updateCellStatus(rowIdentifications []crtype.RowIdentification, columnIdent
 func initTestAnalysisStruct(
 	testStats *crtype.ReportTestStats,
 	reqOptions crtype.RequestOptions,
-	sampleStats crtype.TestStatus,
-	baseStats *crtype.TestStatus) {
+	sampleStatus crtype.TestStatus,
+	baseStatus *crtype.TestStatus) {
 
 	// Default to required confidence from request, middleware may adjust later.
 	testStats.RequiredConfidence = reqOptions.AdvancedOption.Confidence
 
-	successFailCount := sampleStats.TotalCount - sampleStats.FlakeCount - sampleStats.SuccessCount
 	testStats.SampleStats = crtype.TestDetailsReleaseStats{
-		Release: reqOptions.SampleRelease.Release,
-		Start:   &reqOptions.SampleRelease.Start,
-		End:     &reqOptions.SampleRelease.End,
-		TestDetailsTestStats: crtype.TestDetailsTestStats{
-			SuccessRate:  crtype.CalculatePassRate(sampleStats.SuccessCount, successFailCount, sampleStats.FlakeCount, reqOptions.AdvancedOption.FlakeAsFailure),
-			SuccessCount: sampleStats.SuccessCount,
-			FlakeCount:   sampleStats.FlakeCount,
-			FailureCount: successFailCount,
-		},
+		Release:              reqOptions.SampleRelease.Release,
+		Start:                &reqOptions.SampleRelease.Start,
+		End:                  &reqOptions.SampleRelease.End,
+		TestDetailsTestStats: sampleStatus.ToTestStats(reqOptions.AdvancedOption.FlakeAsFailure),
 	}
-	if baseStats != nil {
-		baseRelease := reqOptions.BaseRelease.Release
-		baseStart := reqOptions.BaseRelease.Start
-		baseEnd := reqOptions.BaseRelease.End
-
-		failCount := baseStats.TotalCount - baseStats.FlakeCount - baseStats.SuccessCount
+	if baseStatus != nil {
 		testStats.BaseStats = &crtype.TestDetailsReleaseStats{
-			Release: baseRelease,
-			Start:   &baseStart,
-			End:     &baseEnd,
-			TestDetailsTestStats: crtype.TestDetailsTestStats{
-				SuccessRate:  crtype.CalculatePassRate(baseStats.SuccessCount, failCount, baseStats.FlakeCount, reqOptions.AdvancedOption.FlakeAsFailure),
-				SuccessCount: baseStats.SuccessCount,
-				FlakeCount:   baseStats.FlakeCount,
-				FailureCount: failCount,
-			},
+			Release:              reqOptions.BaseRelease.Release,
+			Start:                &reqOptions.BaseRelease.Start,
+			End:                  &reqOptions.BaseRelease.End,
+			TestDetailsTestStats: baseStatus.ToTestStats(reqOptions.AdvancedOption.FlakeAsFailure),
 		}
 	}
 }

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -720,7 +720,16 @@ func getNewCellStatus(testID crtype.ReportTestIdentification, testStats crtype.R
 	return newCellStatus
 }
 
-func updateCellStatus(rowIdentifications []crtype.RowIdentification, columnIdentifications []crtype.ColumnID, testID crtype.ReportTestIdentification, testStats crtype.ReportTestStats, status map[crtype.RowIdentification]map[crtype.ColumnID]cellStatus, allRows map[crtype.RowIdentification]struct{}, allColumns map[crtype.ColumnID]struct{}) {
+func updateCellStatus(
+	rowIdentifications []crtype.RowIdentification,
+	columnIdentifications []crtype.ColumnID,
+	testID crtype.ReportTestIdentification,
+	testStats crtype.ReportTestStats,
+	// use the inputs above to update the maps below (golang passes maps by reference)
+	status map[crtype.RowIdentification]map[crtype.ColumnID]cellStatus,
+	allRows map[crtype.RowIdentification]struct{},
+	allColumns map[crtype.ColumnID]struct{},
+) {
 	for _, columnIdentification := range columnIdentifications {
 		if _, ok := allColumns[columnIdentification]; !ok {
 			allColumns[columnIdentification] = struct{}{}

--- a/pkg/api/componentreadiness/middleware/list.go
+++ b/pkg/api/componentreadiness/middleware/list.go
@@ -1,0 +1,51 @@
+package middleware
+
+import (
+	"context"
+	"sync"
+
+	crtype "github.com/openshift/sippy/pkg/apis/api/componentreport"
+)
+
+type List []Middleware
+
+func (l List) Query(ctx context.Context, wg *sync.WaitGroup, allJobVariants crtype.JobVariants, baseStatusCh, sampleStatusCh chan map[string]crtype.TestStatus, errCh chan error) {
+	// Invoke the Query phase for each middleware configured:
+	for _, mw := range l {
+		mw.Query(ctx, wg, allJobVariants, baseStatusCh, sampleStatusCh, errCh)
+	}
+}
+
+func (l List) QueryTestDetails(ctx context.Context, wg *sync.WaitGroup, errCh chan error, allJobVariants crtype.JobVariants) {
+	// Invoke the QueryTestDetails phase for each middleware configured:
+	for _, mw := range l {
+		mw.QueryTestDetails(ctx, wg, errCh, allJobVariants)
+	}
+}
+
+func (l List) PreAnalysis(testKey crtype.ReportTestIdentification, testStats *crtype.ReportTestStats) error {
+	for _, mw := range l {
+		if err := mw.PreAnalysis(testKey, testStats); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l List) PostAnalysis(testKey crtype.ReportTestIdentification, testStats *crtype.ReportTestStats) error {
+	for _, mw := range l {
+		if err := mw.PostAnalysis(testKey, testStats); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l List) PreTestDetailsAnalysis(testKey crtype.TestWithVariantsKey, status *crtype.TestJobRunStatuses) error {
+	for _, mw := range l {
+		if err := mw.PreTestDetailsAnalysis(testKey, status); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -446,8 +446,6 @@ func (c *ComponentReportGenerator) getJobRunTestStatusFromBigQuery(ctx context.C
 
 // internalGenerateTestDetailsReport handles the report generation for the lowest level test report including
 // breakdown by job as well as overall stats.
-//
-//nolint:gocyclo
 func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(
 	baseRelease string,
 	baseStart, baseEnd *time.Time,

--- a/pkg/apis/api/componentreport/types.go
+++ b/pkg/apis/api/componentreport/types.go
@@ -172,6 +172,9 @@ func (tc TestCount) Failures() int { // translate to sippy/stats-land
 	}
 	return failure
 }
+func (tc TestCount) ToTestStats(flakeAsFailure bool) TestDetailsTestStats { // translate to sippy/stats-land
+	return NewTestStats(tc.SuccessCount, tc.Failures(), tc.FlakeCount, flakeAsFailure)
+}
 
 // TestStatus is an internal type used to pass data bigquery onwards to the actual
 // report generation. It is not serialized over the API.

--- a/pkg/regressionallowances/types.go
+++ b/pkg/regressionallowances/types.go
@@ -51,22 +51,11 @@ func IntentionalRegressionFor(releaseString string, variant crtype.ColumnIdentif
 }
 
 func (i *IntentionalRegression) RegressedPassPercentage(flakeAsFailure bool) float64 {
-	return passPercentage(flakeAsFailure, i.RegressedSuccesses, i.RegressedFlakes, i.RegressedFailures)
+	return crtype.CalculatePassRate(i.RegressedSuccesses, i.RegressedFailures, i.RegressedFlakes, flakeAsFailure)
 }
 
 func (i *IntentionalRegression) PreviousPassPercentage(flakeAsFailure bool) float64 {
-	return passPercentage(flakeAsFailure, i.PreviousSuccesses, i.PreviousFlakes, i.PreviousFailures)
-}
-
-func passPercentage(flakeAsFailure bool, successes, flakes, failures int) float64 {
-	total := successes + flakes + failures
-	if total == 0 {
-		return 1.0 // prevent division by zero, consider pass rate 100% if no data
-	}
-	if flakeAsFailure {
-		return float64(successes) / float64(total)
-	}
-	return float64(successes+flakes) / float64(total)
+	return crtype.CalculatePassRate(i.PreviousSuccesses, i.PreviousFailures, i.PreviousFlakes, flakeAsFailure)
 }
 
 func keyFor(testID string, variant crtype.ColumnIdentification) string {


### PR DESCRIPTION
Following on previous refactor with some simplifications and finally a refactor to `generateComponentTestReport` in CR.

Also abstracted out middleware calls and CR.getStatusFromBigQuery goroutine management.

No changes to functionality, except that middleware calls consistently bail out at the first error, where before there were places they would keep running (Devan confirmed that wasn't for any reason).

May be easiest to review individual commits; each has fairly limited scope.