### PR TITLE
TRT-2130: hcm spike

### DIFF
--- a/cmd/sippy/automatejira.go
+++ b/cmd/sippy/automatejira.go
@@ -152,7 +152,7 @@ func NewAutomateJiraCommand() *cobra.Command {
 			if err != nil {
 				log.WithError(err).Fatal("unable to load views")
 			}
-			releases, err := api.GetReleases(context.Background(), bigQueryClient)
+			releases, err := api.GetReleases(context.Background(), bigQueryClient, nil)
 			if err != nil {
 				log.WithError(err).Fatal("error querying releases")
 			}

--- a/cmd/sippy/trackregressions.go
+++ b/cmd/sippy/trackregressions.go
@@ -92,7 +92,7 @@ func NewTrackRegressionsCommand() *cobra.Command {
 			if err != nil {
 				log.WithError(err).Fatal("unable to load views")
 			}
-			releases, err := api.GetReleases(context.TODO(), bigQueryClient)
+			releases, err := api.GetReleases(context.TODO(), bigQueryClient, nil)
 			if err != nil {
 				log.WithError(err).Fatal("error querying releases")
 			}

--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -13,7 +13,12 @@ releases:
       periodic-ci-openshift-openshift-ansible-release-3.11-e2e-aws-nightly: true
       periodic-ci-openshift-openshift-ansible-release-3.11-e2e-gcp-nightly: true
       periodic-ci-openshift-origin-release-3.11-e2e-gcp: true
-  "Presubmits":
+  hcm-integration:
+    addRelease: true
+    jobs:
+          periodic-ci-Azure-ARO-HCP-main-periodic-create-aro-hcp-in-integration: true
+  Presubmits:
+    addRelease: true
     regexp:
       - "^pull-ci-openshift-.*-(master|main).*-e2e-.*"
       - "^pull-ci-operator-framework.*-(master|main).*-e2e-.*"

--- a/config/openshift.yaml
+++ b/config/openshift.yaml
@@ -12982,7 +12982,12 @@ releases:
         jobs:
             periodic-ci-openshift-aws-karpenter-provider-aws-release-4.21-periodics-e2e-aws: true
             periodic-ci-openshift-aws-karpenter-provider-aws-release-4.21-periodics-e2e-hypershift: true
+    hcm-integration:
+        addRelease: true
+        jobs:
+          periodic-ci-Azure-ARO-HCP-main-periodic-create-aro-hcp-in-integration: true
     Presubmits:
+        addRelease: true
         regexp:
             - ^pull-ci-openshift-.*-(master|main).*-e2e-.*
             - ^pull-ci-operator-framework.*-(master|main).*-e2e-.*

--- a/pkg/apis/config/v1/types.go
+++ b/pkg/apis/config/v1/types.go
@@ -24,6 +24,9 @@ type ReleaseConfig struct {
 
 	// InformingJobs is the list of informing payload jobs
 	InformingJobs []string `yaml:"informingJobs,omitempty"`
+
+	// AddRelease determines whether the release should be added in for sippy classic
+	AddRelease bool `yaml:"addRelease,omitempty"`
 }
 
 type ComponentReadinessConfig struct {

--- a/pkg/dataloader/crcacheloader/crcacheloader.go
+++ b/pkg/dataloader/crcacheloader/crcacheloader.go
@@ -75,7 +75,7 @@ func (l *ComponentReadinessCacheLoader) Load() {
 		ForceRefresh:         true,
 	}
 
-	releases, err := api.GetReleases(context.TODO(), l.bqClient)
+	releases, err := api.GetReleases(context.TODO(), l.bqClient, nil)
 	if err != nil {
 		l.errs = append(l.errs, errors.Wrap(err, "error querying releases"))
 		return

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -120,7 +120,7 @@ func getReleaseStatus(releases []v1.Release, release string) string {
 func RefreshMetricsDB(ctx context.Context, dbc *db.DB, bqc *bqclient.Client, reportEnd time.Time, cacheOptions cache.RequestOptions, views []crview.View, variantJunitTableOverrides []configv1.VariantJunitTableOverride) error {
 	start := time.Now()
 	log.Info("beginning refresh metrics")
-	releases, err := api.GetReleases(context.Background(), bqc)
+	releases, err := api.GetReleases(context.Background(), bqc, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -655,7 +655,7 @@ func (s *Server) jsonJobVariantsFromBigQuery(w http.ResponseWriter, req *http.Re
 }
 
 func (s *Server) jsonComponentReadinessViews(w http.ResponseWriter, req *http.Request) {
-	allReleases, err := api.GetReleases(req.Context(), s.bigQueryClient)
+	allReleases, err := api.GetReleases(req.Context(), s.bigQueryClient, s.config)
 	if err != nil {
 		failureResponse(w, http.StatusBadRequest, err.Error())
 		return
@@ -696,7 +696,7 @@ func (s *Server) jsonComponentReportFromBigQuery(w http.ResponseWriter, req *htt
 		return
 	}
 
-	allReleases, err := api.GetReleases(req.Context(), s.bigQueryClient)
+	allReleases, err := api.GetReleases(req.Context(), s.bigQueryClient, s.config)
 	if err != nil {
 		failureResponse(w, http.StatusBadRequest, err.Error())
 		return
@@ -739,7 +739,7 @@ func (s *Server) jsonComponentReportTestDetailsFromBigQuery(w http.ResponseWrite
 		failureResponse(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	allReleases, err := api.GetReleases(req.Context(), s.bigQueryClient)
+	allReleases, err := api.GetReleases(req.Context(), s.bigQueryClient, s.config)
 	if err != nil {
 		failureResponse(w, http.StatusBadRequest, err.Error())
 		return
@@ -832,7 +832,7 @@ func (s *Server) jsonReleasesReportFromDB(w http.ResponseWriter, req *http.Reque
 		DeprecatedGADates: gaDateMap,
 		Dates:             dateMap,
 	}
-	releases, err := api.GetReleases(req.Context(), s.bigQueryClient)
+	releases, err := api.GetReleases(req.Context(), s.bigQueryClient, s.config)
 	if err != nil {
 		log.WithError(err).Error("error querying releases")
 		failureResponse(w, http.StatusInternalServerError, "error querying releases")

--- a/pkg/util/param/param.go
+++ b/pkg/util/param/param.go
@@ -29,7 +29,7 @@ var releaseRegexp = regexp.MustCompile(`^\d+\.\d+$`)
 var nonEmptyRegex = regexp.MustCompile(`^.+$`)
 var paramRegexp = map[string]*regexp.Regexp{
 	// sippy classic params
-	"release":         regexp.MustCompile(`^(Presubmits|\d+\.\d+)$`),
+	"release":         regexp.MustCompile(`^[\w.-]+$`), // usually 4.x or Presubmit, but allow any "word"
 	"period":          wordRegexp,
 	"stream":          wordRegexp,
 	"arch":            wordRegexp,


### PR DESCRIPTION
Draft PR for my initial try at adding `hcm-integration` as a release. It would depend on https://github.com/openshift/ci-tools/pull/4624 as well as changes in `continuous-release-jobs` to provide the config file and start loading data for the new release. This sort of works, but we have some further issues to work out first.