### PR TITLE
TRT-2218: Fix testId undefined during env_capability → env_test navigation

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyCapCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCapCell.js
@@ -4,7 +4,6 @@ import { CompReadyVarsContext } from './CompReadyVars'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
 import { sortQueryParams } from './CompReadyUtils'
-import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import CompSeverityIcon from './CompSeverityIcon'
@@ -18,20 +17,6 @@ export default function CompReadyCapCell(props) {
     props
   const theme = useTheme()
   const classes = useContext(ComponentReadinessStyleContext)
-
-  const [componentParam, setComponentParam] = useQueryParam(
-    'component',
-    StringParam
-  )
-  const [capabilityParam, setCapabilityParam] = useQueryParam(
-    'capability',
-    StringParam
-  )
-  const [environmentParam, setEnvironmentParam] = useQueryParam(
-    'environment',
-    StringParam
-  )
-  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
 
   const { expandEnvironment } = useContext(CompReadyVarsContext)
 

--- a/sippy-ng/src/component_readiness/CompReadyCapsCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCapsCell.js
@@ -4,7 +4,6 @@ import { CompReadyVarsContext } from './CompReadyVars'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
 import { sortQueryParams } from './CompReadyUtils'
-import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import CompSeverityIcon from './CompSeverityIcon'
@@ -18,15 +17,6 @@ export default function CompReadyCapsCell(props) {
     props
   const theme = useTheme()
   const classes = useContext(ComponentReadinessStyleContext)
-
-  const [capabilityParam, setCapabilityParam] = useQueryParam(
-    'capability',
-    StringParam
-  )
-  const [environmentParam, setEnvironmentParam] = useQueryParam(
-    'environment',
-    StringParam
-  )
 
   const { expandEnvironment } = useContext(CompReadyVarsContext)
 

--- a/sippy-ng/src/component_readiness/CompReadyCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCell.js
@@ -4,7 +4,6 @@ import { CompReadyVarsContext } from './CompReadyVars'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
 import { sortQueryParams } from './CompReadyUtils'
-import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import CompSeverityIcon from './CompSeverityIcon'
@@ -25,15 +24,6 @@ export default function CompReadyCell(props) {
   } = props
   const theme = useTheme()
   const classes = useContext(ComponentReadinessStyleContext)
-
-  const [componentParam, setComponentParam] = useQueryParam(
-    'component',
-    StringParam
-  )
-  const [environmentParam, setEnvironmentParam] = useQueryParam(
-    'environment',
-    StringParam
-  )
 
   const { expandEnvironment } = useContext(CompReadyVarsContext)
 

--- a/sippy-ng/src/component_readiness/CompReadyTestCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestCell.js
@@ -3,7 +3,6 @@ import { ComponentReadinessStyleContext } from './ComponentReadiness'
 import { CompReadyVarsContext } from './CompReadyVars'
 import { generateTestReport } from './CompReadyUtils'
 import { Link } from 'react-router-dom'
-import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import CompSeverityIcon from './CompSeverityIcon'
@@ -26,24 +25,6 @@ export default function CompReadyTestCell(props) {
   } = props
   const theme = useTheme()
   const classes = useContext(ComponentReadinessStyleContext)
-
-  const [componentParam, setComponentParam] = useQueryParam(
-    'component',
-    StringParam
-  )
-  const [capabilityParam, setCapabilityParam] = useQueryParam(
-    'capability',
-    StringParam
-  )
-  const [environmentParam, setEnvironmentParam] = useQueryParam(
-    'environment',
-    StringParam
-  )
-  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
-  const [testNameParam, setTestNameParam] = useQueryParam(
-    'testName',
-    StringParam
-  )
 
   const { expandEnvironment } = useContext(CompReadyVarsContext)
 

--- a/sippy-ng/src/component_readiness/CompReadyVars.js
+++ b/sippy-ng/src/component_readiness/CompReadyVars.js
@@ -176,6 +176,15 @@ export const CompReadyVarsProvider = ({ children }) => {
     'capability',
     StringParam
   )
+  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
+  const [testNameParam, setTestNameParam] = useQueryParam(
+    'testName',
+    StringParam
+  )
+  const [testBasisReleaseParam, setTestBasisReleaseParam] = useQueryParam(
+    'testBasisRelease',
+    StringParam
+  )
 
   const [baseRelease, setBaseRelease] = React.useState(
     baseReleaseParam || defaultBaseRelease
@@ -338,17 +347,36 @@ export const CompReadyVarsProvider = ({ children }) => {
    ****************************************************************************** */
 
   const [component, setComponent] = React.useState(componentParam)
-  if (component != componentParam) {
+  useEffect(() => {
     setComponent(componentParam)
-  }
+  }, [componentParam])
+
   const [environment, setEnvironment] = React.useState(environmentParam)
-  if (environment != environmentParam) {
+  useEffect(() => {
     setEnvironment(environmentParam)
-  }
+  }, [environmentParam])
+
   const [capability, setCapability] = React.useState(capabilityParam)
-  if (capability != capabilityParam) {
+  useEffect(() => {
     setCapability(capabilityParam)
-  }
+  }, [capabilityParam])
+
+  const [testId, setTestId] = React.useState(testIdParam)
+  useEffect(() => {
+    setTestId(testIdParam)
+  }, [testIdParam])
+
+  const [testName, setTestName] = React.useState(testNameParam)
+  useEffect(() => {
+    setTestName(testNameParam)
+  }, [testNameParam])
+
+  const [testBasisRelease, setTestBasisRelease] = React.useState(
+    testBasisReleaseParam
+  )
+  useEffect(() => {
+    setTestBasisRelease(testBasisReleaseParam)
+  }, [testBasisReleaseParam])
 
   /******************************************************************************
    * Generating the report parameters:
@@ -408,6 +436,9 @@ export const CompReadyVarsProvider = ({ children }) => {
     setComponentParam(component)
     setEnvironmentParam(environment)
     setCapabilityParam(capability)
+    setTestIdParam(testId)
+    setTestNameParam(testName)
+    setTestBasisReleaseParam(testBasisRelease)
 
     // Execute callback after a short delay to allow URL params to update
     if (callback) {
@@ -698,6 +729,12 @@ export const CompReadyVarsProvider = ({ children }) => {
         setCapabilityParam,
         environment,
         setEnvironmentParam,
+        testId,
+        setTestIdParam,
+        testName,
+        setTestNameParam,
+        testBasisRelease,
+        setTestBasisReleaseParam,
         handleGenerateReport,
         syncView,
         isLoaded,

--- a/sippy-ng/src/component_readiness/CompTestRow.js
+++ b/sippy-ng/src/component_readiness/CompTestRow.js
@@ -4,7 +4,6 @@ import { Fragment, useContext } from 'react'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
 import { sortQueryParams } from './CompReadyUtils'
-import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip, Typography } from '@mui/material'
 import CompReadyCapCell from './CompReadyCapCell'
 import PropTypes from 'prop-types'
@@ -48,16 +47,6 @@ export default function CompTestRow(props) {
     component,
     capability,
   } = props
-
-  const [componentParam, setComponentParam] = useQueryParam(
-    'component',
-    StringParam
-  )
-  const [capabilityParam, setCapabilityParam] = useQueryParam(
-    'capability',
-    StringParam
-  )
-  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
 
   // Put the testName on the left side with a link to a test specific
   // test report.

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -212,21 +212,9 @@ export default function ComponentReadiness(props) {
 
   const varsContext = useContext(CompReadyVarsContext)
 
-  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
-  const [testNameParam, setTestNameParam] = useQueryParam(
-    'testName',
-    StringParam
-  )
-  const [testBasisReleaseParam, setTestBasisReleaseParam] = useQueryParam(
-    'testBasisRelease',
-    StringParam
-  )
-
-  const [testId, setTestId] = React.useState(testIdParam)
-  const [testName, setTestName] = React.useState(testNameParam)
-  const [testBasisRelease, setTestBasisRelease] = React.useState(
-    testBasisReleaseParam
-  )
+  // Get test-related parameters from context instead of local state
+  const { testId, testName, testBasisRelease } =
+    useContext(CompReadyVarsContext)
 
   const location = useLocation()
   const currentPath = location.pathname


### PR DESCRIPTION
The ComponentReadiness component was using local React state to store URL parameters (testId, testName, testBasisRelease), but useState only initializes once. When navigating between routes, URL parameters changed but local state didn't update, causing testId to be undefined on certain transitions.  Note this only happens on page transitions (url changes), but visiting the URL greenfield (or hard refresh) worked fine.

This moves these parameters to the VarsContext, like all of our other URL parameters. I'm not sure if there was a reason these aren't part of the context, but clicking around I don't think I've broken anything.

To reproduce:
- [Visit this page](http://sippy.dptools.openshift.org/sippy-ng/component_readiness/env_capability?Architecture=amd64&Network=ovn&Platform=aws&Topology=external&baseEndTime=2025-06-17%2023%3A59%3A59&baseRelease=4.19&baseStartTime=2025-05-18%2000%3A00%3A00&capability=commatrix&columnGroupBy=Architecture%2CNetwork%2CPlatform%2CTopology&component=Networking%20%2F%20cluster-network-operator&confidence=95&dbGroupBy=Platform%2CArchitecture%2CNetwork%2CTopology%2CFeatureSet%2CUpgrade%2CSuite%2CInstaller&environment=Architecture%3Aamd64%20Network%3Aovn%20Platform%3Aaws%20Topology%3Aexternal&flakeAsFailure=false&ignoreDisruption=true&ignoreMissing=false&includeMultiReleaseAnalysis=true&includeVariant=Architecture%3Aamd64&includeVariant=CGroupMode%3Av2&includeVariant=ContainerRuntime%3Acrun&includeVariant=ContainerRuntime%3Arunc&includeVariant=FeatureSet%3Adefault&includeVariant=FeatureSet%3Atechpreview&includeVariant=Installer%3Ahypershift&includeVariant=Installer%3Aipi&includeVariant=Installer%3Aupi&includeVariant=JobTier%3Ablocking&includeVariant=JobTier%3Ainforming&includeVariant=JobTier%3Astandard&includeVariant=LayeredProduct%3Anone&includeVariant=LayeredProduct%3Avirt&includeVariant=Network%3Aovn&includeVariant=Owner%3Aeng&includeVariant=Owner%3Aservice-delivery&includeVariant=Platform%3Aaws&includeVariant=Platform%3Aazure&includeVariant=Platform%3Agcp&includeVariant=Platform%3Ametal&includeVariant=Platform%3Arosa&includeVariant=Platform%3Avsphere&includeVariant=Topology%3Aexternal&includeVariant=Topology%3Aha&includeVariant=Topology%3Amicroshift&minFail=3&passRateAllTests=0&passRateNewTests=95&pity=5&sampleEndTime=2025-07-27%2023%3A59%3A59&sampleRelease=4.20&sampleStartTime=2025-07-20%2000%3A00%3A00)
- Click a square: notice an error, test ID is undefined in the URL

Verify:
- Start sippy locally with this PR
     - `REACT_APP_API_URL="https://sippy.dptools.openshift.org" npm start`
- [Visit the previous page locally](http://localhost:3000/sippy-ng/component_readiness/env_capability?Architecture=amd64&Network=ovn&Platform=aws&Topology=external&baseEndTime=2025-06-17%2023%3A59%3A59&baseRelease=4.19&baseStartTime=2025-05-18%2000%3A00%3A00&capability=commatrix&columnGroupBy=Architecture%2CNetwork%2CPlatform%2CTopology&component=Networking%20%2F%20cluster-network-operator&confidence=95&dbGroupBy=Platform%2CArchitecture%2CNetwork%2CTopology%2CFeatureSet%2CUpgrade%2CSuite%2CInstaller&environment=Architecture%3Aamd64%20Network%3Aovn%20Platform%3Aaws%20Topology%3Aexternal&flakeAsFailure=false&ignoreDisruption=true&ignoreMissing=false&includeMultiReleaseAnalysis=true&includeVariant=Architecture%3Aamd64&includeVariant=CGroupMode%3Av2&includeVariant=ContainerRuntime%3Acrun&includeVariant=ContainerRuntime%3Arunc&includeVariant=FeatureSet%3Adefault&includeVariant=FeatureSet%3Atechpreview&includeVariant=Installer%3Ahypershift&includeVariant=Installer%3Aipi&includeVariant=Installer%3Aupi&includeVariant=JobTier%3Ablocking&includeVariant=JobTier%3Ainforming&includeVariant=JobTier%3Astandard&includeVariant=LayeredProduct%3Anone&includeVariant=LayeredProduct%3Avirt&includeVariant=Network%3Aovn&includeVariant=Owner%3Aeng&includeVariant=Owner%3Aservice-delivery&includeVariant=Platform%3Aaws&includeVariant=Platform%3Aazure&includeVariant=Platform%3Agcp&includeVariant=Platform%3Ametal&includeVariant=Platform%3Arosa&includeVariant=Platform%3Avsphere&includeVariant=Topology%3Aexternal&includeVariant=Topology%3Aha&includeVariant=Topology%3Amicroshift&minFail=3&passRateAllTests=0&passRateNewTests=95&pity=5&sampleEndTime=2025-07-27%2023%3A59%3A59&sampleRelease=4.20&sampleStartTime=2025-07-20%2000%3A00%3A00)
- Click a square: success

