### PR TITLE
OCPNODE-3520: Add usernamespace procedure

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -716,6 +716,7 @@ func setProcedure(_ logrus.FieldLogger, variants map[string]string, jobName stri
 		{"-ipsec", concatProcedureValues(base, "ipsec")},
 		{"-ocl", concatProcedureValues(base, "on-cluster-layering")},
 		{"-machine-config-operator", concatProcedureValues(base, "machine-config-operator")},
+		{"-usernamespace", concatProcedureValues(base, "usernamespace")},
 	}
 
 	for _, entry := range procedurePatterns {

--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -443,7 +443,6 @@ func setSuite(_ logrus.FieldLogger, variants map[string]string, jobName string) 
 		{"-serial", "serial"},
 		{"-etcd-scaling", "etcd-scaling"},
 		{"conformance", "parallel"}, // Jobs with "conformance" but no explicit serial are probably parallel
-		{"usernamespace", "usernamespace"},
 		{"-e2e-external-", "parallel"},
 	}
 


### PR DESCRIPTION
This PR enables sippy for usernamespace suite.
https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.20-e2e-gcp-ovn-usernamespace