### PR TITLE
UI: choose default release that is successor of latest GA

### DIFF
--- a/sippy-ng/src/helpers.js
+++ b/sippy-ng/src/helpers.js
@@ -364,7 +364,13 @@ export function findFirstNonGARelease(releases) {
   }
   let firstNonGA = releases.releases[0]
   releases.releases.forEach((r) => {
-    if (r.includes('.') && releases.ga_dates[r] === undefined) {
+    let attrs = releases.release_attrs[r]
+    if (
+      attrs &&
+      !attrs.ga &&
+      attrs.previous_release &&
+      attrs.previous_release in releases.ga_dates
+    ) {
       firstNonGA = r
     }
   })


### PR DESCRIPTION
right now `4.19-okd` is the default PR, should be an OCP release.