### PR TITLE
TRT-2191: Revert "Allow multiple payload to be used for sample"

### DIFF
--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -853,7 +853,7 @@ func (c *ComponentReportGenerator) generateComponentTestReport(basisStatusMap, s
 			}
 		}
 
-		rowIdentifications, columnIdentifications, err := c.getRowColumnIdentifications(testKeyStr, status)
+		rowIdentifications, columnIdentifications, err := c.getRowColumnIdentifications(testKeyStr, sampleStatus)
 		if err != nil {
 			return crtype.ComponentReport{}, err
 		}

--- a/pkg/api/componentreadiness/query/querygenerators.go
+++ b/pkg/api/componentreadiness/query/querygenerators.go
@@ -215,16 +215,12 @@ func (s *sampleQueryGenerator) QueryTestStatus(ctx context.Context) (bq.ReportTe
 
 	before := time.Now()
 	errs := []error{}
-	sampleString := commonQuery
-	// Only set sample release when PR and payload options are not set
-	if s.ReqOptions.SampleRelease.PullRequestOptions == nil && s.ReqOptions.SampleRelease.PayloadOptions == nil {
-		sampleString += ` AND branch = @SampleRelease`
-	}
+	sampleString := commonQuery + ` AND branch = @SampleRelease`
 	if s.ReqOptions.SampleRelease.PullRequestOptions != nil {
 		sampleString += `  AND org = @Org AND repo = @Repo AND pr_number = @PRNumber`
 	}
 	if s.ReqOptions.SampleRelease.PayloadOptions != nil {
-		sampleString += `  AND release_verify_tag IN UNNEST(@Tags)`
+		sampleString += `  AND release_verify_tag = @Tag`
 	}
 	sampleQuery := s.client.BQ.Query(sampleString + groupByQuery)
 	sampleQuery.Parameters = append(sampleQuery.Parameters, queryParameters...)
@@ -237,15 +233,11 @@ func (s *sampleQueryGenerator) QueryTestStatus(ctx context.Context) (bq.ReportTe
 			Name:  "To",
 			Value: s.End,
 		},
+		{
+			Name:  "SampleRelease",
+			Value: s.ReqOptions.SampleRelease.Name,
+		},
 	}...)
