### PR TITLE
Revert "TRT-2181: Remove spaces when fetching bugs for tests"

### DIFF
--- a/pkg/dataloader/bugloader/bugloader.go
+++ b/pkg/dataloader/bugloader/bugloader.go
@@ -243,9 +243,9 @@ func (bl *BugLoader) getTestBugMappings(ctx context.Context, testCache map[strin
 	querySQL := fmt.Sprintf(
 		`%s
 		JOIN %s.%s.%s j
-		  ON STRPOS(REGEXP_REPLACE(t.summary, r'\s+', ''), REGEXP_REPLACE(j.name, r'\s+', '')) > 0
-		  OR STRPOS(REGEXP_REPLACE(t.description, r'\s+', ''), REGEXP_REPLACE(j.name, r'\s+', '')) > 0
-		  OR STRPOS(REGEXP_REPLACE(t.comment, r'\s+', ''), REGEXP_REPLACE(j.name, r'\s+', '')) > 0
+		  ON STRPOS(t.summary, j.name) > 0
+		  OR STRPOS(t.description, j.name) > 0
+		  OR STRPOS(t.comment, j.name ) > 0
         WHERE j.name != "upgrade"`,
 		TicketDataQuery, ComponentMappingProject, ComponentMappingDataset, ComponentMappingTable)
 	log.Debug(querySQL)

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -208,7 +208,7 @@ func LoadBugsForTest(dbc *db.DB, testName string, filterClosed bool) ([]models.B
 	results := []models.Bug{}
 
 	test := models.Test{}
-	q := dbc.DB.Where("REGEXP_REPLACE(name, '\\s+', '', 'g') = REGEXP_REPLACE(?, '\\s+', '', 'g')", testName)
+	q := dbc.DB.Where("name = ?", testName)
 	timeLimit := "NOW() - last_change_time < interval '14 days'" // filter bugs since we no longer delete them
 	if filterClosed {
 		q = q.Preload("Bugs", timeLimit+" and UPPER(status) != 'CLOSED' and UPPER(status) != 'VERIFIED'")


### PR DESCRIPTION
This [appears](https://grafana-loki.ci.openshift.org/d/WzzGWoiSk/sippy?orgId=1&from=1751846400000&to=1753747199000) to have caused the `bugloader` to use significantly more resources and take longer. As of yesterday, there are [errors](https://redhat-internal.slack.com/archives/C02PY8LCEKG/p1753705045841259?thread_ts=1753704050.407559&cid=C02PY8LCEKG) in `fetchdata` that causes it to fail. 

Reverts openshift/sippy#2780