### PR TITLE
NO-JIRA: remove `load-openshift-ci-bigquery` flag

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -64,7 +64,6 @@ available [here](config/README.md).
   --database-dsn="postgresql://postgres:password@localhost:5432/postgres" \
   --mode=ocp \
   --config ./config/openshift.yaml \
-  --load-openshift-ci-bigquery \
   --google-service-account-credential-file ~/Downloads/openshift-ci-data-analysis-1b68cb387203.json
 ```
 
@@ -83,7 +82,6 @@ or [configure GitHub in your gitconfig](https://stackoverflow.com/questions/8505
   --database-dsn="postgresql://postgres:password@localhost:5432/postgres" \
   --mode=ocp \
   --config ./config/openshift.yaml \
-  --load-openshift-ci-bigquery \
   --google-service-account-credential-file ~/Downloads/openshift-ci-data-analysis-1b68cb387203.json
 ```
 
@@ -102,7 +100,6 @@ releases and architectures like this:
   --database-dsn="postgresql://postgres:password@localhost:5432/postgres" \
   --google-service-account-credential-file ~/Downloads/openshift-ci-data-analysis-1b68cb387203.json \
   --mode=ocp \
-  --load-openshift-ci-bigquery \
   --config ./config/openshift.yaml
 ```
 

--- a/e2e-scripts/sippy-e2e-sippy-e2e-setup-commands.sh
+++ b/e2e-scripts/sippy-e2e-sippy-e2e-setup-commands.sh
@@ -190,7 +190,7 @@ spec:
         terminationMessagePolicy: File
         command:  ["/bin/sh", "-c"]
         args:
-          - /bin/sippy load --init-database --load-openshift-ci-bigquery    --log-level=debug --release 4.14 --database-dsn=postgresql://postgres:password@postgres.sippy-e2e.svc.cluster.local:5432/postgres --mode=ocp --config ./config/e2e-openshift.yaml --google-service-account-credential-file /tmp/secrets/gcs-cred
+          - /bin/sippy load --init-database --log-level=debug --release 4.14 --database-dsn=postgresql://postgres:password@postgres.sippy-e2e.svc.cluster.local:5432/postgres --mode=ocp --config ./config/e2e-openshift.yaml --google-service-account-credential-file /tmp/secrets/gcs-cred
         env:
         - name: GCS_SA_JSON_PATH
           value: /tmp/secrets/gcs-cred

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -43,7 +43,7 @@ export SIPPY_E2E_DSN="postgresql://postgres:password@localhost:$PSQL_PORT/postgr
 echo "Loading database..."
 # use an old release here as they have very few job runs and thus import quickly, ~5 minutes
 make build
-./sippy load --init-database --loader prow --loader prow --load-openshift-ci-bigquery \
+./sippy load --init-database --loader prow --loader prow \
   --mode ocp \
   --release 4.14 \
   --init-database \


### PR DESCRIPTION
The `load-openshift-ci-bigquery` flag has long been the default option for prow loading. Now, the loader errors when that flag is not passed. Remove it.