### PR TITLE
TRT-2166: add the triages to the analysis regression in post-analysis 

### DIFF
--- a/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
+++ b/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
@@ -99,7 +99,7 @@ func (r *RegressionTracker) PreAnalysis(testKey crtest.Identification, testStats
 	return nil
 }
 
-// PostAnalysis adjusts status code (and thus icons) based on the triaged state of open regressions.
+// PostAnalysis adjusts triages and status code (and thus icons) based on the triaged state of open regressions.
 func (r *RegressionTracker) PostAnalysis(testKey crtest.Identification, testStats *testdetails.TestComparison) error {
 	if testStats.ReportStatus > crtest.SignificantTriagedRegression {
 		// no need to adjust status for triage if this is no longer a regression
@@ -118,6 +118,8 @@ func (r *RegressionTracker) PostAnalysis(testKey crtest.Identification, testStat
 		}
 
 		if len(or.Triages) > 0 {
+			// triages need to be included, in case they are not in the cache, in order to show the list on the report
+			testStats.Regression.Triages = or.Triages
 
 			allTriagesResolved := true
 			var lastResolution time.Time

--- a/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker_test.go
+++ b/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker_test.go
@@ -60,6 +60,7 @@ func TestRegressionTracker_PostAnalysis(t *testing.T) {
 		openRegression            models.TestRegression
 		expectStatus              crtest.Status
 		expectedExplanationsCount int
+		expectedTriages           []models.Triage
 	}{
 		{
 			name: "triaged regression",
@@ -67,6 +68,7 @@ func TestRegressionTracker_PostAnalysis(t *testing.T) {
 				ReportStatus: crtest.ExtremeRegression,
 				Explanations: []string{},
 				LastFailure:  &daysAgo4,
+				Regression:   &models.TestRegression{},
 			},
 			openRegression: models.TestRegression{
 				ID:       0,
@@ -94,6 +96,17 @@ func TestRegressionTracker_PostAnalysis(t *testing.T) {
 			},
 			expectStatus:              crtest.ExtremeTriagedRegression,
 			expectedExplanationsCount: 1,
+			expectedTriages: []models.Triage{
+				{
+					ID:          42,
+					CreatedAt:   daysAgo4,
+					UpdatedAt:   daysAgo4,
+					URL:         "https://example.com/foobar",
+					Description: "foobar",
+					Type:        "product",
+					Resolved:    sql.NullTime{},
+				},
+			},
 		},
 		{
 			name: "triage resolved waiting to clear",
@@ -101,6 +114,7 @@ func TestRegressionTracker_PostAnalysis(t *testing.T) {
 				ReportStatus: crtest.ExtremeRegression,
 				Explanations: []string{},
 				LastFailure:  &daysAgo4,
+				Regression:   &models.TestRegression{},
 			},
 			openRegression: models.TestRegression{
 				ID:       0,
@@ -131,6 +145,20 @@ func TestRegressionTracker_PostAnalysis(t *testing.T) {
 			},
 			expectStatus:              crtest.FixedRegression,
 			expectedExplanationsCount: 1,
+			expectedTriages: []models.Triage{
+				{
+					ID:          42,
+					CreatedAt:   daysAgo4,
+					UpdatedAt:   daysAgo4,
+					URL:         "https://example.com/foobar",
+					Description: "foobar",
+					Type:        "product",
+					Resolved: sql.NullTime{
+						Time:  daysAgo3,
+						Valid: true,
+					},
+				},
+			},
 		},
 		{
 			name: "triage resolved but has failed since",
@@ -138,6 +166,7 @@ func TestRegressionTracker_PostAnalysis(t *testing.T) {
 				ReportStatus: crtest.ExtremeRegression,
 				Explanations: []string{},
 				LastFailure:  &daysAgo2,
+				Regression:   &models.TestRegression{},
 			},
 			openRegression: models.TestRegression{
 				ID:       0,
@@ -168,6 +197,20 @@ func TestRegressionTracker_PostAnalysis(t *testing.T) {
 			},
 			expectStatus:              crtest.FailedFixedRegression,
 			expectedExplanationsCount: 1,
+			expectedTriages: []models.Triage{
+				{
+					ID:          42,
+					CreatedAt:   daysAgo4,
+					UpdatedAt:   daysAgo4,
+					URL:         "https://example.com/foobar",
+					Description: "foobar",
+					Type:        "product",
+					Resolved: sql.NullTime{
+						Time:  daysAgo3,
+						Valid: true,
+					},
+				},
+			},
 		},
 		{
 			name: "triage resolved and has cleared entirely",
@@ -175,6 +218,7 @@ func TestRegressionTracker_PostAnalysis(t *testing.T) {
 				ReportStatus: crtest.SignificantImprovement,
 				Explanations: []string{},
 				LastFailure:  nil,
+				Regression:   &models.TestRegression{},
 			},
 			openRegression: models.TestRegression{
 				ID:       0,
@@ -212,6 +256,7 @@ func TestRegressionTracker_PostAnalysis(t *testing.T) {
 				ReportStatus: crtest.NotSignificant,
 				Explanations: []string{},
 				LastFailure:  &daysAgo2,
+				Regression:   &models.TestRegression{},
 			},
 			openRegression: models.TestRegression{
 				ID:       0,
@@ -254,6 +299,7 @@ func TestRegressionTracker_PostAnalysis(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedExplanationsCount, len(tt.testStats.Explanations), tt.testStats.Explanations)
 			assert.Equal(t, tt.expectStatus, tt.testStats.ReportStatus)
+			assert.Equal(t, tt.expectedTriages, tt.testStats.Regression.Triages)
 
 		})
 	}


### PR DESCRIPTION
This allows for the triage list to display on the report when the regression has been triaged since the last cache refresh