### PR TITLE
Update QE views for 4.19 and add 4.20 view

### DIFF
--- a/config/qe-views.yaml
+++ b/config/qe-views.yaml
@@ -542,11 +542,121 @@ component_readiness:
       enabled: false
   - name: 4.19-qe-main
     base_release:
-      release: "4.18"
+      release: "4.19"
       relative_start: ga-30d
       relative_end: ga
     sample_release:
       release: "4.19"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: {}
+        Network: {}
+        Platform: {}
+      db_group_by:
+        Architecture: {}
+        FeatureSet: {}
+        Installer: {}
+        Network: {}
+        Platform: {}
+        Suite: {}
+        Topology: {}
+        Upgrade: {}
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        Network:
+          - ovn
+        Owner:
+          - qe
+          - service-delivery
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - rosa
+          - vsphere
+        Topology:
+          - ha
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+    metrics:
+      enabled: true
+    regression_tracking:
+      enabled: false
+  - name: 4.19-qe-auto-release
+    base_release:
+      release: "4.19"
+      relative_start: ga-30d
+      relative_end: ga
+    sample_release:
+      release: "4.19"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: {}
+        Network: {}
+        Platform: {}
+      db_group_by:
+        Architecture: {}
+        FeatureSet: {}
+        Installer: {}
+        Network: {}
+        Platform: {}
+        Suite: {}
+        Topology: {}
+        Upgrade: {}
+      include_variants:
+        Procedure:
+          - automated-release
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        Network:
+          - ovn
+        Owner:
+          - qe
+          - service-delivery
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - rosa
+          - vsphere
+        Topology:
+          - ha
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+    metrics:
+      enabled: true
+    regression_tracking:
+      enabled: false
+  - name: 4.20-qe-main
+    base_release:
+      release: "4.19"
+      relative_start: ga-30d
+      relative_end: ga
+    sample_release:
+      release: "4.20"
       relative_start: now-7d
       relative_end: now
     variant_options:


### PR DESCRIPTION
Update base release in 4.19-qe-main from 4.18 to 4.19 and add two new views:
- 4.19-qe-auto-release for automated release testing
- 4.20-qe-main for 4.20 release testing