### PR TITLE
TRT-2181: Remove spaces when fetching bugs for tests

### DIFF
--- a/pkg/dataloader/bugloader/bugloader.go
+++ b/pkg/dataloader/bugloader/bugloader.go
@@ -243,9 +243,9 @@ func (bl *BugLoader) getTestBugMappings(ctx context.Context, testCache map[strin
 	querySQL := fmt.Sprintf(
 		`%s
 		JOIN %s.%s.%s j
-		  ON STRPOS(t.summary, j.name) > 0
-		  OR STRPOS(t.description, j.name) > 0
-		  OR STRPOS(t.comment, j.name ) > 0
+		  ON STRPOS(REGEXP_REPLACE(t.summary, r'\s+', ''), REGEXP_REPLACE(j.name, r'\s+', '')) > 0
+		  OR STRPOS(REGEXP_REPLACE(t.description, r'\s+', ''), REGEXP_REPLACE(j.name, r'\s+', '')) > 0
+		  OR STRPOS(REGEXP_REPLACE(t.comment, r'\s+', ''), REGEXP_REPLACE(j.name, r'\s+', '')) > 0
         WHERE j.name != "upgrade"`,
 		TicketDataQuery, ComponentMappingProject, ComponentMappingDataset, ComponentMappingTable)
 	log.Debug(querySQL)

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -208,7 +208,7 @@ func LoadBugsForTest(dbc *db.DB, testName string, filterClosed bool) ([]models.B
 	results := []models.Bug{}
 
 	test := models.Test{}
-	q := dbc.DB.Where("name = ?", testName)
+	q := dbc.DB.Where("REGEXP_REPLACE(name, '\\s+', '', 'g') = REGEXP_REPLACE(?, '\\s+', '', 'g')", testName)
 	timeLimit := "NOW() - last_change_time < interval '14 days'" // filter bugs since we no longer delete them
 	if filterClosed {
 		q = q.Preload("Bugs", timeLimit+" and UPPER(status) != 'CLOSED' and UPPER(status) != 'VERIFIED'")


### PR DESCRIPTION
This helps matching tests when multiple invisible whitespaces are involved. 

The BigQuery portion of this will add a delay of 30s. Since this only occurs once during data loading, team believe it is ok. 