### PR TITLE
Revert "TRT-2235: include LayeredProduct in DBGroupBy"

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -24,7 +24,6 @@ component_readiness:
         Suite: {}
         Topology: {}
         Upgrade: {}
-        LayeredProduct: {}
       include_variants:
         Architecture:
           - amd64
@@ -101,7 +100,6 @@ component_readiness:
         Suite: {}
         Topology: {}
         Upgrade: {}
-        LayeredProduct: {}
       include_variants:
         Architecture:
           - amd64
@@ -179,7 +177,6 @@ component_readiness:
         Platform: {}
         Suite: {}
         Upgrade: {}
-        LayeredProduct: {}
       include_variants:
         Architecture:
           - amd64
@@ -250,7 +247,6 @@ component_readiness:
         Suite: {}
         Topology: {}
         Upgrade: {}
-        LayeredProduct: {}
       include_variants:
         LayeredProduct:
           - none
@@ -302,7 +298,6 @@ component_readiness:
         Upgrade: {}
         Procedure: {}
         JobTier: {}
-        LayeredProduct: {}
       include_variants:
         Architecture:
           - amd64

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -54,7 +54,7 @@ var (
 	// TODO: centralize these configurations for consumption by both the front and backends
 
 	DefaultColumnGroupBy = "Platform,Architecture,Network"
-	DefaultDBGroupBy     = "Platform,Architecture,Network,Topology,FeatureSet,Upgrade,Suite,Installer,LayeredProduct"
+	DefaultDBGroupBy     = "Platform,Architecture,Network,Topology,FeatureSet,Upgrade,Suite,Installer"
 )
 
 func getSingleColumnResultToSlice(ctx context.Context, q *bigquery.Query) ([]string, error) {

--- a/pkg/api/componentreadiness/queryparamparser_test.go
+++ b/pkg/api/componentreadiness/queryparamparser_test.go
@@ -234,7 +234,7 @@ func TestParseComponentReportRequest(t *testing.T) {
 			},
 			variantOption: reqopts.Variants{
 				ColumnGroupBy: sets.NewString("Platform", "Architecture", "Network"),
-				DBGroupBy:     sets.NewString("Platform", "Architecture", "Network", "Topology", "Suite", "FeatureSet", "Upgrade", "Installer", "LayeredProduct"),
+				DBGroupBy:     sets.NewString("Platform", "Architecture", "Network", "Topology", "Suite", "FeatureSet", "Upgrade", "Installer"),
 				IncludeVariants: map[string][]string{
 					"Architecture": {"amd64"},
 					"FeatureSet":   {"default", "techpreview"},


### PR DESCRIPTION
Turns out we can't handle modified DBGroupBy yet.