### PR TITLE
Revert "TRT-2289: Bandage fix for `test_details` reports not showing as regressed when they do on the main report"

### DIFF
--- a/cmd/sippy/load.go
+++ b/cmd/sippy/load.go
@@ -59,7 +59,6 @@ type LoadFlags struct {
 	CacheFlags              *flags.CacheFlags
 	ComponentReadinessFlags *flags.ComponentReadinessFlags
 	JobVariantsInputFile    string
-	LogLevel                string
 }
 
 func NewLoadFlags() *LoadFlags {
@@ -90,7 +89,6 @@ func (f *LoadFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVar(&f.Releases, "release", f.Releases, "Which releases to load (one per arg instance)")
 	fs.StringArrayVar(&f.Architectures, "arch", f.Architectures, "Which architectures to load (one per arg instance)")
 	fs.StringVar(&f.JobVariantsInputFile, "job-variants-input-file", "expected-job-variants.json", "JSON input file for the job-variants loader")
-	fs.StringVar(&f.LogLevel, "log-level", "info", "Log level")
 }
 
 // nolint:gocyclo
@@ -101,12 +99,6 @@ func NewLoadCommand() *cobra.Command {
 		Use:   "load",
 		Short: "Load data in the database",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			level, err := log.ParseLevel(f.LogLevel)
-			if err != nil {
-				log.WithError(err).Fatal("cannot parse log-level")
-			}
-			log.SetLevel(level)
-
 			loaders := make([]dataloader.DataLoader, 0)
 			allErrs := []error{}
 

--- a/pkg/api/componentreadiness/component_report_test.go
+++ b/pkg/api/componentreadiness/component_report_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crtest"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/testdetails"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
@@ -1839,7 +1838,7 @@ func Test_componentReportGenerator_assessComponentStatus(t *testing.T) {
 				},
 			}
 
-			c.assessComponentStatus(testAnalysis, logrus.NewEntry(logrus.New()))
+			c.assessComponentStatus(testAnalysis)
 			assert.Equalf(t, tt.expectedStatus, testAnalysis.ReportStatus, "assessComponentStatus expected status not equal")
 			if tt.expectedFischers != nil {
 				// Mac and Linux do not matchup on floating point precision, so lets approximate the comparison:

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -82,7 +82,7 @@ func (c *ComponentReportGenerator) GenerateTestDetailsReport(ctx context.Context
 		return testdetails.Report{}, errs
 	}
 
-	return c.GenerateDetailsReportForTest(ctx, testIDOptions, componentJobRunTestReportStatus, true)
+	return c.GenerateDetailsReportForTest(ctx, testIDOptions, componentJobRunTestReportStatus)
 }
 
 // GenerateTestDetailsReportMultiTest variant of the function is for multi-test reports, used for cache priming all test detail reports for a view.
@@ -164,7 +164,7 @@ func (c *ComponentReportGenerator) GenerateTestDetailsReportMultiTest(ctx contex
 		}
 		testKeyStr := testKey.KeyOrDie()
 		if statuses, ok := testKeyTestJobRunStatuses[testKeyStr]; ok {
-			report, generateReportErrs := c.GenerateDetailsReportForTest(ctx, tOpt, statuses, false)
+			report, generateReportErrs := c.GenerateDetailsReportForTest(ctx, tOpt, statuses)
 			if len(generateReportErrs) > 0 {
 				errs = append(errs, generateReportErrs...)
 				continue
@@ -180,7 +180,7 @@ func (c *ComponentReportGenerator) GenerateTestDetailsReportMultiTest(ctx contex
 }
 
 // GenerateDetailsReportForTest generates a test detail report for a per-test + variant combo.
-func (c *ComponentReportGenerator) GenerateDetailsReportForTest(ctx context.Context, testIDOption reqopts.TestIdentification, componentJobRunTestReportStatus bq.TestJobRunStatuses, allowUnregressedReports bool) (testdetails.Report, []error) {
+func (c *ComponentReportGenerator) GenerateDetailsReportForTest(ctx context.Context, testIDOption reqopts.TestIdentification, componentJobRunTestReportStatus bq.TestJobRunStatuses) (testdetails.Report, []error) {
 
 	if testIDOption.TestID == "" {
 		return testdetails.Report{}, []error{fmt.Errorf("test_id has to be defined for test details")}
@@ -246,19 +246,6 @@ func (c *ComponentReportGenerator) GenerateDetailsReportForTest(ctx context.Cont
 		// Inject the override report stats into the first position on the main report,
 		// which callers will interpret as the authoritative report in the event multiple are returned
 		report.Analyses = append([]testdetails.Analysis{baseOverrideReport.Analyses[0]}, report.Analyses...)
-	}
-
-	if !allowUnregressedReports {
-		regressed := false
-		for _, analysis := range report.Analyses {
-			if analysis.ReportStatus < crtest.NotSignificant {
-				regressed = true
-				break
-			}
-		}
-		if !regressed {
-			return testdetails.Report{}, []error{fmt.Errorf("report for test: %s is not showing as regressed", report.TestID)}
-		}
 	}
 
 	return report, nil
@@ -500,14 +487,12 @@ func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(
 	if !lastFailure.IsZero() {
 		testStats.LastFailure = &lastFailure
 	}
-	log := logrus.WithFields(logrus.Fields{"testID": testIDOption.TestID, "variants": testIDOption.RequestedVariants})
-	log.Debugf("computed test stats prior to PreAnalysis: %+v", testStats)
 
 	if err := c.middlewares.PreAnalysis(testKey, &testStats); err != nil {
 		logrus.WithError(err).Error("Failure from middleware analysis")
 	}
 
-	c.assessComponentStatus(&testStats, log)
+	c.assessComponentStatus(&testStats)
 	report.TestComparison = testStats
 	result.Analyses = []testdetails.Analysis{report}
 


### PR DESCRIPTION
Reverts openshift/sippy#2948

logger.Debugf("NO regression detected against %s", testStats.BaseStats.Release)

BaseStats can be nil for new tests