### PR TITLE
TRT-2198: prepare for sippy to accept hcm

### DIFF
--- a/cmd/sippy/annotatejobruns.go
+++ b/cmd/sippy/annotatejobruns.go
@@ -145,7 +145,7 @@ Example run: sippy annotate-job-runs  --google-service-account-credential-file=f
 			bigQueryClient, err := bqcachedclient.New(ctx,
 				f.GoogleCloudFlags.ServiceAccountCredentialFile,
 				f.BigQueryFlags.BigQueryProject,
-				f.BigQueryFlags.BigQueryDataset, cacheClient)
+				f.BigQueryFlags.BigQueryDataset, cacheClient, f.BigQueryFlags.ReleasesTable)
 			if err != nil {
 				log.WithError(err).Fatal("error getting BigQuery client")
 			}

--- a/cmd/sippy/automatejira.go
+++ b/cmd/sippy/automatejira.go
@@ -141,7 +141,7 @@ func NewAutomateJiraCommand() *cobra.Command {
 			bigQueryClient, err := bqcachedclient.New(ctx,
 				f.GoogleCloudFlags.ServiceAccountCredentialFile,
 				f.BigQueryFlags.BigQueryProject,
-				f.BigQueryFlags.BigQueryDataset, cacheClient)
+				f.BigQueryFlags.BigQueryDataset, cacheClient, f.BigQueryFlags.ReleasesTable)
 			if err != nil {
 				log.WithError(err).Fatal("CRITICAL error getting BigQuery client which prevents regression tracking")
 			}

