### PR TITLE
TRT-2289: Bandage fix for test_details reports not showing as regressed when they do on the main report

### DIFF
--- a/cmd/sippy/load.go
+++ b/cmd/sippy/load.go
@@ -59,6 +59,7 @@ type LoadFlags struct {
 	CacheFlags              *flags.CacheFlags
 	ComponentReadinessFlags *flags.ComponentReadinessFlags
 	JobVariantsInputFile    string
+	LogLevel                string
 }
 
 func NewLoadFlags() *LoadFlags {
@@ -89,6 +90,7 @@ func (f *LoadFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVar(&f.Releases, "release", f.Releases, "Which releases to load (one per arg instance)")
 	fs.StringArrayVar(&f.Architectures, "arch", f.Architectures, "Which architectures to load (one per arg instance)")
 	fs.StringVar(&f.JobVariantsInputFile, "job-variants-input-file", "expected-job-variants.json", "JSON input file for the job-variants loader")
+	fs.StringVar(&f.LogLevel, "log-level", "info", "Log level")
 }
 
 // nolint:gocyclo
@@ -99,6 +101,12 @@ func NewLoadCommand() *cobra.Command {
 		Use:   "load",
 		Short: "Load data in the database",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			level, err := log.ParseLevel(f.LogLevel)
+			if err != nil {
+				log.WithError(err).Fatal("cannot parse log-level")
+			}
+			log.SetLevel(level)
+
 			loaders := make([]dataloader.DataLoader, 0)
 			allErrs := []error{}
 

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -1055,9 +1055,13 @@ func (c *ComponentReportGenerator) buildFisherExactTestStats(testStats *testdeta
 	testStats.ReportStatus = status
 	testStats.FisherExact = thrift.Float64Ptr(fisherExact)
 
+	baseRelease := "no basis"
+	if testStats.BaseStats != nil {
+		baseRelease = testStats.BaseStats.Release
+	}
 	// If we have a regression, include explanations:
 	if testStats.ReportStatus <= crtest.SignificantTriagedRegression {
-		logger.Debugf("regression detected against %s", testStats.BaseStats.Release)
+		logger.Debugf("regression detected against: %s", baseRelease)
 
 		if testStats.ReportStatus <= crtest.SignificantRegression {
 			testStats.Explanations = append(testStats.Explanations,
@@ -1073,7 +1077,7 @@ func (c *ComponentReportGenerator) buildFisherExactTestStats(testStats *testdeta
 				fmt.Sprintf("%s regression detected.", crtest.StringForStatus(testStats.ReportStatus)))
 		}
 	} else {
-		logger.Debugf("NO regression detected against %s", testStats.BaseStats.Release)
+		logger.Debugf("NO regression detected against: %s", baseRelease)
 	}
 }
 

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -853,7 +853,7 @@ func (c *ComponentReportGenerator) generateComponentTestReport(basisStatusMap, s
 				return crtype.ComponentReport{}, err
 			}
 
-			c.assessComponentStatus(&cellReport)
+			c.assessComponentStatus(&cellReport, log.NewEntry(log.New()))
 			if lastFailure := sampleStatus.LastFailure; !lastFailure.IsZero() {
 				cellReport.LastFailure = &lastFailure // it's a copy, for pointer hygiene
 			}
@@ -968,7 +968,7 @@ func getRegressionStatus(basisPassPercentage, samplePassPercentage float64) crte
 // set of objects relating to analysis, as there's not a lot of overlap between the analyzers
 // (fishers, pass rate, bayes (future)) and the middlewares (fallback, intentional regressions,
 // cross variant compare, rarely run jobs, etc.)
-func (c *ComponentReportGenerator) assessComponentStatus(testStats *testdetails.TestComparison) {
+func (c *ComponentReportGenerator) assessComponentStatus(testStats *testdetails.TestComparison, logger *log.Entry) {
 	// Catch unset required confidence, typically unit tests
 	opts := c.ReqOptions.AdvancedOption
 	if testStats.RequiredConfidence == 0 {
@@ -991,10 +991,10 @@ func (c *ComponentReportGenerator) assessComponentStatus(testStats *testdetails.
 	}
 
 	// Otherwise we fall back to default behavior of Fishers Exact test:
-	c.buildFisherExactTestStats(testStats)
+	c.buildFisherExactTestStats(testStats, logger)
 }
 
-func (c *ComponentReportGenerator) buildFisherExactTestStats(testStats *testdetails.TestComparison) {
+func (c *ComponentReportGenerator) buildFisherExactTestStats(testStats *testdetails.TestComparison, logger *log.Entry) {
 
 	fisherExact := 0.0
 	testStats.Comparison = crtest.FisherExact
@@ -1042,6 +1042,7 @@ func (c *ComponentReportGenerator) buildFisherExactTestStats(testStats *testdeta
 		} else if basisPassPercentage-samplePassPercentage > effectivePityFactor/100 {
 			significant, fisherExact = c.fischerExactTest(testStats.RequiredConfidence, testStats.SampleStats.Total()-samplePass, samplePass, testStats.BaseStats.Total()-basePass, basePass)
 		}
+		logger.Debugf("computed Fisher info: signifcant: %v, fisherExact: %v", significant, fisherExact)
 		if significant {
 			if improved {
 				status = crtest.SignificantImprovement
@@ -1050,11 +1051,13 @@ func (c *ComponentReportGenerator) buildFisherExactTestStats(testStats *testdeta
 			}
 		}
 	}
+	logger.Debugf("computed status: %d", int(status))
 	testStats.ReportStatus = status
 	testStats.FisherExact = thrift.Float64Ptr(fisherExact)
 
 	// If we have a regression, include explanations:
 	if testStats.ReportStatus <= crtest.SignificantTriagedRegression {
+		logger.Debugf("regression detected against %s", testStats.BaseStats.Release)
 
 		if testStats.ReportStatus <= crtest.SignificantRegression {
 			testStats.Explanations = append(testStats.Explanations,
@@ -1069,6 +1072,8 @@ func (c *ComponentReportGenerator) buildFisherExactTestStats(testStats *testdeta
 			testStats.Explanations = append(testStats.Explanations,
 				fmt.Sprintf("%s regression detected.", crtest.StringForStatus(testStats.ReportStatus)))
 		}
+	} else {
+		logger.Debugf("NO regression detected against %s", testStats.BaseStats.Release)
 	}
 }
 

--- a/pkg/api/componentreadiness/component_report_test.go
+++ b/pkg/api/componentreadiness/component_report_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crtest"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/testdetails"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
@@ -1838,7 +1839,7 @@ func Test_componentReportGenerator_assessComponentStatus(t *testing.T) {
 				},
 			}
 
-			c.assessComponentStatus(testAnalysis)
+			c.assessComponentStatus(testAnalysis, logrus.NewEntry(logrus.New()))
 			assert.Equalf(t, tt.expectedStatus, testAnalysis.ReportStatus, "assessComponentStatus expected status not equal")
 			if tt.expectedFischers != nil {
 				// Mac and Linux do not matchup on floating point precision, so lets approximate the comparison:


### PR DESCRIPTION
This is an unrevert with a fix for the panic due to a nil pointer on `testStats.BaseStats` when there is no basis. This is only being used to grab the release for logging, so in this case we will just log `no basis`.