### PR TITLE
add new aro integration e2e to aro-integration version

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -22,4 +22,8 @@ releases:
       jobs:
         periodic-ci-Azure-ARO-HCP-main-periodic-create-aro-hcp-in-integration: true
         periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel: true
+  aro-stage:
+      jobs:
+        periodic-ci-Azure-ARO-HCP-main-periodic-create-aro-hcp-in-stage: true
+        periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel: true
 

--- a/config/openshift.yaml
+++ b/config/openshift.yaml
@@ -13152,4 +13152,8 @@ releases:
         jobs:
             periodic-ci-Azure-ARO-HCP-main-periodic-create-aro-hcp-in-integration: true
             periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel: true
+    aro-stage:
+        jobs:
+            periodic-ci-Azure-ARO-HCP-main-periodic-create-aro-hcp-in-stage: true
+            periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel: true
 


### PR DESCRIPTION
Trying to add job to https://sippy.dptools.openshift.org/sippy-ng/jobs/aro-integration?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22current_runs%22%2C%22operatorValue%22%3A%22%3E%3D%22%2C%22value%22%3A%227%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%2C%22not%22%3Atrue%7D%5D%7D&sortField=net_improvement&sort=asc