### PR TITLE
Add -lp-interop-virt LP filtering

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -311,8 +311,7 @@ component_readiness:
         Upgrade: {}
       include_variants:
         LayeredProduct:
-          - none
-          - virt
+          - lp-interop-virt
         Network:
           - ovn
         Owner:

--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -1079,6 +1079,7 @@ func setLayeredProduct(_ logrus.FieldLogger, variants map[string]string, jobName
 		{"-cnv", "virt"},
 		{"-kubevirt", "virt"},
 		{"-oadp-", "oadp"},
+		{"-lp-interop-cr-cnv", "lp-interop-virt"},
 	}
 
 	variants[VariantLayeredProduct] = VariantNoValue

--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -1075,11 +1075,11 @@ func setLayeredProduct(_ logrus.FieldLogger, variants map[string]string, jobName
 		substring string
 		product   string
 	}{
+		{"-lp-interop-cr-cnv", "lp-interop-virt"},
 		{"-virt", "virt"},
 		{"-cnv", "virt"},
 		{"-kubevirt", "virt"},
 		{"-oadp-", "oadp"},
-		{"-lp-interop-cr-cnv", "lp-interop-virt"},
 	}
 
 	variants[VariantLayeredProduct] = VariantNoValue


### PR DESCRIPTION
This naming convention helps filter by the one specifically matching job that should be collected under the correlated component (`CNV-lp-interop`).
All other related virt data (collected from multiple jobs) can be remain under the `virt` filter.