### PR TITLE
TRT-2192: Bump go version in go.mod to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift/sippy
 
-go 1.22.3
-
-toolchain go1.22.5
+go 1.24
 
 require (
 	cloud.google.com/go v0.115.0
@@ -13,6 +11,7 @@ require (
 	github.com/apache/thrift v0.17.0
 	github.com/glycerine/golang-fisher-exact v0.0.0-20230401153517-53168ae38651
 	github.com/go-git/go-git/v5 v5.12.0
+	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v45 v45.2.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.7.0
@@ -32,6 +31,7 @@ require (
 	github.com/tcnksm/go-gitconfig v0.1.2
 	github.com/tidwall/gjson v1.14.4
 	github.com/trivago/tgo v1.0.7
+	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e
 	golang.org/x/oauth2 v0.23.0
 	google.golang.org/api v0.191.0
 	gopkg.in/redis.v5 v5.2.9
@@ -113,7 +113,6 @@ require (
 	github.com/google/cel-go v0.20.1 // indirect
 	github.com/google/flatbuffers v23.5.26+incompatible // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-github/v62 v62.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea // indirect
@@ -180,7 +179,6 @@ require (
 	go4.org v0.0.0-20201209231011-d4a079459e60 // indirect
 	gocloud.dev v0.40.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e // indirect
 	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect

--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -333,7 +333,7 @@ func JobRunRiskAnalysis(dbc *db.DB, bqc *bigquery.Client, jobRun *models.ProwJob
 
 	// NOTE: we are including bugs for all releases, may want to filter here in future to just those
 	// with an AffectsVersions that seems to match our compareRelease?
-	jobBugs, err := query.LoadBugsForJobs(dbc, []int{int(jobRun.ProwJob.ID)}, true)
+	jobBugs, err := query.LoadBugsForJobs(dbc, []int{int(jobRun.ProwJob.ID)}, true) // nolint:gosec
 	if err != nil {
 		logger.WithError(err).Errorf("Error evaluating bugs for prow job: %d", jobRun.ProwJob.ID)
 	} else {

--- a/pkg/api/jobs.go
+++ b/pkg/api/jobs.go
@@ -254,7 +254,7 @@ func (jobs jobDetailAPIResult) limit(req *http.Request) jobDetailAPIResult {
 
 // PrintJobDetailsReportFromDB renders the detailed list of runs for matching jobs.
 func PrintJobDetailsReportFromDB(w http.ResponseWriter, req *http.Request, dbc *db.DB, release, jobSearchStr string, reportEnd time.Time) error {
-	var min, max int
+	var start, end int
 
 	// List all ProwJobRuns for the given release in the last two weeks.
 	// TODO: 14 days matches orig API behavior, may want to add query params in future to control.
@@ -311,8 +311,8 @@ func PrintJobDetailsReportFromDB(w http.ResponseWriter, req *http.Request, dbc *
 
 	RespondWithJSON(http.StatusOK, w, jobDetailAPIResult{
 		Jobs:  jobs,
-		Start: min,
-		End:   max,
+		Start: start,
+		End:   end,
 	}.limit(req))
 	return nil
 }

--- a/pkg/cache/bigquerycache/bigquery.go
+++ b/pkg/cache/bigquerycache/bigquery.go
@@ -333,13 +333,13 @@ func (c *CacheRecord) Save() (row map[string]bigquery.Value, insertID string, er
 
 func chunk(value []byte, maxChunk int) [][]byte {
 	var ret [][]byte
-	max := len(value)
+	maxValue := len(value)
 
-	for i := 0; i < max; i += maxChunk {
+	for i := 0; i < maxValue; i += maxChunk {
 		end := i + maxChunk
 
-		if end > max {
-			end = max
+		if end > maxValue {
+			end = maxValue
 		}
 
 		ret = append(ret, value[i:end])

--- a/pkg/componentreadiness/resolvedissues/types.go
+++ b/pkg/componentreadiness/resolvedissues/types.go
@@ -12,7 +12,7 @@ var TriageMatchVariants = buildTriageMatchVariants([]string{variantregistry.Vari
 	variantregistry.VariantSuite, variantregistry.VariantInstaller})
 
 func buildTriageMatchVariants(in []string) sets.String {
-	if in == nil || len(in) < 1 {
+	if len(in) < 1 {
 		return nil
 	}
 

--- a/pkg/dataloader/bugloader/bugloader.go
+++ b/pkg/dataloader/bugloader/bugloader.go
@@ -380,7 +380,7 @@ func (bl *BugLoader) getJobBugMappings(ctx context.Context, jobCache map[string]
 			continue
 
 		}
-		bwj.ID = uint(intID)
+		bwj.ID = uint(intID) // nolint:gosec
 
 		if _, ok := jobCache[bwj.LinkName]; !ok {
 			// This is probably common because sippy probably doesn't know about *all* jobs like the BQ table does
@@ -449,7 +449,7 @@ func (bl *BugLoader) getTriageBugMappings(ctx context.Context, triages []models.
 			bl.errors = append(bl.errors, errors.WithMessagef(err, "failed to convert jira id %s", bwt.JiraID))
 			continue
 		}
-		bwt.ID = uint(intID)
+		bwt.ID = uint(intID) // nolint:gosec
 
 		if _, ok := bugs[bwt.ID]; !ok {
 			bugs[bwt.ID] = bigQueryBugToModel(bwt)

--- a/pkg/github/commenter/ghcommenter.go
+++ b/pkg/github/commenter/ghcommenter.go
@@ -46,7 +46,7 @@ func NewGitHubCommenter(githubClient *github.Client, dbc *db.DB, excludedRepos, 
 }
 
 func buildOrgRepos(in []string) (map[string]sets.String, error) {
-	if in == nil || len(in) < 1 {
+	if len(in) < 1 {
 		return nil, nil
 	}
 

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1355,7 +1355,7 @@ func (s *Server) jsonTriages(w http.ResponseWriter, req *http.Request) {
 			failureResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		if triageID != int(triage.ID) {
+		if triageID != int(triage.ID) { // nolint:gosec
 			failureResponse(w, http.StatusBadRequest, "resource triage ID does not match URL")
 			return
 		}

--- a/pkg/synthetictests/ocp_synthetic_tests.go
+++ b/pkg/synthetictests/ocp_synthetic_tests.go
@@ -191,7 +191,7 @@ func (openshiftSyntheticManager) CreateSyntheticTests(jrr *sippyprocessingv1.Raw
 	return &junit.TestSuite{
 		Name:      testidentification.SippySuiteName,
 		NumTests:  uint(len(results)),
-		NumFailed: uint(jrr.TestFailures),
+		NumFailed: uint(jrr.TestFailures), // nolint:gosec
 		TestCases: results,
 	}
 }

--- a/pkg/util/rate_limiter.go
+++ b/pkg/util/rate_limiter.go
@@ -31,10 +31,10 @@ func (rl *RateLimiter) Close() {
 	}
 }
 
-func (rl *RateLimiter) UpdateRate(error bool) {
+func (rl *RateLimiter) UpdateRate(isError bool) {
 
 	update := false
-	if error {
+	if isError {
 
 		if rl.errorCount < maxBackoff {
 			rl.errorCount++

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -83,8 +83,8 @@ func URLForJob(dashboard, jobName string) *gourl.URL {
 	return url
 }
 
-func DatePtr(year int, month time.Month, day, hour, min, sec, nsec int, loc *time.Location) *time.Time {
-	d := time.Date(year, month, day, hour, min, sec, nsec, loc)
+func DatePtr(year int, month time.Month, day, hour, minute, sec, nsec int, loc *time.Location) *time.Time {
+	d := time.Date(year, month, day, hour, minute, sec, nsec, loc)
 	return &d
 }
 


### PR DESCRIPTION
nolint was added for a few integer conversion warnings. I think our use case should be safe. Or we will have to go through code path to make sure we are all consistent with using signed or unsigned integers. 