### PR TITLE
TRT-2179: Add an explicit cache key for release fallback to limit unnecessary cache misses

### DIFF
--- a/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
+++ b/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
@@ -498,10 +498,11 @@ func newFallbackBaseQueryGenerator(client *bqcachedclient.Client, reqOptions req
 }
 
 type fallbackTestQueryGeneratorCacheKey struct {
-	BaseRelease     string
-	BaseStart       time.Time
-	BaseEnd         time.Time
-	AdvancedOptions reqopts.Advanced
+	BaseRelease string
+	BaseStart   time.Time
+	BaseEnd     time.Time
+	// IgnoreDisruption is the only field within AdvancedOption that is used here
+	IgnoreDisruption bool
 	// VariantDBGroupBy is the only field within VariantOption that is used here
 	VariantDBGroupBy sets.String
 }
@@ -514,7 +515,7 @@ func (f *fallbackTestQueryGenerator) getCacheKey() fallbackTestQueryGeneratorCac
 		BaseRelease:      f.BaseRelease,
 		BaseStart:        f.BaseStart,
 		BaseEnd:          f.BaseEnd,
-		AdvancedOptions:  f.ReqOptions.AdvancedOption,
+		IgnoreDisruption: f.ReqOptions.AdvancedOption.IgnoreDisruption,
 		VariantDBGroupBy: f.ReqOptions.VariantOption.DBGroupBy,
 	}
 }

--- a/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
+++ b/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
@@ -101,11 +101,6 @@ func (r *ReleaseFallback) PreAnalysis(testKey crtest.Identification, testStats *
 	testIDBytes, _ := json.Marshal(testIDVariantsKey)
 	testKeyStr := string(testIDBytes)
 
-	if !r.reqOptions.AdvancedOption.IncludeMultiReleaseAnalysis {
-		// nothing to do if this feature is disabled
-		return nil
-	}
-
 	if r.cachedFallbackTestStatuses == nil {
 		// In the test details path, this map is not initialized and we have no work to do for pre analysis.
 		// Fallback is treated as a separate second report entirely, rather than swapping out values on the fly,
@@ -345,10 +340,9 @@ func newFallbackTestQueryReleasesGenerator(
 }
 
 type fallbackTestQueryReleasesGeneratorCacheKey struct {
-	BaseRelease     string
-	BaseStart       time.Time
-	BaseEnd         time.Time
-	AdvancedOptions reqopts.Advanced
+	BaseRelease string
+	BaseStart   time.Time
+	BaseEnd     time.Time
 	// VariantDBGroupBy is the only field within VariantOption that is used here
 	VariantDBGroupBy sets.String
 	// CRTimeRoundingFactor is used by GetReleaseDatesFromBigQuery
@@ -363,7 +357,6 @@ func (f *fallbackTestQueryReleasesGenerator) getCacheKey() fallbackTestQueryRele
 		BaseRelease:          f.BaseRelease,
 		BaseStart:            f.BaseStart,
 		BaseEnd:              f.BaseEnd,
-		AdvancedOptions:      f.ReqOptions.AdvancedOption,
 		VariantDBGroupBy:     f.ReqOptions.VariantOption.DBGroupBy,
 		CRTimeRoundingFactor: f.ReqOptions.CacheOption.CRTimeRoundingFactor,
 	}


### PR DESCRIPTION
Very few of the exported fields within the `fallbackTestQueryGenerator` and `fallbackTestQueryReleasesGenerator` are actually used in their respective queries. These 2 new cache keys only utilize those fields.

I didn't use AI at all to write the code, but I did use Cursor (Claude-4-sonnet) to check my work:

> Looking at the `fallbackTestQueryGenerator` struct and its cache key, I need to examine which exported fields are used in the query logic but not included in the cache key.
> 
> Let me search for how `query.BuildComponentReportQuery` uses the `ReqOptions` parameter to understand what fields are actually needed:
> Ran tool
> 
> Let me examine the `BuildComponentReportQuery` function more closely to see what fields are actually used in fallback queries:
> Read file: pkg/api/componentreadiness/query/querygenerators.go
> 
> Read file: pkg/api/componentreadiness/query/querygenerators.go
> 
> Based on my analysis of the code, **no** - there are no exported fields within `fallbackTestQueryGenerator` that are used during the query logic but not included in `fallbackTestQueryGeneratorCacheKey`.
> 
> Here's why:
> 
> Looking at the `fallbackTestQueryGenerator` struct, the exported fields are:
> - `BaseRelease` - **included in cache key**
> - `BaseStart` - **included in cache key**
> - `BaseEnd` - **included in cache key**
> - `ReqOptions` - **partially included in cache key**
> 
> The key insight is in the `BuildComponentReportQuery` function. When `isFallback = true` (which is the case for fallback queries), it skips the entire variant filtering section that would otherwise use several fields from `ReqOptions`:
> 
> ```363:363:pkg/api/componentreadiness/query/querygenerators.go
> 	// fallback queries get all variants with no filtering
> 	// so all tests are fetched then cached
> 	if !isFallback {
> ```
> 
> This means the following fields from `ReqOptions` are **NOT** used in fallback queries:
> - `VariantOption.VariantCrossCompare`
> - `VariantOption.CompareVariants`
> - `TestIDOptions`
> - `SampleRelease.PullRequestOptions` (also not used because `isSample = false` for fallback)
> 
> The fields from `ReqOptions` that **ARE** used in fallback queries are:
> 1. `VariantOption.DBGroupBy` - used to construct query structure → **included in cache key as `VariantDBGroupBy`**
> 2. `AdvancedOption.IgnoreDisruption` - used for disruption filtering → **included in cache key as part of `AdvancedOptions`**
> 
> Therefore, the `fallbackTestQueryGeneratorCacheKey` correctly captures all the fields that would actually affect the fallback query results. The cache key is properly designed to avoid unnecessary cache misses while ensuring uniqueness for different query variations.