### PR TITLE
NO-JIRA: refactor to remove redundant state and unused query param vars

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyCapCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCapCell.js
@@ -4,7 +4,6 @@ import { CompReadyVarsContext } from './CompReadyVars'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
 import { sortQueryParams } from './CompReadyUtils'
-import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import CompSeverityIcon from './CompSeverityIcon'
@@ -18,21 +17,6 @@ export default function CompReadyCapCell(props) {
     props
   const theme = useTheme()
   const classes = useContext(ComponentReadinessStyleContext)
-
-  const [componentParam, setComponentParam] = useQueryParam(
-    'component',
-    StringParam
-  )
-  const [capabilityParam, setCapabilityParam] = useQueryParam(
-    'capability',
-    StringParam
-  )
-  const [environmentParam, setEnvironmentParam] = useQueryParam(
-    'environment',
-    StringParam
-  )
-  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
-
   const { expandEnvironment } = useContext(CompReadyVarsContext)
 
   // Construct a URL with all existing filters plus testId and environment.

--- a/sippy-ng/src/component_readiness/CompReadyTestCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestCell.js
@@ -3,7 +3,6 @@ import { ComponentReadinessStyleContext } from './ComponentReadiness'
 import { CompReadyVarsContext } from './CompReadyVars'
 import { generateTestReport } from './CompReadyUtils'
 import { Link } from 'react-router-dom'
-import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import CompSeverityIcon from './CompSeverityIcon'
@@ -26,25 +25,6 @@ export default function CompReadyTestCell(props) {
   } = props
   const theme = useTheme()
   const classes = useContext(ComponentReadinessStyleContext)
-
-  const [componentParam, setComponentParam] = useQueryParam(
-    'component',
-    StringParam
-  )
-  const [capabilityParam, setCapabilityParam] = useQueryParam(
-    'capability',
-    StringParam
-  )
-  const [environmentParam, setEnvironmentParam] = useQueryParam(
-    'environment',
-    StringParam
-  )
-  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
-  const [testNameParam, setTestNameParam] = useQueryParam(
-    'testName',
-    StringParam
-  )
-
   const { expandEnvironment } = useContext(CompReadyVarsContext)
 
   if (status === undefined) {

--- a/sippy-ng/src/component_readiness/CompTestRow.js
+++ b/sippy-ng/src/component_readiness/CompTestRow.js
@@ -4,7 +4,6 @@ import { Fragment, useContext } from 'react'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
 import { sortQueryParams } from './CompReadyUtils'
-import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip, Typography } from '@mui/material'
 import CompReadyCapCell from './CompReadyCapCell'
 import PropTypes from 'prop-types'
@@ -48,16 +47,6 @@ export default function CompTestRow(props) {
     component,
     capability,
   } = props
-
-  const [componentParam, setComponentParam] = useQueryParam(
-    'component',
-    StringParam
-  )
-  const [capabilityParam, setCapabilityParam] = useQueryParam(
-    'capability',
-    StringParam
-  )
-  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
 
   // Put the testName on the left side with a link to a test specific
   // test report.

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -212,18 +212,9 @@ export default function ComponentReadiness(props) {
 
   const varsContext = useContext(CompReadyVarsContext)
 
-  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
-  const [testNameParam, setTestNameParam] = useQueryParam('testName', String)
-  const [testBasisReleaseParam, setTestBasisReleaseParam] = useQueryParam(
-    'testBasisRelease',
-    String
-  )
-
-  const [testId, setTestId] = React.useState(testIdParam)
-  const [testName, setTestName] = React.useState(testNameParam)
-  const [testBasisRelease, setTestBasisRelease] = React.useState(
-    testBasisReleaseParam
-  )
+  const [testId] = useQueryParam('testId', StringParam)
+  const [testName] = useQueryParam('testName', StringParam)
+  const [testBasisRelease] = useQueryParam('testBasisRelease', StringParam)
 
   const { path, url } = useRouteMatch()
 
@@ -425,9 +416,6 @@ export default function ComponentReadiness(props) {
                   const filterVals = getUpdatedUrlParts(varsContext)
                   varsContext.setComponentParam(varsContext.component)
                   varsContext.setCapabilityParam(varsContext.capability)
-                  setTestIdParam(testId)
-                  setTestNameParam(testName)
-                  setTestBasisReleaseParam(testBasisRelease)
                   varsContext.setEnvironmentParam(varsContext.environment)
                   return (
                     <TestDetailsReport
@@ -450,7 +438,6 @@ export default function ComponentReadiness(props) {
                   const filterVals = getUpdatedUrlParts(varsContext)
                   varsContext.setComponentParam(varsContext.component)
                   varsContext.setCapabilityParam(varsContext.capability)
-                  setTestIdParam(testId)
                   return (
                     <CompReadyEnvCapabilityTest
                       key="capabilitytest"
@@ -470,7 +457,6 @@ export default function ComponentReadiness(props) {
                   varsContext.setComponentParam(varsContext.component)
                   varsContext.setCapabilityParam(varsContext.capability)
                   varsContext.setEnvironmentParam(varsContext.environment)
-                  setTestIdParam(testId)
                   return (
                     <CompReadyEnvCapabilityTest
                       key="capabilitytest"


### PR DESCRIPTION
I noticed that we had the following (effectively) unused `useState` calls in `ComponentReadiness.js`:
```
const [testId, setTestId] = React.useState(testIdParam)
const [testName, setTestName] = React.useState(testNameParam)
const [testBasisRelease, setTestBasisRelease] = React.useState(testBasisReleaseParam)
```
We were initializing these to the value of the query params and then never changing them again. Removing this led me to notice a few more areas where we were storing the query params and then never using them.

Assisted by Cursor (Claude 4 Sonnet)