### PR TITLE
Mark techprevew-upgrade jobs as candidate tier

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -683,6 +683,9 @@ func (v *OCPVariantLoader) setJobTier(_ logrus.FieldLogger, variants map[string]
 
 		// Storage team job preparing for RHEL 10 to detect regressions early, not yet stable, jsafrane would like to promote eventually:
 		{[]string{"periodic-ci-openshift-cluster-storage-operator", "upgrade-check-dev-symlinks"}, "candidate"},
+
+		// z-stream techpreview jobs should generally upgrade correctly, however also get wedged in some cases (e.g. when we forcibly change an API from alpha to stable).
+		{[]string{"-techpreview-upgrade"}, "candidate"},
 	}
 
 	for _, jobTierPattern := range jobTierPatterns {


### PR DESCRIPTION
I would like to add techpreview-upgrade jobs, but without affecting component readiness results when the jobs fail.
Marking them as candidate based on the following understanding:
```
candidate: a candidate for being shown in default views, used to gauge the stability and promotability of the job
```

Relevant jobs: https://github.com/openshift/release/pull/68903

[Relevant slack thread](https://redhat-internal.slack.com/archives/C01CQA76KMX/p1755012929821259)