### PR TITLE
TRT-2130: sippy classic allows arbitrary release names

### DIFF
--- a/pkg/util/param/param.go
+++ b/pkg/util/param/param.go
@@ -29,7 +29,7 @@ var releaseRegexp = regexp.MustCompile(`^\d+\.\d+$`)
 var nonEmptyRegex = regexp.MustCompile(`^.+$`)
 var paramRegexp = map[string]*regexp.Regexp{
 	// sippy classic params
-	"release":         regexp.MustCompile(`^(Presubmits|\d+\.\d+)$`),
+	"release":         regexp.MustCompile(`^[\w.-]+$`), // usually 4.x or Presubmit, but allow any "word"
 	"period":          wordRegexp,
 	"stream":          wordRegexp,
 	"arch":            wordRegexp,


### PR DESCRIPTION
The release names come from sippy /api/releases which ultimately just draws from a BQ table. They could be anything and Sippy Classic would not really care.

Update param.go to just allow anything that looks like a word.