### PR TITLE
TRT-2235: include LayeredProduct in DBGroupBy

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -24,6 +24,7 @@ component_readiness:
         Suite: {}
         Topology: {}
         Upgrade: {}
+        LayeredProduct: {}
       include_variants:
         Architecture:
           - amd64
@@ -100,6 +101,7 @@ component_readiness:
         Suite: {}
         Topology: {}
         Upgrade: {}
+        LayeredProduct: {}
       include_variants:
         Architecture:
           - amd64
@@ -176,6 +178,7 @@ component_readiness:
         Platform: {}
         Suite: {}
         Upgrade: {}
+        LayeredProduct: {}
       include_variants:
         Architecture:
           - amd64
@@ -246,6 +249,7 @@ component_readiness:
         Suite: {}
         Topology: {}
         Upgrade: {}
+        LayeredProduct: {}
       include_variants:
         LayeredProduct:
           - none
@@ -297,6 +301,7 @@ component_readiness:
         Upgrade: {}
         Procedure: {}
         JobTier: {}
+        LayeredProduct: {}
       include_variants:
         Architecture:
           - amd64

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -54,7 +54,7 @@ var (
 	// TODO: centralize these configurations for consumption by both the front and backends
 
 	DefaultColumnGroupBy = "Platform,Architecture,Network"
-	DefaultDBGroupBy     = "Platform,Architecture,Network,Topology,FeatureSet,Upgrade,Suite,Installer"
+	DefaultDBGroupBy     = "Platform,Architecture,Network,Topology,FeatureSet,Upgrade,Suite,Installer,LayeredProduct"
 )
 
 func getSingleColumnResultToSlice(ctx context.Context, q *bigquery.Query) ([]string, error) {

--- a/pkg/api/componentreadiness/queryparamparser_test.go
+++ b/pkg/api/componentreadiness/queryparamparser_test.go
@@ -234,7 +234,7 @@ func TestParseComponentReportRequest(t *testing.T) {
 			},
 			variantOption: reqopts.Variants{
 				ColumnGroupBy: sets.NewString("Platform", "Architecture", "Network"),
-				DBGroupBy:     sets.NewString("Platform", "Architecture", "Network", "Topology", "Suite", "FeatureSet", "Upgrade", "Installer"),
+				DBGroupBy:     sets.NewString("Platform", "Architecture", "Network", "Topology", "Suite", "FeatureSet", "Upgrade", "Installer", "LayeredProduct"),
 				IncludeVariants: map[string][]string{
 					"Architecture": {"amd64"},
 					"FeatureSet":   {"default", "techpreview"},


### PR DESCRIPTION
in 4.20 we've added `LayeredProduct:virt` to the views, without distinguishing that as a variant. This causes the `virt` and non-`virt` data to be mixed and actually shows up as new regressions.

Once this code is in, we can update the existing regressions to include the new variant with:
`update test_regressions set variants = (variants || '{LayeredProduct:none}') where release='4.20';`