### PR TITLE
NO-JIRA: set current-user on context when updating triage record via bugloader

### DIFF
--- a/pkg/dataloader/bugloader/bugloader.go
+++ b/pkg/dataloader/bugloader/bugloader.go
@@ -218,7 +218,7 @@ func (bl *BugLoader) updateTriageBugLinks(triages []models.Triage) {
 		logger.Info(info)
 		t.Bug = &bug
 		t.BugID = &bug.ID
-		res = bl.dbc.DB.Save(t)
+		res = bl.dbc.DB.WithContext(context.WithValue(context.Background(), models.CurrentUserKey, "bug-loader")).Save(t)
 		if res.Error != nil {
 			bl.addError(logger, res.Error, "error "+info)
 		}


### PR DESCRIPTION
This fixes a panic in `bugloader`. I searched through the code looking for other places that may update the triage without setting the current-user, and can't find anything else. I considered changing the logic so that it wouldn't panic if this were to happen somewhere else, but I am worried that we wouldn't notice the issue and end up with an empty user in the audit logs instead.