### PR TITLE
TRT-2241: 4.21 views

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -1,5 +1,482 @@
 ---
 component_readiness:
+  - name: 4.21-main
+    base_release:
+      release: "4.20"
+      relative_start: now-30d
+      relative_end: now
+    sample_release:
+      release: "4.21"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: { }
+        Network: { }
+        Platform: { }
+        Topology: { }
+      db_group_by:
+        Architecture: { }
+        FeatureSet: { }
+        Installer: { }
+        Network: { }
+        Platform: { }
+        Suite: { }
+        Topology: { }
+        Upgrade: { }
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+          - techpreview
+        Installer:
+          - ipi
+          - upi
+          - hypershift
+        JobTier:
+          - blocking
+          - informing
+          - standard
+        LayeredProduct:
+          - none
+          - virt
+        Network:
+          - ovn
+        Owner:
+          - eng
+          - service-delivery
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - metal
+          - rosa
+          - vsphere
+        Topology:
+          - ha
+          - microshift
+          - external
+        CGroupMode:
+          - v2
+        ContainerRuntime:
+          - runc
+          - crun
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+      flake_as_failure: false
+      pass_rate_required_new_tests: 95
+      include_multi_release_analysis: true
+    metrics:
+      enabled: true
+    regression_tracking:
+      enabled: true
+    prime_cache:
+      enabled: true
+    automate_jira:
+      enabled: true
+  - name: 4.21-hypershift-candidates
+    base_release:
+      release: "4.20"
+      relative_start: now-30d
+      relative_end: now
+    sample_release:
+      release: "4.21"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: { }
+        Network: { }
+        Platform: { }
+        Topology: { }
+      db_group_by:
+        Architecture: { }
+        FeatureSet: { }
+        Installer: { }
+        Network: { }
+        Platform: { }
+        Suite: { }
+        Topology: { }
+        Upgrade: { }
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+          - techpreview
+        Installer:
+          - ipi
+          - upi
+          - hypershift
+        JobTier:
+          - blocking
+          - informing
+          - standard
+          - candidate
+        Network:
+          - ovn
+        Owner:
+          - eng
+          - service-delivery
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - metal
+          - rosa
+          - vsphere
+        Topology:
+          - external
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+      flake_as_failure: false
+      pass_rate_required_new_tests: 95
+      include_multi_release_analysis: true
+  - name: 4.21-multi-arm
+    base_release:
+      release: "4.20"
+      relative_start: now-30d
+      relative_end: now
+    sample_release:
+      release: "4.21"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: { }
+        Network: { }
+        Platform: { }
+        Topology: { }
+      db_group_by:
+        Architecture: { }
+        FeatureSet: { }
+        Installer: { }
+        Network: { }
+        Platform: { }
+        Suite: { }
+        Topology: { }
+        Upgrade: { }
+      include_variants:
+        Architecture:
+          - amd64
+          - arm64
+          - multi
+        FeatureSet:
+          - default
+          - techpreview
+        Installer:
+          - ipi
+          - upi
+          - hypershift
+        JobTier:
+          - blocking
+          - informing
+          - standard
+        LayeredProduct:
+          - none
+          - virt
+        Network:
+          - ovn
+        Owner:
+          - eng
+          - service-delivery
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - metal
+          - rosa
+          - vsphere
+        Topology:
+          - ha
+          - microshift
+          - external
+        CGroupMode:
+          - v2
+        ContainerRuntime:
+          - runc
+          - crun
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+      flake_as_failure: false
+      pass_rate_required_new_tests: 95
+      include_multi_release_analysis: true
+    metrics:
+      enabled: false
+    regression_tracking:
+      enabled: false
+    prime_cache:
+      enabled: false
+    automate_jira:
+      enabled: false
+  - name: 4.21-x86-vs-multi-arm
+    base_release:
+      release: "4.21"
+      relative_start: now-7d
+      relative_end: now
+    sample_release:
+      release: "4.21"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Network: { }
+        Platform: { }
+      db_group_by:
+        FeatureSet: { }
+        Installer: { }
+        Network: { }
+        Platform: { }
+        Suite: { }
+        Topology: { }
+        Upgrade: { }
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+          - techpreview
+        Installer:
+          - ipi
+          - upi
+          - hypershift
+        JobTier:
+          - blocking
+          - informing
+          - standard
+        LayeredProduct:
+          - none
+          - virt
+        Network:
+          - ovn
+        Owner:
+          - eng
+          - service-delivery
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - metal
+          - rosa
+          - vsphere
+        Topology:
+          - ha
+          - microshift
+          - external
+        CGroupMode:
+          - v2
+        ContainerRuntime:
+          - runc
+          - crun
+      compare_variants:
+        Architecture:
+          - arm64
+          - multi
+      variant_cross_compare:
+        - Architecture
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+      flake_as_failure: false
+    metrics:
+      enabled: false
+    regression_tracking:
+      enabled: false
+  - name: 4.21-ha-vs-single
+    base_release:
+      release: "4.21"
+      relative_start: now-7d
+      relative_end: now
+    sample_release:
+      release: "4.21"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: { }
+        Network: { }
+        Platform: { }
+      db_group_by:
+        Architecture: { }
+        FeatureSet: { }
+        Installer: { }
+        Network: { }
+        Platform: { }
+        Suite: { }
+        Upgrade: { }
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        JobTier:
+          - blocking
+          - informing
+          - standard
+        LayeredProduct:
+          - none
+          - virt
+        Owner:
+          - eng
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - metal
+          - vsphere
+        Topology:
+          - ha
+        CGroupMode:
+          - v2
+        ContainerRuntime:
+          - runc
+          - crun
+      compare_variants:
+        Topology:
+          - single
+      variant_cross_compare:
+        - Topology
+    advanced_options:
+      minimum_failure: 3
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+      flake_as_failure: false
+    metrics:
+      enabled: false
+    regression_tracking:
+      enabled: false
+  - name: 4.21-LP-Interop
+    base_release:
+      release: "4.20"
+      relative_start: now-30d
+      relative_end: now
+    sample_release:
+      release: "4.21"
+      relative_start: now-7d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: { }
+        Network: { }
+        Platform: { }
+        Topology: { }
+      db_group_by:
+        Architecture: { }
+        FeatureSet: { }
+        Installer: { }
+        Network: { }
+        Platform: { }
+        Suite: { }
+        Topology: { }
+        Upgrade: { }
+      include_variants:
+        LayeredProduct:
+          - lp-interop-virt
+        Network:
+          - ovn
+        Owner:
+          - mpiit
+    advanced_options:
+      minimum_failure: 2
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+      flake_as_failure: false
+      pass_rate_required_new_tests: 95
+      include_multi_release_analysis: true
+    metrics:
+      enabled: false
+    regression_tracking:
+      enabled: false
+    prime_cache:
+      enabled: false
+  - name: 4.21-rarely-run-jobs
+    base_release:
+      release: "4.20"
+      relative_start: now-1d
+      relative_end: now
+    sample_release:
+      release: "4.21"
+      # need to look much further back for rarely run jobs
+      relative_start: now-90d
+      relative_end: now
+    variant_options:
+      column_group_by:
+        Architecture: { }
+        Network: { }
+        Platform: { }
+        Topology: { }
+        Procedure: { }
+      db_group_by:
+        Architecture: { }
+        FeatureSet: { }
+        Installer: { }
+        Network: { }
+        Platform: { }
+        Suite: { }
+        Topology: { }
+        Upgrade: { }
+        Procedure: { }
+        JobTier: { }
+      include_variants:
+        Architecture:
+          - amd64
+        FeatureSet:
+          - default
+        Installer:
+          - ipi
+          - upi
+        LayeredProduct:
+          - none
+          - virt
+        Network:
+          - ovn
+        Owner:
+          - eng
+        Platform:
+          - aws
+          - azure
+          - gcp
+          - metal
+          - vsphere
+        Topology:
+          - ha
+        JobTier:
+          - rare
+    advanced_options:
+      minimum_failure: 2
+      confidence: 95
+      pity_factor: 5
+      ignore_missing: false
+      ignore_disruption: true
+      flake_as_failure: false
+      pass_rate_required_all_tests: 90
+    metrics:
+      enabled: false
+    regression_tracking:
+      enabled: false
   - name: 4.20-main
     base_release:
       release: "4.19"


### PR DESCRIPTION
Adds 4.21 views including `4.21-multi-arm` as a preview of moving multi and arm to the main 4.21 view

Are we ready for regression tracking and automate_jira to be enabled for 4.21-main at this time?