### PR TITLE
TRT-2222: fix test_details report parameter updates

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyMainInputs.js
+++ b/sippy-ng/src/component_readiness/CompReadyMainInputs.js
@@ -1,10 +1,6 @@
 import './ComponentReadiness.css'
 import { CompReadyVarsContext } from './CompReadyVars'
-import {
-  dateFormat,
-  formatLongDate,
-  getUpdatedUrlParts,
-} from './CompReadyUtils'
+import { dateFormat, formatLongDate } from './CompReadyUtils'
 import { makeStyles, useTheme } from '@mui/styles'
 import { useNavigate } from 'react-router-dom'
 import AdvancedOptions from './AdvancedOptions'
@@ -150,11 +146,7 @@ export default function CompReadyMainInputs(props) {
           variant="contained"
           color="primary"
           onClick={(event) => {
-            varsContext.handleGenerateReport(event, () => {
-              navigate(
-                '/component_readiness/main' + getUpdatedUrlParts(varsContext)
-              )
-            })
+            varsContext.handleGenerateReport(event)
           }}
         >
           <Tooltip

--- a/sippy-ng/src/component_readiness/CompReadyProgress.js
+++ b/sippy-ng/src/component_readiness/CompReadyProgress.js
@@ -10,8 +10,6 @@ import React from 'react'
 export default function CompReadyProgress(props) {
   const { apiLink, cancelFunc } = props
 
-  document.title = 'Loading...'
-
   return (
     <Fragment>
       <p>

--- a/sippy-ng/src/component_readiness/CompReadyVars.js
+++ b/sippy-ng/src/component_readiness/CompReadyVars.js
@@ -382,6 +382,9 @@ export const CompReadyVarsProvider = ({ children }) => {
    * Generating the report parameters:
    ****************************************************************************** */
 
+  // use a simple counter to force re-rendering after pushing the "Generate Report" button
+  const [generatorButtonPushes, setGeneratorButtonPushes] = React.useState(0)
+
   // dbGroupByVariants defines what variants are used for GroupBy in DB query
   const dbGroupByVariants = [
     'Platform',
@@ -396,7 +399,7 @@ export const CompReadyVarsProvider = ({ children }) => {
 
   // This runs when someone pushes the "Generate Report" button.
   // It sets all parameters based on current state; this causes the URL to be updated and page to load with new params.
-  const handleGenerateReport = (event, callback) => {
+  const handleGenerateReport = (event) => {
     if (event && event.preventDefault) {
       event.preventDefault()
     }
@@ -440,10 +443,7 @@ export const CompReadyVarsProvider = ({ children }) => {
     setTestNameParam(testName)
     setTestBasisReleaseParam(testBasisRelease)
 
-    // Execute callback after a short delay to allow URL params to update
-    if (callback) {
-      setTimeout(callback, 100)
-    }
+    setGeneratorButtonPushes(generatorButtonPushes + 1)
   }
 
   const clearAllQueryParams = () => {
@@ -738,6 +738,7 @@ export const CompReadyVarsProvider = ({ children }) => {
         handleGenerateReport,
         syncView,
         isLoaded,
+        generatorButtonPushes,
       }}
     >
       {children}

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -442,7 +442,7 @@ export default function ComponentReadiness(props) {
           className="cr-view"
         ></Grid>
         {/* eslint-disable react/prop-types */}
-        <Routes>
+        <Routes key={'routes-' + varsContext.generatorButtonPushes}>
           <Route index element={<Navigate to="main" replace />} />
           <Route
             path="help"


### PR DESCRIPTION
Fix the inability to change dates on a test_details page and have that actually do anything; broke with the update to react router 6.

This works reasonably well as long as you don't need the browser back button :( or the "Loading..." page title. The browser url and history do get updated when you push the button, but going backwards doesn't seem to re-render.