### PR TITLE
NO-JIRA: adjust confidence level calculations to ensure we never report 0

### DIFF
--- a/pkg/api/componentreadiness/triage.go
+++ b/pkg/api/componentreadiness/triage.go
@@ -345,7 +345,7 @@ func (pm PotentialMatch) calculateConfidenceLevel() int {
 
 	// Calculate score for similarly named tests based on edit distance
 	for _, similarTest := range pm.SimilarlyNamedTests {
-		editDistanceScore := 5 - similarTest.EditDistance // 0->5, 1->4, 2->3, 3->2, 4->1, 5->0
+		editDistanceScore := 6 - similarTest.EditDistance // 1 point for 5 edit distance, 2 points for 4, etc.
 		score += editDistanceScore
 	}
 
@@ -354,6 +354,10 @@ func (pm PotentialMatch) calculateConfidenceLevel() int {
 
 	if score > 10 {
 		score = 10
+	}
+	// This should never happen, but we should never return a score less than 1
+	if score < 1 {
+		score = 1
 	}
 
 	return score

--- a/pkg/api/componentreadiness/triage_test.go
+++ b/pkg/api/componentreadiness/triage_test.go
@@ -178,7 +178,7 @@ func TestPotentialMatch_CalculateConfidenceLevel(t *testing.T) {
 				SimilarlyNamedTests: []SimilarlyNamedTest{},
 				SameLastFailures:    []models.TestRegression{},
 			},
-			expected: 0,
+			expected: 1, // min of 1
 		},
 		{
 			name: "single similar name with low edit distance",
@@ -188,7 +188,7 @@ func TestPotentialMatch_CalculateConfidenceLevel(t *testing.T) {
 				},
 				SameLastFailures: []models.TestRegression{},
 			},
-			expected: 4, // 5 - 1 = 4
+			expected: 5, // 6 - 1 = 5
 		},
 		{
 			name: "single similar name with high edit distance",
@@ -198,7 +198,7 @@ func TestPotentialMatch_CalculateConfidenceLevel(t *testing.T) {
 				},
 				SameLastFailures: []models.TestRegression{},
 			},
