### PR TITLE
Fix class generation logic in invert mode

### DIFF
--- a/sippy-ng/src/datagrid/utils.js
+++ b/sippy-ng/src/datagrid/utils.js
@@ -40,7 +40,7 @@ export function generateClasses(threshold, invert = false) {
     theme.palette.success.light,
   ]
   if (invert) {
-    let scaleColors = [
+    scaleColors = [
       theme.palette.success.light,
       theme.palette.warning.light,
       theme.palette.error.light,


### PR DESCRIPTION
## PR Summary
This small PR fixes class generation in invert mode where a local `scaleColors` variable overshadowed, breaking correct styling. This affected both the Payload Test Failures and Payload Stream Test Failures components.