### PR TITLE
Flag vsphere-insights-runtime jobs as hidden

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -666,6 +666,7 @@ func (v *OCPVariantLoader) setJobTier(_ logrus.FieldLogger, variants map[string]
 		{"-bgp-", "hidden"},
 		{"aggregated", "hidden"},
 		{"-cert-rotation-shutdown-", "hidden"}, // may want to go to rare at some point
+		{"-vsphere-insights-runtime-", "hidden"},
 
 		{"-4.19-e2e-metal-ipi-serial-ovn-ipv6-techpreview-", "candidate"},      // new jobs in https://github.com/openshift/release/pull/64143 have failures that need to be addressed, don't want to regress 4.19
 		{"-4.19-e2e-metal-ipi-serial-ovn-dualstack-techpreview-", "candidate"}, // new jobs in https://github.com/openshift/release/pull/64143 have failures that need to be addressed, don't want to regress 4.19


### PR DESCRIPTION
Per https://redhat-internal.slack.com/archives/C01CQA76KMX/p1755062667189139, `periodic-ci-openshift-insights-operator-release-4.20-periodics-vsphere-insights-runtime-extractor-tests` is causing the OLM component readiness regressed because of instability. 