### PR TITLE
TRT-2138: add soft-validation when user attempts to create a triage with a duplicate Jira

### DIFF
--- a/sippy-ng/src/component_readiness/AddRegressionPanel.js
+++ b/sippy-ng/src/component_readiness/AddRegressionPanel.js
@@ -1,11 +1,10 @@
-import { Button, Tab, Tabs } from '@mui/material'
-import { getTriagesAPIUrl, jiraUrlPrefix } from './CompReadyUtils'
-import Autocomplete from '@mui/lab/Autocomplete'
+import { getTriagesAPIUrl } from './CompReadyUtils'
+import { Tab, Tabs } from '@mui/material'
 import DialogContent from '@mui/material/DialogContent'
 import DialogTitle from '@mui/material/DialogTitle'
+import ExistingTriageSelector from './ExistingTriageSelector'
 import PropTypes from 'prop-types'
 import React, { Fragment } from 'react'
-import TextField from '@mui/material/TextField'
 import TriageFields from './TriageFields'
 
 export default function AddRegressionPanel({
@@ -63,8 +62,7 @@ export default function AddRegressionPanel({
       }
 
       setAlertText(
-        'successfully added test to triage record: ' +
-          formatTriageURLDescription(existingTriage)
+        'successfully added test to triage record: ' + existingTriage.url
       )
       setAlertSeverity('success')
       if (triages.length > 0) {
@@ -72,18 +70,6 @@ export default function AddRegressionPanel({
       }
       completeTriageSubmission()
     })
-  }
-
-  const handleExistingTriageChange = (event, newValue) => {
-    setExistingTriageId(newValue.id)
-  }
-
-  const formatTriageURLDescription = (triage) => {
-    let url = triage.url
-    if (url.startsWith(jiraUrlPrefix)) {
-      url = url.slice(jiraUrlPrefix.length)
-    }
-    return url + ' - ' + triage.description
   }
 
   const addToExisting = tabIndex === 0
@@ -106,41 +92,28 @@ export default function AddRegressionPanel({
         {addToExisting && (
           <Fragment>
             <h3>Add to existing Triage</h3>
-            <Autocomplete
-              id="existing-triage"
-              name="existing-triage"
-              options={triages}
-              value={triages.find((t) => t.id === existingTriageId)}
-              getOptionLabel={(triage) => {
-                return formatTriageURLDescription(triage)
-              }}
-              isOptionEqualToValue={(triage, value) => triage.id === value?.id}
-              renderInput={(params) => (
-                <TextField {...params} label="Existing Triage" />
-              )}
-              onChange={handleExistingTriageChange}
+            <ExistingTriageSelector
+              triages={triages}
+              existingTriageId={existingTriageId}
+              setExistingTriageId={setExistingTriageId}
+              onSubmit={handleAddToExistingTriageSubmit}
             />
-
-            <Button
-              variant="contained"
-              color="primary"
-              sx={{ margin: '10px 0' }}
-              onClick={handleAddToExistingTriageSubmit}
-            >
-              Add to Entry
-            </Button>
           </Fragment>
         )}
         {addToNew && (
           <Fragment>
             <h3>Create new Triage</h3>
             <TriageFields
+              triages={triages}
               setAlertText={setAlertText}
               setAlertSeverity={setAlertSeverity}
               triageEntryData={triageEntryData}
               handleFormCompletion={handleNewTriageFormCompletion}
               setTriageEntryData={setTriageEntryData}
               submitButtonText={'Create Entry'}
+              existingTriageId={existingTriageId}
+              setExistingTriageId={setExistingTriageId}
+              handleAddToExistingTriage={handleAddToExistingTriageSubmit}
             />
           </Fragment>
         )}

--- a/sippy-ng/src/component_readiness/ExistingTriageSelector.js
+++ b/sippy-ng/src/component_readiness/ExistingTriageSelector.js
@@ -1,0 +1,60 @@
+import { Button } from '@mui/material'
+import { jiraUrlPrefix } from './CompReadyUtils'
+import Autocomplete from '@mui/lab/Autocomplete'
+import PropTypes from 'prop-types'
+import React from 'react'
+import TextField from '@mui/material/TextField'
+
+export default function ExistingTriageSelector({
+  triages,
+  existingTriageId,
+  setExistingTriageId,
+  onSubmit,
+}) {
+  const handleExistingTriageChange = (event, newValue) => {
+    setExistingTriageId(newValue.id)
+  }
+
+  const formatTriageURLDescription = (triage) => {
+    let url = triage.url
+    if (url.startsWith(jiraUrlPrefix)) {
+      url = url.slice(jiraUrlPrefix.length)
+    }
+    return url + ' - ' + triage.description
+  }
+
+  return (
+    <>
+      <Autocomplete
+        id="existing-triage"
+        name="existing-triage"
+        options={triages}
+        value={triages.find((t) => t.id === existingTriageId)}
+        getOptionLabel={(triage) => {
+          return formatTriageURLDescription(triage)
+        }}
+        isOptionEqualToValue={(triage, value) => triage.id === value?.id}
+        renderInput={(params) => (
+          <TextField {...params} label="Existing Triage" />
+        )}
+        onChange={handleExistingTriageChange}
+      />
+
+      <Button
+        variant="contained"
+        color="primary"
+        sx={{ margin: '10px 0' }}
+        onClick={onSubmit}
+      >
+        Add to Entry
+      </Button>
+    </>
+  )
+}
+
+ExistingTriageSelector.propTypes = {
+  triages: PropTypes.array.isRequired,
+  existingTriageId: PropTypes.number.isRequired,
+  setExistingTriageId: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+}

--- a/sippy-ng/src/component_readiness/TriageFields.js
+++ b/sippy-ng/src/component_readiness/TriageFields.js
@@ -1,19 +1,32 @@
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 import { DateTimePicker, LocalizationProvider } from '@mui/x-date-pickers'
-import { FormHelperText, MenuItem, Select, TextField } from '@mui/material'
+import {
+  FormHelperText,
+  MenuItem,
+  Select,
+  TextField,
+  Tooltip,
+} from '@mui/material'
 import { getTriagesAPIUrl, jiraUrlPrefix } from './CompReadyUtils'
 import { makeStyles } from '@mui/styles'
 import Button from '@mui/material/Button'
+import ExistingTriageSelector from './ExistingTriageSelector'
+import InfoIcon from '@mui/icons-material/Info'
 import PropTypes from 'prop-types'
 import React from 'react'
 
 const useStyles = makeStyles({
   triageForm: {
     display: 'flex',
+    flexDirection: 'column',
+    gap: 16,
+    padding: '10px 0',
+  },
+  formFields: {
+    display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
     gap: 16,
-    padding: '10px 0',
   },
   validationErrors: {
     color: 'red',
@@ -22,15 +35,20 @@ const useStyles = makeStyles({
 
 export default function TriageFields({
   triageId,
+  triages,
   setAlertText,
   setAlertSeverity,
   triageEntryData,
   setTriageEntryData,
   handleFormCompletion,
   submitButtonText,
+  existingTriageId,
+  setExistingTriageId,
+  handleAddToExistingTriage,
 }) {
   const classes = useStyles()
 
+  const [matchingTriages, setMatchingTriages] = React.useState([])
   const [triageValidationErrors, setTriageValidationErrors] = React.useState([])
 
   const updating = triageId > 0
@@ -38,10 +56,20 @@ export default function TriageFields({
   const handleTriageChange = (e) => {
     const { name, value } = e.target
 
-    setTriageEntryData((prevData) => ({
-      ...prevData,
-      [name]: value,
-    }))
+    setTriageEntryData((prevData) => {
+      const updatedData = {
+        ...prevData,
+        [name]: value,
+      }
+
+      if (!updating && name === 'url') {
+        setMatchingTriages(
+          triages.filter((triage) => triage.url === updatedData.url)
+        )
+      }
+
+      return updatedData
+    })
   }
 
   const handleTriageEntrySubmit = () => {
@@ -62,6 +90,15 @@ export default function TriageFields({
     setTriageValidationErrors(validationErrors)
 
     if (validationErrors.length === 0) {
+      if (matchingTriages.length > 0) {
+        const confirmed = window.confirm(
+          'There are existing triage entries with the same URL. Are you sure you want to create a new entry instead of adding to an existing one?'
+        )
+        if (!confirmed) {
+          return
+        }
+      }
+
       let data
       let triagesAPIUrl
       let method
@@ -129,65 +166,88 @@ export default function TriageFields({
 
   return (
     <div className={classes.triageForm}>
-      <TextField
-        name="url"
-        label="Jira URL"
-        value={triageEntryData.url}
-        onChange={handleTriageChange}
-      />
-      <TextField
-        name="description"
-        label="Description"
-        value={triageEntryData.description}
-        onChange={handleTriageChange}
-      />
-      <Select
-        name="type"
-        label="Type"
-        value={triageEntryData.type}
-        onChange={handleTriageChange}
-      >
-        {triageTypeOptions.map((option, index) => (
-          <MenuItem key={index} value={option}>
-            {option}
-          </MenuItem>
-        ))}
-      </Select>
-      {updating && (
-        <LocalizationProvider dateAdapter={AdapterDateFns}>
-          <DateTimePicker
-            label="Resolution Date"
-            value={
-              triageEntryData.resolved?.Valid
-                ? triageEntryData.resolved?.Time
-                : null
-            }
-            onChange={(date) =>
-              setTriageEntryData((prevData) => ({
-                ...prevData,
-                resolved: { Time: date, Valid: date !== null },
-              }))
-            }
-            renderInput={(props) => <TextField variant="standard" {...props} />}
-          />
-        </LocalizationProvider>
-      )}
-      <Button
-        variant="contained"
-        color="primary"
-        onClick={handleTriageEntrySubmit}
-      >
-        {submitButtonText}
-      </Button>
-      {triageValidationErrors && (
-        <FormHelperText className={classes.validationErrors}>
-          {triageValidationErrors.map((text, index) => (
-            <span key={index}>
-              {text}
-              <br />
-            </span>
+      <div className={classes.formFields}>
+        <TextField
+          name="url"
+          label="Jira URL"
+          value={triageEntryData.url}
+          onChange={handleTriageChange}
+        />
+        <TextField
+          name="description"
+          label="Description"
+          value={triageEntryData.description}
+          onChange={handleTriageChange}
+        />
+        <Select
+          name="type"
+          label="Type"
+          value={triageEntryData.type}
+          onChange={handleTriageChange}
+        >
+          {triageTypeOptions.map((option, index) => (
+            <MenuItem key={index} value={option}>
+              {option}
+            </MenuItem>
           ))}
-        </FormHelperText>
+        </Select>
+        {updating && (
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <DateTimePicker
+              label="Resolution Date"
+              value={
+                triageEntryData.resolved?.Valid
+                  ? triageEntryData.resolved?.Time
+                  : null
+              }
+              onChange={(date) =>
+                setTriageEntryData((prevData) => ({
+                  ...prevData,
+                  resolved: { Time: date, Valid: date !== null },
+                }))
+              }
+              renderInput={(props) => (
+                <TextField variant="standard" {...props} />
+              )}
+            />
+          </LocalizationProvider>
+        )}
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleTriageEntrySubmit}
+        >
+          {submitButtonText}
+        </Button>
+        {triageValidationErrors && (
+          <FormHelperText className={classes.validationErrors}>
+            {triageValidationErrors.map((text, index) => (
+              <span key={index}>
+                {text}
+                <br />
+              </span>
+            ))}
+          </FormHelperText>
+        )}
+      </div>
+      {matchingTriages.length > 0 && (
+        <div>
+          <h4>
+            Triage Entries with Matching Jira Exist
+            <Tooltip title="It is likely unwanted to create a new triage entry for the same Jira. Please select an existing triage entry to add to instead.">
+              <InfoIcon
+                fontSize="small"
+                style={{ marginLeft: 8, verticalAlign: 'middle' }}
+              />
+            </Tooltip>
+          </h4>
+          <ExistingTriageSelector
+            triages={matchingTriages}
+            existingTriageId={existingTriageId}
+            setExistingTriageId={setExistingTriageId}
+            onSubmit={handleAddToExistingTriage}
+          />
+        </div>
       )}
     </div>
   )
@@ -195,10 +255,15 @@ export default function TriageFields({
 
 TriageFields.propTypes = {
   triageId: PropTypes.number,
+  triages: PropTypes.array.isRequired,
   setAlertText: PropTypes.func.isRequired,
   setAlertSeverity: PropTypes.func.isRequired,
   triageEntryData: PropTypes.object.isRequired,
   setTriageEntryData: PropTypes.func.isRequired,
   handleFormCompletion: PropTypes.func.isRequired,
   submitButtonText: PropTypes.string.isRequired,
+  // used when the user opts to add to existing triage with matching url
+  existingTriageId: PropTypes.number.isRequired,
+  setExistingTriageId: PropTypes.func.isRequired,
+  handleAddToExistingTriage: PropTypes.func.isRequired,
 }


### PR DESCRIPTION
This will allow the user to instead select (one of) the other record(s), or continue to create a new one if desired.

Here is what it looks like as soon as the `Jira URL` field matches any existing triage entries:
![Screenshot 2025-06-30 at 1 14 57 PM](https://github.com/user-attachments/assets/f3f9bdf8-02b6-40a1-a455-6cae2a667b2c)

Confirmation when the user still attempts to create a new entry. It doesn't stop them, but makes them aware:
![Screenshot 2025-06-30 at 1 12 23 PM](https://github.com/user-attachments/assets/2a272761-e587-4353-8a3f-b3ae3eaf1270)



Augment assisted with refactoring out the `ExistingTriageSelector` component.