### PR TITLE
TRT-2136: find the most recently started test name for display in the report

### DIFF
--- a/pkg/api/componentreadiness/query/querygenerators.go
+++ b/pkg/api/componentreadiness/query/querygenerators.go
@@ -323,8 +323,8 @@ func BuildComponentReportQuery(
 								SELECT MAX(created_at)
 								FROM %s.component_mapping))
 					SELECT
-						ANY_VALUE(test_name) AS test_name,
-						ANY_VALUE(testsuite) AS test_suite,
+						ANY_VALUE(test_name HAVING MAX prowjob_start) AS test_name,
+						ANY_VALUE(testsuite HAVING MAX prowjob_start) AS test_suite,
 						cm.id as test_id,
 						%s
 						COUNT(cm.id) AS total_count,


### PR DESCRIPTION
BigQuery allows for [any_value](https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#any_value) to be used with a `HAVING MAX` clause that we can use to get the most recent job run's test_name, instead of just a non-deterministic one.

The validity of this is very hard to verify in practice as the current behavior works correctly a significant portion of the time, and there are not that many tests that have been renamed recently to check on. I have spot checked a few, and haven't noticed anywhere where this has pulled back the old name.

@dgoodwin pointed out a potential failure case that we will have to keep an eye on:

> if we were comparing last week of 4.20 vs last week of 4.19, instead of month pre-ga, and 4.19 had the most recent job run, would we get the older name then?

Either way, we don't think that would be worse behavior than what we currently have.

As far as benchmarking goes, this is a bit slower to compute. However, I only ran through this once, and it is within a reasonable margin:

- Existing query: overall time to start the server locally `2:53`
  - Base QueryTestStatus completed in 43.980652959s with 140728 base results from db
  - Sample QueryTestStatus completed in 21.350303792s with 145342 sample results db
- With change: overall time to start the server locally `3:25`
  - Base QueryTestStatus completed in 49.20070525s with 140728 base results from db
  - Sample QueryTestStatus completed in 20.395197667s with 145342 sample results db

