### PR TITLE
Clean up styling on triaged regression test list

### DIFF
--- a/sippy-ng/src/component_readiness/ComponentReadiness.css
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.css
@@ -66,3 +66,7 @@
   border-radius: 4px;
   border-color: grey;
 }
+
+.variants-list {
+  white-space: pre;
+}

--- a/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
@@ -1,9 +1,6 @@
 import { CompReadyVarsContext } from './CompReadyVars'
 import { DataGrid, GridToolbar } from '@mui/x-data-grid'
-import {
-  formColumnName,
-  generateTestReportForRegressedTest,
-} from './CompReadyUtils'
+import { generateTestReportForRegressedTest } from './CompReadyUtils'
 import { NumberParam, useQueryParam } from 'use-query-params'
 import { relativeTime } from '../helpers'
 import { Tooltip, Typography } from '@mui/material'
@@ -60,7 +57,7 @@ export default function TriagedRegressionTestList(props) {
     {
       field: 'test_name',
       headerName: 'Test Name',
-      flex: 40,
+      flex: 50,
       valueGetter: (params) => {
         return params.row.test_name
       },
@@ -69,7 +66,7 @@ export default function TriagedRegressionTestList(props) {
     {
       field: 'release',
       headerName: 'Release',
-      flex: 20,
+      flex: 7,
       valueGetter: (params) => {
         return params.row.release
       },
@@ -78,11 +75,12 @@ export default function TriagedRegressionTestList(props) {
     {
       field: 'variants',
       headerName: 'Variants',
-      flex: 30,
-      valueGetter: (params) => {
-        return formColumnName({ variants: params.row.variants })
-      },
-      renderCell: (param) => <div className="test-name">{param.value}</div>,
+      flex: 20,
+      renderCell: (params) => (
+        <div className="variants-list">
+          {params.value ? params.value.sort().join('\n') : ''}
+        </div>
+      ),
     },
     {
       field: 'opened',
@@ -188,6 +186,7 @@ export default function TriagedRegressionTestList(props) {
           components={{ Toolbar: GridToolbar }}
           rows={triagedRegressions}
           columns={columns}
+          getRowHeight={() => 'auto'}
           getRowId={(row) => row.id}
           selectionModel={activeRow}
           onSelectionModelChange={(newRow) => {


### PR DESCRIPTION
Is this better? The rows are taller, but it fits more of the test name and variants, and matches the variant styling from jobs table. Also fixes a bug in pre-pending the array index on the variant (I don't think `formColumnName` fn is not needed here)

After: 

<img width="1103" height="535" alt="image" src="https://github.com/user-attachments/assets/20bf6069-c6f5-4602-90e9-9700a523528a" />

Before: 

<img width="1111" height="272" alt="image" src="https://github.com/user-attachments/assets/1c619f66-a05d-4b55-8113-557edc87042d" />
