### PR TITLE
TRT-2182: simple triage from `test_details` bug list

### DIFF
--- a/sippy-ng/src/bugs/BugTable.js
+++ b/sippy-ng/src/bugs/BugTable.js
@@ -1,4 +1,5 @@
 import {
+  Button,
   Paper,
   Table,
   TableBody,
@@ -6,8 +7,10 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
 } from '@mui/material'
+import { getTriagesAPIUrl } from '../component_readiness/CompReadyUtils'
 import { relativeTime, safeEncodeURIComponent } from '../helpers'
 import Alert from '@mui/material/Alert'
 import PropTypes from 'prop-types'
@@ -16,6 +19,7 @@ import React, { useEffect } from 'react'
 export default function BugTable(props) {
   const [isLoaded, setLoaded] = React.useState(false)
   const [bugs, setBugs] = React.useState([])
+  const [bugToPotentialTriage, setBugToPotentialTriage] = React.useState({})
   const [fetchError, setFetchError] = React.useState('')
 
   const fetchData = () => {
@@ -29,12 +33,55 @@ export default function BugTable(props) {
     Promise.all([fetch(bugsURL)])
       .then(([bugs]) => {
         if (bugs.status !== 200) {
-          throw new Error('server returned ' + bugs.status)
+          throw new Error('server returned when fetching bugs' + bugs.status)
         }
         return Promise.all([bugs.json()])
       })
       .then(([bugs]) => {
         setBugs(bugs)
+        // If we have a regressionId and bugs, we can try to find a matching triage entry
+        // for each bug that could potentially be used to triage the regression
+        if (
+          props.writeEndpointsEnabled &&
+          props.regressionId &&
+          bugs.length > 0
+        ) {
+          return fetch(getTriagesAPIUrl())
+            .then((res) => {
+              if (res.status !== 200) {
+                throw new Error(
+                  'server returned when fetching triages' + res.status
+                )
+              }
+              return res.json()
+            })
+            .then((triages) => {
+              let btpt = {}
+              bugs.forEach((bug) => {
+                let matchedTriage = undefined
+                for (const triage of triages) {
+                  const alreadyAssociatedWithTriage = triage.regressions.some(
+                    (regression) => regression.id === props.regressionId
+                  )
+                  if (!alreadyAssociatedWithTriage && triage.url === bug.url) {
+                    // If we have multiple matches, we should not add the button to triage to any of them
+                    if (matchedTriage !== undefined) {
+                      matchedTriage = undefined
+                      break
+                    }
+                    matchedTriage = triage
+                  }
+                }
+
+                if (matchedTriage !== undefined) {
+                  btpt[bug.id] = matchedTriage
+                }
+              })
+              setBugToPotentialTriage(btpt)
+            })
+        }
+      })
+      .then(() => {
         setLoaded(true)
       })
       .catch((error) => {
@@ -45,6 +92,22 @@ export default function BugTable(props) {
   useEffect(() => {
     fetchData()
   }, [])
+
+  const addToTriage = (triage) => {
+    triage.regressions.push({ id: props.regressionId })
+    fetch(getTriagesAPIUrl(triage.id), {
+      method: 'PUT',
+      body: JSON.stringify(triage),
+    }).then((res) => {
+      if (res.status !== 200) {
+        setFetchError(
+          'Could not add to triage ' + triage.url + ' error ' + res.status
+        )
+      }
+      // this will refresh the entire test_details report page, resulting in the newly associated triage showing
+      props.setHasBeenTriaged(true)
+    })
+  }
 
   if (!isLoaded) {
     return <p>Loading...</p>
@@ -68,6 +131,7 @@ export default function BugTable(props) {
             <TableCell>Component</TableCell>
             <TableCell>Affects Versions</TableCell>
             <TableCell>Last Modified</TableCell>
+            <TableCell></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -89,6 +153,23 @@ export default function BugTable(props) {
               <TableCell>
                 {relativeTime(new Date(bug.last_change_time), new Date())}
               </TableCell>
+              <TableCell>
+                {bugToPotentialTriage[bug.id] && (
+                  <Tooltip
+                    title={`Add this regression to matching triage entry: "${
+                      bugToPotentialTriage[bug.id].url
+                    }: ${bugToPotentialTriage[bug.id].description}"`}
+                  >
+                    <Button
+                      variant="contained"
+                      color="secondary"
+                      onClick={() => addToTriage(bugToPotentialTriage[bug.id])}
+                    >
+                      Triage
+                    </Button>
+                  </Tooltip>
+                )}
+              </TableCell>
             </TableRow>
           ))}
         </TableBody>
@@ -101,4 +182,7 @@ BugTable.propTypes = {
   bugsURL: PropTypes.string,
   testName: PropTypes.string,
   classes: PropTypes.object,
+  writeEndpointsEnabled: PropTypes.bool,
+  regressionId: PropTypes.number,
+  setHasBeenTriaged: PropTypes.func,
 }

--- a/sippy-ng/src/component_readiness/TestDetailsReport.js
+++ b/sippy-ng/src/component_readiness/TestDetailsReport.js
@@ -355,7 +355,12 @@ Flakes: ${stats.flake_count}`
           )}
 
           <h2>Bugs Mentioning This Test</h2>
-          <BugTable testName={testName} />
+          <BugTable
+            testName={testName}
+            writeEndpointsEnabled={writeEndpointsEnabled}
+            regressionId={regressionId}
+            setHasBeenTriaged={setHasBeenTriaged}
+          />
           <Box
             sx={{
               display: 'flex',


### PR DESCRIPTION
This adds the ability to add regression to triage entry that has the same Jira as a matched bug from the `test_details` bug list. This is only possible when there is exactly one triage entry that has the same Jira url as the bug.