### PR TITLE
NO-JIRA: use the gorilla matcher for autocomplete endpoint

### DIFF
--- a/pkg/api/autocomplete.go
+++ b/pkg/api/autocomplete.go
@@ -3,8 +3,8 @@ package api
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
+	"github.com/gorilla/mux"
 	"github.com/openshift/sippy/pkg/db"
 )
 
@@ -12,7 +12,8 @@ import (
 // such as test or job names. It optionally takes a release and search query filter.
 func PrintAutocompleteFromDB(w http.ResponseWriter, req *http.Request, dbc *db.DB) {
 	result := make([]string, 0)
-	field := strings.TrimPrefix(req.URL.Path, "/api/autocomplete/")
+	vars := mux.Vars(req)
+	field := vars["field"]
 	search := req.URL.Query().Get("search")
 	release := req.URL.Query().Get("release")
 

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1727,7 +1727,7 @@ func (s *Server) Serve() {
 			HandlerFunc:  s.jsonJobRunSummary,
 		},
 		{
-			EndpointPath: "/api/autocomplete/",
+			EndpointPath: "/api/autocomplete/{field}",
 			Description:  "Autocompletes queries from database",
 			Capabilities: []string{LocalDBCapability},
 			HandlerFunc:  s.jsonAutocompleteFromDB,


### PR DESCRIPTION
Broken with https://github.com/openshift/sippy/pull/2870

Cursor doesn't think anything else is broken:

> The server is properly using the Gorilla Mux router for path parameter extraction rather than manual path trimming. The only manual path trimming is for:
Frontend file serving - necessary for React router support
Static asset serving - handled by Go's standard library
All API endpoints that need path parameters (like the triage endpoints and autocomplete) are correctly using mux.Vars() to extract URL parameters, which is the proper approach with the Gorilla Mux router.
Conclusion: The sippy server endpoints are properly implemented and not using problematic manual path trimming for extracting API parameters. The existing path trimming is only used for legitimate file serving purposes.