### PR TITLE
TRT-2198: followup to releases change

### DIFF
--- a/cmd/sippy/load.go
+++ b/cmd/sippy/load.go
@@ -169,7 +169,7 @@ func NewLoadCommand() *cobra.Command {
 					if len(views.ComponentReadiness) == 0 {
 						return fmt.Errorf("no component readiness views provided")
 					}
-					loaders = append(loaders, crcacheloader.New(dbc, cacheClient, bqc, config, views,
+					loaders = append(loaders, crcacheloader.New(dbc, cacheClient, bqc, config, views, releaseConfigs,
 						f.ComponentReadinessFlags.CRTimeRoundingFactor))
 
 				}

--- a/cmd/sippy/load.go
+++ b/cmd/sippy/load.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/sippy/pkg/api"
 	"github.com/openshift/sippy/pkg/api/componentreadiness"
 	"github.com/openshift/sippy/pkg/apis/cache"
+	sippyv1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 	"github.com/openshift/sippy/pkg/dataloader/crcacheloader"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -121,6 +122,7 @@ func NewLoadCommand() *cobra.Command {
 			}
 
 			cacheClient, cacheErr := f.CacheFlags.GetCacheClient()
+			releaseConfigs := []sippyv1.Release{}
 
 			// initializing a different bigquery client to the normal one
 			bqc, bigqueryErr := bqcachedclient.New(ctx,
@@ -130,6 +132,10 @@ func NewLoadCommand() *cobra.Command {
 			if bigqueryErr == nil {
 				if f.CacheFlags.EnablePersistentCaching {
 					bqc = f.CacheFlags.DecorateBiqQueryClientWithPersistentCache(bqc)
+				}
+				releaseConfigs, err = api.GetReleasesFromBigQuery(context.Background(), bqc)
+				if err != nil {
+					return errors.Wrapf(err, "error querying releases from bq")
 				}
 			}
 
@@ -172,7 +178,7 @@ func NewLoadCommand() *cobra.Command {
 					if dbErr != nil {
 						return dbErr
 					}
-					loaders = append(loaders, releaseloader.New(dbc, f.Releases, f.Architectures))
+					loaders = append(loaders, releaseloader.New(dbc, f.Releases, f.Architectures, releaseConfigs))
 				}
 
 				// Prow Loader
@@ -181,7 +187,7 @@ func NewLoadCommand() *cobra.Command {
 					if dbErr != nil {
 						return dbErr
 					}
-					prowLoader, err := f.prowLoader(ctx, dbc, config)
+					prowLoader, err := f.prowLoader(ctx, dbc, config, releaseConfigs)
 					if err != nil {
 						return err
 					}
@@ -251,7 +257,7 @@ func NewLoadCommand() *cobra.Command {
 				// Feature gates
 				if l == "feature-gates" {
 					refreshMatviews = true
-					fgLoader := featuregateloader.New(dbc, bqc)
+					fgLoader := featuregateloader.New(dbc, releaseConfigs)
 					loaders = append(loaders, fgLoader)
 				}
 
@@ -354,7 +360,7 @@ func (f *LoadFlags) jobVariantsLoader(ctx context.Context) (dataloader.DataLoade
 
 }
 
-func (f *LoadFlags) prowLoader(ctx context.Context, dbc *db.DB, sippyConfig *v1.SippyConfig) (dataloader.DataLoader, error) {
+func (f *LoadFlags) prowLoader(ctx context.Context, dbc *db.DB, sippyConfig *v1.SippyConfig, releaseConfigs []sippyv1.Release) (dataloader.DataLoader, error) {
 	gcsClient, err := gcs.NewGCSClient(ctx,
 		f.GoogleCloudFlags.ServiceAccountCredentialFile,
 		f.GoogleCloudFlags.OAuthClientCredentialFile,
@@ -384,6 +390,13 @@ func (f *LoadFlags) prowLoader(ctx context.Context, dbc *db.DB, sippyConfig *v1.
 		return nil, err
 	}
 
+	releases := f.Releases
+	if len(releases) == 0 { // if not specified, use those defined in the Releases table
+		for _, config := range releaseConfigs {
+			releases = append(releases, config.Release) // could filter by capability if needed
+		}
+	}
+
 	return prowloader.New(
 		ctx,
 		dbc,
@@ -392,7 +405,7 @@ func (f *LoadFlags) prowLoader(ctx context.Context, dbc *db.DB, sippyConfig *v1.
 		githubClient,
 		f.ModeFlags.GetVariantManager(ctx, bigQueryClient),
 		f.ModeFlags.GetSyntheticTestManager(),
-		f.Releases,
+		releases,
 		sippyConfig,
 		ghCommenter), nil
 }

--- a/pkg/api/componentreadiness/component_report_test.go
+++ b/pkg/api/componentreadiness/component_report_test.go
@@ -1656,16 +1656,14 @@ func Test_componentReportGenerator_normalizeProwJobName(t *testing.T) {
 		want          string
 	}{
 		{
-			name:        "base release is removed",
-			baseRelease: "4.16",
-			jobName:     "periodic-ci-openshift-release-master-ci-4.16-e2e-azure-ovn-upgrade",
-			want:        "periodic-ci-openshift-release-master-ci-X.X-e2e-azure-ovn-upgrade",
+			name:    "release is removed",
+			jobName: "periodic-ci-openshift-release-master-ci-4.16-e2e-azure-ovn-upgrade",
+			want:    "periodic-ci-openshift-release-master-ci-X.X-e2e-azure-ovn-upgrade",
 		},
 		{
-			name:          "sample release is removed",
-			sampleRelease: "4.16",
-			jobName:       "periodic-ci-openshift-release-master-ci-4.16-e2e-azure-ovn-upgrade",
-			want:          "periodic-ci-openshift-release-master-ci-X.X-e2e-azure-ovn-upgrade",
+			name:    "not-quite-release is NOT removed",
+			jobName: "periodic-ci-openshift-release-master-ci-4.20-with-openssl3.2",
+			want:    "periodic-ci-openshift-release-master-ci-X.X-with-openssl3.2",
 		},
 		{
 			name:    "frequency is removed",
@@ -1675,15 +1673,7 @@ func Test_componentReportGenerator_normalizeProwJobName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &ComponentReportGenerator{}
-			if tt.baseRelease != "" {
-				c.ReqOptions.BaseRelease = reqopts.Release{Name: tt.baseRelease}
-			}
-			if tt.sampleRelease != "" {
-				c.ReqOptions.SampleRelease = reqopts.Release{Name: tt.sampleRelease}
-			}
-
-			assert.Equalf(t, tt.want, utils.NormalizeProwJobName(tt.jobName, c.ReqOptions), "normalizeProwJobName(%v)", tt.jobName)
+			assert.Equalf(t, tt.want, utils.NormalizeProwJobName(tt.jobName), "normalizeProwJobName(%v)", tt.jobName)
 		})
 	}
 }

--- a/pkg/api/componentreadiness/middleware/regressionallowances/regressionallowances_test.go
+++ b/pkg/api/componentreadiness/middleware/regressionallowances/regressionallowances_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crtest"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/testdetails"
+	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 	"github.com/openshift/sippy/pkg/regressionallowances"
 	"github.com/stretchr/testify/assert"
 )
@@ -82,6 +83,12 @@ func Test_PreAnalysis(t *testing.T) {
 		},
 	}
 
+	releaseConfigs := []v1.Release{
+		{Release: "4.19", PreviousRelease: "4.18"},
+		{Release: "4.18", PreviousRelease: "4.17"},
+		{Release: "4.17", PreviousRelease: "4.16"},
+	}
+
 	tests := []struct {
 		name             string
 		testKey          crtest.Identification
@@ -142,7 +149,7 @@ func Test_PreAnalysis(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			rfb := NewRegressionAllowancesMiddleware(test.reqOpts)
+			rfb := NewRegressionAllowancesMiddleware(test.reqOpts, releaseConfigs)
 			rfb.regressionGetterFunc = test.regressionGetter
 			err := rfb.PreAnalysis(test.testKey, test.testStatus)
 			assert.NoError(t, err)

--- a/pkg/api/componentreadiness/middleware/releasefallback/releasefallback_test.go
+++ b/pkg/api/componentreadiness/middleware/releasefallback/releasefallback_test.go
@@ -49,7 +49,7 @@ func Test_PreAnalysis(t *testing.T) {
 	// 4.19 will be our assumed requested base release, which may trigger fallback to 4.18 or 4.17 in these tests
 	start419 := time.Date(2025, 3, 2, 0, 0, 0, 0, time.UTC)
 	end419 := time.Date(2025, 4, 30, 0, 0, 0, 0, time.UTC)
-	release419 := crtest.Release{
+	release419 := crtest.ReleaseTimeRange{
 		Release: "4.19",
 		Start:   &start419,
 		End:     &end419,
@@ -57,13 +57,13 @@ func Test_PreAnalysis(t *testing.T) {
 
 	start418 := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
 	end418 := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
-	release418 := crtest.Release{
+	release418 := crtest.ReleaseTimeRange{
 		Release: "4.18",
 		Start:   &start418,
 		End:     &end418,
 	}
 	fallbackMap418 := ReleaseTestMap{
-		Release: release418,
+		ReleaseTimeRange: release418,
 		Tests: map[string]bq.TestStatus{
 			test1KeyStr: buildTestStatus("test1", test1VariantsFlattened, 100, 95, 0),
 		},
@@ -71,13 +71,13 @@ func Test_PreAnalysis(t *testing.T) {
 
 	start417 := time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC)
 	end417 := time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC)
-	release417 := crtest.Release{
+	release417 := crtest.ReleaseTimeRange{
 		Release: "4.17",
 		Start:   &start417,
 		End:     &end417,
 	}
 	fallbackMap417 := ReleaseTestMap{
-		Release: release417,
+		ReleaseTimeRange: release417,
 		Tests: map[string]bq.TestStatus{
 			test1KeyStr: buildTestStatus("test1", test1VariantsFlattened, 100, 98, 0),
 		},
@@ -103,7 +103,7 @@ func Test_PreAnalysis(t *testing.T) {
 			testKey: test1RTI,
 			fallbackReleases: FallbackReleases{
 				Releases: map[string]ReleaseTestMap{
-					fallbackMap418.Release.Release: fallbackMap418,
+					fallbackMap418.Release: fallbackMap418,
 				},
 			},
 			testStats:      buildTestStats(100, 93, release419, nil),
@@ -115,8 +115,8 @@ func Test_PreAnalysis(t *testing.T) {
 			testKey: test1RTI,
 			fallbackReleases: FallbackReleases{
 				Releases: map[string]ReleaseTestMap{
-					fallbackMap418.Release.Release: fallbackMap418,
-					fallbackMap417.Release.Release: fallbackMap417, // 4.17 improves even further
+					fallbackMap418.Release: fallbackMap418,
+					fallbackMap417.Release: fallbackMap417, // 4.17 improves even further
 				},
 			},
 			testStats:      buildTestStats(100, 93, release419, nil),
@@ -128,8 +128,8 @@ func Test_PreAnalysis(t *testing.T) {
 			testKey: test1RTI,
 			fallbackReleases: FallbackReleases{
 				Releases: map[string]ReleaseTestMap{
-					fallbackMap418.Release.Release: fallbackMap418,
-					fallbackMap417.Release.Release: fallbackMap417, // 4.17 improves even further
+					fallbackMap418.Release: fallbackMap418,
+					fallbackMap417.Release: fallbackMap417, // 4.17 improves even further
 				},
 			},
 			testStats:      buildTestStats(100, 97, release419, nil),
@@ -141,7 +141,7 @@ func Test_PreAnalysis(t *testing.T) {
 			testKey: test1RTI,
 			fallbackReleases: FallbackReleases{
 				Releases: map[string]ReleaseTestMap{
-					fallbackMap418.Release.Release: fallbackMap418,
+					fallbackMap418.Release: fallbackMap418,
 				},
 			},
 			testStats:      buildTestStats(100, 100, release419, nil),
@@ -153,8 +153,8 @@ func Test_PreAnalysis(t *testing.T) {
 			testKey: test1RTI,
 			fallbackReleases: FallbackReleases{
 				Releases: map[string]ReleaseTestMap{
-					fallbackMap418.Release.Release: fallbackMap418,
-					fallbackMap417.Release.Release: fallbackMap417,
+					fallbackMap418.Release: fallbackMap418,
+					fallbackMap417.Release: fallbackMap417,
 				},
 			},
 			testStats: buildTestStats(10000, 9700, release419, nil),
@@ -175,7 +175,7 @@ func Test_PreAnalysis(t *testing.T) {
 func TestCalculateFallbackReleases(t *testing.T) {
 	start419 := time.Date(2025, 3, 2, 0, 0, 0, 0, time.UTC)
 	end419 := time.Date(2025, 4, 30, 0, 0, 0, 0, time.UTC)
-	release419 := crtest.Release{
+	release419 := crtest.ReleaseTimeRange{
 		Release: "4.19",
 		Start:   &start419,
 		End:     &end419,
@@ -183,7 +183,7 @@ func TestCalculateFallbackReleases(t *testing.T) {
 
 	start418 := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
 	end418 := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
-	release418 := crtest.Release{
+	release418 := crtest.ReleaseTimeRange{
 		Release: "4.18",
 		Start:   &start418,
 		End:     &end418,
@@ -191,7 +191,7 @@ func TestCalculateFallbackReleases(t *testing.T) {
 
 	start417 := time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC)
 	end417 := time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC)
-	release417 := crtest.Release{
+	release417 := crtest.ReleaseTimeRange{
 		Release: "4.17",
 		Start:   &start417,
 		End:     &end417,
@@ -199,14 +199,14 @@ func TestCalculateFallbackReleases(t *testing.T) {
 
 	start416 := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
 	end416 := time.Date(2024, 6, 30, 0, 0, 0, 0, time.UTC)
-	release416 := crtest.Release{
+	release416 := crtest.ReleaseTimeRange{
 		Release: "4.16",
 		Start:   &start416,
 		End:     &end416,
 	}
 
-	allReleases := []crtest.Release{release419, release418, release417, release416}
-	expectedReleases := []crtest.Release{release419, release418, release417}
+	allTimeRanges := []crtest.ReleaseTimeRange{release419, release418, release417, release416}
+	expectedTimeRanges := []crtest.ReleaseTimeRange{release419, release418, release417}
 	releaseConfigs := []v1.Release{
 		{Release: "4.20", PreviousRelease: "4.19"},
 		{Release: "4.19", PreviousRelease: "4.18"},
@@ -215,11 +215,11 @@ func TestCalculateFallbackReleases(t *testing.T) {
 		{Release: "4.16", PreviousRelease: ""},
 	}
 
-	fallbackReleases := calculateFallbackReleases("4.20", allReleases, releaseConfigs)
-	for i := range expectedReleases {
-		assert.Equal(t, expectedReleases[i].Release, fallbackReleases[i].Release)
-		assert.Equal(t, expectedReleases[i].Start, fallbackReleases[i].Start)
-		assert.Equal(t, expectedReleases[i].End, fallbackReleases[i].End)
+	fallbackReleases := calculateFallbackReleases("4.20", allTimeRanges, releaseConfigs)
+	for i := range expectedTimeRanges {
+		assert.Equal(t, expectedTimeRanges[i].Release, fallbackReleases[i].Release)
+		assert.Equal(t, expectedTimeRanges[i].Start, fallbackReleases[i].Start)
+		assert.Equal(t, expectedTimeRanges[i].End, fallbackReleases[i].End)
 	}
 }
 
@@ -239,7 +239,7 @@ func buildTestStatus(testName string, variants []string, total, success, flake i
 	}
 }
 
-func buildTestStats(total, success int, baseRelease crtest.Release, explanations []string) *testdetails.TestComparison {
+func buildTestStats(total, success int, baseRelease crtest.ReleaseTimeRange, explanations []string) *testdetails.TestComparison {
 	fails := total - success
 	ts := &testdetails.TestComparison{
 		BaseStats: &testdetails.ReleaseStats{

--- a/pkg/api/componentreadiness/query/querygenerators.go
+++ b/pkg/api/componentreadiness/query/querygenerators.go
@@ -761,7 +761,7 @@ func (b *baseTestDetailsQueryGenerator) QueryTestStatus(ctx context.Context) (bq
 		},
 	}...)
 
-	baseStatus, errs := fetchJobRunTestStatusResults(ctx, b.logger, baseQuery, b.ReqOptions)
+	baseStatus, errs := fetchJobRunTestStatusResults(ctx, b.logger, baseQuery)
 	return bq.TestJobRunStatuses{BaseStatus: baseStatus}, errs
 }
 
@@ -863,7 +863,7 @@ func (s *sampleTestDetailsQueryGenerator) QueryTestStatus(ctx context.Context) (
 		}...)
 	}
 
-	sampleStatus, errs := fetchJobRunTestStatusResults(ctx, log.WithField("generator", "SampleQuery"), sampleQuery, s.ReqOptions)
+	sampleStatus, errs := fetchJobRunTestStatusResults(ctx, log.WithField("generator", "SampleQuery"), sampleQuery)
 
 	return bq.TestJobRunStatuses{SampleStatus: sampleStatus}, errs
 }
@@ -910,7 +910,7 @@ func logQueryWithParamsReplaced(logger log.FieldLogger, query *bigquery.Query) {
 	}
 }
 
-func fetchJobRunTestStatusResults(ctx context.Context, logger log.FieldLogger, query *bigquery.Query, reqOptions reqopts.RequestOptions) (map[string][]bq.TestJobRunRows, []error) {
+func fetchJobRunTestStatusResults(ctx context.Context, logger log.FieldLogger, query *bigquery.Query) (map[string][]bq.TestJobRunRows, []error) {
 	errs := []error{}
 	status := map[string][]bq.TestJobRunRows{}
 
@@ -943,7 +943,7 @@ func fetchJobRunTestStatusResults(ctx context.Context, logger log.FieldLogger, q
 			errs = append(errs, err2)
 			continue
 		}
-		prowName := utils.NormalizeProwJobName(jobRunTestStatusRow.ProwJob, reqOptions)
+		prowName := utils.NormalizeProwJobName(jobRunTestStatusRow.ProwJob)
 		status[prowName] = append(status[prowName], jobRunTestStatusRow)
 	}
 	return status, errs

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -194,7 +194,7 @@ func (c *ComponentReportGenerator) GenerateDetailsReportForTest(ctx context.Cont
 		}
 	}
 
-	releases, errs := query.GetReleaseDatesFromBigQuery(ctx, c.client, c.ReqOptions)
+	timeRanges, errs := query.GetReleaseDatesFromBigQuery(ctx, c.client, c.ReqOptions)
 	if errs != nil {
 		return testdetails.Report{}, errs
 	}
@@ -229,7 +229,7 @@ func (c *ComponentReportGenerator) GenerateDetailsReportForTest(ctx context.Cont
 			return testdetails.Report{}, []error{err}
 		}
 
-		start, end, err := utils.FindStartEndTimesForRelease(releases, testIDOption.BaseOverrideRelease)
+		start, end, err := utils.FindStartEndTimesForRelease(timeRanges, testIDOption.BaseOverrideRelease)
 		if err != nil {
 			return testdetails.Report{}, []error{err}
 		}

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -28,9 +28,8 @@ import (
 	"github.com/openshift/sippy/pkg/util"
 )
 
-func GetTestDetails(ctx context.Context, client *bigquery.Client, dbc *db.DB, reqOptions reqopts.RequestOptions,
-) (testdetails.Report, []error) {
-	generator := NewComponentReportGenerator(client, reqOptions, dbc, nil)
+func GetTestDetails(ctx context.Context, client *bigquery.Client, dbc *db.DB, reqOptions reqopts.RequestOptions, releases []v1.Release) (testdetails.Report, []error) {
+	generator := NewComponentReportGenerator(client, reqOptions, dbc, nil, releases)
 	if os.Getenv("DEV_MODE") == "1" {
 		return generator.GenerateTestDetailsReport(ctx)
 	}

--- a/pkg/api/componentreadiness/utils/utils.go
+++ b/pkg/api/componentreadiness/utils/utils.go
@@ -24,8 +24,10 @@ func PreviousRelease(release string, releaseConfigs []sippyv1.Release) (string, 
 	return "", fmt.Errorf("release %s not found in release list", release)
 }
 
-func FindStartEndTimesForRelease(releases []crtest.Release, release string) (*time.Time, *time.Time, error) {
-	for _, r := range releases {
+// FindStartEndTimesForRelease finds the start and end times for a release from sippyv1.Release objects.
+// The start time is calculated as 30 days before the GA date, and the end time is the GA date.
+func FindStartEndTimesForRelease(timeRanges []crtest.ReleaseTimeRange, release string) (*time.Time, *time.Time, error) {
+	for _, r := range timeRanges {
 		if r.Release == release {
 			return r.Start, r.End, nil
 		}

--- a/pkg/apis/api/componentreport/crtest/types.go
+++ b/pkg/apis/api/componentreport/crtest/types.go
@@ -106,7 +106,7 @@ func (t KeyWithVariants) KeyOrDie() string {
 	return string(testIDBytes)
 }
 
-type Release struct {
+type ReleaseTimeRange struct {
 	Release string
 	End     *time.Time
 	Start   *time.Time

--- a/pkg/dataloader/releaseloader/releasesync.go
+++ b/pkg/dataloader/releaseloader/releasesync.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm/clause"
@@ -34,7 +35,14 @@ type ReleaseLoader struct {
 	errors        []error
 }
 
-func New(dbc *db.DB, releases, architectures []string) *ReleaseLoader {
+func New(dbc *db.DB, releases, architectures []string, releaseConfigs []v1.Release) *ReleaseLoader {
+	if len(releases) == 0 {
+		for _, config := range releaseConfigs {
+			if config.Capabilities[v1.PayloadTagsCap] {
+				releases = append(releases, config.Release)
+			}
+		}
+	}
 	releaseStreams := make([]string, 0)
 	for _, release := range releases {
 		for _, stream := range []string{"nightly", "ci"} {

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -761,7 +761,7 @@ func (s *Server) jsonComponentReportTestDetailsFromBigQuery(w http.ResponseWrite
 		failureResponse(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	outputs, errs := componentreadiness.GetTestDetails(req.Context(), s.bigQueryClient, s.db, reqOptions)
+	outputs, errs := componentreadiness.GetTestDetails(req.Context(), s.bigQueryClient, s.db, reqOptions, allReleases)
 	if len(errs) > 0 {
 		log.Warningf("%d errors were encountered while querying component test details from big query:", len(errs))
 		for _, err := range errs {

--- a/sippy-ng/src/component_readiness/ReleaseSelector.js
+++ b/sippy-ng/src/component_readiness/ReleaseSelector.js
@@ -97,7 +97,8 @@ function ReleaseSelector(props) {
     let tmpRelease = {}
     releases.releases
       .filter((aVersion) => {
-        return releases.release_attrs[aVersion].capabilities.componentReadiness
+        return releases?.release_attrs?.[aVersion]?.capabilities
+          ?.componentReadiness
       })
       .forEach((r) => {
         tmpRelease[r] = releases.ga_dates[r]

--- a/sippy-ng/src/components/Sidebar.js
+++ b/sippy-ng/src/components/Sidebar.js
@@ -241,8 +241,8 @@ export default function Sidebar(props) {
                               <ListItemText primary="Overview" />
                             </StyledListItemButton>
                           </ListItem>
-                          {props.releaseConfig.release_attrs[release]
-                            .capabilities.payloadTags && (
+                          {props.releaseConfig.release_attrs?.[release]
+                            ?.capabilities?.payloadTags && (
                             <CapabilitiesContext.Consumer>
                               {(value) => {
                                 if (value.includes('openshift_releases')) {
@@ -285,8 +285,8 @@ export default function Sidebar(props) {
                             </StyledListItemButton>
                           </ListItem>
 
-                          {props.releaseConfig.release_attrs[release]
-                            .capabilities.pullRequests && (
+                          {props.releaseConfig.release_attrs?.[release]
+                            ?.capabilities?.pullRequests && (
                             <Fragment>
                               <ListItem
                                 key={'release-pull-requests-' + index}
@@ -346,8 +346,8 @@ export default function Sidebar(props) {
                             </StyledListItemButton>
                           </ListItem>
 
-                          {props.releaseConfig.release_attrs[release]
-                            .capabilities.featureGates && (
+                          {props.releaseConfig.release_attrs?.[release]
+                            ?.capabilities?.featureGates && (
                             <CapabilitiesContext.Consumer>
                               {(value) => {
                                 if (value.includes('openshift_releases')) {


### PR DESCRIPTION
It's likely easiest to review a commit at a time.

first commit is in response to [this comment](https://github.com/openshift/sippy/pull/2857/files?diff=unified&w=1#r2263027287). (I chose against the [other nit](https://github.com/openshift/sippy/pull/2857/files?diff=unified&w=1#r2262985126).)

the second commit uses the Releases table by default for loaders that need releases specified. this way we can remove all the `fetchdata` release params (although if supplied they are used) and not need to update the cronjob every time we add a release.

following commits expand on that a little bit to make the Releases table authoritative everywhere in the backend.