### PR TITLE
TRT-2179: do not allow cache refresh to be forced for the `releasefallback` caching

### DIFF
--- a/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
+++ b/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
@@ -326,7 +326,8 @@ func newFallbackTestQueryReleasesGenerator(
 		client:         client,
 		allJobVariants: allJobVariants,
 		cacheOption: cache.RequestOptions{
-			ForceRefresh: reqOptions.CacheOption.ForceRefresh,
+			// never force a refresh, this data should be valid until cache expiry, and it is expensive to refresh it
+			ForceRefresh: false,
 			// increase the time that fallback queries are cached for
 			CRTimeRoundingFactor: fallbackQueryTimeRoundingOverride,
 		},
@@ -486,7 +487,8 @@ func newFallbackBaseQueryGenerator(client *bqcachedclient.Client, reqOptions req
 		allVariants: allVariants,
 		ReqOptions:  reqOptions,
 		cacheOption: cache.RequestOptions{
-			ForceRefresh: reqOptions.CacheOption.ForceRefresh,
+			// never force a refresh, this data should be valid until cache expiry, and it is expensive to refresh it
+			ForceRefresh: false,
 			// increase the time that base query is cached for since it shouldn't be changing
 			CRTimeRoundingFactor: fallbackQueryTimeRoundingOverride,
 		},


### PR DESCRIPTION
This is a follow up to https://github.com/openshift/sippy/pull/2777. After #2777 merged it was noticed that the cache was still being updated every 4 hours (when the cache-primer runs). This is due to the cache-primer setting `ForceRefresh` to true. While that is valid for other usages, we don't want fallback information to be refreshed that frequently.