### PR TITLE
trt-2195: update x86-vs-arm view

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -105,9 +105,11 @@ component_readiness:
           - amd64
         FeatureSet:
           - default
+          - techpreview
         Installer:
           - ipi
           - upi
+          - hypershift
         JobTier:
           - blocking
           - informing
@@ -115,14 +117,22 @@ component_readiness:
         LayeredProduct:
           - none
           - virt
+        Network:
+          - ovn
         Owner:
           - eng
+          - service-delivery
         Platform:
           - aws
           - azure
           - gcp
+          - metal
+          - rosa
+          - vsphere
         Topology:
           - ha
+          - microshift
+          - external
         CGroupMode:
           - v2
         ContainerRuntime:


### PR DESCRIPTION
Sync up variant_options for x86-vs-arm with main 4.20 settings

<img width="1151" height="824" alt="image" src="https://github.com/user-attachments/assets/7a5fd180-e49f-4f85-ab65-cf39a8f5180f" />