--- a/cmd/sippy/load.go
+++ b/cmd/sippy/load.go
@@ -126,7 +126,7 @@ func NewLoadCommand() *cobra.Command {
 			bqc, bigqueryErr := bqcachedclient.New(ctx,
 				f.GoogleCloudFlags.ServiceAccountCredentialFile,
 				f.BigQueryFlags.BigQueryProject,
-				f.BigQueryFlags.BigQueryDataset, cacheClient)
+				f.BigQueryFlags.BigQueryDataset, cacheClient, f.BigQueryFlags.ReleasesTable)
 			if bigqueryErr == nil {
 				if f.CacheFlags.EnablePersistentCaching {
 					bqc = f.CacheFlags.DecorateBiqQueryClientWithPersistentCache(bqc)
@@ -364,7 +364,7 @@ func (f *LoadFlags) prowLoader(ctx context.Context, dbc *db.DB, sippyConfig *v1.
 		return nil, err
 	}
 
-	bigQueryClient, err := bqcachedclient.New(ctx, f.GoogleCloudFlags.ServiceAccountCredentialFile, f.BigQueryFlags.BigQueryProject, f.BigQueryFlags.BigQueryDataset, nil)
+	bigQueryClient, err := bqcachedclient.New(ctx, f.GoogleCloudFlags.ServiceAccountCredentialFile, f.BigQueryFlags.BigQueryProject, f.BigQueryFlags.BigQueryDataset, nil, f.BigQueryFlags.ReleasesTable)
 	if err != nil {
 		log.WithError(err).Error("CRITICAL error getting BigQuery client which prevents importing prow jobs")
 		return nil, err

--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -18,3 +18,6 @@ releases:
       - "^pull-ci-openshift-.*-(master|main).*-e2e-.*"
       - "^pull-ci-operator-framework.*-(master|main).*-e2e-.*"
       - "^pull-ci-openshift-online.*-(master|main).*-(verify|unit).*"
+  aro-integration:
+      jobs:
+        periodic-ci-Azure-ARO-HCP-main-periodic-create-aro-hcp-in-integration: true

--- a/config/openshift.yaml
+++ b/config/openshift.yaml
@@ -13150,4 +13150,7 @@ releases:
             - ^pull-ci-openshift-.*-(master|main).*-e2e-.*
             - ^pull-ci-operator-framework.*-(master|main).*-e2e-.*
             - ^pull-ci-openshift-online.*-(master|main).*-(verify|unit).*
+    aro-integration:
+        jobs:
+          periodic-ci-Azure-ARO-HCP-main-periodic-create-aro-hcp-in-integration: true
 

--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -448,8 +448,7 @@ func releaseFilter(req *http.Request, dbc *gorm.DB) *gorm.DB {
 func GetReleasesFromBigQuery(ctx context.Context, client *bqcachedclient.Client) ([]sippyv1.Release, error) {
 	releases := []sippyv1.Release{}
 
-	//queryString := "SELECT * FROM `openshift-ci-data-analysis.ci_data.Releases` ORDER BY DevelStartDate DESC"
-	queryString := "SELECT * FROM `openshift-ci-data-analysis.lmeyer_test.Releases` ORDER BY DevelStartDate DESC"
+	queryString := fmt.Sprintf("SELECT * FROM `%s` ORDER BY DevelStartDate DESC", client.ReleasesTable)
 
 	q := client.BQ.Query(queryString)
 	it, err := q.Read(ctx)

--- a/pkg/api/releases_test.go
+++ b/pkg/api/releases_test.go
@@ -7,7 +7,7 @@ import (
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
 
-	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
+	sippyv1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 
 	"github.com/stretchr/testify/assert"
 
@@ -23,26 +23,26 @@ func TestTransformRelease(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		releaseRow      apitype.ReleaseRow
-		expectedRelease v1.Release
+		releaseRow      sippyv1.ReleaseRow
+		expectedRelease sippyv1.Release
 	}{
 		{
 			name:            "release without devel start",
-			releaseRow:      apitype.ReleaseRow{Release: "4.20", ReleaseStatus: bigquery.NullString{Valid: true, StringVal: "Development"}},
-			expectedRelease: v1.Release{Release: "4.20", Status: "Development"},
+			releaseRow:      sippyv1.ReleaseRow{Release: "4.20", ReleaseStatus: bigquery.NullString{Valid: true, StringVal: "Development"}},
+			expectedRelease: sippyv1.Release{Release: "4.20", Status: "Development"},
 		},
 		{
 			name: "release with devel start",
-			releaseRow: apitype.ReleaseRow{Release: "4.20", ReleaseStatus: bigquery.NullString{Valid: true, StringVal: "Development"}, DevelStartDate: civil.Date{
+			releaseRow: sippyv1.ReleaseRow{Release: "4.20", ReleaseStatus: bigquery.NullString{Valid: true, StringVal: "Development"}, DevelStartDate: civil.Date{
 				Year:  2025,
 				Month: 4,
 				Day:   18,
 			}},
-			expectedRelease: v1.Release{Release: "4.20", Status: "Development", DevelopmentStartDate: &devStart420},
+			expectedRelease: sippyv1.Release{Release: "4.20", Status: "Development", DevelopmentStartDate: &devStart420},
 		},
 		{
 			name: "release with ga date",
-			releaseRow: apitype.ReleaseRow{Release: "4.19", ReleaseStatus: bigquery.NullString{Valid: true, StringVal: "Development"}, DevelStartDate: civil.Date{
+			releaseRow: sippyv1.ReleaseRow{Release: "4.19", ReleaseStatus: bigquery.NullString{Valid: true, StringVal: "Development"}, DevelStartDate: civil.Date{
 				Year:  2024,
 				Month: 11,
 				Day:   25,
@@ -53,7 +53,7 @@ func TestTransformRelease(t *testing.T) {
 					Day:   9},
 				Valid: true,
 			}},
-			expectedRelease: v1.Release{Release: "4.19", Status: "Development", DevelopmentStartDate: &devStart419, GADate: &gaDate419},
+			expectedRelease: sippyv1.Release{Release: "4.19", Status: "Development", DevelopmentStartDate: &devStart419, GADate: &gaDate419},
 		},
 	}
 

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -6,8 +6,6 @@ import (
 	"math/big"
 	"time"
 
-	"cloud.google.com/go/bigquery"
-	"cloud.google.com/go/civil"
 	"github.com/lib/pq"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crview"
 
@@ -873,11 +871,19 @@ type ReleaseDates struct {
 	GA               *time.Time `json:"ga,omitempty"`
 	DevelopmentStart *time.Time `json:"development_start,omitempty"`
 }
+type Release struct { // this is the Release that goes out to the UI
+	Name string `json:"name"`
+	ReleaseDates
+	PreviousRelease         string `json:"previous_release"`
+	InstallIndicatorsSchema int64  `json:"install_indicators_schema "`
+	sippyv1.ReleaseBools
+}
 type Releases struct {
 	Releases          []string                `json:"releases"`
 	DeprecatedGADates map[string]time.Time    `json:"ga_dates"`
 	Dates             map[string]ReleaseDates `json:"dates"`
 	LastUpdated       time.Time               `json:"last_updated"`
+	ReleaseAttrs      map[string]Release      `json:"release_attrs"`
 }
 
 type Indicator struct {
@@ -979,32 +985,6 @@ type DisruptionReportRow struct {
 	Architecture             string  `json:"architecture"`
 	Relevance                int     `json:"relevance"`
 	FeatureSet               string  `json:"feature_set"`
-}
-
-type ReleaseRow struct {
-	// Release contains the X.Y version of the payload, e.g. 4.8
-	Release string `bigquery:"release"`
-
-	// Major contains the major part of the release, e.g. 4
-	Major int `bigquery:"Major"`
-
-	// Minor contains the minor part of the release, e.g. 8
-	Minor int `bigquery:"Minor"`
-
-	// GADate contains GA date for the release, i.e. the -YYYY-MM-DD
-	GADate bigquery.NullDate `bigquery:"GADate"`
-
-	// DevelStartDate contains start date of development of the release, i.e. the -YYYY-MM-DD
-	DevelStartDate civil.Date `bigquery:"DevelStartDate"`
-
-	// Product contains the product for the release, e.g. OCP
-	Product bigquery.NullString `bigquery:"Product"`
-
-	// Patch contains the patch version number of the release, e.g. 1
-	Patch bigquery.NullInt64 `bigquery:"Patch"`
-
-	// ReleaseStatus contains the status of the release, e.g. Full Support
-	ReleaseStatus bigquery.NullString `bigquery:"ReleaseStatus"`
 }
 
 type SippyViews struct {

--- a/pkg/bigquery/client.go
+++ b/pkg/bigquery/client.go
@@ -12,12 +12,13 @@ import (
 )
 
 type Client struct {
-	BQ      *bigquery.Client
-	Cache   cache.Cache
-	Dataset string
+	BQ            *bigquery.Client
+	Cache         cache.Cache
+	Dataset       string
+	ReleasesTable string
 }
 
-func New(ctx context.Context, credentialFile, project, dataset string, c cache.Cache) (*Client, error) {
+func New(ctx context.Context, credentialFile, project, dataset string, c cache.Cache, releasesTable string) (*Client, error) {
 	bqc, err := bigquery.NewClient(ctx, project, option.WithCredentialsFile(credentialFile))
 	if err != nil {
 		return nil, err
@@ -29,9 +30,10 @@ func New(ctx context.Context, credentialFile, project, dataset string, c cache.C
 	}
 
 	return &Client{
-		BQ:      bqc,
-		Cache:   c,
-		Dataset: dataset,
+		BQ:            bqc,
+		Cache:         c,
+		Dataset:       dataset,
+		ReleasesTable: releasesTable,
 	}, nil
 }
 

--- a/pkg/dataloader/featuregateloader/featuregateloader.go
+++ b/pkg/dataloader/featuregateloader/featuregateloader.go
@@ -87,7 +87,7 @@ func (l *FeatureGateLoader) getTargetReleases() ([]string, error) {
 
 		v, err := version.NewVersion(release.Release)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing release version %s", release)
+			return nil, errors.Wrapf(err, "error parsing release version %s", release.Release)
 		}
 
 		if v.GreaterThanOrEqual(minimumRelease) {

--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -369,8 +369,7 @@ func (pl *ProwLoader) loadDailyTestAnalysisByJob(ctx context.Context) error {
 			log.WithError(res.Error).Error("error creating partition")
 			return res.Error
 		}
-		dLog.Info("partition created")
-		dLog.Warn(pl.releases)
+		dLog.Warnf("partition created for releases %v", pl.releases)
 
 		q := pl.bigQueryClient.BQ.Query(fmt.Sprintf(`WITH
   deduped_testcases AS (

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -126,7 +126,7 @@ WITH results AS (
            unnest(variants)        AS variant
     FROM prow_test_report_7d_matview
 	WHERE release = @release AND name ~* @testsubstrings
-          AND NOT(@excluded && variants)
+          AND NOT(variants is not null and @excluded && variants)
     GROUP BY name, release, variant
 )
 SELECT *,
@@ -182,7 +182,7 @@ func TestReportExcludeVariants(
            sum(previous_flakes)    AS previous_flakes
     FROM prow_test_report_7d_matview
     WHERE release = @release AND name = @testname
-          AND NOT(@excluded && variants)
+          AND NOT(variants is not null and @excluded && variants)
     GROUP BY name, release
 ) SELECT *, %s FROM results;`
 

--- a/pkg/flags/bigquery.go
+++ b/pkg/flags/bigquery.go
@@ -14,15 +14,19 @@ import (
 type BigQueryFlags struct {
 	BigQueryProject string
 	BigQueryDataset string
+	ReleasesTable   string
 }
 
 func NewBigQueryFlags() *BigQueryFlags {
-	return &BigQueryFlags{}
+	return &BigQueryFlags{
+		ReleasesTable: "openshift-ci-data-analysis.ci_data.Releases",
+	}
 }
 
 func (f *BigQueryFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&f.BigQueryProject, "bigquery-project", "openshift-gce-devel", "BigQuery project to use")
 	fs.StringVar(&f.BigQueryDataset, "bigquery-dataset", "ci_analysis_us", "Dataset to use")
+	fs.StringVar(&f.ReleasesTable, "bigquery-releases-table", f.ReleasesTable, "BigQuery table containing release information")
 }
 
 func (f *BigQueryFlags) GetBigQueryClient(ctx context.Context, cacheClient cache.Cache, googleServiceAccountCredentialFile string) (*bqcachedclient.Client, error) {
@@ -30,5 +34,5 @@ func (f *BigQueryFlags) GetBigQueryClient(ctx context.Context, cacheClient cache
 		return nil, fmt.Errorf("service account required")
 	}
 
-	return bqcachedclient.New(ctx, googleServiceAccountCredentialFile, f.BigQueryProject, f.BigQueryDataset, cacheClient)
+	return bqcachedclient.New(ctx, googleServiceAccountCredentialFile, f.BigQueryProject, f.BigQueryDataset, cacheClient, f.ReleasesTable)
 }

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -3,11 +3,9 @@ package metrics
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-version"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crview"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
 	"github.com/pkg/errors"
@@ -399,32 +397,4 @@ func buildPromReportTypes(releases []v1.Release) []promReportType {
 	}
 
 	return promReportTypes
-}
-
-func nextMinor(vStr string) (string, error) {
-	// Parse the version string
-	v, err := version.NewVersion(vStr)
-	if err != nil {
-		return "", err
-	}
-
-	// Get the segments of the version
-	segments := v.Segments()
-	if len(segments) < 2 {
-		return "", fmt.Errorf("version '%s' does not have enough segments to determine minor", vStr)
-	}
-
-	// Increment the minor segment
-	segments[1]++
-
-	// Reconstruct version string with incremented minor version
-	// Only consider major and minor segments
-	nextMinorSegments := segments[:2]
-	nextMinorVersionStr := make([]string, len(nextMinorSegments))
-	for i, seg := range nextMinorSegments {
-		nextMinorVersionStr[i] = strconv.Itoa(seg)
-	}
-
-	// Concatenate the segments to form the new version string
-	return strings.Join(nextMinorVersionStr, "."), nil
 }

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -298,6 +298,9 @@ func refreshBuildClusterMetrics(dbc *db.DB, reportEnd time.Time) error {
 
 func refreshPayloadMetrics(dbc *db.DB, reportEnd time.Time, releases []v1.Release) {
 	for _, r := range releases {
+		if r.ExcludeMetrics {
+			continue
+		}
 		results, err := api.ReleaseHealthReports(dbc, r.Release, reportEnd)
 		if err != nil {
 			log.WithError(err).Error("error calling ReleaseHealthReports")
@@ -388,6 +391,9 @@ func buildPromReportTypes(releases []v1.Release) []promReportType {
 	var promReportTypes []promReportType
 
 	for _, release := range releases {
+		if release.ExcludeMetrics {
+			continue
+		}
 		promReportTypes = append(promReportTypes, promReportType{release: release.Release, period: string(sippyprocessingv1.TwoDayReport)})
 		promReportTypes = append(promReportTypes, promReportType{release: release.Release, period: string(sippyprocessingv1.CurrentReport)})
 	}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -826,17 +826,19 @@ func (s *Server) jsonTestDetailsReportFromDB(w http.ResponseWriter, req *http.Re
 }
 
 func (s *Server) jsonReleasesReportFromDB(w http.ResponseWriter, req *http.Request) {
-	gaDateMap := make(map[string]time.Time)
-	dateMap := make(map[string]apitype.ReleaseDates)
-	response := apitype.Releases{
-		DeprecatedGADates: gaDateMap,
-		Dates:             dateMap,
-	}
 	releases, err := api.GetReleases(req.Context(), s.bigQueryClient)
 	if err != nil {
 		log.WithError(err).Error("error querying releases")
 		failureResponse(w, http.StatusInternalServerError, "error querying releases")
 		return
+	}
+
+	gaDateMap := make(map[string]time.Time)
+	dateMap := make(map[string]apitype.ReleaseDates)
+	response := apitype.Releases{
+		DeprecatedGADates: gaDateMap,
+		Dates:             dateMap,
+		ReleaseAttrs:      make(map[string]apitype.Release, len(releases)),
 	}
 
 	for _, release := range releases {
@@ -850,6 +852,13 @@ func (s *Server) jsonReleasesReportFromDB(w http.ResponseWriter, req *http.Reque
 		if release.DevelopmentStartDate != nil {
 			releaseDate.DevelopmentStart = release.DevelopmentStartDate
 			response.Dates[release.Release] = releaseDate
+		}
+		response.ReleaseAttrs[release.Release] = apitype.Release{
+			Name:                    release.Release,
+			PreviousRelease:         release.PreviousRelease,
+			InstallIndicatorsSchema: release.InstallIndicatorsSchema,
+			ReleaseDates:            releaseDate,
+			ReleaseBools:            release.ReleaseBools,
 		}
 	}
 

--- a/pkg/util/param/param.go
+++ b/pkg/util/param/param.go
@@ -29,7 +29,7 @@ var releaseRegexp = regexp.MustCompile(`^\d+\.\d+$`)
 var nonEmptyRegex = regexp.MustCompile(`^.+$`)
 var paramRegexp = map[string]*regexp.Regexp{
 	// sippy classic params
-	"release":         regexp.MustCompile(`^(Presubmits|\d+\.\d+)$`),
+	"release":         regexp.MustCompile(`^[\w.-]+$`), // usually 4.x or Presubmit, but allow any "word"
 	"period":          wordRegexp,
 	"stream":          wordRegexp,
 	"arch":            wordRegexp,

--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -82,6 +82,7 @@ WITH RecentSuccessfulJobs AS (
         (prowjob_job_name LIKE 'periodic-ci-openshift-%%'
           OR prowjob_job_name LIKE 'periodic-ci-shiftstack-%%'
           OR prowjob_job_name LIKE 'periodic-ci-redhat-chaos-prow-scripts-main-cr-%%'
+          OR prowjob_job_name LIKE 'periodic-ci-Azure-ARO-HCP-%%'
           OR prowjob_job_name LIKE 'release-%%'
           OR prowjob_job_name LIKE 'aggregator-%%'
           OR prowjob_job_name LIKE 'periodic-ci-%%-lp-interop-%%'
@@ -102,6 +103,7 @@ WHERE j.prowjob_start > DATETIME_SUB(CURRENT_DATETIME(), INTERVAL 180 DAY) AND
       ((j.prowjob_job_name LIKE 'periodic-ci-openshift-%%'
         OR j.prowjob_job_name LIKE 'periodic-ci-shiftstack-%%'
         OR j.prowjob_job_name LIKE 'periodic-ci-redhat-chaos-prow-scripts-main-cr-%%'
+        OR j.prowjob_job_name LIKE 'periodic-ci-Azure-ARO-HCP-%%'
         OR j.prowjob_job_name LIKE 'release-%%'
         OR j.prowjob_job_name LIKE 'periodic-ci-%%-lp-interop-%%'
         OR j.prowjob_job_name LIKE 'aggregator-%%')
@@ -419,6 +421,7 @@ func setOwner(_ logrus.FieldLogger, variants map[string]string, jobName string) 
 		{"-telco5g", "cnf"},
 		{"-perfscale", "perfscale"},
 		{"-chaos-", "chaos"},
+		{"-azure-aro-hcp", "aro"},
 		{"-qe", "qe"}, // Keep this one below perfscale
 		{"-openshift-tests-private", "qe"},
 		{"-openshift-verification-tests", "qe"},
@@ -781,6 +784,7 @@ func setInstaller(_ logrus.FieldLogger, variants map[string]string, jobName stri
 		installer string
 	}{
 		{"-assisted", "assisted"},
+		{"-azure-aro-hcp", "aro"}, // check before hypershift as job name includes -hcp
 		{"-hypershift", "hypershift"},
 		{"-hcp", "hypershift"},
 		{"_hcp", "hypershift"},
@@ -838,6 +842,7 @@ func setPlatform(jLog logrus.FieldLogger, variants map[string]string, jobName st
 		{"-rosa", "rosa"}, // Keep above AWS as many ROSA jobs also mention AWS
 		{"-aws", "aws"},
 		{"-alibaba", "alibaba"},
+		{"-azure-aro-hcp", "aro"},
 		{"-azure", "azure"},
 		{"-osd-ccs-gcp", "osd-gcp"},
 		{"-gcp", "gcp"},


### PR DESCRIPTION
This is the first phase to enable arbitrary releases that don't look like "x.y". The groundwork is laid in the backend; this can work with the existing schema / cache / UI, and allows updating the schema and Release table contents independently, running the variant refresh, and updating `BackendDisruptionPercentilesDeltaCurrentVsPrevGAV2`, without clearing old cache content.

The bits that actually need/use these updates will be in the next phase.