### PR TITLE
TRT-2233: Add the ability to list potential matching regressions for a triage

### DIFF
--- a/config/e2e-openshift.yaml
+++ b/config/e2e-openshift.yaml
@@ -1,8 +1,8 @@
 prow:
   url: https://prow.ci.openshift.org/prowjobs.js
 releases:
-  "4.14":
+  "4.20":
     jobs:
-      periodic-ci-openshift-release-master-nightly-4.14-e2e-aws-sdn-serial: true
-      periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade: true
-      periodic-ci-openshift-release-master-nightly-4.14-e2e-gcp-sdn: true
+      periodic-ci-openshift-release-master-nightly-4.20-e2e-aws-sdn-serial: true
+      periodic-ci-openshift-release-master-ci-4.20-e2e-azure-ovn-upgrade: true
+      periodic-ci-openshift-release-master-nightly-4.20-e2e-gcp-sdn: true

--- a/pkg/api/componentreadiness/triage.go
+++ b/pkg/api/componentreadiness/triage.go
@@ -2,10 +2,12 @@ package componentreadiness
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"time"
 
+	"github.com/openshift/sippy/pkg/apis/api/componentreport"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/query"
@@ -201,6 +203,177 @@ func DeleteTriage(dbc *gorm.DB, id int) error {
 		return fmt.Errorf("error deleting triage record: %v", res.Error)
 	}
 	return nil
