### PR TITLE
TRT-2218: Centralize URL params in vars context

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyCapCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCapCell.js
@@ -4,7 +4,6 @@ import { CompReadyVarsContext } from './CompReadyVars'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
 import { sortQueryParams } from './CompReadyUtils'
-import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import CompSeverityIcon from './CompSeverityIcon'
@@ -18,20 +17,6 @@ export default function CompReadyCapCell(props) {
     props
   const theme = useTheme()
   const classes = useContext(ComponentReadinessStyleContext)
-
-  const [componentParam, setComponentParam] = useQueryParam(
-    'component',
-    StringParam
-  )
-  const [capabilityParam, setCapabilityParam] = useQueryParam(
-    'capability',
-    StringParam
-  )
-  const [environmentParam, setEnvironmentParam] = useQueryParam(
-    'environment',
-    StringParam
-  )
-  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
 
   const { expandEnvironment } = useContext(CompReadyVarsContext)
 

--- a/sippy-ng/src/component_readiness/CompReadyCapsCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCapsCell.js
@@ -4,7 +4,6 @@ import { CompReadyVarsContext } from './CompReadyVars'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
 import { sortQueryParams } from './CompReadyUtils'
-import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import CompSeverityIcon from './CompSeverityIcon'
@@ -18,15 +17,6 @@ export default function CompReadyCapsCell(props) {
     props
   const theme = useTheme()
   const classes = useContext(ComponentReadinessStyleContext)
-
-  const [capabilityParam, setCapabilityParam] = useQueryParam(
-    'capability',
-    StringParam
-  )
-  const [environmentParam, setEnvironmentParam] = useQueryParam(
-    'environment',
-    StringParam
-  )
 
   const { expandEnvironment } = useContext(CompReadyVarsContext)
 

--- a/sippy-ng/src/component_readiness/CompReadyCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyCell.js
@@ -4,7 +4,6 @@ import { CompReadyVarsContext } from './CompReadyVars'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
 import { sortQueryParams } from './CompReadyUtils'
-import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import CompSeverityIcon from './CompSeverityIcon'
@@ -25,15 +24,6 @@ export default function CompReadyCell(props) {
   } = props
   const theme = useTheme()
   const classes = useContext(ComponentReadinessStyleContext)
-
-  const [componentParam, setComponentParam] = useQueryParam(
-    'component',
-    StringParam
-  )
-  const [environmentParam, setEnvironmentParam] = useQueryParam(
-    'environment',
-    StringParam
-  )
 
   const { expandEnvironment } = useContext(CompReadyVarsContext)
 

--- a/sippy-ng/src/component_readiness/CompReadyTestCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestCell.js
@@ -3,7 +3,6 @@ import { ComponentReadinessStyleContext } from './ComponentReadiness'
 import { CompReadyVarsContext } from './CompReadyVars'
 import { generateTestReport } from './CompReadyUtils'
 import { Link } from 'react-router-dom'
-import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import CompSeverityIcon from './CompSeverityIcon'
@@ -26,24 +25,6 @@ export default function CompReadyTestCell(props) {
   } = props
   const theme = useTheme()
   const classes = useContext(ComponentReadinessStyleContext)
-
-  const [componentParam, setComponentParam] = useQueryParam(
-    'component',
-    StringParam
-  )
-  const [capabilityParam, setCapabilityParam] = useQueryParam(
-    'capability',
-    StringParam
-  )
-  const [environmentParam, setEnvironmentParam] = useQueryParam(
-    'environment',
-    StringParam
-  )
-  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
-  const [testNameParam, setTestNameParam] = useQueryParam(
-    'testName',
-    StringParam
-  )
 
   const { expandEnvironment } = useContext(CompReadyVarsContext)
 

--- a/sippy-ng/src/component_readiness/CompReadyVars.js
+++ b/sippy-ng/src/component_readiness/CompReadyVars.js
@@ -176,6 +176,15 @@ export const CompReadyVarsProvider = ({ children }) => {
     'capability',
     StringParam
   )
+  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
+  const [testNameParam, setTestNameParam] = useQueryParam(
+    'testName',
+    StringParam
+  )
+  const [testBasisReleaseParam, setTestBasisReleaseParam] = useQueryParam(
+    'testBasisRelease',
+    StringParam
+  )
 
   const [baseRelease, setBaseRelease] = React.useState(
     baseReleaseParam || defaultBaseRelease
@@ -341,13 +350,32 @@ export const CompReadyVarsProvider = ({ children }) => {
   if (component != componentParam) {
     setComponent(componentParam)
   }
+
   const [environment, setEnvironment] = React.useState(environmentParam)
   if (environment != environmentParam) {
     setEnvironment(environmentParam)
   }
+
   const [capability, setCapability] = React.useState(capabilityParam)
   if (capability != capabilityParam) {
     setCapability(capabilityParam)
+  }
+
+  const [testId, setTestId] = React.useState(testIdParam)
+  if (testId != testIdParam) {
+    setTestId(testIdParam)
+  }
+
+  const [testName, setTestName] = React.useState(testNameParam)
+  if (testName != testNameParam) {
+    setTestName(testNameParam)
+  }
+
+  const [testBasisRelease, setTestBasisRelease] = React.useState(
+    testBasisReleaseParam
+  )
+  if (testBasisRelease != testBasisReleaseParam) {
+    setTestBasisRelease(testBasisReleaseParam)
   }
 
   /******************************************************************************
@@ -408,6 +436,9 @@ export const CompReadyVarsProvider = ({ children }) => {
     setComponentParam(component)
     setEnvironmentParam(environment)
     setCapabilityParam(capability)
+    setTestIdParam(testId)
+    setTestNameParam(testName)
+    setTestBasisReleaseParam(testBasisRelease)
 
     // Execute callback after a short delay to allow URL params to update
     if (callback) {
@@ -698,6 +729,12 @@ export const CompReadyVarsProvider = ({ children }) => {
         setCapabilityParam,
         environment,
         setEnvironmentParam,
+        testId,
+        setTestIdParam,
+        testName,
+        setTestNameParam,
+        testBasisRelease,
+        setTestBasisReleaseParam,
         handleGenerateReport,
         syncView,
         isLoaded,

--- a/sippy-ng/src/component_readiness/CompTestRow.js
+++ b/sippy-ng/src/component_readiness/CompTestRow.js
@@ -4,7 +4,6 @@ import { Fragment, useContext } from 'react'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
 import { sortQueryParams } from './CompReadyUtils'
-import { StringParam, useQueryParam } from 'use-query-params'
 import { Tooltip, Typography } from '@mui/material'
 import CompReadyCapCell from './CompReadyCapCell'
 import PropTypes from 'prop-types'
@@ -48,16 +47,6 @@ export default function CompTestRow(props) {
     component,
     capability,
   } = props
-
-  const [componentParam, setComponentParam] = useQueryParam(
-    'component',
-    StringParam
-  )
-  const [capabilityParam, setCapabilityParam] = useQueryParam(
-    'capability',
-    StringParam
-  )
-  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
 
   // Put the testName on the left side with a link to a test specific
   // test report.

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -212,21 +212,9 @@ export default function ComponentReadiness(props) {
 
   const varsContext = useContext(CompReadyVarsContext)
 
-  const [testIdParam, setTestIdParam] = useQueryParam('testId', StringParam)
-  const [testNameParam, setTestNameParam] = useQueryParam(
-    'testName',
-    StringParam
-  )
-  const [testBasisReleaseParam, setTestBasisReleaseParam] = useQueryParam(
-    'testBasisRelease',
-    StringParam
-  )
-
-  const [testId, setTestId] = React.useState(testIdParam)
-  const [testName, setTestName] = React.useState(testNameParam)
-  const [testBasisRelease, setTestBasisRelease] = React.useState(
-    testBasisReleaseParam
-  )
+  // Get test-related parameters from context instead of local state
+  const { testId, testName, testBasisRelease } =
+    useContext(CompReadyVarsContext)
 
   const location = useLocation()
   const currentPath = location.pathname


### PR DESCRIPTION
This fixes testId undefined during env_capability → env_test navigation, and makes URL params consistent.

The ComponentReadiness component was using local React state to store URL parameters (testId, testName, testBasisRelease, etc), but useState only initializes once. When navigating between routes, URL parameters changed but local state didn't update, causing testId to be undefined on certain transitions.

Assisted-by: Cursor AI