-	if s.ReqOptions.SampleRelease.PullRequestOptions == nil && s.ReqOptions.SampleRelease.PayloadOptions == nil {
-		sampleQuery.Parameters = append(sampleQuery.Parameters, []bigquery.QueryParameter{
-			{
-				Name:  "SampleRelease",
-				Value: s.ReqOptions.SampleRelease.Name,
-			},
-		}...)
-	}
 	if s.ReqOptions.SampleRelease.PullRequestOptions != nil {
 		sampleQuery.Parameters = append(sampleQuery.Parameters, []bigquery.QueryParameter{
 			{
@@ -265,8 +257,8 @@ func (s *sampleQueryGenerator) QueryTestStatus(ctx context.Context) (bq.ReportTe
 	if s.ReqOptions.SampleRelease.PayloadOptions != nil {
 		sampleQuery.Parameters = append(sampleQuery.Parameters, []bigquery.QueryParameter{
 			{
-				Name:  "Tags",
-				Value: s.ReqOptions.SampleRelease.PayloadOptions.Tags,
+				Name:  "Tag",
+				Value: s.ReqOptions.SampleRelease.PayloadOptions.Tag,
 			},
 		}...)
 	}
@@ -488,19 +480,14 @@ func buildTestDetailsQuery(
 	commonParams := []bigquery.QueryParameter{}
 
 	for i, testIDOption := range testIDOpts {
-		queryString = addTestFilters(testIDOption, i, queryString, c, includeVariants)
+		queryString = addTestFilters(testIDOption, i, queryString, c, includeVariants, isSample)
 
 	}
 
 	if isSample {
 		queryString += filterByCrossCompareVariants(c.VariantOption.VariantCrossCompare, c.VariantOption.CompareVariants, &commonParams)
-		// Only set sample release when PR and payload options are not set
-		if c.SampleRelease.PayloadOptions == nil && c.SampleRelease.PullRequestOptions == nil {
-			queryString += ` AND branch = @SampleRelease`
-		}
 	} else {
 		queryString += filterByCrossCompareVariants(c.VariantOption.VariantCrossCompare, includeVariants, &commonParams)
-		queryString += ` AND branch = @BaseRelease`
 	}
 	return queryString, groupString, commonParams
 }
@@ -511,16 +498,21 @@ func addTestFilters(
 	index int,
 	queryString string,
 	c reqopts.RequestOptions,
-	includeVariants map[string][]string) string {
+	includeVariants map[string][]string,
+	isSample bool) string {
 
 	if index > 0 {
 		queryString += " OR "
 	}
-
-	queryString += fmt.Sprintf(`(cm.id = '%s'
+	if isSample {
+		queryString += fmt.Sprintf(`(cm.id = '%s' AND branch = @SampleRelease
 
 `, param.Cleanse(testIDOption.TestID))
+	} else {
+		queryString += fmt.Sprintf(`(cm.id = '%s' AND branch = @BaseRelease
 
+`, param.Cleanse(testIDOption.TestID))
+	}
 	for _, key := range sortedKeys(includeVariants) {
 		// only add in include variants that aren't part of the requested or cross-compared variants
 		if _, ok := testIDOption.RequestedVariants[key]; ok {
@@ -814,7 +806,7 @@ func (s *sampleTestDetailsQueryGenerator) QueryTestStatus(ctx context.Context) (
 		sampleString += `  AND jobs.org = @Org AND jobs.repo = @Repo AND jobs.pr_number = @PRNumber`
 	}
 	if s.ReqOptions.SampleRelease.PayloadOptions != nil {
-		sampleString += `  AND jobs.release_verify_tag IN UNNEST(@Tags)`
+		sampleString += `  AND jobs.release_verify_tag = @Tag`
 	}
 	sampleQuery := s.client.BQ.Query(sampleString + groupByQuery)
 	sampleQuery.Parameters = append(sampleQuery.Parameters, queryParameters...)
@@ -827,15 +819,11 @@ func (s *sampleTestDetailsQueryGenerator) QueryTestStatus(ctx context.Context) (
 			Name:  "To",
 			Value: s.End,
 		},
+		{
+			Name:  "SampleRelease",
+			Value: s.ReqOptions.SampleRelease.Name,
+		},
 	}...)
-	if s.ReqOptions.SampleRelease.PullRequestOptions == nil && s.ReqOptions.SampleRelease.PayloadOptions == nil {
-		sampleQuery.Parameters = append(sampleQuery.Parameters, []bigquery.QueryParameter{
-			{
-				Name:  "SampleRelease",
-				Value: s.ReqOptions.SampleRelease.Name,
-			},
-		}...)
-	}
 	if s.ReqOptions.SampleRelease.PullRequestOptions != nil {
 		sampleQuery.Parameters = append(sampleQuery.Parameters, []bigquery.QueryParameter{
 			{
@@ -855,8 +843,8 @@ func (s *sampleTestDetailsQueryGenerator) QueryTestStatus(ctx context.Context) (
 	if s.ReqOptions.SampleRelease.PayloadOptions != nil {
 		sampleQuery.Parameters = append(sampleQuery.Parameters, []bigquery.QueryParameter{
 			{
-				Name:  "Tags",
-				Value: s.ReqOptions.SampleRelease.PayloadOptions.Tags,
+				Name:  "Tag",
+				Value: s.ReqOptions.SampleRelease.PayloadOptions.Tag,
 			},
 		}...)
 	}

--- a/pkg/api/componentreadiness/queryparamparser.go
+++ b/pkg/api/componentreadiness/queryparamparser.go
@@ -200,13 +200,13 @@ func parsePROptions(req *http.Request) *reqopts.PullRequest {
 }
 
 func parsePayloadOptions(req *http.Request) *reqopts.Payload {
-	tags := req.URL.Query()["samplePayloadTag"]
-	if len(tags) == 0 {
+	po := reqopts.Payload{
+		Tag: param.SafeRead(req, "samplePayloadTag"),
+	}
+	if po.Tag == "" {
 		return nil
 	}
-	return &reqopts.Payload{
-		Tags: tags,
-	}
+	return &po
 }
 
 func parseVariantOptions(req *http.Request, allJobVariants crtest.JobVariants, overrides []configv1.VariantJunitTableOverride) (opts reqopts.Variants, err error) {

--- a/pkg/apis/api/componentreport/reqopts/types.go
+++ b/pkg/apis/api/componentreport/reqopts/types.go
@@ -32,7 +32,7 @@ type PullRequest struct {
 // Payload specifies a specific payload tag to use as the
 // sample for the report. This is only used for sample, not basis.
 type Payload struct {
-	Tags []string
+	Tag string
 }
 
 type Release struct {

--- a/pkg/util/param/param.go
+++ b/pkg/util/param/param.go
@@ -52,6 +52,7 @@ var paramRegexp = map[string]*regexp.Regexp{
 	"samplePROrg":      nameRegexp,
 	"samplePRRepo":     nameRegexp,
 	"samplePRNumber":   uintRegexp,
+	"samplePayloadTag": nameRegexp,
 	// jobartifacts params
 	"prowJobRuns":        regexp.MustCompile(`^\d+(,\d+)*$`), // comma-separated integers
 	"pathGlob":           nonEmptyRegex,                      // a glob can be anything

--- a/sippy-ng/src/component_readiness/CompReadyMainInputs.js
+++ b/sippy-ng/src/component_readiness/CompReadyMainInputs.js
@@ -128,8 +128,8 @@ export default function CompReadyMainInputs(props) {
           pullRequestNumber={varsContext.samplePRNumber}
           setPullRequestNumber={varsContext.setSamplePRNumber}
           payloadSupport={true}
-          payloadTags={varsContext.samplePayloadTags}
-          setPayloadTags={varsContext.setSamplePayloadTags}
+          payloadTag={varsContext.samplePayloadTag}
+          setPayloadTag={varsContext.setSamplePayloadTag}
         ></ReleaseSelector>
       </div>
       <div className={classes.crRelease}>

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -390,6 +390,10 @@ export function getUpdatedUrlParts(vars) {
 
   // TODO: inject the PR vars into query params
 
+  if (vars.samplePayloadTag) {
+    valuesMap.samplePayloadTag = vars.samplePayloadTag
+  }
+
   function filterOutVariantCC(values) {
     return values.filter((value) => !vars.variantCrossCompare.includes(value))
   }
@@ -431,9 +435,6 @@ export function getUpdatedUrlParts(vars) {
   )
   vars.variantCrossCompare.forEach((item) => {
     queryParams.append('variantCrossCompare', item)
-  })
-  vars.samplePayloadTags.forEach((item) => {
-    queryParams.append('samplePayloadTag', item)
   })
 
   // Stringify and put the begin param character.

--- a/sippy-ng/src/component_readiness/CompReadyVars.js
+++ b/sippy-ng/src/component_readiness/CompReadyVars.js
@@ -213,10 +213,12 @@ export const CompReadyVarsProvider = ({ children }) => {
   )
   const [samplePRNumber, setSamplePRNumber] =
     React.useState(samplePRNumberParam)
-  const [samplePayloadTagsParam = [], setSamplePayloadTagsParam] =
-    useQueryParam('samplePayloadTag', ArrayParam)
-  const [samplePayloadTags, setSamplePayloadTags] = React.useState(
-    samplePayloadTagsParam
+  const [samplePayloadTagParam = '', setSamplePayloadTagParam] = useQueryParam(
+    'samplePayloadTag',
+    StringParam
+  )
+  const [samplePayloadTag, setSamplePayloadTag] = React.useState(
+    samplePayloadTagParam
   )
 
   const setBaseReleaseWithDates = (event) => {
@@ -391,7 +393,7 @@ export const CompReadyVarsProvider = ({ children }) => {
     setSamplePROrgParam(samplePROrg)
     setSamplePRRepoParam(samplePRRepo)
     setSamplePRNumberParam(samplePRNumber)
-    setSamplePayloadTagsParam(samplePayloadTags)
+    setSamplePayloadTagParam(samplePayloadTag)
     setPityParam(pity)
     setMinFailParam(minFail)
     setPassRateNewTestsParam(passRateNewTests)
@@ -653,8 +655,8 @@ export const CompReadyVarsProvider = ({ children }) => {
         setSamplePRRepo,
         samplePRNumber,
         setSamplePRNumber,
-        samplePayloadTags,
-        setSamplePayloadTags,
+        samplePayloadTag,
+        setSamplePayloadTag,
         columnGroupByCheckedItems,
         setColumnGroupByCheckedItems,
         dbGroupByVariants,

--- a/sippy-ng/src/component_readiness/ReleaseSelector.js
+++ b/sippy-ng/src/component_readiness/ReleaseSelector.js
@@ -55,8 +55,8 @@ function ReleaseSelector(props) {
     pullRequestNumber,
     setPullRequestNumber,
     payloadSupport,
-    payloadTags,
-    setPayloadTags,
+    payloadTag,
+    setPayloadTag,
   } = props
 
   const days = 24 * 60 * 60 * 1000
@@ -68,7 +68,7 @@ function ReleaseSelector(props) {
   const [pullRequestURL, setPullRequestURL] = useState('')
   const [pullRequestURLError, setPullRequestURLError] = useState(false)
 
-  const [payloadTagsError, setPayloadTagsError] = useState(false)
+  const [payloadTagError, setPayloadTagError] = useState(false)
 
   const setGADate = () => {
     let start = new Date(versions[version])
@@ -115,17 +115,17 @@ function ReleaseSelector(props) {
   }, [pullRequestOrg, pullRequestRepo, pullRequestNumber])
 
   useEffect(() => {
-    if (payloadTags && payloadTags.length !== 0) {
-      setPayloadTags(payloadTags)
+    if (payloadTag) {
+      setPayloadTag(payloadTag)
     }
-  }, [payloadTags])
+  }, [payloadTag])
 
   const handlePullRequestURLChange = (e) => {
     const newURL = e.target.value
     setPullRequestURL(newURL)
 
     // Don't allow PRURL and payload tag at the same time
-    if (payloadTags && payloadTags.length !== 0) {
+    if (payloadTag !== '') {
       setPullRequestURLError(true)
       return
     }
@@ -150,41 +150,32 @@ function ReleaseSelector(props) {
     }
   }
 
-  const handlePayloadTagsChange = (e) => {
-    const newTags = e.target.value
+  const handlePayloadTagChange = (e) => {
+    const newTag = e.target.value
 
     // Don't allow PRURL and payload tag at the same time
     if (pullRequestURL !== '') {
-      setPayloadTagsError(true)
+      setPayloadTagError(true)
       return
     }
     // Allow clearing the URL:
-    if (newTags === '') {
-      setPayloadTagsError(false)
-      setPayloadTags([])
+    if (newTag === '') {
+      setPayloadTagError(false)
+      setPayloadTag('')
       return
     }
 
-    // Match string like
-    // 4.20.0-ec.3,
-    // 4.19.0-rc.5,
-    // 4.19.0,
-    // 4.20.0-0.ci-2025-06-30-145044,
-    // 4.20.0-0.konflux-nightly-2025-05-21-161707 and
-    // 4.19.0-0.nightly-2025-06-30-135545
+    // Match string like 4.19.0-0.nightly-2025-03-14-061055
     const regex =
-      /^\d+\.\d+\.\d+(?:-(?:ec\.\d+|rc\.\d+|\d+\.(?:ci|konflux-nightly|nightly)-\d{4}-\d{2}-\d{2}-\d{6}))?$/
-
-    const tags = newTags.split(',')
-    for (const tag of tags) {
-      if (!tag.match(regex)) {
-        setPayloadTagsError(true)
-        setPayloadTags([])
-        return
-      }
+      /^\d+\.\d+\.\d+-\d+\.(nightly|ci|konflux-nightly)-\d{4}-\d{2}-\d{2}-(\d+)$/
+    const match = newTag.match(regex)
+    if (match) {
+      setPayloadTagError(false)
+      setPayloadTag(newTag)
+    } else {
+      setPayloadTagError(true)
+      setPayloadTag('')
     }
-    setPayloadTagsError(false)
-    setPayloadTags(tags)
   }
 
   // Ensure that versions has a list of versions before trying to display the Form
@@ -232,42 +223,38 @@ function ReleaseSelector(props) {
                   value={pullRequestURL}
                   onChange={handlePullRequestURLChange}
                 />
-                {pullRequestURLError &&
-                  payloadTags &&
-                  payloadTags.length !== 0 && (
-                    <FormHelperText>
-                      Cannot have payload tags and pull request URL at the same
-                      time!
-                    </FormHelperText>
-                  )}
-                {pullRequestURLError &&
-                  (!payloadTags || payloadTags.length === 0) && (
-                    <FormHelperText>Invalid Pull Request URL</FormHelperText>
-                  )}
+                {pullRequestURLError && payloadTag !== '' && (
+                  <FormHelperText>
+                    Cannot have payload tag and pull request URL at the same
+                    time!
+                  </FormHelperText>
+                )}
+                {pullRequestURLError && payloadTag === '' && (
+                  <FormHelperText>Invalid Pull Request URL</FormHelperText>
+                )}
               </FormControl>
             )}
           </div>
           <div>
             {payloadSupport && (
-              <FormControl error={payloadTagsError}>
-                <InputLabel htmlFor="payloadTags">
-                  Payload Tags (optional)
+              <FormControl error={payloadTagError}>
+                <InputLabel htmlFor="payloadTag">
+                  Payload Tag (optional)
                 </InputLabel>
                 <Input
-                  id="payloadTags"
-                  value={payloadTags}
-                  onChange={handlePayloadTagsChange}
+                  id="payloadTag"
+                  value={payloadTag}
+                  onChange={handlePayloadTagChange}
                 />
-                {payloadTagsError && pullRequestURL !== '' && (
+                {payloadTagError && pullRequestURL !== '' && (
                   <FormHelperText>
                     Cannot have pull request URL and payload tag at the same
                     time!
                   </FormHelperText>
                 )}
-                {payloadTagsError && pullRequestURL === '' && (
+                {payloadTagError && pullRequestURL === '' && (
                   <FormHelperText>
-                    Valid format: comma separately tags like
-                    4.19.0-0.ci-2025-05-17-032906,4.20.0-ec.3,4.19.0-rc.5,4.19.0
+                    Valid tag format: 4.19.0-0.ci-2025-05-17-032906
                   </FormHelperText>
                 )}
               </FormControl>
@@ -378,8 +365,8 @@ ReleaseSelector.propTypes = {
   pullRequestNumber: PropTypes.string,
   setPullRequestNumber: PropTypes.func,
   payloadSupport: PropTypes.bool,
-  payloadTags: PropTypes.string,
-  setPayloadTags: PropTypes.func,
+  payloadTag: PropTypes.string,
+  setPayloadTag: PropTypes.func,
 }
 
 ReleaseSelector.defaultProps = {


### PR DESCRIPTION
This functionality broke the cache-primer by making it calculate the sample stats utilizing job runs from multiple releases.

This reverts commit 0911cbb98d889b3829959f759ebf1fc343554cf2.