### PR TITLE
TRT-2198: enable sippy to accept hcm releases

### DIFF
--- a/cmd/sippy/annotatejobruns.go
+++ b/cmd/sippy/annotatejobruns.go
@@ -145,7 +145,7 @@ Example run: sippy annotate-job-runs  --google-service-account-credential-file=f
 			bigQueryClient, err := bqcachedclient.New(ctx,
 				f.GoogleCloudFlags.ServiceAccountCredentialFile,
 				f.BigQueryFlags.BigQueryProject,
-				f.BigQueryFlags.BigQueryDataset, cacheClient)
+				f.BigQueryFlags.BigQueryDataset, cacheClient, f.BigQueryFlags.ReleasesTable)
 			if err != nil {
 				log.WithError(err).Fatal("error getting BigQuery client")
 			}

--- a/cmd/sippy/automatejira.go
+++ b/cmd/sippy/automatejira.go
@@ -141,7 +141,7 @@ func NewAutomateJiraCommand() *cobra.Command {
 			bigQueryClient, err := bqcachedclient.New(ctx,
 				f.GoogleCloudFlags.ServiceAccountCredentialFile,
 				f.BigQueryFlags.BigQueryProject,
-				f.BigQueryFlags.BigQueryDataset, cacheClient)
+				f.BigQueryFlags.BigQueryDataset, cacheClient, f.BigQueryFlags.ReleasesTable)
 			if err != nil {
 				log.WithError(err).Fatal("CRITICAL error getting BigQuery client which prevents regression tracking")
 			}

