### PR TITLE
add junit suites for ARO-HCP

### DIFF
--- a/pkg/db/suites.go
+++ b/pkg/db/suites.go
@@ -28,6 +28,7 @@ var testSuites = []string{
 	"integration/parallel",
 	"stage/parallel",
 	"prod/parallel",
+	"aro-hcp-tests",
 
 	// ROSA
 	"OSD e2e suite",


### PR DESCRIPTION
We currently use prod/parallel and we're likely to try to combine in the future so we can compare the same tests run under different binary suites.