### PR TITLE
NO-JIRA: fix bugloader panic, save needs to be passed a pointer

### DIFF
--- a/pkg/dataloader/bugloader/bugloader.go
+++ b/pkg/dataloader/bugloader/bugloader.go
@@ -218,7 +218,7 @@ func (bl *BugLoader) updateTriageBugLinks(triages []models.Triage) {
 		logger.Info(info)
 		t.Bug = &bug
 		t.BugID = &bug.ID
-		res = bl.dbc.DB.WithContext(context.WithValue(context.Background(), models.CurrentUserKey, "bug-loader")).Save(t)
+		res = bl.dbc.DB.WithContext(context.WithValue(context.Background(), models.CurrentUserKey, "bug-loader")).Save(&t)
 		if res.Error != nil {
 			bl.addError(logger, res.Error, "error "+info)
 		}


### PR DESCRIPTION
I thought it was fixed in https://github.com/openshift/sippy/pull/2765, but the error was actually happening prior to the audit log logic being executed.