+}
+
+// GetRegressions returns all regressions for the provided view
+func GetRegressions(dbc *gorm.DB, view string) ([]models.TestRegression, error) {
+	var regressions []models.TestRegression
+	res := dbc.Preload("Triages").Where("view = ?", view).Find(&regressions)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return regressions, nil
+}
+
+// GetTriagePotentialMatches returns a list of PotentialMatch including all possible matching regressions for a given
+// triage, and componentReport. It calculates this based on similarly named tests being regressed, and regressions that
+// have the same last failure time. It includes a confidence level for each match that states how likely the match is to be relevant.
+func GetTriagePotentialMatches(triage *models.Triage, allRegressions []models.TestRegression, componentReport componentreport.ComponentReport) ([]PotentialMatch, error) {
+	var potentialMatches []PotentialMatch
+	for _, reg := range allRegressions {
+		if reg.Closed.Valid {
+			// Don't bother listing closed regressions as potential matches
+			continue
+		}
+		match := PotentialMatch{}
+		for _, tr := range triage.Regressions {
+			if tr.ID == reg.ID {
+				// if this regression is already associated with the triage, never list it as a potential match
+				match = PotentialMatch{}
+				break
+			}
+			similarTestName, editDistance := isSimilarTestName(reg.TestName, tr.TestName)
+			if similarTestName {
+				match.SimilarlyNamedTests = append(match.SimilarlyNamedTests, SimilarlyNamedTest{
+					Regression:   tr,
+					EditDistance: editDistance,
+				})
+			}
+			if isSameLastFailure(reg.LastFailure, tr.LastFailure) {
+				match.SameLastFailures = append(match.SameLastFailures, tr)
+			}
+		}
+		// Only add the potential match if it is valid
+		if len(match.SimilarlyNamedTests) > 0 || len(match.SameLastFailures) > 0 {
+			match.ConfidenceLevel = calculateConfidenceLevel(match)
+			regressedTest := GetMatchingRegressedTestForRegression(reg, componentReport)
+			if regressedTest == nil {
+				return nil, fmt.Errorf("no regression found for test %s", reg.TestID)
+			}
+			match.RegressedTest = *regressedTest
+			potentialMatches = append(potentialMatches, match)
+		}
+	}
+
+	return potentialMatches, nil
+}
+
+type PotentialMatch struct {
+	// SimilarlyNamedTests contains each of the already associated regressions that have a similar name, and their editDistance difference
+	SimilarlyNamedTests []SimilarlyNamedTest `json:"similarly_named_tests"`
+	// SameLastFailures contains each of the already associated regressions that have the same last failure time
+	SameLastFailures []models.TestRegression `json:"same_last_failures"`
+	// RegressedTest contains all the info about the potentially matching regression
+	RegressedTest componentreport.ReportTestSummary `json:"regressed_test"`
+	// ConfidenceLevel is a number between 0-10 with a higher number being more likely to be a proper match
+	ConfidenceLevel int `json:"confidence_level"`
+}
+
+type SimilarlyNamedTest struct {
+	Regression   models.TestRegression `json:"regression"`
+	EditDistance int                   `json:"edit_distance"`
+}
+
+func GetMatchingRegressedTestForRegression(regression models.TestRegression, report componentreport.ComponentReport) *componentreport.ReportTestSummary {
+	for _, row := range report.Rows {
+		for _, column := range row.Columns {
+			for _, regressedTest := range column.RegressedTests {
+				if regressedTest.Regression != nil && regressedTest.Regression.ID == regression.ID {
+					return &regressedTest
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// calculateEditDistance calculates the Levenshtein distance between two strings
+func calculateEditDistance(s1, s2 string) int {
+	if s1 == s2 {
+		return 0
+	}
+
+	len1, len2 := len(s1), len(s2)
+	if len1 == 0 {
+		return len2
+	}
+	if len2 == 0 {
+		return len1
+	}
+
+	// Create a matrix to store distances
+	matrix := make([][]int, len1+1)
+	for i := range matrix {
+		matrix[i] = make([]int, len2+1)
+	}
+
+	// Initialize first row and column
+	for i := 0; i <= len1; i++ {
+		matrix[i][0] = i
+	}
+	for j := 0; j <= len2; j++ {
+		matrix[0][j] = j
+	}
+
+	// Fill the matrix
+	for i := 1; i <= len1; i++ {
+		for j := 1; j <= len2; j++ {
+			cost := 0
+			if s1[i-1] != s2[j-1] {
+				cost = 1
+			}
+
+			matrix[i][j] = min(
+				matrix[i-1][j]+1,      // deletion
+				matrix[i][j-1]+1,      // insertion
+				matrix[i-1][j-1]+cost, // substitution
+			)
+		}
+	}
+
+	return matrix[len1][len2]
+}
+
+// isSimilarTestName checks if two test names are similar based on edit distance
+// Returns true if the edit distance is 5 or less, false otherwise.
+// It also returns the edit distance
+func isSimilarTestName(testName1, testName2 string) (bool, int) {
+	editDistance := calculateEditDistance(testName1, testName2)
+	return editDistance <= 5, editDistance
+}
+
+// isSameLastFailure simply returns if the times are the same, including that they both have the same validity
+func isSameLastFailure(time1, time2 sql.NullTime) bool {
+	if !time1.Valid && !time2.Valid {
+		return true
+	}
+	if time1.Valid != time2.Valid {
+		return false
+	}
+
+	return time1.Time.Equal(time2.Time)
+}
+
+// calculateConfidenceLevel calculates confidence level (1-10) for a potential match
+// based on the number and type of matches, with edit distance affecting name match scores
+func calculateConfidenceLevel(match PotentialMatch) int {
+	score := 0
+
+	// Calculate score for similarly named tests based on edit distance
+	for _, similarTest := range match.SimilarlyNamedTests {
+		editDistanceScore := 5 - similarTest.EditDistance // 0->5, 1->4, 2->3, 3->2, 4->1, 5->0
+		score += editDistanceScore
+	}
+
+	// Add 1 point for each same last failure match
+	score += len(match.SameLastFailures)
+
+	if score > 10 {
+		score = 10
+	}
+
+	return score
 }
 
 // injectHATEOASLinks adds restful links clients can follow for this triage record.

--- a/pkg/api/componentreadiness/triage_test.go
+++ b/pkg/api/componentreadiness/triage_test.go
@@ -1,0 +1,242 @@
+package componentreadiness
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalculateEditDistance(t *testing.T) {
+	tests := []struct {
+		name     string
+		s1       string
+		s2       string
+		expected int
+	}{
+		{
+			name:     "identical strings",
+			s1:       "test",
+			s2:       "test",
+			expected: 0,
+		},
+		{
+			name:     "completely different strings",
+			s1:       "abc",
+			s2:       "xyz",
+			expected: 3,
+		},
+		{
+			name:     "single character difference",
+			s1:       "test",
+			s2:       "best",
+			expected: 1,
+		},
+		{
+			name:     "empty strings",
+			s1:       "",
+			s2:       "",
+			expected: 0,
+		},
+		{
+			name:     "one empty string",
+			s1:       "test",
+			s2:       "",
+			expected: 4,
+		},
+		{
+			name:     "typical test name similarity",
+			s1:       "[sig-storage] PersistentVolumes-test-name",
+			s2:       "[sig-storage] PersistentVolume-test-name",
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calculateEditDistance(tt.s1, tt.s2)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsSimilarTestName(t *testing.T) {
+	tests := []struct {
+		name           string
+		testName1      string
+		testName2      string
+		expectSimilar  bool
+		expectDistance int
+	}{
+		{
+			name:           "identical names",
+			testName1:      "test-name",
+			testName2:      "test-name",
+			expectSimilar:  true,
+			expectDistance: 0,
+		},
+		{
+			name:           "similar names within threshold",
+			testName1:      "test-name-1",
+			testName2:      "test-name-2",
+			expectSimilar:  true,
+			expectDistance: 1,
+		},
+		{
+			name:           "similar names at threshold boundary",
+			testName1:      "abcde",
+			testName2:      "fghij",
+			expectSimilar:  true,
+			expectDistance: 5,
+		},
+		{
+			name:           "different names beyond threshold",
+			testName1:      "completely-different-test-name",
+			testName2:      "another-unrelated-test",
+			expectSimilar:  false,
+			expectDistance: 23,
+		},
+		{
+			name:           "empty names",
+			testName1:      "",
+			testName2:      "",
+			expectSimilar:  true,
+			expectDistance: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			similar, distance := isSimilarTestName(tt.testName1, tt.testName2)
+			assert.Equal(t, tt.expectSimilar, similar)
+			assert.Equal(t, tt.expectDistance, distance)
+		})
+	}
+}
+
+func TestIsSameLastFailure(t *testing.T) {
+	testTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	differentTime := time.Date(2024, 1, 2, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		time1    sql.NullTime
+		time2    sql.NullTime
+		expected bool
+	}{
+		{
+			name:     "both null times",
+			time1:    sql.NullTime{Valid: false},
+			time2:    sql.NullTime{Valid: false},
+			expected: true,
+		},
+		{
+			name:     "same valid times",
+			time1:    sql.NullTime{Time: testTime, Valid: true},
+			time2:    sql.NullTime{Time: testTime, Valid: true},
+			expected: true,
+		},
+		{
+			name:     "different valid times",
+			time1:    sql.NullTime{Time: testTime, Valid: true},
+			time2:    sql.NullTime{Time: differentTime, Valid: true},
+			expected: false,
+		},
+		{
+			name:     "one null one valid",
+			time1:    sql.NullTime{Valid: false},
+			time2:    sql.NullTime{Time: testTime, Valid: true},
+			expected: false,
+		},
+		{
+			name:     "one valid one null",
+			time1:    sql.NullTime{Time: testTime, Valid: true},
+			time2:    sql.NullTime{Valid: false},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isSameLastFailure(tt.time1, tt.time2)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCalculateConfidenceLevel(t *testing.T) {
+	tests := []struct {
+		name     string
+		match    PotentialMatch
+		expected int
+	}{
+		{
+			name: "no matches",
+			match: PotentialMatch{
+				SimilarlyNamedTests: []SimilarlyNamedTest{},
+				SameLastFailures:    []models.TestRegression{},
+			},
+			expected: 0,
+		},
+		{
+			name: "single similar name with low edit distance",
+			match: PotentialMatch{
+				SimilarlyNamedTests: []SimilarlyNamedTest{
+					{EditDistance: 1},
+				},
+				SameLastFailures: []models.TestRegression{},
+			},
+			expected: 4, // 5 - 1 = 4
+		},
+		{
+			name: "single similar name with high edit distance",
+			match: PotentialMatch{
+				SimilarlyNamedTests: []SimilarlyNamedTest{
+					{EditDistance: 5},
+				},
+				SameLastFailures: []models.TestRegression{},
+			},
+			expected: 0, // 5 - 5 = 0
+		},
+		{
+			name: "single same last failure",
+			match: PotentialMatch{
+				SimilarlyNamedTests: []SimilarlyNamedTest{},
+				SameLastFailures:    []models.TestRegression{{}},
+			},
+			expected: 1,
+		},
+		{
+			name: "multiple matches",
+			match: PotentialMatch{
+				SimilarlyNamedTests: []SimilarlyNamedTest{
+					{EditDistance: 1}, // 4 points
+					{EditDistance: 2}, // 3 points
+				},
+				SameLastFailures: []models.TestRegression{{}, {}}, // 2 points
+			},
+			expected: 9, // 4 + 3 + 2 = 9
+		},
+		{
+			name: "score capped at 10",
+			match: PotentialMatch{
+				SimilarlyNamedTests: []SimilarlyNamedTest{
+					{EditDistance: 0}, // 5 points
+					{EditDistance: 0}, // 5 points
+					{EditDistance: 0}, // 5 points
+				},
+				SameLastFailures: []models.TestRegression{{}, {}, {}}, // 3 points
+			},
+			expected: 10, // capped at 10
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calculateConfidenceLevel(tt.match)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -8,6 +8,8 @@
 DOCKER="podman"
 PSQL_CONTAINER="sippy-e2e-test-postgresql"
 PSQL_PORT="23433"
+REDIS_CONTAINER="sippy-e2e-test-redis"
+REDIS_PORT="23479"
 
 if [[ -z "$GCS_SA_JSON_PATH" ]]; then
     echo "Must provide path to GCS credential in GCS_SA_JSON_PATH env var" 1>&2
@@ -22,23 +24,34 @@ clean_up () {
 	echo "Tearing down container $PSQL_CONTAINER"
 	$DOCKER stop -i $PSQL_CONTAINER
 	$DOCKER rm -i $PSQL_CONTAINER
+	echo "Tearing down container $REDIS_CONTAINER"
+	$DOCKER stop -i $REDIS_CONTAINER
+	$DOCKER rm -i $REDIS_CONTAINER
     exit $ARG
 }
 trap clean_up EXIT
 
-# make sure no old container running
+# make sure no old containers are running
 echo "Cleaning up old sippy postgresql container if present"
 $DOCKER stop -i $PSQL_CONTAINER
 $DOCKER rm -i $PSQL_CONTAINER
+echo "Cleaning up old sippy redis container if present"
+$DOCKER stop -i $REDIS_CONTAINER
+$DOCKER rm -i $REDIS_CONTAINER
 
 # start postgresql in a container:
 echo "Starting new sippy postgresql container: $PSQL_CONTAINER"
 $DOCKER run --name $PSQL_CONTAINER -e POSTGRES_PASSWORD=password -p $PSQL_PORT:5432 -d quay.io/enterprisedb/postgresql
 
-echo "Wait 5s for postgresql to start..."
+# start redis in a container:
+echo "Starting new sippy redis container: $REDIS_CONTAINER"
+$DOCKER run --name $REDIS_CONTAINER -p $REDIS_PORT:6379 -d quay.io/openshiftci/redis:latest
+
+echo "Wait 5s for postgresql and redis to start..."
 sleep 5
 
 export SIPPY_E2E_DSN="postgresql://postgres:password@localhost:$PSQL_PORT/postgres"
+export REDIS_URL="redis://localhost:$REDIS_PORT"
 
 echo "Loading database..."
 # use an old release here as they have very few job runs and thus import quickly, ~5 minutes
@@ -46,7 +59,7 @@ go build -mod vendor ./cmd/sippy
 ./sippy seed-data  \
   --init-database \
   --database-dsn="$SIPPY_E2E_DSN" \
-  --release="4.14"
+  --release="4.20"
 
 # Spawn sippy server off into a separate process:
 export SIPPY_API_PORT="18080"
@@ -59,14 +72,15 @@ export SIPPY_ENDPOINT="127.0.0.1"
   --enable-write-endpoints \
   --log-level debug \
   --views config/views.yaml \
-  --google-service-account-credential-file $GCS_SA_JSON_PATH > e2e.log 2>&1
+  --google-service-account-credential-file $GCS_SA_JSON_PATH \
+  --redis-url="$REDIS_URL" > e2e.log 2>&1
 )&
 # store the child process for cleanup
 CHILD_PID=$!
 
-# Give it time to start up
+# Give it time to start up, and fill the redis cache
 echo "Waiting for sippy API to start on port $SIPPY_API_PORT, see e2e.log for output..."
-TIMEOUT=120
+TIMEOUT=600
 ELAPSED=0
 while [ $ELAPSED -lt $TIMEOUT ]; do
     if curl -s "http://localhost:$SIPPY_API_PORT/api/health" > /dev/null 2>&1; then

--- a/sippy-ng/src/component_readiness/TriageFields.js
+++ b/sippy-ng/src/component_readiness/TriageFields.js
@@ -1,6 +1,12 @@
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
+import { CompReadyVarsContext } from './CompReadyVars'
 import { DateTimePicker, LocalizationProvider } from '@mui/x-date-pickers'
 import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   FormHelperText,
   MenuItem,
   Select,
@@ -13,7 +19,7 @@ import Button from '@mui/material/Button'
 import ExistingTriageSelector from './ExistingTriageSelector'
 import InfoIcon from '@mui/icons-material/Info'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useContext } from 'react'
 
 const useStyles = makeStyles({
   triageForm: {
@@ -47,11 +53,33 @@ export default function TriageFields({
   handleAddToExistingTriage,
 }) {
   const classes = useStyles()
+  const { view } = useContext(CompReadyVarsContext)
 
   const [matchingTriages, setMatchingTriages] = React.useState([])
   const [triageValidationErrors, setTriageValidationErrors] = React.useState([])
+  const [potentialMatchesDialog, setPotentialMatchesDialog] = React.useState({
+    open: false,
+    count: 0,
+    triageId: null,
+  })
 
   const updating = triageId > 0
+
+  const handlePotentialMatchesYes = () => {
+    const triageDetailsUrl = `/sippy-ng/triages/${potentialMatchesDialog.triageId}?openMatches=1`
+    window.open(triageDetailsUrl, '_blank', 'noopener,noreferrer')
+    setPotentialMatchesDialog({ open: false, count: 0, triageId: null })
+    setAlertText('successfully created triage entry')
+    setAlertSeverity('success')
+    handleFormCompletion()
+  }
+
+  const handlePotentialMatchesNo = () => {
+    setPotentialMatchesDialog({ open: false, count: 0, triageId: null })
+    setAlertText('successfully created triage entry')
+    setAlertSeverity('success')
+    handleFormCompletion()
+  }
 
   const handleTriageChange = (e) => {
     const { name, value } = e.target
@@ -147,11 +175,39 @@ export default function TriageFields({
 
         if (updating) {
           setAlertText('successfully updated triage entry')
+          setAlertSeverity('success')
+          handleFormCompletion()
         } else {
-          setAlertText('successfully created triage entry')
+          response.json().then((createdTriage) => {
+            fetch(`${getTriagesAPIUrl(createdTriage.id)}/matches?view=${view}`)
+              .then((matchesResponse) => {
+                if (matchesResponse.status === 200) {
+                  return matchesResponse.json()
+                }
+                return []
+              })
+              .then((potentialMatches) => {
+                if (potentialMatches && potentialMatches.length > 0) {
+                  setPotentialMatchesDialog({
+                    open: true,
+                    count: potentialMatches.length,
+                    triageId: createdTriage.id,
+                  })
+                } else {
+                  setAlertText('successfully created triage entry')
+                  setAlertSeverity('success')
+                  handleFormCompletion()
+                }
+              })
+              .catch((error) => {
+                console.error('Error fetching potential matches:', error)
+                // If fetching matches fails, proceed with normal flow
+                setAlertText('successfully created triage entry')
+                setAlertSeverity('success')
+                handleFormCompletion()
+              })
+          })
         }
-        setAlertSeverity('success')
-        handleFormCompletion()
       })
     }
   }
@@ -249,6 +305,37 @@ export default function TriageFields({
           />
         </div>
       )}
+
+      <Dialog
+        open={potentialMatchesDialog.open}
+        onClose={handlePotentialMatchesNo}
+        aria-labelledby="potential-matches-dialog-title"
+        aria-describedby="potential-matches-dialog-description"
+      >
+        <DialogTitle id="potential-matches-dialog-title">
+          Potential Matching Regressions Found
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="potential-matches-dialog-description">
+            We found {potentialMatchesDialog.count} potentially matching
+            regression{potentialMatchesDialog.count !== 1 ? 's' : ''} for this
+            triage. Would you like to view them, and potentially link them to
+            this triage?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handlePotentialMatchesNo} color="secondary">
+            No, Continue
+          </Button>
+          <Button
+            onClick={handlePotentialMatchesYes}
+            color="primary"
+            variant="contained"
+          >
+            Yes, View Matches
+          </Button>
+        </DialogActions>
+      </Dialog>
     </div>
   )
 }

--- a/sippy-ng/src/component_readiness/TriagePotentialMatches.js
+++ b/sippy-ng/src/component_readiness/TriagePotentialMatches.js
@@ -1,0 +1,453 @@
+import { BooleanParam, useQueryParam } from 'use-query-params'
+import {
+  Button,
+  Checkbox,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  FormGroup,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import { Close } from '@mui/icons-material'
+import { CompReadyVarsContext } from './CompReadyVars'
+import { DataGrid, GridToolbar } from '@mui/x-data-grid'
+import {
+  generateTestReportForRegressedTest,
+  getTriagesAPIUrl,
+} from './CompReadyUtils'
+import { makeStyles } from '@mui/styles'
+import { relativeTime } from '../helpers'
+import CompSeverityIcon from './CompSeverityIcon'
+import PropTypes from 'prop-types'
+import React, { Fragment, useContext } from 'react'
+
+const useStyles = makeStyles((theme) => ({
+  dialogPaper: {
+    width: '90%',
+    maxWidth: 'none',
+  },
+  loadingContainer: {
+    textAlign: 'center',
+    padding: '40px',
+  },
+  loadingText: {
+    marginTop: '16px',
+  },
+  statusCell: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: '100%',
+  },
+  confidenceTooltip: {
+    cursor: 'help',
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    alignItems: 'center',
+  },
+  dialogActions: {
+    justifyContent: 'flex-start',
+  },
+  filterContainer: {
+    marginBottom: theme.spacing(2),
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(2),
+  },
+  filterGroup: {
+    display: 'flex',
+    flexDirection: 'row',
+    gap: theme.spacing(2),
+    alignItems: 'center',
+  },
+  filterTitle: {
+    marginRight: theme.spacing(1),
+    fontWeight: 'bold',
+  },
+}))
+
+export default function TriagePotentialMatches({
+  triage,
+  setMessage,
+  setLinkingComplete,
+}) {
+  const classes = useStyles()
+  const [isModalOpen, setIsModalOpen] = React.useState(false)
+  const [potentialMatches, setPotentialMatches] = React.useState([])
+  const [isLoading, setIsLoading] = React.useState(false)
+  const [selectedRegressions, setSelectedRegressions] = React.useState([])
+  const [isLinking, setIsLinking] = React.useState(false)
+  const [filterSimilarNames, setFilterSimilarNames] = React.useState(true)
+  const [filterSameLastFailures, setFilterSameLastFailures] =
+    React.useState(true)
+  const { view, expandEnvironment } = useContext(CompReadyVarsContext)
+  const [autoOpenMatches, setAutoOpenMatches] = useQueryParam(
+    'openMatches',
+    BooleanParam
+  )
+
+  React.useEffect(() => {
+    if (autoOpenMatches === true) {
+      findPotentialMatches()
+    }
+  }, [autoOpenMatches])
+
+  const findPotentialMatches = () => {
+    setIsLoading(true)
+    setIsModalOpen(true)
+    fetch(`${getTriagesAPIUrl(triage.id)}/matches?view=${view}`)
+      .then((response) => {
+        if (response.status !== 200) {
+          throw new Error('API server returned ' + response.status)
+        }
+        return response.json()
+      })
+      .then((matches) => {
+        console.log('Potential matching regressions:', matches)
+        setPotentialMatches(matches || [])
+        setSelectedRegressions([])
+        setFilterSimilarNames(true)
+        setFilterSameLastFailures(true)
+        setIsModalOpen(true)
+      })
+      .catch((error) => {
+        console.error('Error finding potential matches:', error)
+        setMessage('Error finding potential matches: ' + error.toString())
+      })
+      .finally(() => {
+        setIsLoading(false)
+      })
+  }
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false)
+    setAutoOpenMatches(undefined)
+  }
+
+  const linkSelectedRegressions = () => {
+    if (selectedRegressions.length === 0) {
+      setMessage('No regressions selected')
+      return
+    }
+
+    setIsLinking(true)
+
+    // Update triage with selected regressions
+    const updatedTriage = {
+      ...triage,
+      regressions: [
+        ...triage.regressions,
+        ...selectedRegressions.map((id) => ({ id: Number(id) })),
+      ],
+    }
+
+    fetch(getTriagesAPIUrl(triage.id), {
+      method: 'PUT',
+      body: JSON.stringify(updatedTriage),
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('Failed to link regressions: ' + response.status)
+        }
+        setLinkingComplete(true)
+        setAutoOpenMatches(undefined)
+      })
+      .catch((error) => {
+        console.error('Error linking regressions:', error)
+        setMessage('Error linking regressions: ' + error.message)
+        setIsLinking(false)
+      })
+  }
+
+  const filteredMatches = React.useMemo(() => {
+    if (filterSimilarNames && filterSameLastFailures) {
+      return potentialMatches
+    }
+
+    return potentialMatches.filter((match) => {
+      const hasSimilarNames =
+        match.similarly_named_tests && match.similarly_named_tests.length > 0
+      const hasSameLastFailures =
+        match.same_last_failures && match.same_last_failures.length > 0
+
+      if (!filterSimilarNames && !filterSameLastFailures) {
+        return false
+      }
+      if (filterSimilarNames && !filterSameLastFailures) {
+        return hasSimilarNames
+      }
+      if (!filterSimilarNames && filterSameLastFailures) {
+        return hasSameLastFailures
+      }
+
+      return false
+    })
+  }, [potentialMatches, filterSimilarNames, filterSameLastFailures])
+
+  const columns = [
+    {
+      field: 'triage',
+      headerName: 'Triage',
+      flex: 4,
+      sortable: false,
+      filterable: false,
+      disableColumnMenu: true,
+      renderCell: (params) => (
+        <input
+          type="checkbox"
+          checked={selectedRegressions.includes(
+            params.row.regressed_test.regression.id
+          )}
+          onChange={(e) => {
+            const regressionId = params.row.regressed_test.regression.id
+            if (e.target.checked) {
+              setSelectedRegressions([...selectedRegressions, regressionId])
+            } else {
+              setSelectedRegressions(
+                selectedRegressions.filter((id) => id !== regressionId)
+              )
+            }
+          }}
+        />
+      ),
+    },
+    {
+      field: 'test_name',
+      headerName: 'Test Name',
+      flex: 60,
+      valueGetter: (params) => {
+        return params.row.regressed_test.test_name
+      },
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'release',
+      headerName: 'Release',
+      flex: 4,
+      valueGetter: (params) => {
+        return params.row.regressed_test.regression.release
+      },
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'variants',
+      headerName: 'Variants',
+      flex: 40,
+      valueGetter: (params) => {
+        const variants = params.row.regressed_test.regression.variants
+        if (variants && Array.isArray(variants)) {
+          return variants.join(', ')
+        }
+        return variants || ''
+      },
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'opened',
+      headerName: 'Regressed Since',
+      flex: 12,
+      valueGetter: (params) => {
+        const opened = params.row.regressed_test.regression.opened
+        if (!opened) {
+          return ''
+        }
+        const regressedSinceDate = new Date(opened)
+        return relativeTime(regressedSinceDate, new Date())
+      },
+      renderCell: (param) => (
+        <div className="regressed-since">{param.value}</div>
+      ),
+    },
+    {
+      field: 'status',
+      headerName: 'Status',
+      flex: 4,
+      valueGetter: (params) => {
+        const regressedTest = params.row.regressed_test
+        const filterVals = `?view=${view}`
+        const testDetailsUrl = generateTestReportForRegressedTest(
+          regressedTest,
+          filterVals,
+          expandEnvironment
+        )
+
+        return {
+          status: regressedTest.status || 0,
+          explanations: regressedTest.explanations || [],
+          url: testDetailsUrl,
+        }
+      },
+      renderCell: (params) => (
+        <div className={classes.statusCell}>
+          <a href={params.value.url} target="_blank" rel="noopener noreferrer">
+            <CompSeverityIcon
+              status={params.value.status}
+              explanations={params.value.explanations}
+            />
+          </a>
+        </div>
+      ),
+    },
+    {
+      field: 'confidence_level',
+      headerName: 'Confidence',
+      flex: 6,
+      renderCell: (params) => {
+        const row = params.row
+        const similarlyNamedCount = row.similarly_named_tests
+          ? row.similarly_named_tests.length
+          : 0
+        const sameLastFailureCount = row.same_last_failures
+          ? row.same_last_failures.length
+          : 0
+
+        const tooltipContent = (
+          <div>
+            <div>Match Breakdown:</div>
+            <div>• Similarly Named Tests: {similarlyNamedCount}</div>
+            <div>• Same Last Failure: {sameLastFailureCount}</div>
+          </div>
+        )
+
+        return (
+          <Tooltip title={tooltipContent} arrow placement="top">
+            <div className={classes.confidenceTooltip}>{params.value}</div>
+          </Tooltip>
+        )
+      },
+    },
+  ]
+
+  return (
+    <Fragment>
+      <Button
+        onClick={findPotentialMatches}
+        variant="contained"
+        color="primary"
+        sx={{ marginTop: '10px' }}
+        disabled={isLoading}
+      >
+        {isLoading
+          ? 'Finding Matches...'
+          : 'Link Additional Matching Regressions'}
+      </Button>
+
+      <Dialog
+        open={isModalOpen}
+        onClose={handleCloseModal}
+        maxWidth={false}
+        classes={{
+          paper: classes.dialogPaper,
+        }}
+      >
+        <DialogTitle>
+          Potential Matching Regressions
+          <IconButton
+            aria-label="close"
+            onClick={handleCloseModal}
+            sx={{ position: 'absolute', right: 8, top: 8 }}
+          >
+            <Close />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent>
+          {isLoading ? (
+            <div className={classes.loadingContainer}>
+              <CircularProgress />
+              <div className={classes.loadingText}>
+                Loading potential matches...
+              </div>
+            </div>
+          ) : (
+            <>
+              <div className={classes.filterContainer}>
+                <Typography className={classes.filterTitle}>
+                  Filter by:
+                </Typography>
+                <FormGroup className={classes.filterGroup}>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={filterSimilarNames}
+                        onChange={(e) =>
+                          setFilterSimilarNames(e.target.checked)
+                        }
+                      />
+                    }
+                    label={`Similar Names (${
+                      potentialMatches.filter(
+                        (m) => m.similarly_named_tests?.length > 0
+                      ).length
+                    })`}
+                  />
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={filterSameLastFailures}
+                        onChange={(e) =>
+                          setFilterSameLastFailures(e.target.checked)
+                        }
+                      />
+                    }
+                    label={`Same Last Failures (${
+                      potentialMatches.filter(
+                        (m) => m.same_last_failures?.length > 0
+                      ).length
+                    })`}
+                  />
+                </FormGroup>
+              </div>
+              <DataGrid
+                rows={filteredMatches}
+                columns={columns}
+                components={{ Toolbar: GridToolbar }}
+                getRowId={(row) => row.regressed_test.regression.id}
+                autoHeight
+                rowHeight={80}
+                pageSize={10}
+                rowsPerPageOptions={[10, 25, 50]}
+                disableSelectionOnClick
+                componentsProps={{
+                  toolbar: {
+                    columns: columns,
+                  },
+                }}
+              />
+            </>
+          )}
+        </DialogContent>
+        <DialogActions className={classes.dialogActions}>
+          <Button
+            onClick={linkSelectedRegressions}
+            disabled={selectedRegressions.length === 0 || isLinking}
+            variant="contained"
+            color="primary"
+          >
+            {isLinking
+              ? 'Linking...'
+              : `Add ${
+                  selectedRegressions.length > 0
+                    ? `(${selectedRegressions.length})`
+                    : ''
+                } to Triage`}
+          </Button>
+          <Button onClick={handleCloseModal} color="secondary">
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Fragment>
+  )
+}
+
+TriagePotentialMatches.propTypes = {
+  triage: PropTypes.object.isRequired,
+  setMessage: PropTypes.func.isRequired,
+  setLinkingComplete: PropTypes.func.isRequired,
+}

--- a/test/e2e/util/cache_manipulator.go
+++ b/test/e2e/util/cache_manipulator.go
@@ -1,0 +1,238 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"gopkg.in/redis.v5"
+
+	"github.com/openshift/sippy/pkg/api/componentreadiness"
+	"github.com/openshift/sippy/pkg/apis/api/componentreport"
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/crtest"
+	log "github.com/sirupsen/logrus"
+)
+
+// E2ECacheManipulator provides utilities for manipulating values in the Redis cache
+type E2ECacheManipulator struct {
+	release string
+	client  *redis.Client
+}
+
+func NewE2ECacheManipulator(release string) (*E2ECacheManipulator, error) {
+	client, err := connectToRedis()
+	if err != nil {
+		return nil, err
+	}
+	return &E2ECacheManipulator{
+		release: release,
+		client:  client,
+	}, nil
+}
+
+func (c *E2ECacheManipulator) Close() {
+	if c.client != nil {
+		c.client.Close()
+	}
+}
+
+// connectToRedis creates a Redis client connection
+func connectToRedis() (*redis.Client, error) {
+	redisURL := os.Getenv("REDIS_URL")
+	if redisURL == "" {
+		redisURL = "redis://localhost:23479" // Default for e2e tests
+	}
+
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Redis URL: %w", err)
+	}
+
+	client := redis.NewClient(opts)
+
+	// Test Redis connection
+	if err := client.Ping().Err(); err != nil {
+		client.Close()
+		return nil, fmt.Errorf("failed to connect to Redis: %w", err)
+	}
+
+	return client, nil
+}
+
+// AddTestRegressionsToReport adds test regressions to the component report in cache
+// so they can be found by GetTriagePotentialMatches function
+func (c *E2ECacheManipulator) AddTestRegressionsToReport(testRegressions []componentreport.ReportTestSummary) error {
+	// Get the current component report directly from the cache
+	report, cacheKey, err := c.GetReport()
+	if err != nil {
+		return fmt.Errorf("failed to get component report from cache: %w", err)
+	}
+
+	// Add each test regression to the appropriate place in the report
+	for _, testRegression := range testRegressions {
+		if testRegression.Regression == nil {
+			continue // Skip if no regression data
+		}
+
+		// Find or create the appropriate row for this component
+		var targetRowIndex = -1
+		for i, row := range report.Rows {
+			if row.Component == testRegression.Component {
+				targetRowIndex = i
+				break
+			}
+		}
+
+		// If no row exists for this component, create one
+		if targetRowIndex == -1 {
+			newRow := componentreport.ReportRow{
+				RowIdentification: crtest.RowIdentification{
+					Component:  testRegression.Component,
+					Capability: testRegression.Capability,
+				},
+				Columns: []componentreport.ReportColumn{
+					{
+						ColumnIdentification: crtest.ColumnIdentification{
+							Variants: testRegression.Variants,
+						},
+						Status:         crtest.SignificantRegression,
+						RegressedTests: []componentreport.ReportTestSummary{testRegression},
+					},
+				},
+			}
+			report.Rows = append(report.Rows, newRow)
+		} else {
+			// Add to existing row - find or create a matching column
+			row := &report.Rows[targetRowIndex]
+			var targetColumnIndex = -1
+
+			// Look for a column with matching variants
+			for i, col := range row.Columns {
+				if variantsMatch(col.Variants, testRegression.Variants) {
+					targetColumnIndex = i
+					break
+				}
+			}
+
+			if targetColumnIndex == -1 {
+				// Create new column
+				newColumn := componentreport.ReportColumn{
+					ColumnIdentification: crtest.ColumnIdentification{
+						Variants: testRegression.Variants,
+					},
+					Status:         crtest.SignificantRegression,
+					RegressedTests: []componentreport.ReportTestSummary{testRegression},
+				}
+				row.Columns = append(row.Columns, newColumn)
+			} else {
+				// Add to existing column
+				row.Columns[targetColumnIndex].RegressedTests = append(row.Columns[targetColumnIndex].RegressedTests, testRegression)
+			}
+		}
+	}
+
+	// Update the cached component report so GetTriagePotentialMatches can find the test regressions
+	err = c.updateReportWithKey(report, cacheKey)
+	if err != nil {
+		log.WithError(err).Warn("Failed to update cached component report, test may not work as expected")
+	}
+
+	return nil
+}
+
+// GetReport retrieves the component report directly from Redis cache
+func (c *E2ECacheManipulator) GetReport() (componentreport.ComponentReport, string, error) {
+	// Find the ComponentReport cache key by scanning for keys that start with "ComponentReport~"
+	keyPattern := "_SIPPY_*ComponentReport~*"
+	keys, err := c.client.Keys(keyPattern).Result()
+	if err != nil {
+		return componentreport.ComponentReport{}, "", fmt.Errorf("failed to scan for ComponentReport keys: %w", err)
+	}
+
+	var cacheKey string
+	for _, key := range keys {
+		// Strip the prefixes to get the JSON part
+		// Key format: "_SIPPY_cc:ComponentReport~{JSON}" or "_SIPPY_ComponentReport~{JSON}"
+		jsonPart := key
+
+		// Remove "_SIPPY_" prefix if present
+		jsonPart = strings.TrimPrefix(jsonPart, "_SIPPY_")
+
+		// Remove "cc:" prefix if present (compressed cache prefix)
+		jsonPart = strings.TrimPrefix(jsonPart, "cc:")
+
+		// Remove "ComponentReport~" prefix
+		if !strings.HasPrefix(jsonPart, "ComponentReport~") {
+			log.Warnf("Unexpected cache key format, missing ComponentReport~ prefix: %s", key)
+			continue
+		}
+		jsonPart = jsonPart[len("ComponentReport~"):]
+
+		gk := &componentreadiness.GeneratorCacheKey{}
+		if err := json.Unmarshal([]byte(jsonPart), gk); err != nil {
+			log.Warnf("Failed to unmarshal ComponentReport key JSON '%s' from key '%s': %v", jsonPart, key, err)
+			continue
+		}
+		if gk.SampleRelease.Name == Release {
+			cacheKey = key
+			break
+		}
+	}
+	if cacheKey == "" {
+		return componentreport.ComponentReport{}, "", fmt.Errorf("failed to find proper ComponentReport key")
+	}
+	log.Debugf("Found ComponentReport cache key: %s", cacheKey)
+
+	// Get the cached data
+	cachedData, err := c.client.Get(cacheKey).Bytes()
+	if err != nil {
+		return componentreport.ComponentReport{}, "", fmt.Errorf("failed to get cached data for key %s: %w", cacheKey, err)
+	}
+
+	// Unmarshal the component report
+	var report componentreport.ComponentReport
+	err = json.Unmarshal(cachedData, &report)
+	if err != nil {
+		return componentreport.ComponentReport{}, "", fmt.Errorf("failed to unmarshal component report: %w", err)
+	}
+
+	log.Debugf("Retrieved cached component report with %d rows", len(report.Rows))
+	return report, cacheKey, nil
+}
+
+// updateReportWithKey updates the Redis cache with the modified component report using the exact cache key
+func (c *E2ECacheManipulator) updateReportWithKey(report componentreport.ComponentReport, cacheKey string) error {
+	if cacheKey == "" {
+		return fmt.Errorf("cache key is empty, cannot update cache")
+	}
+
+	// Marshal the modified report to JSON
+	reportJSON, err := json.Marshal(report)
+	if err != nil {
+		return fmt.Errorf("failed to marshal component report: %w", err)
+	}
+
+	// Store plain JSON in Redis cache with a reasonable expiration (1 hour)
+	err = c.client.Set(cacheKey, reportJSON, time.Hour).Err()
+	if err != nil {
+		return fmt.Errorf("failed to store in Redis cache: %w", err)
+	}
+
+	log.Debugf("Updated cached component report with key %s, %d rows", cacheKey, len(report.Rows))
+	return nil
+}
+
+// variantsMatch checks if two variant maps are equivalent
+func variantsMatch(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/test/e2e/util/e2erequest.go
+++ b/test/e2e/util/e2erequest.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// Needs to match what we import in the e2e.sh script
-	Release = "4.14"
+	Release = "4.20"
 
 	// APIPort is the port e2e.sh launches the sippy API on. These values must be kept in sync.
 	APIPort = 18080


### PR DESCRIPTION
Provides a deep link to the potential matches when creating a new triage (assuming the user selects to see it). The potential matches are currently determined via two factors.

1. Similar test names, which is defined as having an edit distance of <= 5.
2. Same last failure time.

A confidence level is computed based on:
- which factors are matching
- how many currently associated regressions they match
- the actual edit distance (more confident if it is the same name vs. off by 5 chars)

Checkboxes are displayed alongside the list, and there is a button that will add the regressions selected to the triage. There is also filtering based on either of the matching criteria (if you want to hide same last failure time, for example).

<img width="2353" height="787" alt="Screenshot 2025-08-20 at 11 56 35 AM" src="https://github.com/user-attachments/assets/3d6cc4cf-c4cc-4485-b79c-9ec188c1a9bc" />

Also, the regressed tests now show status and test_details link on triage details page.


There are some pretty substantial e2e changes buried in here. We needed to use the component_report to be able to display the status and link to test_details on each of the regressions in the potential matches list (and the triage details page in general). In order to verify that this works properly we must start using Redis in the e2e tests, and manipulate the cache to add the regressed_tests that we create within the e2e test to it. I created a util to do this, as I think the concept will be useful for future e2e testing as well.

Assisted by Cursor