--- a/cmd/sippy/automatejira.go
+++ b/cmd/sippy/automatejira.go
@@ -152,7 +152,7 @@ func NewAutomateJiraCommand() *cobra.Command {
 			if err != nil {
 				log.WithError(err).Fatal("unable to load views")
 			}
-			releases, err := api.GetReleases(context.Background(), bigQueryClient)
+			releases, err := api.GetReleases(context.Background(), bigQueryClient, false)
 			if err != nil {
 				log.WithError(err).Fatal("error querying releases")
 			}

--- a/cmd/sippy/load.go
+++ b/cmd/sippy/load.go
@@ -126,7 +126,7 @@ func NewLoadCommand() *cobra.Command {
 			bqc, bigqueryErr := bqcachedclient.New(ctx,
 				f.GoogleCloudFlags.ServiceAccountCredentialFile,
 				f.BigQueryFlags.BigQueryProject,
-				f.BigQueryFlags.BigQueryDataset, cacheClient)
+				f.BigQueryFlags.BigQueryDataset, cacheClient, f.BigQueryFlags.ReleasesTable)
 			if bigqueryErr == nil {
 				if f.CacheFlags.EnablePersistentCaching {
 					bqc = f.CacheFlags.DecorateBiqQueryClientWithPersistentCache(bqc)
@@ -364,7 +364,7 @@ func (f *LoadFlags) prowLoader(ctx context.Context, dbc *db.DB, sippyConfig *v1.
 		return nil, err
 	}
 
-	bigQueryClient, err := bqcachedclient.New(ctx, f.GoogleCloudFlags.ServiceAccountCredentialFile, f.BigQueryFlags.BigQueryProject, f.BigQueryFlags.BigQueryDataset, nil)
+	bigQueryClient, err := bqcachedclient.New(ctx, f.GoogleCloudFlags.ServiceAccountCredentialFile, f.BigQueryFlags.BigQueryProject, f.BigQueryFlags.BigQueryDataset, nil, f.BigQueryFlags.ReleasesTable)
 	if err != nil {
 		log.WithError(err).Error("CRITICAL error getting BigQuery client which prevents importing prow jobs")
 		return nil, err

--- a/cmd/sippy/load.go
+++ b/cmd/sippy/load.go
@@ -271,7 +271,7 @@ func NewLoadCommand() *cobra.Command {
 					if len(views.ComponentReadiness) == 0 {
 						return fmt.Errorf("no component readiness views provided")
 					}
-					releases, err := api.GetReleases(context.TODO(), bqc)
+					releases, err := api.GetReleases(context.TODO(), bqc, false)
 					if err != nil {
 						log.WithError(err).Fatal("error querying releases")
 					}

--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -18,3 +18,6 @@ releases:
       - "^pull-ci-openshift-.*-(master|main).*-e2e-.*"
       - "^pull-ci-operator-framework.*-(master|main).*-e2e-.*"
       - "^pull-ci-openshift-online.*-(master|main).*-(verify|unit).*"
+  aro-integration:
+      jobs:
+        periodic-ci-Azure-ARO-HCP-main-periodic-create-aro-hcp-in-integration: true

--- a/config/openshift.yaml
+++ b/config/openshift.yaml
@@ -13150,4 +13150,7 @@ releases:
             - ^pull-ci-openshift-.*-(master|main).*-e2e-.*
             - ^pull-ci-operator-framework.*-(master|main).*-e2e-.*
             - ^pull-ci-openshift-online.*-(master|main).*-(verify|unit).*
+    aro-integration:
+        jobs:
+          periodic-ci-Azure-ARO-HCP-main-periodic-create-aro-hcp-in-integration: true
 

--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -58,68 +58,35 @@ func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release 
 		infraTestName = testidentification.NewInfrastructureTestName
 		installTestName = testidentification.NewInstallTestName
 	}
-	// Infrastructure
-	infraIndicator, err := query.TestReportExcludeVariants(dbc, release, infraTestName, excludedVariants)
-	if err != nil {
-		log.WithError(err).Error("error querying infrastructure test report")
-		return
-	}
-	indicators["infrastructure"] = infraIndicator
 
-	// Install Configuration
-	installConfigIndicator, err := query.TestReportExcludeVariants(dbc, release, testidentification.InstallConfigTestName, excludedInstallVariants)
-	if err != nil {
-		log.WithError(err).Error("error querying install test report")
-		return
+	if infraIndicator, found := query.TestReportExcludeVariants(dbc, release, infraTestName, excludedVariants); found {
+		indicators["infrastructure"] = infraIndicator
 	}
-	indicators["installConfig"] = installConfigIndicator
-
-	// Bootstrap
-	bootstrapIndicator, err := query.TestReportExcludeVariants(dbc, release, testidentification.InstallBootstrapTestName, excludedInstallVariants)
-	if err != nil {
-		log.WithError(err).Error("error querying bootstrap test report")
-		return
+	if installConfigIndicator, found := query.TestReportExcludeVariants(dbc, release, testidentification.InstallConfigTestName, excludedInstallVariants); found {
+		indicators["installConfig"] = installConfigIndicator
 	}
-	indicators["bootstrap"] = bootstrapIndicator
-
-	// Install Other
-	installOtherIndicator, err := query.TestReportExcludeVariants(dbc, release, testidentification.InstallOtherTestName, excludedInstallVariants)
-	if err != nil {
-		log.WithError(err).Error("error querying install (other) test report")
-		return
+	if bootstrapIndicator, found := query.TestReportExcludeVariants(dbc, release, testidentification.InstallBootstrapTestName, excludedInstallVariants); found {
+		indicators["bootstrap"] = bootstrapIndicator
 	}
-	indicators["installOther"] = installOtherIndicator
-
-	// Install
-	installIndicator, err := query.TestReportExcludeVariants(dbc, release, installTestName, excludedInstallVariants)
-	if err != nil {
-		log.WithError(err).Error("error querying install test report")
-		return
+	if installOtherIndicator, found := query.TestReportExcludeVariants(dbc, release, testidentification.InstallOtherTestName, excludedInstallVariants); found {
+		indicators["installOther"] = installOtherIndicator
 	}
-	indicators["install"] = installIndicator
-
-	// Upgrade
-	upgradeIndicator, err := query.TestReportExcludeVariants(dbc, release, testidentification.UpgradeTestName, excludedVariants)
-	if err != nil {
-		log.WithError(err).Error("error querying upgrade test report")
-		return
+	if installIndicator, found := query.TestReportExcludeVariants(dbc, release, installTestName, excludedInstallVariants); found {
+		indicators["install"] = installIndicator
 	}
-	indicators["upgrade"] = upgradeIndicator
+	if upgradeIndicator, found := query.TestReportExcludeVariants(dbc, release, testidentification.UpgradeTestName, excludedVariants); found {
+		indicators["upgrade"] = upgradeIndicator
+	}
 
-	// Tests
 	// NOTE: this is not actually representing the percentage of tests that passed, it's representing
 	// the percentage of time that all tests passed. We should probably fix that.
-	testsIndicator, err := query.TestReportExcludeVariants(dbc, release, testidentification.OpenShiftTestsName, excludedVariants)
-	if err != nil {
-		log.WithError(err).Error("error querying test report")
-		return
+	if testsIndicator, found := query.TestReportExcludeVariants(dbc, release, testidentification.OpenShiftTestsName, excludedVariants); found {
+		indicators["tests"] = testsIndicator
 	}
-	indicators["tests"] = testsIndicator
 
 	var lastUpdated time.Time
-	r := dbc.DB.Raw("SELECT MAX(created_at) FROM prow_job_runs").Scan(&lastUpdated)
-	if r.Error != nil {
-		log.WithError(err).Error("error querying last update time")
+	if r := dbc.DB.Raw("SELECT MAX(created_at) FROM prow_job_runs").Scan(&lastUpdated); r.Error != nil {
+		log.WithError(r.Error).Error("error querying last update time")
 		return
 	}
 	log.WithField("lastUpdated", lastUpdated).Info("ran the last update query")

--- a/pkg/api/install.go
+++ b/pkg/api/install.go
@@ -105,11 +105,7 @@ func VariantTestsReport(dbc *db.DB, release string, reportType v1.ReportType,
 
 	// Add in the All column for each test:
 	for testName := range tests {
-		allReport, err := query.TestReportExcludeVariants(dbc, release, testName, excludedVariants)
-		if err != nil {
-			// log the error and keep going
-			log.WithError(err).Errorf("Failed to query test report for: %s", testName)
-		} else {
+		if allReport, found := query.TestReportExcludeVariants(dbc, release, testName, excludedVariants); found {
 			tests[testName]["All"] = allReport
 		}
 	}

--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -448,8 +448,7 @@ func releaseFilter(req *http.Request, dbc *gorm.DB) *gorm.DB {
 func GetReleasesFromBigQuery(ctx context.Context, client *bqcachedclient.Client) ([]sippyv1.Release, error) {
 	releases := []sippyv1.Release{}
 
-	//queryString := "SELECT * FROM `openshift-ci-data-analysis.ci_data.Releases` ORDER BY DevelStartDate DESC"
-	queryString := "SELECT * FROM `openshift-ci-data-analysis.lmeyer_test.Releases` ORDER BY DevelStartDate DESC"
+	queryString := fmt.Sprintf("SELECT * FROM `%s` ORDER BY DevelStartDate DESC", client.ReleasesTable)
 
 	q := client.BQ.Query(queryString)
 	it, err := q.Read(ctx)

--- a/pkg/api/releases_test.go
+++ b/pkg/api/releases_test.go
@@ -7,7 +7,7 @@ import (
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
 
-	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
+	sippyv1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 
 	"github.com/stretchr/testify/assert"
 
@@ -23,26 +23,26 @@ func TestTransformRelease(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		releaseRow      apitype.ReleaseRow
-		expectedRelease v1.Release
+		releaseRow      sippyv1.ReleaseRow
+		expectedRelease sippyv1.Release
 	}{
 		{
 			name:            "release without devel start",
-			releaseRow:      apitype.ReleaseRow{Release: "4.20", ReleaseStatus: bigquery.NullString{Valid: true, StringVal: "Development"}},
-			expectedRelease: v1.Release{Release: "4.20", Status: "Development"},
+			releaseRow:      sippyv1.ReleaseRow{Release: "4.20", ReleaseStatus: bigquery.NullString{Valid: true, StringVal: "Development"}},
+			expectedRelease: sippyv1.Release{Release: "4.20", Status: "Development"},
 		},
 		{
 			name: "release with devel start",
-			releaseRow: apitype.ReleaseRow{Release: "4.20", ReleaseStatus: bigquery.NullString{Valid: true, StringVal: "Development"}, DevelStartDate: civil.Date{
+			releaseRow: sippyv1.ReleaseRow{Release: "4.20", ReleaseStatus: bigquery.NullString{Valid: true, StringVal: "Development"}, DevelStartDate: civil.Date{
 				Year:  2025,
 				Month: 4,
 				Day:   18,
 			}},
-			expectedRelease: v1.Release{Release: "4.20", Status: "Development", DevelopmentStartDate: &devStart420},
+			expectedRelease: sippyv1.Release{Release: "4.20", Status: "Development", DevelopmentStartDate: &devStart420},
 		},
 		{
 			name: "release with ga date",
-			releaseRow: apitype.ReleaseRow{Release: "4.19", ReleaseStatus: bigquery.NullString{Valid: true, StringVal: "Development"}, DevelStartDate: civil.Date{
+			releaseRow: sippyv1.ReleaseRow{Release: "4.19", ReleaseStatus: bigquery.NullString{Valid: true, StringVal: "Development"}, DevelStartDate: civil.Date{
 				Year:  2024,
 				Month: 11,
 				Day:   25,
@@ -53,7 +53,7 @@ func TestTransformRelease(t *testing.T) {
 					Day:   9},
 				Valid: true,
 			}},
-			expectedRelease: v1.Release{Release: "4.19", Status: "Development", DevelopmentStartDate: &devStart419, GADate: &gaDate419},
+			expectedRelease: sippyv1.Release{Release: "4.19", Status: "Development", DevelopmentStartDate: &devStart419, GADate: &gaDate419},
 		},
 	}
 

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -156,14 +156,14 @@ func (r *releaseGenerator) ListReleases(ctx context.Context) ([]v1.Release, []er
 }
 
 // GetReleases gets all the releases defined in the BQ Releases table.
-func GetReleases(ctx context.Context, bqc *bqclient.Client) ([]v1.Release, error) {
+func GetReleases(ctx context.Context, bqc *bqclient.Client, forceRefresh bool) ([]v1.Release, error) {
 	releaseGen := releaseGenerator{bqc}
 
 	var err error
 	rels, errs := GetDataFromCacheOrGenerate[[]v1.Release](
 		ctx,
 		bqc.Cache,
-		cache.RequestOptions{},
+		cache.RequestOptions{ForceRefresh: forceRefresh},
 		GetPrefixedCacheKey("Releases~", v1.Release{}), // no cache options needed here, global list
 		releaseGen.ListReleases,
 		[]v1.Release{})

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -23,8 +23,6 @@ var (
 	defaultCacheDuration = 8 * time.Hour
 )
 
-const releasePresubmits = "Presubmits"
-
 type CacheData struct {
 	cacheKey func() ([]byte, error)
 }
@@ -154,8 +152,6 @@ func (r *releaseGenerator) ListReleases(ctx context.Context) ([]v1.Release, []er
 		log.WithError(err).Error("error getting releases from bigquery")
 		return releases, []error{err}
 	}
-	// Add special release Presubmits for prow jobs
-	releases = append(releases, v1.Release{Release: releasePresubmits})
 	return releases, nil
 }
 

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -6,8 +6,6 @@ import (
 	"math/big"
 	"time"
 
-	"cloud.google.com/go/bigquery"
-	"cloud.google.com/go/civil"
 	"github.com/lib/pq"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crview"
 
@@ -873,11 +871,18 @@ type ReleaseDates struct {
 	GA               *time.Time `json:"ga,omitempty"`
 	DevelopmentStart *time.Time `json:"development_start,omitempty"`
 }
+type Release struct { // this is the Release that goes out to the UI
+	Name string `json:"name"`
+	ReleaseDates
+	PreviousRelease string                             `json:"previous_release"`
+	Capabilities    map[sippyv1.ReleaseCapability]bool `json:"capabilities"`
+}
 type Releases struct {
 	Releases          []string                `json:"releases"`
 	DeprecatedGADates map[string]time.Time    `json:"ga_dates"`
 	Dates             map[string]ReleaseDates `json:"dates"`
 	LastUpdated       time.Time               `json:"last_updated"`
+	ReleaseAttrs      map[string]Release      `json:"release_attrs"`
 }
 
 type Indicator struct {
@@ -979,32 +984,6 @@ type DisruptionReportRow struct {
 	Architecture             string  `json:"architecture"`
 	Relevance                int     `json:"relevance"`
 	FeatureSet               string  `json:"feature_set"`
-}
-
-type ReleaseRow struct {
-	// Release contains the X.Y version of the payload, e.g. 4.8
-	Release string `bigquery:"release"`
-
-	// Major contains the major part of the release, e.g. 4
-	Major int `bigquery:"Major"`
-
-	// Minor contains the minor part of the release, e.g. 8
-	Minor int `bigquery:"Minor"`
-
-	// GADate contains GA date for the release, i.e. the -YYYY-MM-DD
-	GADate bigquery.NullDate `bigquery:"GADate"`
-
-	// DevelStartDate contains start date of development of the release, i.e. the -YYYY-MM-DD
-	DevelStartDate civil.Date `bigquery:"DevelStartDate"`
-
-	// Product contains the product for the release, e.g. OCP
-	Product bigquery.NullString `bigquery:"Product"`
-
-	// Patch contains the patch version number of the release, e.g. 1
-	Patch bigquery.NullInt64 `bigquery:"Patch"`
-
-	// ReleaseStatus contains the status of the release, e.g. Full Support
-	ReleaseStatus bigquery.NullString `bigquery:"ReleaseStatus"`
 }
 
 type SippyViews struct {

--- a/pkg/bigquery/client.go
+++ b/pkg/bigquery/client.go
@@ -12,12 +12,13 @@ import (
 )
 
 type Client struct {
-	BQ      *bigquery.Client
-	Cache   cache.Cache
-	Dataset string
+	BQ            *bigquery.Client
+	Cache         cache.Cache
+	Dataset       string
+	ReleasesTable string
 }
 
-func New(ctx context.Context, credentialFile, project, dataset string, c cache.Cache) (*Client, error) {
+func New(ctx context.Context, credentialFile, project, dataset string, c cache.Cache, releasesTable string) (*Client, error) {
 	bqc, err := bigquery.NewClient(ctx, project, option.WithCredentialsFile(credentialFile))
 	if err != nil {
 		return nil, err
@@ -29,9 +30,10 @@ func New(ctx context.Context, credentialFile, project, dataset string, c cache.C
 	}
 
 	return &Client{
-		BQ:      bqc,
-		Cache:   c,
-		Dataset: dataset,
+		BQ:            bqc,
+		Cache:         c,
+		Dataset:       dataset,
+		ReleasesTable: releasesTable,
 	}, nil
 }
 

--- a/pkg/dataloader/crcacheloader/crcacheloader.go
+++ b/pkg/dataloader/crcacheloader/crcacheloader.go
@@ -75,7 +75,7 @@ func (l *ComponentReadinessCacheLoader) Load() {
 		ForceRefresh:         true,
 	}
 
-	releases, err := api.GetReleases(context.TODO(), l.bqClient)
+	releases, err := api.GetReleases(context.TODO(), l.bqClient, false)
 	if err != nil {
 		l.errs = append(l.errs, errors.Wrap(err, "error querying releases"))
 		return

--- a/pkg/dataloader/featuregateloader/featuregateloader.go
+++ b/pkg/dataloader/featuregateloader/featuregateloader.go
@@ -88,7 +88,7 @@ func (l *FeatureGateLoader) getTargetReleases() ([]string, error) {
 
 		v, err := version.NewVersion(release.Release)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing release version %s", release)
+			return nil, errors.Wrapf(err, "error parsing release version %s", release.Release)
 		}
 
 		if v.GreaterThanOrEqual(minimumRelease) {

--- a/pkg/dataloader/featuregateloader/featuregateloader.go
+++ b/pkg/dataloader/featuregateloader/featuregateloader.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/hashicorp/go-version"
+	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -81,7 +82,7 @@ func (l *FeatureGateLoader) getTargetReleases() ([]string, error) {
 	}
 
 	for _, release := range releases {
-		if release.Release == "Presubmits" {
+		if !release.Capabilities[v1.FeatureGatesCap] {
 			continue
 		}
 

--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -369,8 +369,7 @@ func (pl *ProwLoader) loadDailyTestAnalysisByJob(ctx context.Context) error {
 			log.WithError(res.Error).Error("error creating partition")
 			return res.Error
 		}
-		dLog.Info("partition created")
-		dLog.Warn(pl.releases)
+		dLog.Warnf("partition created for releases %v", pl.releases)
 
 		q := pl.bigQueryClient.BQ.Query(fmt.Sprintf(`WITH
   deduped_testcases AS (

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -159,13 +160,12 @@ FROM results;
 
 // TestReportExcludeVariants returns a single test report the given test name in the db,
 // all variants collapsed, optionally with some excluded.
-func TestReportExcludeVariants(
-	dbc *db.DB,
-	release string,
-	testName string,
-	excludeVariants []string,
-) (api.Test, error) {
+// If the query fails, it is logged and the bool is left false.
+func TestReportExcludeVariants(dbc *db.DB, release, testName string, excludeVariants []string) (api.Test, bool) {
 	now := time.Now()
+	logger := log.WithField("func", "TestReportExcludeVariants").
+		WithField("release", release).
+		WithField("test", testName)
 
 	// Query and group by variant:
 	var testReport api.Test
@@ -192,15 +192,17 @@ func TestReportExcludeVariants(
 		sql.Named("release", release),
 		sql.Named("testname", testName),
 	}
-	r := dbc.DB.Raw(q, qParams...).First(&testReport)
-	if r.Error != nil {
-		log.Error(r.Error)
-		return testReport, r.Error
+	if r := dbc.DB.Raw(q, qParams...).First(&testReport); r.Error != nil {
+		if errors.Is(r.Error, gorm.ErrRecordNotFound) {
+			logger.Debug("test not found")
+		} else {
+			logger.WithError(r.Error).Error("query failed")
+		}
+		return testReport, false
 	}
 
-	elapsed := time.Since(now)
-	log.Infof("TestReportExcludeVariants completed in %s for release %s and test %q", elapsed, release, testName)
-	return testReport, nil
+	logger.Debugf("completed in %s", time.Since(now))
+	return testReport, true
 }
 
 // LoadBugsForTest returns all bugs in the database for the given test, across all releases.

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -126,7 +126,7 @@ WITH results AS (
            unnest(variants)        AS variant
     FROM prow_test_report_7d_matview
 	WHERE release = @release AND name ~* @testsubstrings
-          AND NOT(@excluded && variants)
+          AND NOT(variants is not null and @excluded && variants)
     GROUP BY name, release, variant
 )
 SELECT *,
@@ -182,7 +182,7 @@ func TestReportExcludeVariants(
            sum(previous_flakes)    AS previous_flakes
     FROM prow_test_report_7d_matview
     WHERE release = @release AND name = @testname
-          AND NOT(@excluded && variants)
+          AND NOT(variants is not null and @excluded && variants)
     GROUP BY name, release
 ) SELECT *, %s FROM results;`
 

--- a/pkg/flags/bigquery.go
+++ b/pkg/flags/bigquery.go
@@ -14,15 +14,19 @@ import (
 type BigQueryFlags struct {
 	BigQueryProject string
 	BigQueryDataset string
+	ReleasesTable   string
 }
 
 func NewBigQueryFlags() *BigQueryFlags {
-	return &BigQueryFlags{}
+	return &BigQueryFlags{
+		ReleasesTable: "openshift-ci-data-analysis.ci_data.Releases",
+	}
 }
 
 func (f *BigQueryFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&f.BigQueryProject, "bigquery-project", "openshift-gce-devel", "BigQuery project to use")
 	fs.StringVar(&f.BigQueryDataset, "bigquery-dataset", "ci_analysis_us", "Dataset to use")
+	fs.StringVar(&f.ReleasesTable, "bigquery-releases-table", f.ReleasesTable, "BigQuery table containing release information")
 }
 
 func (f *BigQueryFlags) GetBigQueryClient(ctx context.Context, cacheClient cache.Cache, googleServiceAccountCredentialFile string) (*bqcachedclient.Client, error) {
@@ -30,5 +34,5 @@ func (f *BigQueryFlags) GetBigQueryClient(ctx context.Context, cacheClient cache
 		return nil, fmt.Errorf("service account required")
 	}
 
-	return bqcachedclient.New(ctx, googleServiceAccountCredentialFile, f.BigQueryProject, f.BigQueryDataset, cacheClient)
+	return bqcachedclient.New(ctx, googleServiceAccountCredentialFile, f.BigQueryProject, f.BigQueryDataset, cacheClient, f.ReleasesTable)
 }

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -3,11 +3,9 @@ package metrics
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-version"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crview"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
 	"github.com/pkg/errors"
@@ -399,32 +397,4 @@ func buildPromReportTypes(releases []v1.Release) []promReportType {
 	}
 
 	return promReportTypes
-}
-
-func nextMinor(vStr string) (string, error) {
-	// Parse the version string
-	v, err := version.NewVersion(vStr)
-	if err != nil {
-		return "", err
-	}
-
-	// Get the segments of the version
-	segments := v.Segments()
-	if len(segments) < 2 {
-		return "", fmt.Errorf("version '%s' does not have enough segments to determine minor", vStr)
-	}
-
-	// Increment the minor segment
-	segments[1]++
-
-	// Reconstruct version string with incremented minor version
-	// Only consider major and minor segments
-	nextMinorSegments := segments[:2]
-	nextMinorVersionStr := make([]string, len(nextMinorSegments))
-	for i, seg := range nextMinorSegments {
-		nextMinorVersionStr[i] = strconv.Itoa(seg)
-	}
-
-	// Concatenate the segments to form the new version string
-	return strings.Join(nextMinorVersionStr, "."), nil
 }

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -298,6 +298,9 @@ func refreshBuildClusterMetrics(dbc *db.DB, reportEnd time.Time) error {
 
 func refreshPayloadMetrics(dbc *db.DB, reportEnd time.Time, releases []v1.Release) {
 	for _, r := range releases {
+		if !r.Capabilities[v1.MetricsCap] {
+			continue
+		}
 		results, err := api.ReleaseHealthReports(dbc, r.Release, reportEnd)
 		if err != nil {
 			log.WithError(err).Error("error calling ReleaseHealthReports")
@@ -388,6 +391,9 @@ func buildPromReportTypes(releases []v1.Release) []promReportType {
 	var promReportTypes []promReportType
 
 	for _, release := range releases {
+		if !release.Capabilities[v1.MetricsCap] {
+			continue
+		}
 		promReportTypes = append(promReportTypes, promReportType{release: release.Release, period: string(sippyprocessingv1.TwoDayReport)})
 		promReportTypes = append(promReportTypes, promReportType{release: release.Release, period: string(sippyprocessingv1.CurrentReport)})
 	}

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -118,7 +118,7 @@ func getReleaseStatus(releases []v1.Release, release string) string {
 func RefreshMetricsDB(ctx context.Context, dbc *db.DB, bqc *bqclient.Client, reportEnd time.Time, cacheOptions cache.RequestOptions, views []crview.View, variantJunitTableOverrides []configv1.VariantJunitTableOverride) error {
 	start := time.Now()
 	log.Info("beginning refresh metrics")
-	releases, err := api.GetReleases(context.Background(), bqc)
+	releases, err := api.GetReleases(context.Background(), bqc, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -655,7 +655,7 @@ func (s *Server) jsonJobVariantsFromBigQuery(w http.ResponseWriter, req *http.Re
 }
 
 func (s *Server) jsonComponentReadinessViews(w http.ResponseWriter, req *http.Request) {
-	allReleases, err := api.GetReleases(req.Context(), s.bigQueryClient)
+	allReleases, err := api.GetReleases(req.Context(), s.bigQueryClient, false)
 	if err != nil {
 		failureResponse(w, http.StatusBadRequest, err.Error())
 		return
@@ -696,7 +696,7 @@ func (s *Server) jsonComponentReportFromBigQuery(w http.ResponseWriter, req *htt
 		return
 	}
 
-	allReleases, err := api.GetReleases(req.Context(), s.bigQueryClient)
+	allReleases, err := api.GetReleases(req.Context(), s.bigQueryClient, false)
 	if err != nil {
 		failureResponse(w, http.StatusBadRequest, err.Error())
 		return
@@ -739,7 +739,7 @@ func (s *Server) jsonComponentReportTestDetailsFromBigQuery(w http.ResponseWrite
 		failureResponse(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	allReleases, err := api.GetReleases(req.Context(), s.bigQueryClient)
+	allReleases, err := api.GetReleases(req.Context(), s.bigQueryClient, false)
 	if err != nil {
 		failureResponse(w, http.StatusBadRequest, err.Error())
 		return
@@ -826,7 +826,8 @@ func (s *Server) jsonTestDetailsReportFromDB(w http.ResponseWriter, req *http.Re
 }
 
 func (s *Server) jsonReleasesReportFromDB(w http.ResponseWriter, req *http.Request) {
-	releases, err := api.GetReleases(req.Context(), s.bigQueryClient)
+	forceRefresh := req.URL.Query().Get("forceRefresh") != "" // use to refresh cached releases from BQ
+	releases, err := api.GetReleases(req.Context(), s.bigQueryClient, forceRefresh)
 	if err != nil {
 		log.WithError(err).Error("error querying releases")
 		failureResponse(w, http.StatusInternalServerError, "error querying releases")

--- a/pkg/util/param/param.go
+++ b/pkg/util/param/param.go
@@ -29,7 +29,7 @@ var releaseRegexp = regexp.MustCompile(`^\d+\.\d+$`)
 var nonEmptyRegex = regexp.MustCompile(`^.+$`)
 var paramRegexp = map[string]*regexp.Regexp{
 	// sippy classic params
-	"release":         regexp.MustCompile(`^(Presubmits|\d+\.\d+)$`),
+	"release":         regexp.MustCompile(`^[\w.-]+$`), // usually 4.x or Presubmit, but allow any "word"
 	"period":          wordRegexp,
 	"stream":          wordRegexp,
 	"arch":            wordRegexp,

--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -82,6 +82,7 @@ WITH RecentSuccessfulJobs AS (
         (prowjob_job_name LIKE 'periodic-ci-openshift-%%'
           OR prowjob_job_name LIKE 'periodic-ci-shiftstack-%%'
           OR prowjob_job_name LIKE 'periodic-ci-redhat-chaos-prow-scripts-main-cr-%%'
+          OR prowjob_job_name LIKE 'periodic-ci-Azure-ARO-HCP-%%'
           OR prowjob_job_name LIKE 'release-%%'
           OR prowjob_job_name LIKE 'aggregator-%%'
           OR prowjob_job_name LIKE 'periodic-ci-%%-lp-interop-%%'
@@ -102,6 +103,7 @@ WHERE j.prowjob_start > DATETIME_SUB(CURRENT_DATETIME(), INTERVAL 180 DAY) AND
       ((j.prowjob_job_name LIKE 'periodic-ci-openshift-%%'
         OR j.prowjob_job_name LIKE 'periodic-ci-shiftstack-%%'
         OR j.prowjob_job_name LIKE 'periodic-ci-redhat-chaos-prow-scripts-main-cr-%%'
+        OR j.prowjob_job_name LIKE 'periodic-ci-Azure-ARO-HCP-%%'
         OR j.prowjob_job_name LIKE 'release-%%'
         OR j.prowjob_job_name LIKE 'periodic-ci-%%-lp-interop-%%'
         OR j.prowjob_job_name LIKE 'aggregator-%%')
@@ -419,6 +421,7 @@ func setOwner(_ logrus.FieldLogger, variants map[string]string, jobName string) 
 		{"-telco5g", "cnf"},
 		{"-perfscale", "perfscale"},
 		{"-chaos-", "chaos"},
+		{"-azure-aro-hcp", "aro"},
 		{"-qe", "qe"}, // Keep this one below perfscale
 		{"-openshift-tests-private", "qe"},
 		{"-openshift-verification-tests", "qe"},
@@ -781,6 +784,7 @@ func setInstaller(_ logrus.FieldLogger, variants map[string]string, jobName stri
 		installer string
 	}{
 		{"-assisted", "assisted"},
+		{"-azure-aro-hcp", "aro"}, // check before hypershift as job name includes -hcp
 		{"-hypershift", "hypershift"},
 		{"-hcp", "hypershift"},
 		{"_hcp", "hypershift"},
@@ -838,6 +842,7 @@ func setPlatform(jLog logrus.FieldLogger, variants map[string]string, jobName st
 		{"-rosa", "rosa"}, // Keep above AWS as many ROSA jobs also mention AWS
 		{"-aws", "aws"},
 		{"-alibaba", "alibaba"},
+		{"-azure-aro-hcp", "aro"},
 		{"-azure", "azure"},
 		{"-osd-ccs-gcp", "osd-gcp"},
 		{"-gcp", "gcp"},

--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -791,7 +791,7 @@ export default function App(props) {
                           </IconButton>
                         </DrawerHeader>
                         <Sidebar
-                          releases={releases['releases']}
+                          releaseConfig={releases}
                           defaultRelease={defaultRelease}
                         />
                       </Drawer>

--- a/sippy-ng/src/component_readiness/ReleaseSelector.js
+++ b/sippy-ng/src/component_readiness/ReleaseSelector.js
@@ -97,8 +97,7 @@ function ReleaseSelector(props) {
     let tmpRelease = {}
     releases.releases
       .filter((aVersion) => {
-        // We won't process Presubmits or 3.11
-        return aVersion !== 'Presubmits' && aVersion !== '3.11'
+        return releases.release_attrs[aVersion].capabilities.componentReadiness
       })
       .forEach((r) => {
         tmpRelease[r] = releases.ga_dates[r]

--- a/sippy-ng/src/component_readiness/TestDetailsReport.js
+++ b/sippy-ng/src/component_readiness/TestDetailsReport.js
@@ -208,8 +208,7 @@ export default function TestDetailsReport(props) {
     let tmpRelease = {}
     releases.releases
       .filter((aVersion) => {
-        // We won't process Presubmits or 3.11
-        return aVersion !== 'Presubmits' && aVersion != '3.11'
+        return !releases.release_attrs[aVersion].capabilities.componentReadiness
       })
       .forEach((r) => {
         tmpRelease[r] = releases.ga_dates[r]

--- a/sippy-ng/src/components/Sidebar.js
+++ b/sippy-ng/src/components/Sidebar.js
@@ -59,14 +59,16 @@ export default function Sidebar(props) {
       let parts = location.pathname.split('/')
       let tmpOpen = open
       if (parts.length >= 3) {
-        let index = props.releases.indexOf(parts[2])
+        let index = props.releaseConfig.releases.indexOf(parts[2])
         if (index !== -1) {
           tmpOpen[index] = true
         }
       } else {
         let defaultIndex = 0
         if (props.defaultRelease != undefined) {
-          defaultIndex = props.releases.indexOf(props.defaultRelease)
+          defaultIndex = props.releaseConfig.releases.indexOf(
+            props.defaultRelease
+          )
           if (defaultIndex < 0) {
             defaultIndex = 0
           }
@@ -213,7 +215,7 @@ export default function Sidebar(props) {
                     </ListSubheader>
                   }
                 >
-                  {props.releases.map((release, index) => (
+                  {props.releaseConfig.releases.map((release, index) => (
                     <Fragment key={'section-release-' + index}>
                       <ListItem
                         key={'item-release-' + index}
@@ -239,7 +241,8 @@ export default function Sidebar(props) {
                               <ListItemText primary="Overview" />
                             </StyledListItemButton>
                           </ListItem>
-                          {release !== 'Presubmits' ? (
+                          {props.releaseConfig.release_attrs[release]
+                            .capabilities.payloadTags && (
                             <CapabilitiesContext.Consumer>
                               {(value) => {
                                 if (value.includes('openshift_releases')) {
@@ -261,8 +264,6 @@ export default function Sidebar(props) {
                                 }
                               }}
                             </CapabilitiesContext.Consumer>
-                          ) : (
-                            ''
                           )}
                           <ListItem
                             key={'release-jobs-' + index}
@@ -284,41 +285,37 @@ export default function Sidebar(props) {
                             </StyledListItemButton>
                           </ListItem>
 
-                          {
-                            // FIXME: Base this on something like a per-release capabilities feature instead.
-                            release === 'Presubmits' ? (
-                              <Fragment>
-                                <ListItem
-                                  key={'release-pull-requests-' + index}
-                                  component={Link}
-                                  to={`/pull_requests/${release}`}
-                                  className={classes.nested}
-                                >
-                                  <StyledListItemButton>
-                                    <ListItemIcon>
-                                      <GitHub />
-                                    </ListItemIcon>
-                                    <ListItemText primary="Pull Requests" />
-                                  </StyledListItemButton>
-                                </ListItem>
-                                <ListItem
-                                  key={'release-repositories-' + index}
-                                  component={Link}
-                                  to={`/repositories/${release}`}
-                                  className={classes.nested}
-                                >
-                                  <StyledListItemButton>
-                                    <ListItemIcon>
-                                      <Code />
-                                    </ListItemIcon>
-                                    <ListItemText primary="Repositories" />
-                                  </StyledListItemButton>
-                                </ListItem>
-                              </Fragment>
-                            ) : (
-                              ''
-                            )
-                          }
+                          {props.releaseConfig.release_attrs[release]
+                            .capabilities.pullRequests && (
+                            <Fragment>
+                              <ListItem
+                                key={'release-pull-requests-' + index}
+                                component={Link}
+                                to={`/pull_requests/${release}`}
+                                className={classes.nested}
+                              >
+                                <StyledListItemButton>
+                                  <ListItemIcon>
+                                    <GitHub />
+                                  </ListItemIcon>
+                                  <ListItemText primary="Pull Requests" />
+                                </StyledListItemButton>
+                              </ListItem>
+                              <ListItem
+                                key={'release-repositories-' + index}
+                                component={Link}
+                                to={`/repositories/${release}`}
+                                className={classes.nested}
+                              >
+                                <StyledListItemButton>
+                                  <ListItemIcon>
+                                    <Code />
+                                  </ListItemIcon>
+                                  <ListItemText primary="Repositories" />
+                                </StyledListItemButton>
+                              </ListItem>
+                            </Fragment>
+                          )}
 
                           <ListItem
                             key={'release-tests-' + index}
@@ -349,27 +346,30 @@ export default function Sidebar(props) {
                             </StyledListItemButton>
                           </ListItem>
 
-                          <CapabilitiesContext.Consumer>
-                            {(value) => {
-                              if (value.includes('openshift_releases')) {
-                                return (
-                                  <ListItem
-                                    key={'release-feature-gates-' + index}
-                                    component={Link}
-                                    to={'/feature_gates/' + release}
-                                    className={classes.nested}
-                                  >
-                                    <StyledListItemButton>
-                                      <ListItemIcon>
-                                        <Apps />
-                                      </ListItemIcon>
-                                      <ListItemText primary="Feature Gates" />
-                                    </StyledListItemButton>
-                                  </ListItem>
-                                )
-                              }
-                            }}
-                          </CapabilitiesContext.Consumer>
+                          {props.releaseConfig.release_attrs[release]
+                            .capabilities.featureGates && (
+                            <CapabilitiesContext.Consumer>
+                              {(value) => {
+                                if (value.includes('openshift_releases')) {
+                                  return (
+                                    <ListItem
+                                      key={'release-feature-gates-' + index}
+                                      component={Link}
+                                      to={'/feature_gates/' + release}
+                                      className={classes.nested}
+                                    >
+                                      <StyledListItemButton>
+                                        <ListItemIcon>
+                                          <Apps />
+                                        </ListItemIcon>
+                                        <ListItemText primary="Feature Gates" />
+                                      </StyledListItemButton>
+                                    </ListItem>
+                                  )
+                                }
+                              }}
+                            </CapabilitiesContext.Consumer>
+                          )}
 
                           <CapabilitiesContext.Consumer>
                             {(value) => {
@@ -502,6 +502,6 @@ export default function Sidebar(props) {
 }
 
 Sidebar.propTypes = {
-  releases: PropTypes.array,
+  releaseConfig: PropTypes.object,
   defaultRelease: PropTypes.string,
 }

--- a/sippy-ng/src/releases/InstallTopLevelIndicators.js
+++ b/sippy-ng/src/releases/InstallTopLevelIndicators.js
@@ -39,10 +39,8 @@ export default function TopLevelIndicators(props) {
     'bootstrap',
     'install',
   ].forEach((indicator) => {
-    if (
-      props.indicators[indicator].current_runs !== 0 ||
-      props.indicators[indicator].previous_runs !== 0
-    ) {
+    let ind = props.indicators[indicator]
+    if (ind && (ind.current_runs !== 0 || ind.previous_runs !== 0)) {
       noData = false
     }
   })
@@ -54,87 +52,97 @@ export default function TopLevelIndicators(props) {
 
   return (
     <Fragment>
-      <Grid item md={2} sm={4}>
-        <SummaryCard
-          key="infrastructure-summary"
-          threshold={INFRASTRUCTURE_THRESHOLDS}
-          name="Infrastructure"
-          link={pathForTestByVariant(
-            props.release,
-            'install should succeed: infrastructure'
-          )}
-          success={props.indicators.infrastructure.current_pass_percentage}
-          flakes={props.indicators.infrastructure.current_flake_percentage}
-          fail={props.indicators.infrastructure.current_failure_percentage}
-          caption={indicatorCaption(props.indicators.infrastructure)}
-          tooltip="How often install fails due to infrastructure failures."
-        />
-      </Grid>
+      {props.indicators.infrastructure && (
+        <Grid item md={2} sm={4}>
+          <SummaryCard
+            key="infrastructure-summary"
+            threshold={INFRASTRUCTURE_THRESHOLDS}
+            name="Infrastructure"
+            link={pathForTestByVariant(
+              props.release,
+              'install should succeed: infrastructure'
+            )}
+            success={props.indicators.infrastructure.current_pass_percentage}
+            flakes={props.indicators.infrastructure.current_flake_percentage}
+            fail={props.indicators.infrastructure.current_failure_percentage}
+            caption={indicatorCaption(props.indicators.infrastructure)}
+            tooltip="How often install fails due to infrastructure failures."
+          />
+        </Grid>
+      )}
 
-      <Grid item md={2} sm={4}>
-        <SummaryCard
-          key="install-config-summary"
-          threshold={INSTALL_CONFIG_THRESHOLDS}
-          name="Install-Config"
-          link={pathForTestByVariant(
-            props.release,
-            'install should succeed: configuration'
-          )}
-          success={props.indicators.installConfig.current_pass_percentage}
-          flakes={props.indicators.installConfig.current_flake_percentage}
-          fail={props.indicators.installConfig.current_failure_percentage}
-          caption={indicatorCaption(props.indicators.installConfig)}
-          tooltip="How often the install configuration check completes successfully."
-        />
-      </Grid>
+      {props.indicators.installConfig && (
+        <Grid item md={2} sm={4}>
+          <SummaryCard
+            key="install-config-summary"
+            threshold={INSTALL_CONFIG_THRESHOLDS}
+            name="Install-Config"
+            link={pathForTestByVariant(
+              props.release,
+              'install should succeed: configuration'
+            )}
+            success={props.indicators.installConfig.current_pass_percentage}
+            flakes={props.indicators.installConfig.current_flake_percentage}
+            fail={props.indicators.installConfig.current_failure_percentage}
+            caption={indicatorCaption(props.indicators.installConfig)}
+            tooltip="How often the install configuration check completes successfully."
+          />
+        </Grid>
+      )}
 
-      <Grid item md={2} sm={4}>
-        <SummaryCard
-          key="bootstrap-summary"
-          threshold={BOOTSTRAP_THRESHOLDS}
-          name="Bootstrap"
-          link={pathForTestByVariant(
-            props.release,
-            'install should succeed: cluster bootstrap'
-          )}
-          success={props.indicators.bootstrap.current_pass_percentage}
-          flakes={props.indicators.bootstrap.current_flake_percentage}
-          fail={props.indicators.bootstrap.current_failure_percentage}
-          caption={indicatorCaption(props.indicators.bootstrap)}
-          tooltip="How often bootstrap completes successfully."
-        />
-      </Grid>
+      {props.indicators.bootstrap && (
+        <Grid item md={2} sm={4}>
+          <SummaryCard
+            key="bootstrap-summary"
+            threshold={BOOTSTRAP_THRESHOLDS}
+            name="Bootstrap"
+            link={pathForTestByVariant(
+              props.release,
+              'install should succeed: cluster bootstrap'
+            )}
+            success={props.indicators.bootstrap.current_pass_percentage}
+            flakes={props.indicators.bootstrap.current_flake_percentage}
+            fail={props.indicators.bootstrap.current_failure_percentage}
+            caption={indicatorCaption(props.indicators.bootstrap)}
+            tooltip="How often bootstrap completes successfully."
+          />
+        </Grid>
+      )}
 
-      <Grid item md={2} sm={4}>
-        <SummaryCard
-          key="install-other"
-          threshold={INSTALL_OTHER_THRESHOLDS}
-          name="Install Other"
-          link={pathForTestByVariant(
-            props.release,
-            'install should succeed: other'
-          )}
-          success={props.indicators.installOther.current_pass_percentage}
-          flakes={props.indicators.installOther.current_flake_percentage}
-          fail={props.indicators.installOther.current_failure_percentage}
-          caption={indicatorCaption(props.indicators.installOther)}
-          tooltip="How often install fails because other reasons."
-        />
-      </Grid>
+      {props.indicators.installOther && (
+        <Grid item md={2} sm={4}>
+          <SummaryCard
+            key="install-other"
+            threshold={INSTALL_OTHER_THRESHOLDS}
+            name="Install Other"
+            link={pathForTestByVariant(
+              props.release,
+              'install should succeed: other'
+            )}
+            success={props.indicators.installOther.current_pass_percentage}
+            flakes={props.indicators.installOther.current_flake_percentage}
+            fail={props.indicators.installOther.current_failure_percentage}
+            caption={indicatorCaption(props.indicators.installOther)}
+            tooltip="How often install fails because other reasons."
+          />
+        </Grid>
+      )}
 
-      <Grid item md={2} sm={4}>
-        <SummaryCard
-          key="install-summary"
-          threshold={INSTALL_THRESHOLDS}
-          name="Install"
-          link={'/install/' + props.release}
-          success={props.indicators.install.current_pass_percentage}
-          flakes={props.indicators.install.current_flake_percentage}
-          fail={props.indicators.install.current_failure_percentage}
-          caption={indicatorCaption(props.indicators.install)}
-          tooltip="How often the install completes successfully."
-        />
-      </Grid>
+      {props.indicators.install && (
+        <Grid item md={2} sm={4}>
+          <SummaryCard
+            key="install-summary"
+            threshold={INSTALL_THRESHOLDS}
+            name="Install"
+            link={'/install/' + props.release}
+            success={props.indicators.install.current_pass_percentage}
+            flakes={props.indicators.install.current_flake_percentage}
+            fail={props.indicators.install.current_failure_percentage}
+            caption={indicatorCaption(props.indicators.install)}
+            tooltip="How often the install completes successfully."
+          />
+        </Grid>
+      )}
     </Fragment>
   )
 }

--- a/sippy-ng/src/releases/TopLevelIndicators.js
+++ b/sippy-ng/src/releases/TopLevelIndicators.js
@@ -33,10 +33,8 @@ export default function TopLevelIndicators(props) {
   // Hide this if there's no data
   let noData = true
   ;['infrastructure', 'install', 'tests', 'upgrade'].forEach((indicator) => {
-    if (
-      props.indicators[indicator].current_runs !== 0 ||
-      props.indicators[indicator].previous_runs !== 0
-    ) {
+    let ind = props.indicators[indicator]
+    if (ind && (ind.current_runs !== 0 || ind.previous_runs !== 0)) {
       noData = false
     }
   })
@@ -56,7 +54,7 @@ export default function TopLevelIndicators(props) {
         </Typography>
       </Grid>
 
-      {newInstall ? (
+      {props.indicators.infrastructure && (
         <Grid item md={3} sm={6}>
           <SummaryCard
             key="infrastructure-summary"
@@ -64,82 +62,77 @@ export default function TopLevelIndicators(props) {
             name="Infrastructure"
             link={pathForTestByVariant(
               props.release,
-              'install should succeed: infrastructure'
+              newInstall
+                ? 'install should succeed: infrastructure'
+                : '[sig-sippy] infrastructure should work'
             )}
             success={props.indicators.infrastructure.current_pass_percentage}
             flakes={props.indicators.infrastructure.current_flake_percentage}
             fail={props.indicators.infrastructure.current_failure_percentage}
             caption={indicatorCaption(props.indicators.infrastructure)}
-            tooltip="How often install fails due to infrastructure failures."
-          />
-        </Grid>
-      ) : (
-        <Grid item md={3} sm={6}>
-          <SummaryCard
-            key="infrastructure-summary"
-            threshold={INFRASTRUCTURE_THRESHOLDS}
-            name="Infrastructure"
-            link={pathForTestByVariant(
-              props.release,
-              '[sig-sippy] infrastructure should work'
-            )}
-            success={props.indicators.infrastructure.current_pass_percentage}
-            flakes={props.indicators.infrastructure.current_flake_percentage}
-            fail={props.indicators.infrastructure.current_failure_percentage}
-            caption={indicatorCaption(props.indicators.infrastructure)}
-            tooltip="How often we get to the point of running the installer. This is judged by whether a kube-apiserver is available, it's not perfect, but it's very close."
+            tooltip={
+              newInstall
+                ? 'How often install fails due to infrastructure failures.'
+                : "How often we get to the point of running the installer. This is judged by whether a kube-apiserver is available, it's not perfect, but it's very close."
+            }
           />
         </Grid>
       )}
 
-      <Grid item md={3} sm={6}>
-        <SummaryCard
-          key="install-summary"
-          threshold={INSTALL_THRESHOLDS}
-          name="Install"
-          link={'/install/' + props.release}
-          success={props.indicators.install.current_pass_percentage}
-          flakes={props.indicators.install.current_flake_percentage}
-          fail={props.indicators.install.current_failure_percentage}
-          caption={indicatorCaption(props.indicators.install)}
-          tooltip="How often the install completes successfully."
-        />
-      </Grid>
+      {props.indicators.install && (
+        <Grid item md={3} sm={6}>
+          <SummaryCard
+            key="install-summary"
+            threshold={INSTALL_THRESHOLDS}
+            name="Install"
+            link={'/install/' + props.release}
+            success={props.indicators.install.current_pass_percentage}
+            flakes={props.indicators.install.current_flake_percentage}
+            fail={props.indicators.install.current_failure_percentage}
+            caption={indicatorCaption(props.indicators.install)}
+            tooltip="How often the install completes successfully."
+          />
+        </Grid>
+      )}
 
-      <Grid item md={3} sm={6}>
-        <SummaryCard
-          key="upgrade-summary"
-          threshold={UPGRADE_THRESHOLDS}
-          name="Upgrade"
-          link={'/upgrade/' + props.release}
-          success={props.indicators.upgrade.current_pass_percentage}
-          flakes={props.indicators.upgrade.current_flake_percentage}
-          fail={props.indicators.upgrade.current_failure_percentage}
-          caption={indicatorCaption(props.indicators.upgrade)}
-          tooltip="How often an upgrade that is started completes successfully."
-        />
-      </Grid>
+      {props.indicators.upgrade && (
+        <Grid item md={3} sm={6}>
+          <SummaryCard
+            key="upgrade-summary"
+            threshold={UPGRADE_THRESHOLDS}
+            name="Upgrade"
+            link={'/upgrade/' + props.release}
+            success={props.indicators.upgrade.current_pass_percentage}
+            flakes={props.indicators.upgrade.current_flake_percentage}
+            fail={props.indicators.upgrade.current_failure_percentage}
+            caption={indicatorCaption(props.indicators.upgrade)}
+            tooltip="How often an upgrade that is started completes successfully."
+          />
+        </Grid>
+      )}
 
-      <Grid item md={3} sm={6}>
-        <SummaryCard
-          key="test-summary"
-          threshold={TEST_THRESHOLDS}
-          link={pathForTestByVariant(
-            props.release,
-            '[sig-sippy] openshift-tests should work'
-          )}
-          name="Tests"
-          success={props.indicators.tests.current_pass_percentage}
-          flakes={props.indicators.tests.current_flake_percentage}
-          fail={props.indicators.tests.current_failure_percentage}
-          caption={indicatorCaption(props.indicators.tests)}
-          tooltip={
-            'How often e2e tests complete successfully. Sippy tries to figure out which runs ran an e2e test ' +
-            'suite, and then determine which failed. A low pass rate could be due to any number of temporary ' +
-            'problems, most of the utility from this noisy metric is monitoring changes over time.'
-          }
-        />
-      </Grid>
+      {props.indicators.tests && (
+        <Grid item md={3} sm={6}>
+          <SummaryCard
+            key="test-summary"
+            threshold={TEST_THRESHOLDS}
+            link={pathForTestByVariant(
+              props.release,
+              '[sig-sippy] openshift-tests should work'
+            )}
+            name="Tests"
+            success={props.indicators.tests.current_pass_percentage}
+            flakes={props.indicators.tests.current_flake_percentage}
+            fail={props.indicators.tests.current_failure_percentage}
+            caption={indicatorCaption(props.indicators.tests)}
+            tooltip={
+              'How often e2e tests complete successfully. Sippy tries to figure out which runs ran an e2e test ' +
+              'suite, and then determine which failed. A low pass rate could be due to any number of temporary ' +
+              'problems, most of the utility from this noisy metric is monitoring changes over time.'
+            }
+          />
+        </Grid>
+      )}
     </Fragment>
   )
 }


### PR DESCRIPTION
Enable arbitrary releases that don't look like "x.y". Define capabilities in the BQ Releases table, and stop treating Presubmits as special (mostly). This enables adding releases like aro-integration with a subset of capabilities.

/hold
This requires updating the Release table schema and contents and updating BackendDisruptionPercentilesDeltaCurrentVsPrevGAV2, then clearing old cache content and re-priming.