-			expected: 0, // 5 - 5 = 0
+			expected: 1, // 5 - 5 = 0; min of 1
 		},
 		{
 			name: "single same last failure",
@@ -212,12 +212,13 @@ func TestPotentialMatch_CalculateConfidenceLevel(t *testing.T) {
 			name: "multiple matches",
 			match: PotentialMatch{
 				SimilarlyNamedTests: []SimilarlyNamedTest{
-					{EditDistance: 1}, // 4 points
+					{EditDistance: 1}, // 5 points
 					{EditDistance: 2}, // 3 points
 				},
 				SameLastFailures: []models.TestRegression{{}, {}}, // 2 points
 			},
-			expected: 9, // 4 + 3 + 2 = 9
+			// nolint:gocritic
+			expected: 10, // 5 + 3 + 2 = 10
 		},
 		{
 			name: "score capped at 10",

--- a/test/e2e/componentreadiness/triage/triageapi_test.go
+++ b/test/e2e/componentreadiness/triage/triageapi_test.go
@@ -598,7 +598,7 @@ func Test_RegressionPotentialMatchingTriages(t *testing.T) {
 		assert.True(t, found, "Should find triage with similar named test")
 		assert.Len(t, nameMatch.SimilarlyNamedTests, 1, "Should have one similarly named test")
 		assert.Equal(t, 1, nameMatch.SimilarlyNamedTests[0].EditDistance, "Edit distance should be 1")
-		assert.Equal(t, 4, nameMatch.ConfidenceLevel, "Confidence should be 4 (5-1)")
+		assert.Equal(t, 5, nameMatch.ConfidenceLevel, "Confidence should be 5 (6-1)")
 
 		// Verify match by same failure time
 		timeMatch, found := triagesByID[triageResponse2.ID]
@@ -982,8 +982,8 @@ func Test_TriagePotentialMatchingRegressions(t *testing.T) {
 			matches := matchesBySimilarName[testRegressions[2].Regression.ID]
 			assert.Equal(t, 1, len(matches), "Should match exactly one similar name")
 			assert.Equal(t, testRegressions[0].Regression.ID, matches[0].Regression.ID, "Should match against TestSomething regression")
-			// TestSomthng vs TestSomething = edit distance 2, so score = 5-2 = 3
-			assert.Equal(t, 3, confidenceLevels[testRegressions[2].Regression.ID], "Confidence should be 3 (edit distance 2: 5-2)")
+			// TestSomthng vs TestSomething = edit distance 2, so score = 6-2 = 4
+			assert.Equal(t, 4, confidenceLevels[testRegressions[2].Regression.ID], "Confidence should be 4 (edit distance 2: 6-2)")
 		}
 
 		// Regression 3: Should match by same failure time
@@ -1004,8 +1004,8 @@ func Test_TriagePotentialMatchingRegressions(t *testing.T) {
 			failureMatches := matchesBySameFailure[testRegressions[4].Regression.ID]
 			assert.Equal(t, 1, len(failureMatches), "Should match exactly one same failure time")
 			assert.Equal(t, testRegressions[0].Regression.ID, failureMatches[0].ID, "Should match against commonFailureTime regression")
-			// TestAnoterOne vs TestAnotherOne = edit distance 1, so name score = 5-1 = 4, failure = 1, total = 5
-			assert.Equal(t, 5, confidenceLevels[testRegressions[4].Regression.ID], "Confidence should be 5 (name edit distance 1: 5-1=4, plus 1 failure match)")
+			// TestAnoterOne vs TestAnotherOne = edit distance 1, so name score = 6-1 = 5, failure = 1, total = 6
+			assert.Equal(t, 6, confidenceLevels[testRegressions[4].Regression.ID], "Confidence should be 6 (name edit distance 1: 6-1=5, plus 1 failure match)")
 		}
 
 		// Regression 5: Should match by similar name only
@@ -1013,8 +1013,8 @@ func Test_TriagePotentialMatchingRegressions(t *testing.T) {
 			matches := matchesBySimilarName[testRegressions[5].Regression.ID]
 			assert.Equal(t, 1, len(matches), "Should match exactly one similar name")
 			assert.Equal(t, testRegressions[0].Regression.ID, matches[0].Regression.ID, "Should match against TestSomething regression")
-			// TestSomthing vs TestSomething = edit distance 1, so score = 5-1 = 4
-			assert.Equal(t, 4, confidenceLevels[testRegressions[5].Regression.ID], "Confidence should be 4 (edit distance 1: 5-1)")
+			// TestSomthing vs TestSomething = edit distance 1, so score = 6-1 = 5
+			assert.Equal(t, 5, confidenceLevels[testRegressions[5].Regression.ID], "Confidence should be 5 (edit distance 1: 6-1)")
 		}
 		assert.NotContains(t, matchesBySameFailure, testRegressions[5].Regression.ID, "Should not match by failure time")
 
@@ -1032,8 +1032,8 @@ func Test_TriagePotentialMatchingRegressions(t *testing.T) {
 			matches := matchesBySimilarName[testRegressions[9].Regression.ID]
 			assert.Equal(t, 1, len(matches), "Should match exactly one similar name")
 			assert.Equal(t, testRegressions[1].Regression.ID, matches[0].Regression.ID, "Should match against TestAnotherOne regression")
-			// TestAnotheOne vs TestAnotherOne = edit distance 1, so score = 5-1 = 4
-			assert.Equal(t, 4, confidenceLevels[testRegressions[9].Regression.ID], "Confidence should be 4 (edit distance 1: 5-1)")
+			// TestAnotheOne vs TestAnotherOne = edit distance 1, so score = 6-1 = 5
+			assert.Equal(t, 5, confidenceLevels[testRegressions[9].Regression.ID], "Confidence should be 5 (edit distance 1: 6-1)")
 		}
 	})
 


### PR DESCRIPTION
I have noticed a few cases where there is one similar test name with an edit distance of `5` reported as `0` confidence. This should not happen as it makes it seem like this isn't a match. If we find a match, the confidence should be a min of `1`.

Assisted by Cursor