### PR TITLE
Fix test analysis links again

### DIFF
--- a/sippy-ng/src/component_readiness/TestDetailsReport.js
+++ b/sippy-ng/src/component_readiness/TestDetailsReport.js
@@ -426,17 +426,16 @@ View the [test details report|${document.location.href}] for additional context.
             >
               View other open regressions
             </Button>
-            <Button
-              variant="contained"
-              color="secondary"
-              href={pathForExactTestAnalysisWithFilter(
-                sampleRelease,
-                testName,
-                { items: [] }
-              )}
+            <Link
+              to={pathForExactTestAnalysisWithFilter(sampleRelease, testName, {
+                items: [],
+              })}
+              style={{ textDecoration: 'none' }}
             >
-              View Test Analysis
-            </Button>
+              <Button variant="contained" color="secondary">
+                View Test Analysis
+              </Button>
+            </Link>
           </Box>
         </Grid>
       </Grid>

--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -157,7 +157,7 @@ export function pathForExactTestAnalysisWithFilter(release, test, filter) {
       }
     })
   }
-  return `/sippy-ng/tests/${release}/analysis?test=${safeEncodeURIComponent(
+  return `/tests/${release}/analysis?test=${safeEncodeURIComponent(
     test
   )}&${multiple(...filters)}`
 }


### PR DESCRIPTION
Previous fix broke other pre-existing callers of this function, so only the links from comp readiness are working.

The use of Link prevents us having to construct our own full href and is
more consistent with existing code.
