### PR TITLE
TRT-1474: Triage Auditing

### DIFF
--- a/pkg/api/componentreadiness/triage.go
+++ b/pkg/api/componentreadiness/triage.go
@@ -1,6 +1,7 @@
 package componentreadiness
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -55,7 +56,7 @@ func validateTriage(triage models.Triage, update bool) error {
 	return nil
 }
 
-func CreateTriage(dbc *db.DB, triage models.Triage) (models.Triage, error) {
+func CreateTriage(dbc *gorm.DB, triage models.Triage) (models.Triage, error) {
 	err := validateTriage(triage, false)
 	if err != nil {
 		log.WithError(err).Error("error validating triage record")
@@ -73,7 +74,7 @@ func CreateTriage(dbc *db.DB, triage models.Triage) (models.Triage, error) {
 	// If we have a bug in the db matching the url we were given, link them up now.
 	// If not, this should be handled later during the next fetchdata cron job.
 	var bug models.Bug
-	res := dbc.DB.Where("url = ?", triage.URL).First(&bug)
+	res := dbc.Where("url = ?", triage.URL).First(&bug)
 	switch {
 	case res.Error != nil && !errors.Is(res.Error, gorm.ErrRecordNotFound):
 		log.WithError(res.Error).Errorf("unexpected error looking up bug: %s", triage.URL)
@@ -83,7 +84,7 @@ func CreateTriage(dbc *db.DB, triage models.Triage) (models.Triage, error) {
 		triage.BugID = &bug.ID
 	}
 
-	res = dbc.DB.Create(&triage)
+	res = dbc.Create(&triage)
 	if res.Error != nil {
 		log.WithError(res.Error).Error("error creating triage record")
 		return triage, res.Error
@@ -94,7 +95,7 @@ func CreateTriage(dbc *db.DB, triage models.Triage) (models.Triage, error) {
 	return triage, nil
 }
 
-func linkRegressions(dbc *db.DB, triage *models.Triage) error {
+func linkRegressions(dbc *gorm.DB, triage *models.Triage) error {
 	// We support linking to regressions by just setting the ID in the request, lookup
 	// full regressions for association.
 	regressionIDs := []uint{}
@@ -102,7 +103,7 @@ func linkRegressions(dbc *db.DB, triage *models.Triage) error {
 		regressionIDs = append(regressionIDs, trIDR.ID)
 	}
 	var linkedRegressions []models.TestRegression
-	res := dbc.DB.Where("id IN ?", regressionIDs).Find(&linkedRegressions)
+	res := dbc.Where("id IN ?", regressionIDs).Find(&linkedRegressions)
 	if res.Error != nil {
 		log.WithError(res.Error).Errorf("error looking up regression IDs: %v", regressionIDs)
 		return res.Error
@@ -132,7 +133,7 @@ func linkRegressions(dbc *db.DB, triage *models.Triage) error {
 	return nil
 }
 
-func UpdateTriage(dbc *db.DB, triage models.Triage) (models.Triage, error) {
+func UpdateTriage(dbc *gorm.DB, triage models.Triage) (models.Triage, error) {
 	err := validateTriage(triage, true)
 	if err != nil {
 		log.WithError(err).Error("error validating triage record")
@@ -142,7 +143,7 @@ func UpdateTriage(dbc *db.DB, triage models.Triage) (models.Triage, error) {
 	// Ensure the record exists and preserve fields you're not allowed to update:
 	// Side effect of not requiring you to specify them in your json.
 	existingTriage := models.Triage{}
-	res := dbc.DB.First(&existingTriage, triage.ID)
+	res := dbc.First(&existingTriage, triage.ID)
 	if res.Error != nil {
 		log.WithError(res.Error).Errorf("error looking up existing triage record: %v", triage.ID)
 		return triage, res.Error
@@ -157,7 +158,7 @@ func UpdateTriage(dbc *db.DB, triage models.Triage) (models.Triage, error) {
 	// If we have a bug in the db matching the url we were given, link them up now.
 	// If not, this should be handled later during the next fetchdata cron job.
 	var bug models.Bug
-	res = dbc.DB.Where("url = ?", triage.URL).First(&bug)
+	res = dbc.Where("url = ?", triage.URL).First(&bug)
 	switch {
 	case res.Error != nil && !errors.Is(res.Error, gorm.ErrRecordNotFound):
 		log.WithError(res.Error).Errorf("unexpected error looking up bug: %s", triage.URL)
@@ -167,28 +168,35 @@ func UpdateTriage(dbc *db.DB, triage models.Triage) (models.Triage, error) {
 		triage.BugID = &bug.ID
 	}
 
-	// When we have removed regressions, we must replace the associations directly, as Save will not handle it.
-	// This results in rows being deleted and re-created even when there are no changes, but this shouldn't happen
-	// enough that it makes a difference.
-	err = dbc.DB.Model(&triage).Association("Regressions").Replace(triage.Regressions)
-	if err != nil {
-		log.WithError(res.Error).Error("error replacing regressions on triage record")
-		return triage, res.Error
-	}
+	// Use a transaction to handle both model update and association changes atomically
+	// Gorm is unable to handle this in a single save operation when regressions are removed
+	err = dbc.Transaction(func(tx *gorm.DB) error {
+		// Capture the old triage state before making any changes, this is necessary to avoid multiple audit logs for the transaction
+		var oldTriage models.Triage
+		if err := tx.Preload("Regressions").First(&oldTriage, triage.ID).Error; err != nil {
+			return err
+		}
+		ctx := context.WithValue(tx.Statement.Context, "old_triage", oldTriage)
+		txWithContext := tx.WithContext(ctx)
 
-	res = dbc.DB.Save(&triage)
-	if res.Error != nil {
-		log.WithError(res.Error).Error("error updating triage record")
-		return triage, res.Error
+		if err := txWithContext.Session(&gorm.Session{SkipHooks: true}).Model(&triage).Association("Regressions").Replace(triage.Regressions); err != nil {
+			return err
+		}
+
+		return txWithContext.Save(&triage).Error
+	})
+	if err != nil {
+		log.WithError(err).Error("error updating triage record and associations")
+		return triage, err
 	}
 
 	injectHATEOASLinks(&triage)
 	return triage, nil
 }
 
-func DeleteTriage(dbc *db.DB, id int) error {
+func DeleteTriage(dbc *gorm.DB, id int) error {
 	existingTriage := &models.Triage{}
-	res := dbc.DB.First(existingTriage, id).Delete(existingTriage)
+	res := dbc.First(existingTriage, id).Delete(existingTriage)
 	if res.Error != nil {
 		return fmt.Errorf("error deleting triage record: %v", res.Error)
 	}

--- a/pkg/db/models/audit.go
+++ b/pkg/db/models/audit.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"time"
+)
+
+type AuditLog struct {
+	Id        uint      `json:"id" gorm:"primaryKey"`
+	TableName string    `json:"table_name" gorm:"not null"`
+	Operation string    `json:"operation" gorm:"not null"`
+	RowId     uint      `json:"row_id" gorm:"not null"`
+	OldData   []byte    `json:"old_data" gorm:"type:jsonb"`
+	NewData   []byte    `json:"new_data" gorm:"type:jsonb"`
+	User      string    `json:"user" gorm:"not null"`
+	CreatedAt time.Time `json:"created_at" gorm:"autoCreateTime"`
+}
+
+type OperationType string
+
+const (
+	Create OperationType = "CREATE"
+	Update OperationType = "UPDATE"
+	Delete OperationType = "DELETE"
+)

--- a/pkg/db/models/triage.go
+++ b/pkg/db/models/triage.go
@@ -1,10 +1,14 @@
 package models
 
 import (
+	"context"
 	"database/sql"
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/lib/pq"
+	"gorm.io/gorm"
 )
 
 // Triage contains data tying failures or regressions to specific bugs.
@@ -49,6 +53,107 @@ type Triage struct {
 	// Setting this will immediately change the regressions icon to one indicate the issue is believed to
 	// be fixed. If we see failures beyond the resolved time, you will see another icon to highlight this situation.
 	Resolved sql.NullTime `json:"resolved"`
+}
+
+func (t *Triage) BeforeUpdate(db *gorm.DB) error {
+	return t.before(db)
+}
+
+func (t *Triage) BeforeDelete(db *gorm.DB) error {
+	return t.before(db)
+}
+
+func (t *Triage) before(db *gorm.DB) error {
+	// Check if we've already captured the old triage in this transaction
+	if existing := db.Statement.Context.Value("old_triage"); existing != nil {
+		return nil
+	}
+
+	var old Triage
+	if err := db.Preload("Regressions").First(&old, t.ID).Error; err != nil {
+		return err
+	}
+
+	db.Statement.Context = context.WithValue(db.Statement.Context, "old_triage", old)
+	return nil
+}
+
+func (t *Triage) AfterUpdate(db *gorm.DB) error {
+	return t.after(db, Update)
+}
+
+func (t *Triage) AfterCreate(db *gorm.DB) error {
+	return t.after(db, Create)
+}
+
+func (t *Triage) AfterDelete(db *gorm.DB) error {
+	return t.after(db, Delete)
+}
+
+func (t *Triage) after(db *gorm.DB, operation OperationType) error {
+	var oldTriageJSON []byte
+	if operation == Update || operation == Delete {
+		var err error
+		oldTriage, ok := db.Statement.Context.Value("old_triage").(Triage)
+		if !ok {
+			return fmt.Errorf("value of old_triage is not a Triage type")
+		}
+		oldTriageJSON, err = oldTriage.marshalJSONForAudit()
+		if err != nil {
+			return fmt.Errorf("error marshalling old triage record: %w", err)
+		}
+	}
+
+	var newTriageJSON []byte
+	if operation != Delete {
+		var err error
+		newTriageJSON, err = t.marshalJSONForAudit()
+		if err != nil {
+			return fmt.Errorf("error marshalling new triage record: %w", err)
+		}
+	}
+	user := db.Statement.Context.Value("current_user")
+	if user == nil {
+		return fmt.Errorf("current user not found in context")
+	}
+	audit := AuditLog{
+		TableName: "triage",
+		Operation: string(operation),
+		RowId:     t.ID,
+		User:      user.(string),
+		OldData:   oldTriageJSON,
+		NewData:   newTriageJSON,
+	}
+
+	return db.Create(&audit).Error
+}
+
+// marshalJSONForAudit serializes only the necessary details for audit purposes, leaving out the rest.
+// Critically, it removes all details except for the id from the included regressions.
+func (t *Triage) marshalJSONForAudit() ([]byte, error) {
+	type Alias Triage
+
+	type MinimalRegression struct {
+		ID uint `json:"id"`
+	}
+	regressions := make([]MinimalRegression, len(t.Regressions))
+	for i, reg := range t.Regressions {
+		regressions[i] = MinimalRegression{ID: reg.ID}
+	}
+
+	auditJSON := struct {
+		Alias
+		Bug         *Bug                `json:"bug,omitempty"`
+		Links       map[string]string   `json:"links,omitempty"`
+		Regressions []MinimalRegression `json:"regressions"`
+	}{
+		Alias:       Alias(*t),
+		Bug:         nil,
+		Links:       nil,
+		Regressions: regressions,
+	}
+
+	return json.Marshal(auditJSON)
 }
 
 type TriageType string

--- a/pkg/db/models/triage_test.go
+++ b/pkg/db/models/triage_test.go
@@ -1,0 +1,107 @@
+package models
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMarshalJSONForAudit(t *testing.T) {
+	tests := []struct {
+		name     string
+		triage   Triage
+		expected string
+	}{
+		{
+			name: "basic triage with multiple regressions",
+			triage: Triage{
+				ID:          1,
+				CreatedAt:   time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC),
+				UpdatedAt:   time.Date(2025, 1, 2, 4, 5, 6, 0, time.UTC),
+				URL:         "https://issues.redhat.com/browse/OCPBUGS-1234",
+				Description: "Example bug",
+				Type:        TriageType("infra"),
+				Regressions: []TestRegression{
+					{
+						ID:          42,
+						View:        "4.19-main",
+						Release:     "4.19",
+						TestID:      "some-test-id",
+						TestName:    "TestSomethingCritical",
+						Variants:    []string{"variant-a", "variant-b"},
+						Opened:      time.Date(2022, 12, 15, 0, 0, 0, 0, time.UTC),
+						Closed:      sql.NullTime{Time: time.Date(2023, 1, 5, 0, 0, 0, 0, time.UTC), Valid: true},
+						LastFailure: sql.NullTime{Time: time.Date(2023, 1, 3, 0, 0, 0, 0, time.UTC), Valid: true},
+						MaxFailures: 7,
+					},
+					{
+						ID:          100,
+						View:        "4.19-main",
+						Release:     "4.19",
+						TestID:      "some-test-other-id",
+						TestName:    "TestSomethingCritical",
+						Variants:    []string{"variant-a", "variant-b"},
+						Opened:      time.Date(2022, 12, 15, 0, 0, 0, 0, time.UTC),
+						Closed:      sql.NullTime{Time: time.Date(2023, 1, 5, 0, 0, 0, 0, time.UTC), Valid: true},
+						LastFailure: sql.NullTime{Time: time.Date(2023, 1, 3, 0, 0, 0, 0, time.UTC), Valid: true},
+						MaxFailures: 7,
+					},
+				},
+			},
+			expected: `{"id":1,"created_at":"2025-01-02T03:04:05Z","updated_at":"2025-01-02T04:05:06Z","url":"https://issues.redhat.com/browse/OCPBUGS-1234","description":"Example bug","type":"infra","resolved":{"Time":"0001-01-01T00:00:00Z","Valid":false},"regressions":[{"id":42},{"id":100}]}`,
+		},
+		{
+			name: "triage with no regressions",
+			triage: Triage{
+				ID:        2,
+				CreatedAt: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2025, 6, 1, 1, 0, 0, 0, time.UTC),
+				URL:       "https://issues.redhat.com/browse/OCPBUGS-1234",
+				Type:      TriageType("ci-infra"),
+			},
+			expected: `{"id":2,"created_at":"2025-06-01T00:00:00Z","updated_at":"2025-06-01T01:00:00Z","url":"https://issues.redhat.com/browse/OCPBUGS-1234","type":"ci-infra","resolved":{"Time":"0001-01-01T00:00:00Z","Valid":false},"regressions":[]}`,
+		},
+		{
+			name: "triage with bug populated, but bug should be omitted from audit json",
+			triage: Triage{
+				ID:        3,
+				CreatedAt: time.Date(2023, 3, 1, 12, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2023, 3, 1, 13, 0, 0, 0, time.UTC),
+				URL:       "https://issues.redhat.com/browse/OCPBUGS-1234",
+				Type:      TriageType("test"),
+				Bug: &Bug{
+					ID:      99,
+					Key:     "BUG-456",
+					Status:  "OPEN",
+					Summary: "This should be omitted",
+					URL:     "https://issues.redhat.com/browse/OCPBUGS-1234",
+				},
+				BugID: ptrUint(99),
+				Regressions: []TestRegression{
+					{ID: 100},
+				},
+				Resolved: sql.NullTime{},
+			},
+			expected: `{"id":3,"created_at":"2023-03-01T12:00:00Z","updated_at":"2023-03-01T13:00:00Z","url":"https://issues.redhat.com/browse/OCPBUGS-1234","type":"test","bug_id":99,"resolved":{"Time":"0001-01-01T00:00:00Z","Valid":false},"regressions":[{"id":100}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := tt.triage.marshalJSONForAudit()
+			if err != nil {
+				t.Fatalf("unexpected error = %v", err)
+			}
+
+			if diff := cmp.Diff(tt.expected, string(data)); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func ptrUint(val uint) *uint {
+	return &val
+}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1272,13 +1272,6 @@ func (s *Server) jsonTriages(w http.ResponseWriter, req *http.Request) {
 		log.Infof("Extracted triage ID: %d", triageID)
 	}
 
-	if req.Method == http.MethodPost || req.Method == http.MethodPut {
-		user := req.Header.Get("X-Forwarded-User")
-		email := req.Header.Get("X-Forwarded-Email")
-
-		log.Infof("triage %s being made by user: %s, email: %s", req.Method, user, email)
-	}
-
 	switch req.Method {
 	case http.MethodGet:
 		// Was a specific record requested?
@@ -1309,13 +1302,16 @@ func (s *Server) jsonTriages(w http.ResponseWriter, req *http.Request) {
 			failureResponse(w, http.StatusNotImplemented, "POST triages is not available on this server")
 			return
 		}
+		user := getUserForRequest(req)
+		log.Infof("triage POST made by user: %s", user)
 		var triage models.Triage
 		if err := json.NewDecoder(req.Body).Decode(&triage); err != nil {
 			log.WithError(err).Error("error parsing new triage record")
 			failureResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		triage, err := componentreadiness.CreateTriage(s.db, triage)
+		ctx := context.WithValue(req.Context(), "current_user", user)
+		triage, err := componentreadiness.CreateTriage(s.db.DB.WithContext(ctx), triage)
 		if err != nil {
 			failureResponse(w, http.StatusBadRequest, err.Error())
 			return
@@ -1330,6 +1326,8 @@ func (s *Server) jsonTriages(w http.ResponseWriter, req *http.Request) {
 			failureResponse(w, http.StatusBadRequest, "no triage ID specified in URL")
 			return
 		}
+		user := getUserForRequest(req)
+		log.Infof("triage PUT made by user: %s", user)
 		var triage models.Triage
 		if err := json.NewDecoder(req.Body).Decode(&triage); err != nil {
 			log.WithError(err).Error("error parsing new triage record")
@@ -1340,7 +1338,8 @@ func (s *Server) jsonTriages(w http.ResponseWriter, req *http.Request) {
 			failureResponse(w, http.StatusBadRequest, "resource triage ID does not match URL")
 			return
 		}
-		triage, err := componentreadiness.UpdateTriage(s.db, triage)
+		ctx := context.WithValue(req.Context(), "current_user", user)
+		triage, err := componentreadiness.UpdateTriage(s.db.DB.WithContext(ctx), triage)
 		if err != nil {
 			log.WithError(err).Error("error updating triage")
 			failureResponse(w, http.StatusBadRequest, err.Error())
@@ -1352,7 +1351,10 @@ func (s *Server) jsonTriages(w http.ResponseWriter, req *http.Request) {
 			failureResponse(w, http.StatusNotImplemented, "DELETE triages is not available on this server")
 			return
 		}
-		if err := componentreadiness.DeleteTriage(s.db, triageID); err != nil {
+		user := getUserForRequest(req)
+		log.Infof("triage DELETE made by user: %s", user)
+		ctx := context.WithValue(req.Context(), "current_user", user)
+		if err := componentreadiness.DeleteTriage(s.db.DB.WithContext(ctx), triageID); err != nil {
 			failureResponse(w, http.StatusInternalServerError, err.Error())
 			return
 		}
@@ -1365,6 +1367,14 @@ func (s *Server) jsonTriages(w http.ResponseWriter, req *http.Request) {
 	default:
 		failureResponse(w, http.StatusBadRequest, "Unsupported method")
 	}
+}
+
+func getUserForRequest(req *http.Request) string {
+	user := req.Header.Get("X-Forwarded-User")
+	if user == "" && os.Getenv("DEV_MODE") == "1" {
+		user = "developer"
+	}
+	return user
 }
 
 // queryJobArtifacts is an API to query GCS for artifacts from a set of job runs. Parameters:

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -43,7 +43,8 @@ export SIPPY_E2E_DSN="postgresql://postgres:password@localhost:$PSQL_PORT/postgr
 echo "Loading database..."
 # use an old release here as they have very few job runs and thus import quickly, ~5 minutes
 make build
-./sippy load --loader prow --loader prow --load-openshift-ci-bigquery \
+./sippy load --init-database --loader prow --loader prow --load-openshift-ci-bigquery \
+  --mode ocp \
   --release 4.14 \
   --database-dsn="$SIPPY_E2E_DSN" \
   --config ./config/e2e-openshift.yaml \
@@ -55,6 +56,7 @@ make build
   --listen ":18080" \
   --listen-metrics ":12112" \
   --database-dsn="$SIPPY_E2E_DSN" \
+  --enable-write-endpoints \
   --log-level debug \
   --google-service-account-credential-file $GCS_SA_JSON_PATH
 )&

--- a/test/e2e/componentreadiness/triage/triageapi_test.go
+++ b/test/e2e/componentreadiness/triage/triageapi_test.go
@@ -1,6 +1,8 @@
 package triage
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -13,6 +15,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 var view = componentreport.View{
@@ -37,7 +40,7 @@ func Test_TriageAPI(t *testing.T) {
 	dbc := util.CreateE2EPostgresConnection(t)
 	tracker := componentreadiness.NewPostgresRegressionStore(dbc)
 
-	jiraBug := createBug(t, dbc)
+	jiraBug := createBug(t, dbc.DB)
 	defer dbc.DB.Delete(jiraBug)
 
 	testRegression1 := createTestRegression(t, tracker, view, "faketestid")
@@ -63,6 +66,40 @@ func Test_TriageAPI(t *testing.T) {
 		triage1.Type = "fake"
 		err = util.SippyPost("/api/component_readiness/triages", &triage1, &triageResponse)
 		require.Error(t, err)
+	})
+
+	t.Run("create generates audit_log record", func(t *testing.T) {
+		defer cleanupAllTriages(dbc)
+		triage1 := models.Triage{
+			URL: jiraBug.URL,
+			Regressions: []models.TestRegression{
+				{
+					ID: testRegression1.ID,
+				},
+			},
+			Type: "test",
+		}
+
+		var triageResponse models.Triage
+		err := util.SippyPost("/api/component_readiness/triages", &triage1, &triageResponse)
+		require.NoError(t, err)
+
+		var auditLog models.AuditLog
+		res := dbc.DB.
+			Where("table_name = ?", "triage").
+			Where("row_id = ?", triageResponse.ID).
+			First(&auditLog)
+		require.NoError(t, res.Error)
+
+		assert.Equal(t, models.Create, models.OperationType(auditLog.Operation))
+		assert.Equal(t, "developer", auditLog.User)
+		assert.NotEmpty(t, auditLog.NewData, "NewData should contain the created triage record")
+
+		var auditedTriage models.Triage
+		err = json.Unmarshal(auditLog.NewData, &auditedTriage)
+		require.NoError(t, err, "NewData should be valid JSON")
+
+		assertTriageDataMatches(t, triageResponse, auditedTriage, "NewData")
 	})
 
 	t.Run("get", func(t *testing.T) {
@@ -114,6 +151,33 @@ func Test_TriageAPI(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d", triageResponse2.ID),
 			triageResponse2.Links["self"])
 	})
+	t.Run("update to remove a regression", func(t *testing.T) {
+		defer cleanupAllTriages(dbc)
+
+		triage := models.Triage{
+			URL:  jiraBug.URL,
+			Type: models.TriageTypeProduct,
+			Regressions: []models.TestRegression{
+				{ID: testRegression1.ID},
+				{ID: testRegression2.ID},
+			},
+		}
+
+		var triageResponse models.Triage
+		err := util.SippyPost("/api/component_readiness/triages", &triage, &triageResponse)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(triageResponse.Regressions))
+
+		// Update to remove one regression - keep only testRegression1
+		triageResponse.Regressions = []models.TestRegression{{ID: testRegression1.ID}}
+		var triageResponse2 models.Triage
+		err = util.SippyPut(fmt.Sprintf("/api/component_readiness/triages/%d", triageResponse.ID), &triageResponse, &triageResponse2)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(triageResponse2.Regressions))
+		assert.Equal(t, testRegression1.ID, triageResponse2.Regressions[0].ID, "should keep testRegression1")
+		assert.Equal(t, triageResponse.CreatedAt, triageResponse2.CreatedAt)
+		assert.NotEqual(t, triageResponse.UpdatedAt, triageResponse2.UpdatedAt)
+	})
 	t.Run("update to remove all regressions", func(t *testing.T) {
 		defer cleanupAllTriages(dbc)
 		triageResponse := createAndValidateTriageRecord(t, jiraBug.URL, testRegression1)
@@ -150,6 +214,66 @@ func Test_TriageAPI(t *testing.T) {
 		err := util.SippyPut("/api/component_readiness/triages/128736182736128736", &triageResponse, &triageResponse2)
 		require.Error(t, err)
 	})
+	t.Run("update generates audit_log record", func(t *testing.T) {
+		defer cleanupAllTriages(dbc)
+		triageResponse := createAndValidateTriageRecord(t, jiraBug.URL, testRegression1)
+		originalTriage := deepCopyTriage(t, triageResponse)
+
+		// Update with a new regression, and a changed description:
+		triageResponse.Regressions = append(triageResponse.Regressions, models.TestRegression{ID: testRegression2.ID})
+		triageResponse.Description = "updated description"
+		var triageResponse2 models.Triage
+		err := util.SippyPut(fmt.Sprintf("/api/component_readiness/triages/%d", triageResponse.ID), &triageResponse, &triageResponse2)
+		require.NoError(t, err)
+
+		var auditLog models.AuditLog
+		res := dbc.DB.
+			Where("table_name = ?", "triage").
+			Where("operation = ?", models.Update).
+			Where("row_id = ?", triageResponse.ID).
+			First(&auditLog)
+		require.NoError(t, res.Error)
+
+		assert.Equal(t, "developer", auditLog.User)
+		assert.NotEmpty(t, auditLog.NewData, "NewData should contain the updated triage record")
+		assert.NotEmpty(t, auditLog.OldData, "OldData should contain the original triage record")
+
+		var newTriageData models.Triage
+		err = json.Unmarshal(auditLog.NewData, &newTriageData)
+		require.NoError(t, err, "NewData should be valid JSON")
+		assertTriageDataMatches(t, triageResponse2, newTriageData, "NewData")
+
+		var oldTriageData models.Triage
+		err = json.Unmarshal(auditLog.OldData, &oldTriageData)
+		require.NoError(t, err, "OldData should be valid JSON")
+		assertTriageDataMatches(t, originalTriage, oldTriageData, "OldData")
+	})
+	t.Run("delete generates audit_log record", func(t *testing.T) {
+		defer cleanupAllTriages(dbc)
+		triageResponse := createAndValidateTriageRecord(t, jiraBug.URL, testRegression1)
+		originalTriage := deepCopyTriage(t, triageResponse)
+
+		// Delete the triage record
+		err := util.SippyDelete(fmt.Sprintf("/api/component_readiness/triages/%d", triageResponse.ID))
+		require.NoError(t, err)
+
+		var auditLog models.AuditLog
+		res := dbc.DB.
+			Where("table_name = ?", "triage").
+			Where("operation = ?", models.Delete).
+			Where("row_id = ?", triageResponse.ID).
+			First(&auditLog)
+		require.NoError(t, res.Error)
+
+		assert.Equal(t, "developer", auditLog.User)
+		assert.NotEmpty(t, auditLog.OldData, "OldData should contain the deleted triage record")
+		assert.Empty(t, auditLog.NewData, "NewData should be empty for delete operations")
+
+		var oldTriageData models.Triage
+		err = json.Unmarshal(auditLog.OldData, &oldTriageData)
+		require.NoError(t, err, "OldData should be valid JSON")
+		assertTriageDataMatches(t, originalTriage, oldTriageData, "OldData")
+	})
 }
 
 func createAndValidateTriageRecord(t *testing.T, bugURL string, testRegression1 *models.TestRegression) models.Triage {
@@ -177,7 +301,7 @@ func createAndValidateTriageRecord(t *testing.T, bugURL string, testRegression1 
 	return lookupTriage
 }
 
-func createBug(t *testing.T, dbc *db.DB) *models.Bug {
+func createBug(t *testing.T, dbc *gorm.DB) *models.Bug {
 	jiraBug := models.Bug{
 		Key:        "MYBUGS-100",
 		Status:     "New",
@@ -186,7 +310,7 @@ func createBug(t *testing.T, dbc *db.DB) *models.Bug {
 		Labels:     pq.StringArray{"label1", "label2"},
 		URL:        "https://issues.redhat.com/browse/MYBUGS-100",
 	}
-	res := dbc.DB.Create(&jiraBug)
+	res := dbc.Create(&jiraBug)
 	require.NoError(t, res.Error)
 	return &jiraBug
 }
@@ -194,6 +318,7 @@ func createBug(t *testing.T, dbc *db.DB) *models.Bug {
 // Test_TriageRawDB ensures our gorm postgresql mappings are working as we'd expect.
 func Test_TriageRawDB(t *testing.T) {
 	dbc := util.CreateE2EPostgresConnection(t)
+	dbWithContext := dbc.DB.WithContext(context.WithValue(context.TODO(), "current_user", "developer"))
 	tracker := componentreadiness.NewPostgresRegressionStore(dbc)
 
 	testRegression := createTestRegression(t, tracker, view, "faketestid")
@@ -208,26 +333,26 @@ func Test_TriageRawDB(t *testing.T) {
 				*testRegression,
 			},
 		}
-		res := dbc.DB.Create(&triage1)
+		res := dbWithContext.Create(&triage1)
 		require.NoError(t, res.Error)
 		testRegression.Triages = append(testRegression.Triages, triage1)
-		res = dbc.DB.Save(&testRegression)
+		res = dbWithContext.Save(&testRegression)
 		require.NoError(t, res.Error)
 
 		// Lookup the Triage again to ensure we persisted what we expect:
-		res = dbc.DB.First(&triage1, triage1.ID)
+		res = dbWithContext.First(&triage1, triage1.ID)
 		require.NoError(t, res.Error)
 		assert.Equal(t, 1, len(triage1.Regressions))
 
 		// Ensure loading a regression can load the triage records for it:
 		var lookupRegression models.TestRegression
-		res = dbc.DB.First(&lookupRegression, testRegression.ID).Preload("Triages")
+		res = dbWithContext.First(&lookupRegression, testRegression.ID).Preload("Triages")
 		require.NoError(t, res.Error)
 		assert.Equal(t, 1, len(testRegression.Triages))
 
 		openRegressions := make([]*models.TestRegression, 0)
 
-		res = dbc.DB.
+		res = dbWithContext.
 			Model(&models.TestRegression{}).
 			Preload("Triages").
 			Where("test_regressions.release = ?", view.SampleRelease.Release).
@@ -245,44 +370,44 @@ func Test_TriageRawDB(t *testing.T) {
 				*testRegression,
 			},
 		}
-		res = dbc.DB.Create(&triage2)
+		res = dbWithContext.Create(&triage2)
 		require.NoError(t, res.Error)
 		testRegression.Triages = append(testRegression.Triages, triage2)
-		res = dbc.DB.Save(&testRegression)
+		res = dbWithContext.Save(&testRegression)
 		require.NoError(t, res.Error)
 
 		// Query for triages for a specific regression:
-		res = dbc.DB.First(&testRegression, testRegression.ID).Preload("Triages")
+		res = dbWithContext.First(&testRegression, testRegression.ID).Preload("Triages")
 		require.NoError(t, res.Error)
 		assert.Equal(t, 2, len(testRegression.Triages))
 
 		// Delete the association:
 		triage1.Regressions = []models.TestRegression{}
-		res = dbc.DB.Save(&triage1)
+		res = dbWithContext.Save(&triage1)
 		require.NoError(t, res.Error)
-		res = dbc.DB.First(&triage1, triage1.ID)
+		res = dbWithContext.First(&triage1, triage1.ID)
 		require.Nil(t, res.Error)
 		assert.Equal(t, 0, len(triage1.Regressions))
 		// Make sure we didn't wipe out the regression itself:
-		res = dbc.DB.First(&lookupRegression, testRegression.ID)
+		res = dbWithContext.First(&lookupRegression, testRegression.ID)
 		require.NoError(t, res.Error)
 	})
 
 	t.Run("test Triage model Bug relationship", func(t *testing.T) {
 		defer cleanupAllTriages(dbc)
 
-		jiraBug := createBug(t, dbc)
-		defer dbc.DB.Delete(jiraBug)
+		jiraBug := createBug(t, dbWithContext)
+		defer dbWithContext.Delete(jiraBug)
 
 		triage1 := models.Triage{
 			URL: "http://myjira",
 			Bug: jiraBug,
 		}
-		res := dbc.DB.Create(&triage1)
+		res := dbWithContext.Create(&triage1)
 		require.NoError(t, res.Error)
 
 		// Lookup the Triage again to ensure we persisted what we expect:
-		res = dbc.DB.First(&triage1, triage1.ID)
+		res = dbWithContext.First(&triage1, triage1.ID)
 		require.NoError(t, res.Error)
 		assert.Equal(t, "MYBUGS-100", triage1.Bug.Key)
 
@@ -310,4 +435,26 @@ func createTestRegression(t *testing.T, tracker componentreadiness.RegressionSto
 	testRegression, err := tracker.OpenRegression(view, newRegression)
 	require.NoError(t, err)
 	return testRegression
+}
+
+// deepCopyTriage creates a deep copy of a Triage struct using JSON marshal/unmarshal
+func deepCopyTriage(t *testing.T, original models.Triage) models.Triage {
+	data, err := json.Marshal(original)
+	require.NoError(t, err, "Failed to marshal triage for deep copy")
+
+	var copy models.Triage
+	err = json.Unmarshal(data, &copy)
+	require.NoError(t, err, "Failed to unmarshal triage for deep copy")
+
+	return copy
+}
+
+func assertTriageDataMatches(t *testing.T, expectedTriage, actualTriage models.Triage, field string) {
+	assert.Equal(t, expectedTriage.ID, actualTriage.ID, "%s ID should match the expected triage ID", field)
+	assert.Equal(t, expectedTriage.URL, actualTriage.URL, "%s URL should match the expected triage URL", field)
+	assert.Len(t, actualTriage.Regressions, len(expectedTriage.Regressions), "%s regressions count should match", field)
+
+	if len(actualTriage.Regressions) > 0 && len(expectedTriage.Regressions) > 0 {
+		assert.Equal(t, expectedTriage.Regressions[0].ID, actualTriage.Regressions[0].ID, "%s regression ID should match", field)
+	}
 }


### PR DESCRIPTION
Using some helpful hooks from Gorm, we can add an `audit_log` record whenever a triage record is created or modified. 

The OpenShift oauth that runs in front of `auth-sippy` will tell us the user making the request in the `X-Forwarded-User` header, but we must set that directly during e2e testing. Setting the `DEV_MODE=1` env var will allow `developer` to be added to the `user` column for local development, but this is not necessary unless you actually want to test this out.

There is a little bit of complication due to the associated regression updates. I have handled this by doing the entire update in a single transaction, and only using the hooks on the final `Save` call.

The `old_data` and `new_data` columns are both `jsonb` for better indexing, and have been `GIN` indexed for quicker searching. They do not store all of the data, just the relevant parts that are actually modifiable by a user. This is done via a custom serializer.

There is currently no API (or plans for one) to access this data, it will simply be queried directly from the db when needed.

A very small portion of this code was created with some (heavily guided) AI assistance