### PR TITLE
TRT-2210: Include HATEOAS style test details links in main report

### DIFF
--- a/e2e-scripts/sippy-e2e-sippy-e2e-test-commands.sh
+++ b/e2e-scripts/sippy-e2e-sippy-e2e-test-commands.sh
@@ -112,6 +112,8 @@ ${KUBECTL_CMD} -n sippy-e2e logs sippy-server > ${ARTIFACT_DIR}/sippy-server.log
 
 echo "Setup services and port forwarding for the sippy api server ..."
 
+export SIPPY_ENDPOINT="127.0.0.1"
+
 # Random port between 18000 and 18500 so we don't collide with other test jobs
 SIPPY_API_PORT=$((RANDOM % 501 + 18000))
 export SIPPY_API_PORT

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -17,6 +17,7 @@ import (
 	"cloud.google.com/go/bigquery"
 	"github.com/apache/thrift/lib/go/thrift"
 	fischer "github.com/glycerine/golang-fisher-exact"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/middleware/linkinjector"
 	regressionallowances2 "github.com/openshift/sippy/pkg/api/componentreadiness/middleware/regressionallowances"
 	"github.com/openshift/sippy/pkg/api/componentreadiness/middleware/regressiontracker"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/bq"
@@ -109,13 +110,14 @@ func GetComponentReportFromBigQuery(
 	dbc *db.DB,
 	reqOptions reqopts.RequestOptions,
 	variantJunitTableOverrides []configv1.VariantJunitTableOverride,
+	baseURL string,
 ) (report crtype.ComponentReport, errs []error) {
 	releaseConfigs, err := api.GetReleases(ctx, client, false)
 	if err != nil {
 		return report, []error{err}
 	}
 
-	generator := NewComponentReportGenerator(client, reqOptions, dbc, variantJunitTableOverrides, releaseConfigs)
+	generator := NewComponentReportGenerator(client, reqOptions, dbc, variantJunitTableOverrides, releaseConfigs, baseURL)
 
 	if os.Getenv("DEV_MODE") == "1" {
 		return generator.GenerateReport(ctx)
@@ -171,13 +173,14 @@ func (c *ComponentReportGenerator) PostAnalysis(report *crtype.ComponentReport) 
 	return nil
 }
 
-func NewComponentReportGenerator(client *bqcachedclient.Client, reqOptions reqopts.RequestOptions, dbc *db.DB, variantJunitTableOverrides []configv1.VariantJunitTableOverride, releaseConfigs []v1.Release) ComponentReportGenerator {
+func NewComponentReportGenerator(client *bqcachedclient.Client, reqOptions reqopts.RequestOptions, dbc *db.DB, variantJunitTableOverrides []configv1.VariantJunitTableOverride, releaseConfigs []v1.Release, baseURL string) ComponentReportGenerator {
 	generator := ComponentReportGenerator{
 		client:                     client,
 		ReqOptions:                 reqOptions,
 		dbc:                        dbc,
 		variantJunitTableOverrides: variantJunitTableOverrides,
 		releaseConfigs:             releaseConfigs,
+		baseURL:                    baseURL,
 	}
 	generator.initializeMiddleware()
 	return generator
@@ -196,6 +199,7 @@ type ComponentReportGenerator struct {
 	variantJunitTableOverrides []configv1.VariantJunitTableOverride
 	middlewares                middleware.List
 	releaseConfigs             []v1.Release
+	baseURL                    string
 }
 
 type GeneratorCacheKey struct {
@@ -345,6 +349,10 @@ func (c *ComponentReportGenerator) initializeMiddleware() {
 		log.Warnf("no db connection provided, skipping regressiontracker middleware")
 	}
 	c.middlewares = append(c.middlewares, regressionallowances2.NewRegressionAllowancesMiddleware(c.ReqOptions, c.releaseConfigs))
+
+	// Initialize LinkInjector middleware
+	linkInjector := linkinjector.NewLinkInjectorMiddleware(c.ReqOptions, c.baseURL)
+	c.middlewares = append(c.middlewares, linkInjector)
 }
 
 // GenerateReport is the main entry point for generation of a component readiness report.
@@ -515,7 +523,7 @@ func (c *ComponentReportGenerator) goRunOverrideSampleQueries(
 	errCh chan error,
 ) {
 	for i, or := range c.variantJunitTableOverrides {
-		if !containsOverriddenVariant(c.ReqOptions.VariantOption.IncludeVariants, or.VariantName, or.VariantValue) {
+		if !utils.ContainsOverriddenVariant(c.ReqOptions.VariantOption.IncludeVariants, or.VariantName, or.VariantValue) {
 			continue
 		}
 
@@ -610,20 +618,6 @@ func shouldSkipVariant(overrides []configv1.VariantJunitTableOverride, currOverr
 		}
 		if override.VariantName == key && override.VariantValue == value {
 			return true
-		}
-	}
-	return false
-}
-
-func containsOverriddenVariant(includeVariants map[string][]string, key, value string) bool {
-	for k, v := range includeVariants {
-		if k != key {
-			continue
-		}
-		for _, vv := range v {
-			if vv == value {
-				return true
-			}
 		}
 	}
 	return false

--- a/pkg/api/componentreadiness/middleware/linkinjector/linkinjector.go
+++ b/pkg/api/componentreadiness/middleware/linkinjector/linkinjector.go
@@ -1,0 +1,96 @@
+package linkinjector
+
+import (
+	"context"
+	"sync"
+
+	"github.com/openshift/sippy/pkg/api/componentreadiness/middleware"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/bq"
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/crtest"
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/testdetails"
+	log "github.com/sirupsen/logrus"
+)
+
+var _ middleware.Middleware = &LinkInjector{}
+
+func NewLinkInjectorMiddleware(reqOptions reqopts.RequestOptions, baseURL string) *LinkInjector {
+	return &LinkInjector{
+		log:        log.WithField("middleware", "LinkInjector"),
+		reqOptions: reqOptions,
+		baseURL:    baseURL,
+	}
+}
+
+// LinkInjector middleware injects HATEOAS-style links into test analysis results.
+// It adds a "test_details" link that points to the test details API endpoint with
+// appropriate query parameters based on the test data and request options.
+type LinkInjector struct {
+	log        log.FieldLogger
+	reqOptions reqopts.RequestOptions
+	baseURL    string
+}
+
+func (l *LinkInjector) Query(ctx context.Context, wg *sync.WaitGroup, allJobVariants crtest.JobVariants, baseStatusCh, sampleStatusCh chan map[string]bq.TestStatus, errCh chan error) {
+	// unused
+}
+
+func (l *LinkInjector) QueryTestDetails(ctx context.Context, wg *sync.WaitGroup, errCh chan error, allJobVariants crtest.JobVariants) {
+	// unused
+}
+
+func (l *LinkInjector) PreAnalysis(testKey crtest.Identification, testStats *testdetails.TestComparison) error {
+	// unused
+	return nil
+}
+
+// PostAnalysis injects HATEOAS links into test analysis results
+func (l *LinkInjector) PostAnalysis(testKey crtest.Identification, testStats *testdetails.TestComparison) error {
+	// Early return if status is above SignificantTriagedRegression (i.e. not a regression)
+	if testStats.ReportStatus > crtest.SignificantTriagedRegression {
+		return nil
+	}
+
+	// Initialize Links map if it doesn't exist
+	if testStats.Links == nil {
+		testStats.Links = make(map[string]string)
+	}
+
+	// Convert variants map to string slice for GenerateTestDetailsURL
+	variants := utils.VariantsMapToStringSlice(testKey.Variants)
+
+	// Determine base release override if one was used
+	baseReleaseOverride := ""
+	if testStats.BaseStats != nil && testStats.BaseStats.Release != l.reqOptions.BaseRelease.Name {
+		baseReleaseOverride = testStats.BaseStats.Release
+	}
+
+	// Generate test details URL
+	testDetailsURL, err := utils.GenerateTestDetailsURL(
+		testKey.TestID,
+		l.baseURL,
+		l.reqOptions.BaseRelease,
+		l.reqOptions.SampleRelease,
+		l.reqOptions.AdvancedOption,
+		l.reqOptions.VariantOption,
+		testKey.Component,
+		testKey.Capability,
+		variants,
+		baseReleaseOverride,
+	)
+	if err != nil {
+		l.log.WithError(err).Warnf("failed to generate test details URL for test %s", testKey.TestID)
+		return err
+	}
+
+	// Add the test_details link
+	testStats.Links["test_details"] = testDetailsURL
+
+	return nil
+}
+
+func (l *LinkInjector) PreTestDetailsAnalysis(testKey crtest.KeyWithVariants, status *bq.TestJobRunStatuses) error {
+	// unused
+	return nil
+}

--- a/pkg/api/componentreadiness/queryparamparser_test.go
+++ b/pkg/api/componentreadiness/queryparamparser_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crtest"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crview"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
@@ -401,7 +402,7 @@ func TestParseComponentReportRequest(t *testing.T) {
 			// path/body are irrelevant at this point in time, we only parse query params in the func being tested
 			req, err := http.NewRequest("GET", "https://example.com/path?"+params.Encode(), nil)
 			require.NoError(t, err)
-			options, err := ParseComponentReportRequest(views, releases, req, allJobVariants, time.Duration(0), []v2.VariantJunitTableOverride{})
+			options, err := utils.ParseComponentReportRequest(views, releases, req, allJobVariants, time.Duration(0), []v2.VariantJunitTableOverride{})
 
 			if tc.errMessage != "" {
 				require.Error(t, err)

--- a/pkg/api/componentreadiness/regressiontracker.go
+++ b/pkg/api/componentreadiness/regressiontracker.go
@@ -66,7 +66,6 @@ func (prs *PostgresRegressionStore) ListCurrentRegressionsForRelease(release str
 func (prs *PostgresRegressionStore) OpenRegression(view crview.View, newRegressedTest crtype.ReportTestSummary) (*models.TestRegression, error) {
 
 	variants := utils.VariantsMapToStringSlice(newRegressedTest.Variants)
-	log.Infof("variants: %s", strings.Join(variants, ","))
 
 	newRegression := &models.TestRegression{
 		View:        view.Name,
@@ -77,6 +76,18 @@ func (prs *PostgresRegressionStore) OpenRegression(view crview.View, newRegresse
 		Variants:    variants,
 		MaxFailures: newRegressedTest.SampleStats.FailureCount,
 	}
+
+	// Store the base release
+	// so we can generate accurate test_details API links.
+	// Start with the view's base release, but if the test got a base release override to a prior release, we use that instead.
+	newRegression.BaseRelease = view.BaseRelease.Name
+	if newRegressedTest.BaseStats != nil {
+		newRegression.BaseRelease = newRegressedTest.BaseStats.Release
+	}
+
+	newRegression.Capability = newRegressedTest.Capability
+	newRegression.Component = newRegressedTest.Component
+
 	if newRegressedTest.LastFailure != nil {
 		newRegression.LastFailure = sql.NullTime{Valid: true, Time: *newRegressedTest.LastFailure}
 	}
@@ -212,13 +223,13 @@ func (rt *RegressionTracker) Errors() []error {
 func (rt *RegressionTracker) SyncRegressionsForView(ctx context.Context, view crview.View) error {
 	rLog := rt.logger.WithField("view", view.Name)
 
-	baseRelease, err := GetViewReleaseOptions(
+	baseRelease, err := utils.GetViewReleaseOptions(
 		rt.releases, "basis", view.BaseRelease, rt.cacheOpts.CRTimeRoundingFactor)
 	if err != nil {
 		return err
 	}
 
-	sampleRelease, err := GetViewReleaseOptions(
+	sampleRelease, err := utils.GetViewReleaseOptions(
 		rt.releases, "sample", view.SampleRelease, rt.cacheOpts.CRTimeRoundingFactor)
 	if err != nil {
 		return err
@@ -237,7 +248,7 @@ func (rt *RegressionTracker) SyncRegressionsForView(ctx context.Context, view cr
 	}
 
 	report, errs := GetComponentReportFromBigQuery(
-		ctx, rt.bigqueryClient, rt.dbc, reportOpts, rt.variantJunitTableOverrides)
+		ctx, rt.bigqueryClient, rt.dbc, reportOpts, rt.variantJunitTableOverrides, "")
 	if len(errs) > 0 {
 		var strErrors []string
 		for _, err := range errs {
@@ -282,6 +293,26 @@ func (rt *RegressionTracker) SyncRegressionsForReport(ctx context.Context, view 
 					modifiedRegression = true
 				}
 			}
+
+			// BaseRelease was added to test_regressions later, this block allows us to set it for any pre-existing
+			// regressions as soon as the reg tracker runs.
+			// TODO: remove this block and make the field non-nullable once the db is updated
+			if regTest.BaseStats.Release != openReg.BaseRelease {
+				openReg.BaseRelease = regTest.BaseStats.Release
+				modifiedRegression = true
+			}
+
+			// Technically component and capability could get remapped during the time the regression is open,
+			// and we need this to roll out the storing of these fields initially:
+			if regTest.Component != openReg.Component {
+				openReg.Component = regTest.Component
+				modifiedRegression = true
+			}
+			if regTest.Capability != openReg.Capability {
+				openReg.Capability = regTest.Capability
+				modifiedRegression = true
+			}
+
 			if modifiedRegression {
 				statsUpdatedRegs++
 				err := rt.backend.UpdateRegression(openReg)

--- a/pkg/api/componentreadiness/regressiontracker.go
+++ b/pkg/api/componentreadiness/regressiontracker.go
@@ -297,7 +297,11 @@ func (rt *RegressionTracker) SyncRegressionsForReport(ctx context.Context, view 
 			// BaseRelease was added to test_regressions later, this block allows us to set it for any pre-existing
 			// regressions as soon as the reg tracker runs.
 			// TODO: remove this block and make the field non-nullable once the db is updated
-			if regTest.BaseStats.Release != openReg.BaseRelease {
+			baseRelease := view.BaseRelease.Name
+			if regTest.BaseStats != nil {
+				baseRelease = regTest.BaseStats.Release
+			}
+			if baseRelease != openReg.BaseRelease {
 				openReg.BaseRelease = regTest.BaseStats.Release
 				modifiedRegression = true
 			}

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -28,8 +28,8 @@ import (
 	"github.com/openshift/sippy/pkg/util"
 )
 
-func GetTestDetails(ctx context.Context, client *bigquery.Client, dbc *db.DB, reqOptions reqopts.RequestOptions, releases []v1.Release) (testdetails.Report, []error) {
-	generator := NewComponentReportGenerator(client, reqOptions, dbc, nil, releases)
+func GetTestDetails(ctx context.Context, client *bigquery.Client, dbc *db.DB, reqOptions reqopts.RequestOptions, releases []v1.Release, baseURL string) (testdetails.Report, []error) {
+	generator := NewComponentReportGenerator(client, reqOptions, dbc, nil, releases, baseURL)
 	if os.Getenv("DEV_MODE") == "1" {
 		return generator.GenerateTestDetailsReport(ctx)
 	}
@@ -367,7 +367,7 @@ func (c *ComponentReportGenerator) getJobRunTestStatusFromBigQuery(ctx context.C
 
 	// fork additional sample queries for the overrides
 	for i, or := range c.variantJunitTableOverrides {
-		if !containsOverriddenVariant(c.ReqOptions.VariantOption.IncludeVariants, or.VariantName, or.VariantValue) {
+		if !utils.ContainsOverriddenVariant(c.ReqOptions.VariantOption.IncludeVariants, or.VariantName, or.VariantValue) {
 			continue
 		}
 		// only do this additional query if the specified override variant is actually included in this request

--- a/pkg/api/componentreadiness/triage.go
+++ b/pkg/api/componentreadiness/triage.go
@@ -6,10 +6,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"slices"
 	"time"
 
+	sippyapi "github.com/openshift/sippy/pkg/api"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport"
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/crview"
+	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/query"
@@ -17,7 +22,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func GetTriage(dbc *db.DB, id int) (*models.Triage, error) {
+func GetTriage(dbc *db.DB, id int, req *http.Request) (*models.Triage, error) {
 	existingTriage := &models.Triage{}
 	res := dbc.DB.Preload("Bug").Preload("Regressions").First(existingTriage, id)
 	if res.Error != nil {
@@ -26,18 +31,34 @@ func GetTriage(dbc *db.DB, id int) (*models.Triage, error) {
 		}
 		log.WithError(res.Error).Errorf("error looking up existing triage record: %d", id)
 	}
-	injectHATEOASLinks(existingTriage)
+	injectHATEOASLinks(existingTriage, sippyapi.GetBaseURL(req))
 	return existingTriage, res.Error
 }
 
-func ListTriages(dbc *db.DB) ([]models.Triage, error) {
+func ListTriages(dbc *db.DB, req *http.Request) ([]models.Triage, error) {
 	var triages []models.Triage
 	var err error
 	triages, err = query.ListTriages(dbc)
 	for i := range triages {
-		injectHATEOASLinks(&triages[i])
+		injectHATEOASLinks(&triages[i], sippyapi.GetBaseURL(req))
 	}
 	return triages, err
+}
+
+func ListRegressions(dbc *db.DB, view, release string, views []crview.View, releases []v1.Release, crTimeRoundingFactor time.Duration, req *http.Request) ([]models.TestRegression, error) {
+	var regressions []models.TestRegression
+	var err error
+	regressions, err = query.ListRegressions(dbc, view, release)
+	if err != nil {
+		return regressions, err
+	}
+
+	// Add HATEOAS links to each regression
+	for i := range regressions {
+		InjectRegressionHATEOASLinks(&regressions[i], views, releases, crTimeRoundingFactor, sippyapi.GetBaseURL(req))
+	}
+
+	return regressions, err
 }
 
 // validateTriage ensures the Triage record coming into the API appears valid. Small
@@ -60,7 +81,7 @@ func validateTriage(triage models.Triage, update bool) error {
 	return nil
 }
 
-func CreateTriage(dbc *gorm.DB, triage models.Triage) (models.Triage, error) {
+func CreateTriage(dbc *gorm.DB, triage models.Triage, req *http.Request) (models.Triage, error) {
 	err := validateTriage(triage, false)
 	if err != nil {
 		log.WithError(err).Error("error validating triage record")
@@ -95,7 +116,7 @@ func CreateTriage(dbc *gorm.DB, triage models.Triage) (models.Triage, error) {
 	}
 	log.WithField("triageID", triage.ID).Info("triage record created")
 
-	injectHATEOASLinks(&triage)
+	injectHATEOASLinks(&triage, sippyapi.GetBaseURL(req))
 	return triage, nil
 }
 
@@ -137,7 +158,7 @@ func linkRegressions(dbc *gorm.DB, triage *models.Triage) error {
 	return nil
 }
 
-func UpdateTriage(dbc *gorm.DB, triage models.Triage) (models.Triage, error) {
+func UpdateTriage(dbc *gorm.DB, triage models.Triage, req *http.Request) (models.Triage, error) {
 	err := validateTriage(triage, true)
 	if err != nil {
 		log.WithError(err).Error("error validating triage record")
@@ -203,7 +224,7 @@ func UpdateTriage(dbc *gorm.DB, triage models.Triage) (models.Triage, error) {
 		return triage, err
 	}
 
-	injectHATEOASLinks(&triage)
+	injectHATEOASLinks(&triage, sippyapi.GetBaseURL(req))
 	return triage, nil
 }
 
@@ -227,13 +248,17 @@ func GetRegressions(dbc *gorm.DB, view string) ([]models.TestRegression, error) 
 }
 
 // GetRegression returns the regression with the matching ID
-func GetRegression(dbc *gorm.DB, id int) (*models.TestRegression, error) {
-	var regression models.TestRegression
-	res := dbc.Preload("Triages").First(&regression, id)
+func GetRegression(dbc *db.DB, id int, views []crview.View, releases []v1.Release, crTimeRoundingFactor time.Duration, req *http.Request) (*models.TestRegression, error) {
+	existingRegression := &models.TestRegression{}
+	res := dbc.DB.Preload("Triages").First(existingRegression, id)
 	if res.Error != nil {
-		return nil, res.Error
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		log.WithError(res.Error).Errorf("error looking up existing regression record: %d", id)
 	}
-	return &regression, nil
+	InjectRegressionHATEOASLinks(existingRegression, views, releases, crTimeRoundingFactor, sippyapi.GetBaseURL(req))
+	return existingRegression, res.Error
 }
 
 // GetTriagePotentialMatches returns a list of PotentialMatchingRegression including all possible matching regressions for a given
@@ -626,10 +651,84 @@ const (
 )
 
 // injectHATEOASLinks adds restful links clients can follow for this triage record.
-func injectHATEOASLinks(triage *models.Triage) {
+func injectHATEOASLinks(triage *models.Triage, baseURL string) {
 	triage.Links = map[string]string{
 		"self":              fmt.Sprintf(triageLink, triage.ID),
 		"potential_matches": fmt.Sprintf(potentialMatchesLink, triage.ID),
 		"audit_logs":        fmt.Sprintf(auditLogsLink, triage.ID),
 	}
+
+	// If we have a base URL, which should be irtually all the time, include fully qualified
+	// links that can be clicked/copied easily.
+	if baseURL != "" {
+		for k, v := range triage.Links {
+			triage.Links[k] = baseURL + triage.Links[v]
+		}
+	}
+}
+
+// InjectRegressionHATEOASLinks adds restful links clients can follow for this regression record.
+func InjectRegressionHATEOASLinks(regression *models.TestRegression, views []crview.View, releases []v1.Release, crTimeRoundingFactor time.Duration, baseURL string) {
+	if regression.Links == nil {
+		regression.Links = make(map[string]string)
+	}
+
+	// Add self link with fully qualified URL using the correct protocol
+	regression.Links["self"] = fmt.Sprintf("%s/api/component_readiness/regressions/%d", baseURL, regression.ID)
+
+	// Generate test details URL - extract the required data from the regression and view
+	testDetailsURL, err := generateTestDetailsURLFromRegression(regression, views, releases, crTimeRoundingFactor, baseURL)
+	if err != nil {
+		log.WithError(err).Warnf("failed to generate test details URL for regression %d", regression.ID)
+		return
+	}
+
+	regression.Links["test_details"] = testDetailsURL
+}
+
+// generateTestDetailsURLFromRegression extracts the required data from a regression and view
+// and calls the refactored GenerateTestDetailsURL function.
+func generateTestDetailsURLFromRegression(regression *models.TestRegression, views []crview.View, releases []v1.Release, crTimeRoundingFactor time.Duration, baseURL string) (string, error) {
+	if regression == nil {
+		return "", fmt.Errorf("regression cannot be nil")
+	}
+
+	// Find the view for this regression
+	var view crview.View
+	var found bool
+	for i := range views {
+		if views[i].Name == regression.View {
+			view = views[i]
+			found = true
+			break
+		}
+	}
+	if !found {
+		return "", fmt.Errorf("view %s not found", regression.View)
+	}
+
+	// Get base and sample release options from the view
+	baseReleaseOpts, err := utils.GetViewReleaseOptions(releases, "basis", view.BaseRelease, crTimeRoundingFactor)
+	if err != nil {
+		return "", fmt.Errorf("failed to get base release options: %w", err)
+	}
+
+	sampleReleaseOpts, err := utils.GetViewReleaseOptions(releases, "sample", view.SampleRelease, crTimeRoundingFactor)
+	if err != nil {
+		return "", fmt.Errorf("failed to get sample release options: %w", err)
+	}
+
+	// Call the refactored GenerateTestDetailsURL function with explicit parameters
+	return utils.GenerateTestDetailsURL(
+		regression.TestID,
+		baseURL,
+		baseReleaseOpts,
+		sampleReleaseOpts,
+		view.AdvancedOptions,
+		view.VariantOptions,
+		regression.Component,
+		regression.Capability,
+		regression.Variants,
+		regression.BaseRelease,
+	)
 }

--- a/pkg/api/componentreadiness/utils/queryparamparser.go
+++ b/pkg/api/componentreadiness/utils/queryparamparser.go
@@ -1,4 +1,4 @@
-package componentreadiness
+package utils
 
 import (
 	"errors"
@@ -230,7 +230,7 @@ func parseVariantOptions(req *http.Request, allJobVariants crtest.JobVariants, o
 	// check if any included variants have a junit table override:
 	var overriddenVariant string
 	for _, or := range overrides {
-		if containsOverriddenVariant(opts.IncludeVariants, or.VariantName, or.VariantValue) {
+		if ContainsOverriddenVariant(opts.IncludeVariants, or.VariantName, or.VariantValue) {
 			overriddenVariant = fmt.Sprintf("%s=%s", or.VariantName, or.VariantValue)
 			break
 		}

--- a/pkg/api/componentreadiness/utils/utils.go
+++ b/pkg/api/componentreadiness/utils/utils.go
@@ -3,13 +3,19 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"regexp"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/bq"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crtest"
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
 	sippyv1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
-	"github.com/sirupsen/logrus"
 )
 
 func PreviousRelease(release string, releaseConfigs []sippyv1.Release) (string, error) {
@@ -81,4 +87,150 @@ func VariantsMapToStringSlice(variants map[string]string) []string {
 		vs = append(vs, fmt.Sprintf("%s:%s", k, v))
 	}
 	return vs
+}
+
+// GenerateTestDetailsURL creates a HATEOAS-style URL for the test_details API endpoint
+// based on explicit parameters. This function is focused on URL generation rather than
+// data processing, with the caller responsible for extracting the required data.
+func GenerateTestDetailsURL(
+	testID string,
+	baseURL string,
+	baseReleaseOpts reqopts.Release,
+	sampleReleaseOpts reqopts.Release,
+	advancedOptions reqopts.Advanced,
+	variantOptions reqopts.Variants,
+	component string,
+	capability string,
+	variants []string,
+	baseReleaseOverride string,
+) (string, error) {
+
+	if testID == "" {
+		return "", fmt.Errorf("testID cannot be empty")
+	}
+
+	// Parse variants from the variants slice (which is a []string of "key:value" pairs)
+	variantMap := make(map[string]string)
+	for _, variant := range variants {
+		parts := strings.SplitN(variant, ":", 2)
+		if len(parts) == 2 {
+			variantMap[parts[0]] = parts[1]
+		}
+	}
+
+	// Build the URL with query parameters
+	var fullURL string
+	if baseURL == "" {
+		// For backward compatibility, return relative URL if no baseURL provided
+		logrus.Warn("GenerateTestDetailsURL was given an empty baseURL")
+		fullURL = "/api/component_readiness/test_details"
+	} else {
+		// Create fully qualified URL
+		fullURL = fmt.Sprintf("%s/api/component_readiness/test_details", baseURL)
+	}
+
+	u, err := url.Parse(fullURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	params := url.Values{}
+
+	params.Add("testId", testID)
+
+	// Add release and time parameters
+	params.Add("baseRelease", baseReleaseOpts.Name)
+	params.Add("sampleRelease", sampleReleaseOpts.Name)
+	params.Add("baseStartTime", baseReleaseOpts.Start.Format("2006-01-02T15:04:05Z"))
+	params.Add("baseEndTime", baseReleaseOpts.End.Format("2006-01-02T15:04:05Z"))
+	params.Add("sampleStartTime", sampleReleaseOpts.Start.Format("2006-01-02T15:04:05Z"))
+	params.Add("sampleEndTime", sampleReleaseOpts.End.Format("2006-01-02T15:04:05Z"))
+
+	// Check if release fallback was used and add the override
+	if baseReleaseOverride != "" && baseReleaseOverride != baseReleaseOpts.Name {
+		params.Add("testBasisRelease", baseReleaseOverride)
+	}
+
+	// Add advanced options
+	params.Add("confidence", strconv.Itoa(advancedOptions.Confidence))
+	params.Add("minFail", strconv.Itoa(advancedOptions.MinimumFailure))
+	params.Add("pity", strconv.Itoa(advancedOptions.PityFactor))
+	params.Add("passRateNewTests", strconv.Itoa(advancedOptions.PassRateRequiredNewTests))
+	params.Add("passRateAllTests", strconv.Itoa(advancedOptions.PassRateRequiredAllTests))
+	params.Add("ignoreDisruption", strconv.FormatBool(advancedOptions.IgnoreDisruption))
+	params.Add("ignoreMissing", strconv.FormatBool(advancedOptions.IgnoreMissing))
+	params.Add("flakeAsFailure", strconv.FormatBool(advancedOptions.FlakeAsFailure))
+	params.Add("includeMultiReleaseAnalysis", strconv.FormatBool(advancedOptions.IncludeMultiReleaseAnalysis))
+
+	if component != "" {
+		params.Add("component", component)
+	}
+	if capability != "" {
+		params.Add("capability", capability)
+	}
+
+	// Add variant options
+	if variantOptions.ColumnGroupBy != nil {
+		params.Add("columnGroupBy", strings.Join(variantOptions.ColumnGroupBy.List(), ","))
+	}
+	if variantOptions.DBGroupBy != nil {
+		params.Add("dbGroupBy", strings.Join(variantOptions.DBGroupBy.List(), ","))
+	}
+
+	// Add include variants
+	// Sort variant keys to ensure consistent parameter ordering
+	includeVariantKeys := make([]string, 0, len(variantOptions.IncludeVariants))
+	for variantKey := range variantOptions.IncludeVariants {
+		includeVariantKeys = append(includeVariantKeys, variantKey)
+	}
+	sort.Strings(includeVariantKeys)
+
+	for _, variantKey := range includeVariantKeys {
+		variantValues := variantOptions.IncludeVariants[variantKey]
+		// Sort variant values to ensure consistent parameter ordering
+		sortedValues := make([]string, len(variantValues))
+		copy(sortedValues, variantValues)
+		sort.Strings(sortedValues)
+
+		for _, variantValue := range sortedValues {
+			params.Add("includeVariant", fmt.Sprintf("%s:%s", variantKey, variantValue))
+		}
+	}
+
+	// Add the specific variants as individual parameters
+	// Sort the keys to ensure consistent environment parameter ordering
+	variantKeys := make([]string, 0, len(variantMap))
+	for key := range variantMap {
+		variantKeys = append(variantKeys, key)
+	}
+	sort.Strings(variantKeys)
+
+	environment := make([]string, 0, len(variantMap))
+	for _, key := range variantKeys {
+		value := variantMap[key]
+		params.Add(key, value)
+		environment = append(environment, fmt.Sprintf("%s:%s", key, value))
+	}
+
+	// Add environment parameter (space-separated variant pairs)
+	if len(environment) > 0 {
+		params.Add("environment", strings.Join(environment, " "))
+	}
+
+	u.RawQuery = params.Encode()
+	return u.String(), nil
+}
+
+func ContainsOverriddenVariant(includeVariants map[string][]string, key, value string) bool {
+	for k, v := range includeVariants {
+		if k != key {
+			continue
+		}
+		for _, vv := range v {
+			if vv == value {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/api/componentreadiness/utils/utils_test.go
+++ b/pkg/api/componentreadiness/utils/utils_test.go
@@ -1,0 +1,366 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/crview"
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
+	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateTestDetailsURL(t *testing.T) {
+	// Define releases with GA dates for all tests
+	ga419 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	ga420 := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	releases := []v1.Release{
+		{
+			Release: "4.19",
+			GADate:  &ga419,
+		},
+		{
+			Release: "4.20",
+			GADate:  &ga420,
+		},
+	}
+
+	// Define a common view to use across all tests
+	testView := crview.View{
+		Name: "test-view",
+		BaseRelease: reqopts.RelativeRelease{
+			Release: reqopts.Release{
+				Name: "4.19",
+			},
+			RelativeStart: "ga-30d",
+			RelativeEnd:   "ga",
+		},
+		SampleRelease: reqopts.RelativeRelease{
+			Release: reqopts.Release{
+				Name: "4.20",
+			},
+			RelativeStart: "ga-7d",
+			RelativeEnd:   "ga",
+		},
+		AdvancedOptions: reqopts.Advanced{
+			MinimumFailure:              3,
+			Confidence:                  95,
+			PityFactor:                  5,
+			IncludeMultiReleaseAnalysis: true,
+		},
+	}
+
+	// Helper function to get release options from view
+	getBaseReleaseOpts := func() reqopts.Release {
+		opts, err := GetViewReleaseOptions(releases, "basis", testView.BaseRelease, 0)
+		require.NoError(t, err)
+		return opts
+	}
+	getSampleReleaseOpts := func() reqopts.Release {
+		opts, err := GetViewReleaseOptions(releases, "sample", testView.SampleRelease, 0)
+		require.NoError(t, err)
+		return opts
+	}
+
+	t.Run("empty base URL", func(t *testing.T) {
+		url, err := GenerateTestDetailsURL(
+			"test-id",
+			"",
+			getBaseReleaseOpts(),
+			getSampleReleaseOpts(),
+			testView.AdvancedOptions,
+			testView.VariantOptions,
+			"",
+			"",
+			[]string{"Platform:aws"},
+			"",
+		)
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(url, "/api/component_readiness/test_details"))
+	})
+
+	t.Run("empty test ID", func(t *testing.T) {
+		_, err := GenerateTestDetailsURL(
+			"",
+			"https://example.com",
+			getBaseReleaseOpts(),
+			getSampleReleaseOpts(),
+			testView.AdvancedOptions,
+			testView.VariantOptions,
+			"",
+			"",
+			[]string{},
+			"",
+		)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "testID cannot be empty")
+	})
+
+	t.Run("variants with malformed entries", func(t *testing.T) {
+		url, err := GenerateTestDetailsURL(
+			"test-id",
+			"",
+			getBaseReleaseOpts(),
+			getSampleReleaseOpts(),
+			testView.AdvancedOptions,
+			testView.VariantOptions,
+			"",
+			"",
+			[]string{"Architecture:amd64", "InvalidVariant", "Platform:aws"},
+			"",
+		)
+		require.NoError(t, err)
+
+		// Should still work, just ignoring malformed variants
+		assert.Contains(t, url, "Architecture=amd64")
+		assert.Contains(t, url, "Platform=aws")
+		assert.NotContains(t, url, "InvalidVariant")
+	})
+
+	t.Run("environment parameter is sorted", func(t *testing.T) {
+		url, err := GenerateTestDetailsURL(
+			"test-id",
+			"",
+			getBaseReleaseOpts(),
+			getSampleReleaseOpts(),
+			testView.AdvancedOptions,
+			testView.VariantOptions,
+			"",
+			"",
+			// Use variants in non-alphabetical order to test sorting
+			[]string{"Topology:ha", "Architecture:amd64", "Platform:aws", "Network:ovn"},
+			"",
+		)
+		require.NoError(t, err)
+
+		// Environment should be sorted alphabetically regardless of input order
+		assert.Contains(t, url, "environment=Architecture%3Aamd64+Network%3Aovn+Platform%3Aaws+Topology%3Aha")
+	})
+
+	t.Run("URL generation with view", func(t *testing.T) {
+		url, err := GenerateTestDetailsURL(
+			"openshift-tests:abc123",
+			"https://sippy.example.com",
+			getBaseReleaseOpts(),
+			getSampleReleaseOpts(),
+			testView.AdvancedOptions,
+			testView.VariantOptions,
+			"component-example",
+			"capability-example",
+			[]string{"Architecture:amd64", "Platform:aws"},
+			"",
+		)
+		require.NoError(t, err)
+		assert.NotEmpty(t, url)
+
+		// Should use view configuration
+		assert.Contains(t, url, "https://sippy.example.com/api/component_readiness/test_details")
+		assert.Contains(t, url, "testId=openshift-tests%3Aabc123")
+		assert.Contains(t, url, "baseRelease=4.19")
+		assert.Contains(t, url, "sampleRelease=4.20")
+		assert.Contains(t, url, "confidence=95")
+		assert.Contains(t, url, "minFail=3")
+		assert.Contains(t, url, "pity=5")
+		assert.Contains(t, url, "includeMultiReleaseAnalysis=true")
+		assert.Contains(t, url, "Architecture=amd64")
+		assert.Contains(t, url, "Platform=aws")
+		assert.Contains(t, url, "component=component-example")
+		assert.Contains(t, url, "capability=capability-example")
+		assert.NotContains(t, url, "testBasisRelease")
+	})
+
+	t.Run("URL generation with release fallback", func(t *testing.T) {
+		url, err := GenerateTestDetailsURL(
+			"openshift-tests:abc123",
+			"https://sippy.example.com",
+			getBaseReleaseOpts(),
+			getSampleReleaseOpts(),
+			testView.AdvancedOptions,
+			testView.VariantOptions,
+			"",
+			"",
+			[]string{"Architecture:amd64", "Platform:aws"},
+			"4.17", // Different from view's base release
+		)
+		require.NoError(t, err)
+		assert.NotEmpty(t, url)
+
+		assert.Contains(t, url, "https://sippy.example.com/api/component_readiness/test_details")
+		assert.Contains(t, url, "testId=openshift-tests%3Aabc123")
+		assert.Contains(t, url, "baseRelease=4.19")
+		assert.Contains(t, url, "sampleRelease=4.20")
+		assert.Contains(t, url, "testBasisRelease=4.17")
+		assert.Contains(t, url, "confidence=95")
+		assert.Contains(t, url, "minFail=3")
+		assert.Contains(t, url, "pity=5")
+		assert.Contains(t, url, "includeMultiReleaseAnalysis=true")
+		assert.Contains(t, url, "Architecture=amd64")
+		assert.Contains(t, url, "Platform=aws")
+	})
+
+	t.Run("URL generation with real-world regression data", func(t *testing.T) {
+		// Add a more comprehensive view for this test
+		realWorldView := crview.View{
+			Name: "4.20-main",
+			BaseRelease: reqopts.RelativeRelease{
+				Release: reqopts.Release{
+					Name: "4.19",
+				},
+				RelativeStart: "ga-30d",
+				RelativeEnd:   "ga",
+			},
+			SampleRelease: reqopts.RelativeRelease{
+				Release: reqopts.Release{
+					Name: "4.20",
+				},
+				RelativeStart: "ga-7d",
+				RelativeEnd:   "ga",
+			},
+			AdvancedOptions: reqopts.Advanced{
+				MinimumFailure:              3,
+				Confidence:                  95,
+				PityFactor:                  5,
+				IncludeMultiReleaseAnalysis: true,
+				PassRateRequiredNewTests:    95,
+				PassRateRequiredAllTests:    0,
+				FlakeAsFailure:              false,
+				IgnoreDisruption:            true,
+				IgnoreMissing:               false,
+			},
+		}
+
+		// Get release options from the real-world view
+		baseReleaseOpts, err := GetViewReleaseOptions(releases, "basis", realWorldView.BaseRelease, time.Hour)
+		require.NoError(t, err)
+		sampleReleaseOpts, err := GetViewReleaseOptions(releases, "sample", realWorldView.SampleRelease, time.Hour)
+		require.NoError(t, err)
+
+		url, err := GenerateTestDetailsURL(
+			"openshift-tests:9f3fb60052539c29ab66564689f616ce",
+			"https://sippy-auth.dptools.openshift.org",
+			baseReleaseOpts,
+			sampleReleaseOpts,
+			realWorldView.AdvancedOptions,
+			realWorldView.VariantOptions,
+			"",
+			"",
+			[]string{
+				"Installer:ipi",
+				"Network:ovn",
+				"Platform:vsphere",
+				"Suite:serial",
+				"Topology:ha",
+				"Upgrade:none",
+				"Architecture:amd64",
+				"FeatureSet:default",
+			},
+			"4.18",
+		)
+		require.NoError(t, err)
+		assert.NotEmpty(t, url)
+		fmt.Println(url)
+
+		// Verify the URL contains the expected components
+		assert.Contains(t, url, "https://sippy-auth.dptools.openshift.org/api/component_readiness/test_details")
+
+		// Test identification parameters
+		assert.Contains(t, url, "testId=openshift-tests%3A9f3fb60052539c29ab66564689f616ce")
+		assert.Contains(t, url, "baseRelease=4.19")
+		assert.Contains(t, url, "sampleRelease=4.20")
+		assert.Contains(t, url, "testBasisRelease=4.18")
+		assert.Contains(t, url, "confidence=95")
+		assert.Contains(t, url, "minFail=3")
+		assert.Contains(t, url, "pity=5")
+		assert.Contains(t, url, "includeMultiReleaseAnalysis=true")
+		assert.Contains(t, url, "passRateNewTests=95")
+		assert.Contains(t, url, "passRateAllTests=0")
+		assert.Contains(t, url, "ignoreDisruption=true")
+		assert.Contains(t, url, "flakeAsFailure=false")
+
+		// Verify all variants are included in the environment parameter
+		assert.Contains(t, url, "environment=Architecture%3Aamd64+FeatureSet%3Adefault+Installer%3Aipi+Network%3Aovn+Platform%3Avsphere+Suite%3Aserial+Topology%3Aha+Upgrade%3Anone")
+
+		// Verify individual variant parameters
+		assert.Contains(t, url, "Architecture=amd64")
+		assert.Contains(t, url, "FeatureSet=default")
+		assert.Contains(t, url, "Installer=ipi")
+		assert.Contains(t, url, "Network=ovn")
+		assert.Contains(t, url, "Platform=vsphere")
+		assert.Contains(t, url, "Suite=serial")
+		assert.Contains(t, url, "Topology=ha")
+		assert.Contains(t, url, "Upgrade=none")
+	})
+
+	t.Run("includeVariant parameters are sorted", func(t *testing.T) {
+		// Create a view with includeVariants in non-alphabetical order
+		viewWithVariants := crview.View{
+			Name: "test-view-with-variants",
+			BaseRelease: reqopts.RelativeRelease{
+				Release: reqopts.Release{
+					Name: "4.19",
+				},
+				RelativeStart: "ga-30d",
+				RelativeEnd:   "ga",
+			},
+			SampleRelease: reqopts.RelativeRelease{
+				Release: reqopts.Release{
+					Name: "4.20",
+				},
+				RelativeStart: "ga-7d",
+				RelativeEnd:   "ga",
+			},
+			VariantOptions: reqopts.Variants{
+				IncludeVariants: map[string][]string{
+					// Keys and values in non-alphabetical order to test sorting
+					"Platform":     {"gcp", "aws", "azure"},
+					"Architecture": {"amd64"},
+					"Network":      {"ovn", "sdn"},
+				},
+			},
+			AdvancedOptions: reqopts.Advanced{
+				MinimumFailure:              3,
+				Confidence:                  95,
+				PityFactor:                  5,
+				IncludeMultiReleaseAnalysis: true,
+			},
+		}
+
+		// Get release options from the view with variants
+		baseReleaseOpts, err := GetViewReleaseOptions(releases, "basis", viewWithVariants.BaseRelease, 0)
+		require.NoError(t, err)
+		sampleReleaseOpts, err := GetViewReleaseOptions(releases, "sample", viewWithVariants.SampleRelease, 0)
+		require.NoError(t, err)
+
+		url, err := GenerateTestDetailsURL(
+			"test-id",
+			"https://example.com",
+			baseReleaseOpts,
+			sampleReleaseOpts,
+			viewWithVariants.AdvancedOptions,
+			viewWithVariants.VariantOptions,
+			"",
+			"",
+			[]string{},
+			"",
+		)
+		require.NoError(t, err)
+
+		// Verify that includeVariant parameters are sorted by key and value
+		// Architecture should come first (alphabetically), then Network, then Platform
+		// Within Platform, values should be sorted: aws, azure, gcp
+		assert.Contains(t, url, "includeVariant=Architecture%3Aamd64")
+		assert.Contains(t, url, "includeVariant=Network%3Aovn")
+		assert.Contains(t, url, "includeVariant=Network%3Asdn")
+		assert.Contains(t, url, "includeVariant=Platform%3Aaws")
+		assert.Contains(t, url, "includeVariant=Platform%3Aazure")
+		assert.Contains(t, url, "includeVariant=Platform%3Agcp")
+
+		// Check that the order is correct by looking at the raw query
+		// The URL encoding makes this a bit tricky, but we can check the pattern
+		assert.Regexp(t, `includeVariant=Architecture.*includeVariant=Network.*includeVariant=Platform`, url)
+	})
+
+}

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"reflect"
 	"strings"
 	"time"
@@ -218,4 +219,17 @@ func VariantListToMap(allJobVariants crtest.JobVariants, variants []string) (map
 		}
 	}
 	return variantsMap, err
+}
+
+// GetBaseURL returns the base URL (protocol + host) from the request.
+// It handles TLS and X-Forwarded-Proto header to determine the protocol.
+func GetBaseURL(req *http.Request) string {
+	protocol := "http"
+	if req.TLS != nil {
+		protocol = "https"
+	}
+	if proto := req.Header.Get("X-Forwarded-Proto"); proto != "" {
+		protocol = proto
+	}
+	return protocol + "://" + req.Host
 }

--- a/pkg/apis/api/componentreport/testdetails/types.go
+++ b/pkg/apis/api/componentreport/testdetails/types.go
@@ -60,6 +60,9 @@ type TestComparison struct {
 	// RequiredPassRateAdjustment can be used to adjust the tolerance for failures for a new test.
 	RequiredPassRateAdjustment float64 `json:"-"`
 
+	// Links contains HATEOAS-style links for this regression record (not stored in database)
+	Links map[string]string `json:"links,omitempty"`
+
 	// Optional fields depending on the Comparison mode
 
 	// FisherExact indicates the confidence of a regression after applying Fisher's Exact Test.

--- a/pkg/componentreadiness/jiraautomator/jiraautomator.go
+++ b/pkg/componentreadiness/jiraautomator/jiraautomator.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/andygrunwald/go-jira"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crtest"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crview"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
@@ -113,12 +114,12 @@ func NewJiraAutomator(
 }
 
 func (j JiraAutomator) getRequestOptionForView(view crview.View) (reqopts.RequestOptions, error) {
-	baseRelease, err := componentreadiness.GetViewReleaseOptions(j.releases, "basis", view.BaseRelease, j.cacheOptions.CRTimeRoundingFactor)
+	baseRelease, err := utils.GetViewReleaseOptions(j.releases, "basis", view.BaseRelease, j.cacheOptions.CRTimeRoundingFactor)
 	if err != nil {
 		return reqopts.RequestOptions{}, err
 	}
 
-	sampleRelease, err := componentreadiness.GetViewReleaseOptions(j.releases, "sample", view.SampleRelease, j.cacheOptions.CRTimeRoundingFactor)
+	sampleRelease, err := utils.GetViewReleaseOptions(j.releases, "sample", view.SampleRelease, j.cacheOptions.CRTimeRoundingFactor)
 	if err != nil {
 		return reqopts.RequestOptions{}, err
 	}
@@ -147,7 +148,7 @@ func (j JiraAutomator) getComponentReportForView(view crview.View) (crtype.Compo
 	}
 
 	// Passing empty gcs bucket and prow URL, they are not needed outside test details reports
-	report, errs := componentreadiness.GetComponentReportFromBigQuery(context.Background(), j.bqClient, j.dbc, reportOpts, j.variantJunitTableOverrides)
+	report, errs := componentreadiness.GetComponentReportFromBigQuery(context.Background(), j.bqClient, j.dbc, reportOpts, j.variantJunitTableOverrides, "")
 	if len(errs) > 0 {
 		var strErrors []string
 		for _, err := range errs {

--- a/pkg/dataloader/crcacheloader/crcacheloader.go
+++ b/pkg/dataloader/crcacheloader/crcacheloader.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openshift/sippy/pkg/api"
 	"github.com/openshift/sippy/pkg/api/componentreadiness"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
 	sippytypes "github.com/openshift/sippy/pkg/apis/api"
 	crtype "github.com/openshift/sippy/pkg/apis/api/componentreport"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crtest"
@@ -223,13 +224,13 @@ func (l *ComponentReadinessCacheLoader) buildGenerator(
 	testIDOpts []reqopts.TestIdentification,
 ) (*componentreadiness.ComponentReportGenerator, error) {
 
-	baseRelease, err := componentreadiness.GetViewReleaseOptions(
+	baseRelease, err := utils.GetViewReleaseOptions(
 		l.releases, "basis", view.BaseRelease, cacheOpts.CRTimeRoundingFactor)
 	if err != nil {
 		return nil, err
 	}
 
-	sampleRelease, err := componentreadiness.GetViewReleaseOptions(
+	sampleRelease, err := utils.GetViewReleaseOptions(
 		l.releases, "sample", view.SampleRelease, cacheOpts.CRTimeRoundingFactor)
 	if err != nil {
 		return nil, err
@@ -251,6 +252,6 @@ func (l *ComponentReadinessCacheLoader) buildGenerator(
 	// Making a generator directly as we are going to bypass the caching to ensure we get fresh report,
 	// explicitly set our reports in the cache, thus resetting the timer for all expiry and keeping the cache
 	// primed.
-	generator := componentreadiness.NewComponentReportGenerator(l.bqClient, reqOpts, l.dbc, l.config.ComponentReadinessConfig.VariantJunitTableOverrides, l.releases)
+	generator := componentreadiness.NewComponentReportGenerator(l.bqClient, reqOpts, l.dbc, l.config.ComponentReadinessConfig.VariantJunitTableOverrides, l.releases, "")
 	return &generator, nil
 }

--- a/pkg/db/models/triage.go
+++ b/pkg/db/models/triage.go
@@ -205,19 +205,27 @@ func ValidTriageType(triageType TriageType) bool {
 // TestRegression is used for rows in the test_regressions table and is used to track when we detect test
 // regressions opening and closing.
 type TestRegression struct {
-	ID       uint           `json:"id" gorm:"primaryKey,column:id"`
-	View     string         `json:"view" gorm:"not null"`
-	Release  string         `json:"release" gorm:"not null;index:idx_test_regression_release"`
-	TestID   string         `json:"test_id" gorm:"not null"`
-	TestName string         `json:"test_name" gorm:"not null;index:idx_test_regression_test_name"`
-	Variants pq.StringArray `json:"variants" gorm:"not null;type:text[]"`
-	Opened   time.Time      `json:"opened" gorm:"not null"`
-	Closed   sql.NullTime   `json:"closed"`
-	Triages  []Triage       `json:"triages" gorm:"many2many:triage_regressions;"`
+	ID      uint   `json:"id" gorm:"primaryKey,column:id"`
+	View    string `json:"view" gorm:"not null"`
+	Release string `json:"release" gorm:"not null;index:idx_test_regression_release"`
+	// BaseRelease is the release this test was marked regressed against. It may not match the view's base release
+	// if the view uses release fallback and this test was flagged regressed against a prior release with better pass rate.
+	BaseRelease string         `json:"base_release"`
+	Component   string         `json:"component"`
+	Capability  string         `json:"capability"`
+	TestID      string         `json:"test_id" gorm:"not null"`
+	TestName    string         `json:"test_name" gorm:"not null;index:idx_test_regression_test_name"`
+	Variants    pq.StringArray `json:"variants" gorm:"not null;type:text[]"`
+	Opened      time.Time      `json:"opened" gorm:"not null"`
+	Closed      sql.NullTime   `json:"closed"`
+	Triages     []Triage       `json:"triages" gorm:"many2many:triage_regressions;"`
 	// LastFailure is the last failure in the sample we saw while this regression was open.
 	LastFailure sql.NullTime `json:"last_failure"`
 	// MaxFailures is the maximum number of failures we found in the reporting window while this regression was open.
 	// This is intended to help inform the min fail thresholds we should be using, and what kind of regressions
 	// disappear on their own.
 	MaxFailures int `json:"max_failures"`
+
+	// Links contains HATEOAS-style links for this regression record (not stored in database)
+	Links map[string]string `json:"links,omitempty" gorm:"-"`
 }

--- a/pkg/db/query/triage_queries.go
+++ b/pkg/db/query/triage_queries.go
@@ -28,3 +28,21 @@ func ListOpenRegressions(dbc *db.DB, release string) ([]*models.TestRegression, 
 	}
 	return openRegressions, res.Error
 }
+
+func ListRegressions(dbc *db.DB, view, release string) ([]models.TestRegression, error) {
+	var regressions []models.TestRegression
+	query := dbc.DB.Model(&models.TestRegression{}).Preload("Triages")
+
+	if view != "" {
+		query = query.Where("test_regressions.view = ?", view)
+	}
+	if release != "" {
+		query = query.Where("test_regressions.release = ?", release)
+	}
+
+	res := query.Find(&regressions)
+	if res.Error != nil {
+		log.WithError(res.Error).Error("error listing regressions")
+	}
+	return regressions, res.Error
+}

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crview"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
 	"github.com/pkg/errors"
@@ -208,13 +209,13 @@ func updateComponentReadinessMetricsForView(ctx context.Context, client *bqclien
 	logger := log.WithField("view", view.Name)
 	logger.Info("generating report for view")
 
-	baseRelease, err := componentreadiness.GetViewReleaseOptions(
+	baseRelease, err := utils.GetViewReleaseOptions(
 		releases, "basis", view.BaseRelease, cacheOptions.CRTimeRoundingFactor)
 	if err != nil {
 		return err
 	}
 
-	sampleRelease, err := componentreadiness.GetViewReleaseOptions(
+	sampleRelease, err := utils.GetViewReleaseOptions(
 		releases, "sample", view.SampleRelease, cacheOptions.CRTimeRoundingFactor)
 	if err != nil {
 		return err
@@ -232,7 +233,7 @@ func updateComponentReadinessMetricsForView(ctx context.Context, client *bqclien
 		CacheOption:    cacheOptions,
 	}
 
-	report, errs := componentreadiness.GetComponentReportFromBigQuery(ctx, client, dbc, reportOpts, overrides)
+	report, errs := componentreadiness.GetComponentReportFromBigQuery(ctx, client, dbc, reportOpts, overrides, "")
 	if len(errs) > 0 {
 		var strErrors []string
 		for _, err := range errs {

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1555,6 +1555,10 @@ func (s *Server) jsonRegressions(w http.ResponseWriter, req *http.Request) {
 	}
 
 	regressions, err := componentreadiness.ListRegressions(s.db, view, release, s.views.ComponentReadiness, allReleases, s.crTimeRoundingFactor, req)
+	if err != nil {
+		failureResponse(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 	api.RespondWithJSON(http.StatusOK, w, regressions)
 }
 

--- a/pkg/util/param/param.go
+++ b/pkg/util/param/param.go
@@ -52,6 +52,8 @@ var paramRegexp = map[string]*regexp.Regexp{
 	"samplePROrg":      nameRegexp,
 	"samplePRRepo":     nameRegexp,
 	"samplePRNumber":   uintRegexp,
+	"samplePayloadTag": nameRegexp,
+	"view":             nameRegexp, // component readiness view name
 	// jobartifacts params
 	"prowJobRuns":        regexp.MustCompile(`^\d+(,\d+)*$`), // comma-separated integers
 	"pathGlob":           nonEmptyRegex,                      // a glob can be anything

--- a/sippy-ng/package-lock.json
+++ b/sippy-ng/package-lock.json
@@ -21529,6 +21529,7 @@
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
       "integrity": "sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",

--- a/sippy-ng/src/component_readiness/AddRegressionPanel.js
+++ b/sippy-ng/src/component_readiness/AddRegressionPanel.js
@@ -58,8 +58,9 @@ export default function AddRegressionPanel({
   }
 
   const defaultTriageId = triages.length > 0 ? triages[0].id : null
-  const [existingTriageId, setExistingTriageId] =
-    React.useState(defaultTriageId)
+  const [existingTriageId, setExistingTriageId] = React.useState(
+    triages.length > 0 ? triages[0].id : null
+  )
 
   const handleAddToExistingTriageSubmit = () => {
     const existingTriage = triages.find(

--- a/sippy-ng/src/component_readiness/CompCapTestRow.js
+++ b/sippy-ng/src/component_readiness/CompCapTestRow.js
@@ -12,49 +12,39 @@ import TableRow from '@mui/material/TableRow'
 export default function CompCapTestRow(props) {
   const classes = useContext(ComponentReadinessStyleContext)
 
-  // testName is the name of the test (called testName)
-  // testId is the unique test ID that maps to the testName
-  // results is an array of columns and contains the status value per columnName
+  // regressedTestCols is the full test data structure
   // columnNames is the calculated array of columns
   // filterVals: the parts of the url containing input values
-  // component, capability: these are passed because we need them in the /test endpoint
-  const {
-    testName,
-    testSuite,
-    testId,
-    results,
-    columnNames,
-    filterVals,
-    component,
-    capability,
-  } = props
+  const { regressedTestCols, columnNames, filterVals } = props
 
   // Put the testName on the left side with no link.
   const testNameColumn = (
-    <TableCell className={classes.componentName} key={testName}>
-      <Tooltip title={testId}>
+    <TableCell
+      className={classes.componentName}
+      key={regressedTestCols.test_name}
+    >
+      <Tooltip title={regressedTestCols.test_id}>
         <Typography className={classes.crCellName}>
-          {[testSuite, testName].filter(Boolean).join('.')}
+          {[regressedTestCols.test_suite, regressedTestCols.test_name]
+            .filter(Boolean)
+            .join('.')}
         </Typography>
       </Tooltip>
     </TableCell>
   )
 
+  console.log(regressedTestCols)
   return (
     <Fragment>
       <TableRow>
         {testNameColumn}
-        {results.map((columnVal, idx) => (
+        {regressedTestCols.columns.map((columnVal, idx) => (
           <CompReadyTestCell
             key={'testName-' + idx}
             status={columnVal.status}
             environment={columnNames[idx]}
-            testId={testId}
             filterVals={filterVals}
-            component={component}
-            capability={capability}
-            testName={testName}
-            regressedTests={columnVal.regressed_tests}
+            regressedTest={columnVal.regressed_tests[0]}
           />
         ))}
       </TableRow>
@@ -63,12 +53,7 @@ export default function CompCapTestRow(props) {
 }
 
 CompCapTestRow.propTypes = {
-  testName: PropTypes.string.isRequired,
-  testSuite: PropTypes.string.isRequired,
-  testId: PropTypes.string.isRequired,
-  results: PropTypes.array.isRequired,
+  regressedTestCols: PropTypes.object.isRequired,
   columnNames: PropTypes.array.isRequired,
   filterVals: PropTypes.string.isRequired,
-  component: PropTypes.string.isRequired,
-  capability: PropTypes.string.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompCapTestRow.js
+++ b/sippy-ng/src/component_readiness/CompCapTestRow.js
@@ -33,7 +33,6 @@ export default function CompCapTestRow(props) {
     </TableCell>
   )
 
-  console.log(regressedTestCols)
   return (
     <Fragment>
       <TableRow>
@@ -44,7 +43,7 @@ export default function CompCapTestRow(props) {
             status={columnVal.status}
             environment={columnNames[idx]}
             filterVals={filterVals}
-            regressedTest={columnVal.regressed_tests[0]}
+            regressedTest={columnVal.regressed_tests?.[0] || null}
           />
         ))}
       </TableRow>

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
@@ -243,14 +243,9 @@ export default function CompReadyEnvCapabilityTest(props) {
                 return (
                   <CompCapTestRow
                     key={componentIndex}
-                    testSuite={data.rows[componentIndex].test_suite}
-                    testName={data.rows[componentIndex].test_name}
-                    testId={data.rows[componentIndex].test_id}
-                    results={data.rows[componentIndex].columns}
+                    regressedTestCols={data.rows[componentIndex]}
                     columnNames={columnNames}
                     filterVals={filterVals}
-                    component={component}
-                    capability={capability}
                   />
                 )
               })

--- a/sippy-ng/src/component_readiness/CompReadyTestCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestCell.js
@@ -41,15 +41,19 @@ export default function CompReadyTestCell(props) {
           textAlign: 'center',
         }}
       >
-        <a
-          href={generateTestDetailsReportLink(
-            regressedTest,
-            filterVals,
-            expandEnvironment
-          )}
-        >
+        {regressedTest ? (
+          <a
+            href={generateTestDetailsReportLink(
+              regressedTest,
+              filterVals,
+              expandEnvironment
+            )}
+          >
+            <CompSeverityIcon status={status} />
+          </a>
+        ) : (
           <CompSeverityIcon status={status} />
-        </a>
+        )}
       </TableCell>
     )
   }
@@ -59,5 +63,5 @@ CompReadyTestCell.propTypes = {
   status: PropTypes.number.isRequired,
   environment: PropTypes.string.isRequired,
   filterVals: PropTypes.string.isRequired,
-  regressedTest: PropTypes.object.isRequired,
+  regressedTest: PropTypes.object,
 }

--- a/sippy-ng/src/component_readiness/CompReadyTestCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestCell.js
@@ -1,8 +1,7 @@
 import './ComponentReadiness.css'
 import { ComponentReadinessStyleContext } from './ComponentReadiness'
 import { CompReadyVarsContext } from './CompReadyVars'
-import { generateTestReport } from './CompReadyUtils'
-import { Link } from 'react-router-dom'
+import { generateTestDetailsReportLink } from './CompReadyUtils'
 import { Tooltip } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import CompSeverityIcon from './CompSeverityIcon'
@@ -13,16 +12,7 @@ import TableCell from '@mui/material/TableCell'
 
 // CompReadyTestCall is for rendering the cells on the right of page4 or page4a
 export default function CompReadyTestCell(props) {
-  const {
-    status,
-    environment,
-    testId,
-    filterVals,
-    component,
-    capability,
-    testName,
-    regressedTests,
-  } = props
+  const { status, environment, filterVals, regressedTest } = props
   const theme = useTheme()
   const classes = useContext(ComponentReadinessStyleContext)
 
@@ -43,6 +33,7 @@ export default function CompReadyTestCell(props) {
       </Tooltip>
     )
   } else {
+    console.log('regressedTest', regressedTest)
     return (
       <TableCell
         className={classes.crCellResult}
@@ -50,19 +41,15 @@ export default function CompReadyTestCell(props) {
           textAlign: 'center',
         }}
       >
-        <Link
-          to={generateTestReport(
-            testId,
-            expandEnvironment(environment),
+        <a
+          href={generateTestDetailsReportLink(
+            regressedTest,
             filterVals,
-            component,
-            capability,
-            testName,
-            regressedTests
+            expandEnvironment
           )}
         >
           <CompSeverityIcon status={status} />
-        </Link>
+        </a>
       </TableCell>
     )
   }
@@ -71,10 +58,6 @@ export default function CompReadyTestCell(props) {
 CompReadyTestCell.propTypes = {
   status: PropTypes.number.isRequired,
   environment: PropTypes.string.isRequired,
-  testId: PropTypes.string.isRequired,
   filterVals: PropTypes.string.isRequired,
-  component: PropTypes.string.isRequired,
-  capability: PropTypes.string.isRequired,
-  testName: PropTypes.string.isRequired,
-  regressedTests: PropTypes.object,
+  regressedTest: PropTypes.object.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -841,10 +841,12 @@ export function generateTestDetailsReportLink(
     // http://localhost:8080/api/ to http://localhost:3000/sippy-ng/
     // This hack allows us to keep the param generation logic in one place. (server side)
     const testDetailsUrl = regressedTest.links.test_details
+    console.log('testDetailsUrl', testDetailsUrl)
     const apiIndex = testDetailsUrl.indexOf('/api/')
     if (apiIndex !== -1) {
       const pathAfterApi = testDetailsUrl.substring(apiIndex + 5) // +5 to skip '/api/'
       const modifiedUrl = '/sippy-ng/' + pathAfterApi
+      console.log('modifiedUrl', modifiedUrl)
       return modifiedUrl
     }
     return testDetailsUrl

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -94,11 +94,6 @@ export function getComponentReadinessViewsAPIUrl() {
   return getAPIUrl('component_readiness/views')
 }
 
-// Make one place to create the Component Readiness test_details api call
-export function getTestDetailsAPIUrl() {
-  return getAPIUrl('component_readiness/test_details')
-}
-
 export function getTriagesAPIUrl(id = null) {
   return getAPIUrl(
     id ? `component_readiness/triages/${id}` : 'component_readiness/triages'
@@ -693,6 +688,7 @@ export function generateTestReport(
   regressedTests
 ) {
   let testBasisRelease = ''
+  console.log(regressedTests)
   if (
     typeof regressedTests != 'undefined' &&
     regressedTests.length > 0 &&
@@ -717,13 +713,100 @@ export function generateTestReport(
   return sortQueryParams(retUrl)
 }
 
+// Helper function to compare query parameters between two URLs
+export function compareUrlQueryParams(newURL, oldURL) {
+  // Extract query parameters from both URLs
+  const [, queryString1] = newURL.split('?')
+  const [, queryString2] = oldURL.split('?')
+
+  if (!queryString1 || !queryString2) {
+    console.log('One or both URLs do not have query parameters')
+    return
+  }
+
+  // Parse query parameters
+  const params1 = new URLSearchParams(queryString1)
+  const params2 = new URLSearchParams(queryString2)
+
+  // Convert to objects for easier comparison
+  const paramsObjNew = {}
+  const paramsObjOld = {}
+
+  for (const [key, value] of params1.entries()) {
+    paramsObjNew[key] = value
+  }
+
+  for (const [key, value] of params2.entries()) {
+    paramsObjOld[key] = value
+  }
+
+  // Find differences
+  const differences = {
+    onlyInNew: {},
+    onlyInOld: {},
+    differentValues: {},
+  }
+
+  // Check for params in url1 but not in url2 or with different values
+  for (const key in paramsObjNew) {
+    if (!(key in paramsObjOld)) {
+      differences.onlyInNew[key] = paramsObjNew[key]
+    } else if (paramsObjNew[key] !== paramsObjOld[key]) {
+      differences.differentValues[key] = {
+        newURL: paramsObjNew[key],
+        oldURL: paramsObjOld[key],
+      }
+    }
+  }
+
+  // Check for params in old but not in new
+  for (const key in paramsObjOld) {
+    if (!(key in paramsObjNew)) {
+      differences.onlyInOld[key] = paramsObjOld[key]
+    }
+  }
+
+  // Log differences
+  if (Object.keys(differences.onlyInNew).length > 0) {
+    console.log(
+      'Parameters only in new URL from server:',
+      differences.onlyInNew
+    )
+  }
+
+  if (Object.keys(differences.onlyInOld).length > 0) {
+    console.log(
+      'Parameters only in old URL from frontend:',
+      differences.onlyInOld
+    )
+  }
+
+  if (Object.keys(differences.differentValues).length > 0) {
+    console.log(
+      'Parameters with different values:',
+      differences.differentValues
+    )
+  }
+
+  if (
+    Object.keys(differences.onlyInNew).length === 0 &&
+    Object.keys(differences.onlyInOld).length === 0 &&
+    Object.keys(differences.differentValues).length === 0
+  ) {
+    console.log('Both URLs have identical query parameters')
+  }
+
+  return differences
+}
+
 // Construct a URL with all existing filters utilizing the necessary info from the regressed test.
 // We pass these arguments to the component that generates the test details report.
-export function generateTestReportForRegressedTest(
+export function generateTestDetailsReportLink(
   regressedTest,
   filterVals,
   expandEnvironment
 ) {
+  // Generate the URL we would have created for comparison
   const environmentVal = formColumnName({ variants: regressedTest.variants })
   const safeComponentName = safeEncodeURIComponent(regressedTest.component)
   const safeTestId = safeEncodeURIComponent(regressedTest.test_id)
@@ -731,7 +814,11 @@ export function generateTestReportForRegressedTest(
   const safeTestBasisRelease = safeEncodeURIComponent(
     regressedTest.base_stats?.release
   )
-  const retUrl =
+
+  // The old code generated these URLs here, but now we expect the server to always include them.
+  // I'm keeping backward compatability plus adding a compare function, so we can check the console to see
+  // differences.
+  const generatedUrl =
     '/sippy-ng/component_readiness/test_details' +
     filterVals +
     `&testBasisRelease=${safeTestBasisRelease}` +
@@ -741,5 +828,31 @@ export function generateTestReportForRegressedTest(
     `&capability=${regressedTest.capability}` +
     `&testName=${safeTestName}`
 
-  return sortQueryParams(retUrl)
+  const sortedGeneratedUrl = sortQueryParams(generatedUrl)
+  // Check if regressedTest.links.test_details is defined
+  if (regressedTest.links?.test_details) {
+    // Compare the query parameters between the two URLs
+    console.log(
+      'Comparing query parameters between provided URL and generated URL:'
+    )
+    compareUrlQueryParams(regressedTest.links.test_details, sortedGeneratedUrl)
+
+    // We are assuming the API query params are identical to the UI query params, but we have to adjust the host port and prefix from
+    // http://localhost:8080/api/ to http://localhost:3000/sippy-ng/
+    // This hack allows us to keep the param generation logic in one place. (server side)
+    const testDetailsUrl = regressedTest.links.test_details
+    const apiIndex = testDetailsUrl.indexOf('/api/')
+    if (apiIndex !== -1) {
+      const pathAfterApi = testDetailsUrl.substring(apiIndex + 5) // +5 to skip '/api/'
+      const modifiedUrl = '/sippy-ng/' + pathAfterApi
+      return modifiedUrl
+    }
+    return testDetailsUrl
+  }
+  console.log(
+    'WARNING: report had no test details url, using old generated url: ' +
+      generatedUrl
+  )
+
+  return generatedUrl
 }

--- a/sippy-ng/src/component_readiness/RegressedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsPanel.js
@@ -2,10 +2,7 @@ import { CapabilitiesContext } from '../App'
 import { CompReadyVarsContext } from './CompReadyVars'
 import { DataGrid, GridToolbar } from '@mui/x-data-grid'
 import { FileCopy } from '@mui/icons-material'
-import {
-  formColumnName,
-  generateTestReportForRegressedTest,
-} from './CompReadyUtils'
+import { formColumnName, generateTestDetailsReportLink } from './CompReadyUtils'
 import { NumberParam, StringParam, useQueryParam } from 'use-query-params'
 import { Popover, Snackbar, Tooltip } from '@mui/material'
 import { relativeTime } from '../helpers'
@@ -222,7 +219,7 @@ export default function RegressedTestsPanel(props) {
           className="status"
         >
           <a
-            href={generateTestReportForRegressedTest(
+            href={generateTestDetailsReportLink(
               params.row,
               filterVals,
               expandEnvironment

--- a/sippy-ng/src/component_readiness/TestDetailsReport.js
+++ b/sippy-ng/src/component_readiness/TestDetailsReport.js
@@ -16,6 +16,7 @@ import {
   getStatusAndIcon,
   gotFetchError,
   makePageTitle,
+  makeRFC3339Time,
   noDataTable,
 } from './CompReadyUtils'
 import { CapabilitiesContext, ReleasesContext } from '../App'
@@ -136,7 +137,8 @@ export default function TestDetailsReport(props) {
   let testDetailsApiCall
   if (sippyNgIndex !== -1) {
     const pathAfterSippyNg = currentUrl.substring(sippyNgIndex + 10) // +10 to skip '/sippy-ng/'
-    testDetailsApiCall = getAPIUrl(pathAfterSippyNg)
+    // We have to format the url to RFC3339Time in case the date picker has been used to update report params
+    testDetailsApiCall = makeRFC3339Time(getAPIUrl(pathAfterSippyNg))
   } else {
     console.error('No /sippy-ng/ found in URL, this is a bug')
   }
@@ -144,7 +146,7 @@ export default function TestDetailsReport(props) {
   useEffect(() => {
     setIsLoaded(false)
     setHasBeenTriaged(false)
-    if (!testName) return // wait until the vars are initialized from params
+    if (!testId) return // wait until the vars are initialized from params
 
     // fetch the test_details data followed by any triage records that match the regressionId (if found)
     fetch(testDetailsApiCall, { signal: abortController.signal })
@@ -191,7 +193,7 @@ export default function TestDetailsReport(props) {
       .finally(() => {
         setIsLoaded(true)
       })
-  }, [hasBeenTriaged, urlParams, testName])
+  }, [hasBeenTriaged, urlParams, testId])
 
   useEffect(() => {
     let tmpRelease = {}
@@ -320,6 +322,7 @@ View the [test details report|${document.location.href}] for additional context.
             `
 
     const commonProps = {
+      testName: data.test_name,
       component,
       capability,
       labels: ['component-regression'],
@@ -544,10 +547,8 @@ View the [test details report|${document.location.href}] for additional context.
 }
 
 TestDetailsReport.propTypes = {
-  filterVals: PropTypes.string.isRequired,
   component: PropTypes.string.isRequired,
   capability: PropTypes.string.isRequired,
   testId: PropTypes.string.isRequired,
   environment: PropTypes.string.isRequired,
-  testBasisRelease: PropTypes.string.isRequired,
 }

--- a/sippy-ng/src/component_readiness/TestDetailsReport.js
+++ b/sippy-ng/src/component_readiness/TestDetailsReport.js
@@ -11,23 +11,18 @@ import {
 } from '@mui/material'
 import {
   cancelledDataTable,
+  getAPIUrl,
   getColumns,
   getStatusAndIcon,
-  getTestDetailsAPIUrl,
   gotFetchError,
   makePageTitle,
-  makeRFC3339Time,
   noDataTable,
 } from './CompReadyUtils'
 import { CapabilitiesContext, ReleasesContext } from '../App'
-import { ComponentReadinessStyleContext } from './ComponentReadiness'
 import { CompReadyVarsContext } from './CompReadyVars'
 import { FileCopy, Help } from '@mui/icons-material'
 import { Link } from 'react-router-dom'
-import {
-  pathForExactTestAnalysisWithFilter,
-  safeEncodeURIComponent,
-} from '../helpers'
+import { pathForExactTestAnalysisWithFilter } from '../helpers'
 import { Tooltip } from '@mui/material'
 import BugButton from '../bugs/BugButton'
 import BugTable from '../bugs/BugTable'
@@ -93,7 +88,6 @@ function TestsReportTabPanel(props) {
 // This component runs when we see /component_readiness/test_details
 // This is page 5 which runs when you click a test cell on the right of page 4 or page 4a
 export default function TestDetailsReport(props) {
-  const classes = useContext(ComponentReadinessStyleContext)
   const { accessibilityModeOn } = useContext(AccessibilityModeContext)
 
   const [activeTabIndex, setActiveTabIndex] = React.useState(0)
@@ -102,15 +96,7 @@ export default function TestDetailsReport(props) {
     setActiveTabIndex(newValue)
   }
 
-  const {
-    filterVals,
-    component,
-    capability,
-    testId,
-    environment,
-    testName,
-    testBasisRelease,
-  } = props
+  const { component, capability, testId, environment } = props
 
   const [fetchError, setFetchError] = React.useState('')
   const [isLoaded, setIsLoaded] = React.useState(false)
@@ -124,15 +110,10 @@ export default function TestDetailsReport(props) {
   document.title =
     'Sippy > Component Readiness > Capabilities > Tests > Capability Tests > Test Details' +
     (environment ? `Env` : '')
-  const safeComponent = safeEncodeURIComponent(component)
-  const safeCapability = safeEncodeURIComponent(capability)
-  const safeTestId = safeEncodeURIComponent(testId)
-  const safeTestBasisRelease = safeEncodeURIComponent(testBasisRelease)
 
   const capabilitiesContext = React.useContext(CapabilitiesContext)
   const writeEndpointsEnabled = capabilitiesContext.includes('write_endpoints')
-  const { expandEnvironment, sampleRelease, urlParams } =
-    useContext(CompReadyVarsContext)
+  const { sampleRelease, urlParams } = useContext(CompReadyVarsContext)
 
   // Helpers for copying the test ID to clipboard
   const [copyPopoverEl, setCopyPopoverEl] = React.useState(null)
@@ -146,14 +127,19 @@ export default function TestDetailsReport(props) {
 
   const [hasBeenTriaged, setHasBeenTriaged] = React.useState(false)
 
-  const testDetailsApiCall =
-    getTestDetailsAPIUrl() +
-    makeRFC3339Time(filterVals) +
-    `&component=${safeComponent}` +
-    `&capability=${safeCapability}` +
-    `&testId=${safeTestId}` +
-    `&testBasisRelease=${safeTestBasisRelease}` +
-    (environment ? expandEnvironment(environment) : '')
+  // This is the inverse of the hack in CompReadyUtils.generateTestDetailsReportLink.
+  // We are assuming the API query params are identical to the UI query params, but we have to adjust the host port and prefix from
+  // http://localhost:3000/sippy-ng/ to http://localhost:8080/api/
+  // This hack allows us to keep the param generation logic in one place. (server side)
+  const currentUrl = window.location.href
+  const sippyNgIndex = currentUrl.indexOf('/sippy-ng/')
+  let testDetailsApiCall
+  if (sippyNgIndex !== -1) {
+    const pathAfterSippyNg = currentUrl.substring(sippyNgIndex + 10) // +10 to skip '/sippy-ng/'
+    testDetailsApiCall = getAPIUrl(pathAfterSippyNg)
+  } else {
+    console.error('No /sippy-ng/ found in URL, this is a bug')
+  }
 
   useEffect(() => {
     setIsLoaded(false)
@@ -235,7 +221,7 @@ export default function TestDetailsReport(props) {
     `component: ${component}`,
     `capability: ${capability}`,
     `testId: ${testId}`,
-    `testName: ${testName}`,
+    `testName: ${data.test_name}`,
     `environment: ${environment}`
   )
 
@@ -311,7 +297,7 @@ Flakes: ${stats.flake_count}`
 (_Feel free to update this bug's summary to be more specific._)
 Component Readiness has found a potential regression in the following test:
 
-{code:none}${testName}{code}
+{code:none}${data.test_name}{code}
 
 ${(data.analyses[0].explanations || []).join('\n')}
 ${printStatsText(
@@ -334,7 +320,6 @@ View the [test details report|${document.location.href}] for additional context.
             `
 
     const commonProps = {
-      testName,
       component,
       capability,
       labels: ['component-regression'],
@@ -389,11 +374,11 @@ View the [test details report|${document.location.href}] for additional context.
       <h3>
         <Link to="/component_readiness">
           / {environment} &gt; {component}
-          &gt; {testName}
+          &gt; {data.test_name}
         </Link>
       </h3>
       <div align="center" style={{ marginTop: 50 }}>
-        <h2>{testName}</h2>
+        <h2>{data.test_name}</h2>
       </div>
       <Grid container>
         <Grid item xs={12}>
@@ -415,7 +400,7 @@ View the [test details report|${document.location.href}] for additional context.
 
           <h2>Bugs Mentioning This Test</h2>
           <BugTable
-            testName={testName}
+            testName={data.test_name}
             writeEndpointsEnabled={writeEndpointsEnabled}
             regressionId={regressionId}
             setHasBeenTriaged={setHasBeenTriaged}
@@ -437,9 +422,13 @@ View the [test details report|${document.location.href}] for additional context.
               View other open regressions
             </Button>
             <Link
-              to={pathForExactTestAnalysisWithFilter(sampleRelease, testName, {
-                items: [],
-              })}
+              to={pathForExactTestAnalysisWithFilter(
+                sampleRelease,
+                data.test_name,
+                {
+                  items: [],
+                }
+              )}
               style={{ textDecoration: 'none' }}
             >
               <Button variant="contained" color="secondary">
@@ -449,9 +438,7 @@ View the [test details report|${document.location.href}] for additional context.
           </Box>
         </Grid>
       </Grid>
-
       <h2>Regression Report</h2>
-
       <Table>
         <TableBody>
           <TableRow>
@@ -508,7 +495,7 @@ View the [test details report|${document.location.href}] for additional context.
               data={data.analyses[0]}
               versions={versions}
               loadedParams={loadedParams}
-              testName={testName}
+              testName={data.test_name}
               environment={environment}
               component={component}
             />
@@ -518,7 +505,7 @@ View the [test details report|${document.location.href}] for additional context.
               data={data.analyses[1]}
               versions={versions}
               loadedParams={loadedParams}
-              testName={testName}
+              testName={data.test_name}
               environment={environment}
               component={component}
             />
@@ -529,7 +516,7 @@ View the [test details report|${document.location.href}] for additional context.
           data={data.analyses[0]}
           versions={versions}
           loadedParams={loadedParams}
-          testName={testName}
+          testName={data.test_name}
           environment={environment}
           component={component}
         />
@@ -562,6 +549,5 @@ TestDetailsReport.propTypes = {
   capability: PropTypes.string.isRequired,
   testId: PropTypes.string.isRequired,
   environment: PropTypes.string.isRequired,
-  testName: PropTypes.string.isRequired,
   testBasisRelease: PropTypes.string.isRequired,
 }

--- a/sippy-ng/src/component_readiness/Triage.js
+++ b/sippy-ng/src/component_readiness/Triage.js
@@ -66,7 +66,7 @@ export default function Triage({ id }) {
       'Are you sure you want to delete this triage record?'
     )
     if (confirmed) {
-      fetch(getTriagesAPIUrl(id), {
+      fetch(triage.links.self, {
         method: 'DELETE',
       })
         .then((response) => {
@@ -104,7 +104,7 @@ export default function Triage({ id }) {
       >
         <h2 style={{ margin: 0 }}>Triage Details</h2>
         <Box>
-          {localDBEnabled && <TriageAuditLogsModal triageId={id} />}
+          {localDBEnabled && <TriageAuditLogsModal triage={triage} />}
           {triageEnabled && (
             <Fragment>
               <UpsertTriageModal

--- a/sippy-ng/src/component_readiness/TriageAuditLogsModal.js
+++ b/sippy-ng/src/component_readiness/TriageAuditLogsModal.js
@@ -17,7 +17,6 @@ import {
   Typography,
 } from '@mui/material'
 import { formatDateToSeconds, relativeTime } from '../helpers'
-import { getTriagesAPIUrl } from './CompReadyUtils'
 import { History } from '@mui/icons-material'
 import { makeStyles } from '@mui/styles'
 import PropTypes from 'prop-types'
@@ -55,7 +54,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
-export default function TriageAuditLogsModal({ triageId }) {
+export default function TriageAuditLogsModal({ triage }) {
   const classes = useStyles()
   const [auditLogs, setAuditLogs] = useState([])
   const [loading, setLoading] = useState(false)
@@ -63,13 +62,11 @@ export default function TriageAuditLogsModal({ triageId }) {
   const [open, setOpen] = useState(false)
 
   const fetchAuditLogs = async () => {
-    if (!triageId) return
-
     setLoading(true)
     setError('')
 
     try {
-      const response = await fetch(`${getTriagesAPIUrl(triageId)}/audit`)
+      const response = await fetch(triage.links.audit_logs)
       if (response.status !== 200) {
         throw new Error(`API server returned ${response.status}`)
       }
@@ -92,10 +89,10 @@ export default function TriageAuditLogsModal({ triageId }) {
 
   // Fetch audit logs when modal opens
   React.useEffect(() => {
-    if (open && triageId) {
+    if (open) {
       fetchAuditLogs()
     }
-  }, [open, triageId])
+  }, [open])
 
   const formatOperation = (operation) => {
     switch (operation?.toLowerCase()) {
@@ -255,5 +252,5 @@ export default function TriageAuditLogsModal({ triageId }) {
 }
 
 TriageAuditLogsModal.propTypes = {
-  triageId: PropTypes.string.isRequired,
+  triage: PropTypes.object.isRequired,
 }

--- a/sippy-ng/src/component_readiness/TriagePotentialMatches.js
+++ b/sippy-ng/src/component_readiness/TriagePotentialMatches.js
@@ -17,7 +17,7 @@ import { Close } from '@mui/icons-material'
 import { CompReadyVarsContext } from './CompReadyVars'
 import { DataGrid, GridToolbar } from '@mui/x-data-grid'
 import {
-  generateTestReportForRegressedTest,
+  generateTestDetailsReportLink,
   getTriagesAPIUrl,
 } from './CompReadyUtils'
 import { makeStyles } from '@mui/styles'
@@ -271,7 +271,7 @@ export default function TriagePotentialMatches({
       valueGetter: (params) => {
         const regressedTest = params.row.regressed_test
         const filterVals = `?view=${view}`
-        const testDetailsUrl = generateTestReportForRegressedTest(
+        const testDetailsUrl = generateTestDetailsReportLink(
           regressedTest,
           filterVals,
           expandEnvironment

--- a/sippy-ng/src/component_readiness/TriagePotentialMatches.js
+++ b/sippy-ng/src/component_readiness/TriagePotentialMatches.js
@@ -16,10 +16,7 @@ import {
 import { Close } from '@mui/icons-material'
 import { CompReadyVarsContext } from './CompReadyVars'
 import { DataGrid, GridToolbar } from '@mui/x-data-grid'
-import {
-  generateTestDetailsReportLink,
-  getTriagesAPIUrl,
-} from './CompReadyUtils'
+import { generateTestDetailsReportLink } from './CompReadyUtils'
 import { makeStyles } from '@mui/styles'
 import { relativeTime } from '../helpers'
 import CompSeverityIcon from './CompSeverityIcon'
@@ -101,7 +98,7 @@ export default function TriagePotentialMatches({
   const findPotentialMatches = () => {
     setIsLoading(true)
     setIsModalOpen(true)
-    fetch(`${getTriagesAPIUrl(triage.id)}/matches?view=${view}`)
+    fetch(`${triage.links.potential_matches}?view=${view}`)
       .then((response) => {
         if (response.status !== 200) {
           throw new Error('API server returned ' + response.status)
@@ -147,7 +144,7 @@ export default function TriagePotentialMatches({
       ],
     }
 
-    fetch(getTriagesAPIUrl(triage.id), {
+    fetch(triage.links.self, {
       method: 'PUT',
       body: JSON.stringify(updatedTriage),
     })
@@ -271,6 +268,7 @@ export default function TriagePotentialMatches({
       valueGetter: (params) => {
         const regressedTest = params.row.regressed_test
         const filterVals = `?view=${view}`
+        //TODO: we need to get this off of the regression...
         const testDetailsUrl = generateTestDetailsReportLink(
           regressedTest,
           filterVals,

--- a/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
@@ -1,6 +1,6 @@
 import { CompReadyVarsContext } from './CompReadyVars'
 import { DataGrid, GridToolbar } from '@mui/x-data-grid'
-import { generateTestReportForRegressedTest } from './CompReadyUtils'
+import { generateTestDetailsReportLink } from './CompReadyUtils'
 import { NumberParam, useQueryParam } from 'use-query-params'
 import { relativeTime } from '../helpers'
 import { Tooltip, Typography } from '@mui/material'
@@ -143,7 +143,7 @@ export default function TriagedRegressionTestList(props) {
               if (matchingRegression) {
                 value.status = matchingRegression.status
                 value.explanations = matchingRegression.explanations
-                value.url = generateTestReportForRegressedTest(
+                value.url = generateTestDetailsReportLink(
                   matchingRegression,
                   props.filterVals,
                   expandEnvironment

--- a/test/e2e/componentreadiness/regressiontracker/regressiontracker_test.go
+++ b/test/e2e/componentreadiness/regressiontracker/regressiontracker_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crtest"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crview"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/testdetails"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/test/e2e/util"
@@ -32,6 +33,11 @@ func Test_RegressionTracker(t *testing.T) {
 	dbc := util.CreateE2EPostgresConnection(t)
 	tracker := componentreadiness.NewPostgresRegressionStore(dbc)
 	newRegression := componentreport.ReportTestSummary{
+		TestComparison: testdetails.TestComparison{
+			BaseStats: &testdetails.ReleaseStats{
+				Release: "4.18",
+			},
+		},
 		Identification: crtest.Identification{
 			RowIdentification: crtest.RowIdentification{
 				Component:  "comp",
@@ -140,6 +146,11 @@ func Test_RegressionTracker(t *testing.T) {
 
 		// Create a second regression that will remain open
 		secondRegression := componentreport.ReportTestSummary{
+			TestComparison: testdetails.TestComparison{
+				BaseStats: &testdetails.ReleaseStats{
+					Release: "4.18",
+				},
+			},
 			Identification: crtest.Identification{
 				RowIdentification: crtest.RowIdentification{
 					Component:  "comp2",

--- a/test/e2e/componentreadiness/triage/triageapi_test.go
+++ b/test/e2e/componentreadiness/triage/triageapi_test.go
@@ -117,9 +117,9 @@ func Test_TriageAPI(t *testing.T) {
 		// ensure hateoas links are present
 		assert.Equal(t, fmt.Sprintf("http://%s:%s/api/component_readiness/triages/%d", os.Getenv("SIPPY_ENDPOINT"), os.Getenv("SIPPY_API_PORT"), triageResponse.ID),
 			triageResponse.Links["self"])
-		assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d/matches", triageResponse.ID),
+		assert.Equal(t, fmt.Sprintf("http://%s:%s/api/component_readiness/triages/%d/matches", os.Getenv("SIPPY_ENDPOINT"), os.Getenv("SIPPY_API_PORT"), triageResponse.ID),
 			triageResponse.Links["potential_matches"])
-		assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d/audit", triageResponse.ID),
+		assert.Equal(t, fmt.Sprintf("http://%s:%s/api/component_readiness/triages/%d/audit", os.Getenv("SIPPY_ENDPOINT"), os.Getenv("SIPPY_API_PORT"), triageResponse.ID),
 			triageResponse.Links["audit_logs"])
 	})
 	t.Run("get with expanded regressions", func(t *testing.T) {
@@ -201,9 +201,9 @@ func Test_TriageAPI(t *testing.T) {
 		for _, triage := range allTriages {
 			assert.Equal(t, fmt.Sprintf("http://%s:%s/api/component_readiness/triages/%d", os.Getenv("SIPPY_ENDPOINT"), os.Getenv("SIPPY_API_PORT"), triage.ID),
 				triage.Links["self"])
-			assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d/matches", triage.ID),
+			assert.Equal(t, fmt.Sprintf("http://%s:%s/api/component_readiness/triages/%d/matches", os.Getenv("SIPPY_ENDPOINT"), os.Getenv("SIPPY_API_PORT"), triage.ID),
 				triage.Links["potential_matches"])
-			assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d/audit", triage.ID),
+			assert.Equal(t, fmt.Sprintf("http://%s:%s/api/component_readiness/triages/%d/audit", os.Getenv("SIPPY_ENDPOINT"), os.Getenv("SIPPY_API_PORT"), triage.ID),
 				triage.Links["audit_logs"])
 		}
 	})
@@ -223,9 +223,9 @@ func Test_TriageAPI(t *testing.T) {
 		// ensure hateoas links are present
 		assert.Equal(t, fmt.Sprintf("http://%s:%s/api/component_readiness/triages/%d", os.Getenv("SIPPY_ENDPOINT"), os.Getenv("SIPPY_API_PORT"), triageResponse2.ID),
 			triageResponse2.Links["self"])
-		assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d/matches", triageResponse2.ID),
+		assert.Equal(t, fmt.Sprintf("http://%s:%s/api/component_readiness/triages/%d/matches", os.Getenv("SIPPY_ENDPOINT"), os.Getenv("SIPPY_API_PORT"), triageResponse2.ID),
 			triageResponse2.Links["potential_matches"])
-		assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d/audit", triageResponse2.ID),
+		assert.Equal(t, fmt.Sprintf("http://%s:%s/api/component_readiness/triages/%d/audit", os.Getenv("SIPPY_ENDPOINT"), os.Getenv("SIPPY_API_PORT"), triageResponse2.ID),
 			triageResponse2.Links["audit_logs"])
 	})
 	t.Run("update to remove a regression", func(t *testing.T) {
@@ -307,101 +307,6 @@ func Test_TriageAPI(t *testing.T) {
 		var triageResponse2 models.Triage
 		err := util.SippyPut("/api/component_readiness/triages/128736182736128736", &triageResponse, &triageResponse2)
 		require.Error(t, err)
-	})
-
-}
-
-func Test_RegressionAPI(t *testing.T) {
-	dbc := util.CreateE2EPostgresConnection(t)
-	tracker := componentreadiness.NewPostgresRegressionStore(dbc)
-
-	testRegression1 := createTestRegression(t, tracker, view, "faketestid1")
-	defer dbc.DB.Delete(testRegression1)
-
-	testRegression2 := createTestRegression(t, tracker, view, "faketestid2")
-	defer dbc.DB.Delete(testRegression2)
-
-	jiraBug := createBug(t, dbc.DB)
-	defer dbc.DB.Delete(jiraBug)
-
-	t.Run("list regressions", func(t *testing.T) {
-		defer cleanupAllTriages(dbc)
-		_ = createAndValidateTriageRecord(t, jiraBug.URL, testRegression1)
-
-		// Test listing all regressions
-		var allRegressions []models.TestRegression
-		err := util.SippyGet("/api/component_readiness/regressions", &allRegressions)
-		require.NoError(t, err)
-
-		// Should find at least our test regression
-		var foundRegression *models.TestRegression
-		for i, regression := range allRegressions {
-			if regression.ID == testRegression1.ID {
-				foundRegression = &allRegressions[i]
-				break
-			}
-		}
-		require.NotNil(t, foundRegression, "expected regression was not found in list")
-		assert.Equal(t, testRegression1.TestName, foundRegression.TestName)
-		assert.Equal(t, testRegression1.View, foundRegression.View)
-		assert.Equal(t, testRegression1.Release, foundRegression.Release)
-
-		// Verify HATEOAS links are present
-		assert.NotNil(t, foundRegression.Links, "regression should have HATEOAS links")
-		assert.Contains(t, foundRegression.Links, "test_details", "regression should have test_details link")
-		testDetailsLink := foundRegression.Links["test_details"]
-		assert.Contains(t, testDetailsLink, "/api/component_readiness/test_details", "test_details link should point to correct endpoint")
-		// Note: testId will be URL encoded, so we check for the encoded version
-		assert.Contains(t, testDetailsLink, "testId=", "test_details link should contain testId parameter")
-	})
-	t.Run("list regressions with view filter", func(t *testing.T) {
-		defer cleanupAllTriages(dbc)
-		_ = createAndValidateTriageRecord(t, jiraBug.URL, testRegression1)
-
-		// Test listing regressions filtered by view
-		var filteredRegressions []models.TestRegression
-		err := util.SippyGet("/api/component_readiness/regressions?view="+view.Name, &filteredRegressions)
-		require.NoError(t, err)
-
-		// Should find our test regression
-		var foundRegression *models.TestRegression
-		for i, regression := range filteredRegressions {
-			if regression.ID == testRegression1.ID {
-				foundRegression = &filteredRegressions[i]
-				break
-			}
-		}
-		require.NotNil(t, foundRegression, "expected regression was not found in filtered list")
-		assert.Equal(t, view.Name, foundRegression.View)
-	})
-	t.Run("list regressions with release filter", func(t *testing.T) {
-		defer cleanupAllTriages(dbc)
-		_ = createAndValidateTriageRecord(t, jiraBug.URL, testRegression1)
-
-		// Test listing regressions filtered by release
-		var filteredRegressions []models.TestRegression
-		err := util.SippyGet("/api/component_readiness/regressions?release="+view.SampleRelease.Name, &filteredRegressions)
-		require.NoError(t, err)
-
-		// Should find our test regression
-		var foundRegression *models.TestRegression
-		for i, regression := range filteredRegressions {
-			if regression.ID == testRegression1.ID {
-				foundRegression = &filteredRegressions[i]
-				break
-			}
-		}
-		require.NotNil(t, foundRegression, "expected regression was not found in release filtered list")
-		assert.Equal(t, view.SampleRelease.Release.Name, foundRegression.Release)
-	})
-	t.Run("error when both view and release are specified", func(t *testing.T) {
-		defer cleanupAllTriages(dbc)
-		_ = createAndValidateTriageRecord(t, jiraBug.URL, testRegression1)
-
-		// Test that specifying both view and release parameters returns an error
-		var regressions []models.TestRegression
-		err := util.SippyGet("/api/component_readiness/regressions?view="+view.Name+"&release="+view.SampleRelease.Name, &regressions)
-		require.Error(t, err, "Expected error when both view and release are specified")
 	})
 	t.Run("update generates audit_log record", func(t *testing.T) {
 		defer cleanupAllTriages(dbc)
@@ -594,12 +499,108 @@ func Test_RegressionAPI(t *testing.T) {
 		assert.True(t, updateLog.CreatedAt.Before(deleteLog.CreatedAt), "Update should be before delete")
 
 		// Verify HATEOAS links are present in audit log responses
+		baseURL := fmt.Sprintf("http://%s:%s", os.Getenv("SIPPY_ENDPOINT"), os.Getenv("SIPPY_API_PORT"))
 		for _, auditLog := range auditLogs {
-			assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d/audit", triageResponse.ID),
+			assert.Equal(t, fmt.Sprintf("%s/api/component_readiness/triages/%d/audit", baseURL, triageResponse.ID),
 				auditLog.Links["self"], "Audit log should have self link")
-			assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d", triageResponse.ID),
+			assert.Equal(t, fmt.Sprintf("%s/api/component_readiness/triages/%d", baseURL, triageResponse.ID),
 				auditLog.Links["triage"], "Audit log should have triage link")
 		}
+	})
+
+}
+
+func Test_RegressionAPI(t *testing.T) {
+	dbc := util.CreateE2EPostgresConnection(t)
+	tracker := componentreadiness.NewPostgresRegressionStore(dbc)
+
+	testRegression1 := createTestRegression(t, tracker, view, "faketestid1")
+	defer dbc.DB.Delete(testRegression1)
+
+	testRegression2 := createTestRegression(t, tracker, view, "faketestid2")
+	defer dbc.DB.Delete(testRegression2)
+
+	jiraBug := createBug(t, dbc.DB)
+	defer dbc.DB.Delete(jiraBug)
+
+	t.Run("list regressions", func(t *testing.T) {
+		defer cleanupAllTriages(dbc)
+		_ = createAndValidateTriageRecord(t, jiraBug.URL, testRegression1)
+
+		// Test listing all regressions
+		var allRegressions []models.TestRegression
+		err := util.SippyGet("/api/component_readiness/regressions", &allRegressions)
+		require.NoError(t, err)
+
+		// Should find at least our test regression
+		var foundRegression *models.TestRegression
+		for i, regression := range allRegressions {
+			if regression.ID == testRegression1.ID {
+				foundRegression = &allRegressions[i]
+				break
+			}
+		}
+		require.NotNil(t, foundRegression, "expected regression was not found in list")
+		assert.Equal(t, testRegression1.TestName, foundRegression.TestName)
+		assert.Equal(t, testRegression1.View, foundRegression.View)
+		assert.Equal(t, testRegression1.Release, foundRegression.Release)
+
+		// Verify HATEOAS links are present
+		assert.NotNil(t, foundRegression.Links, "regression should have HATEOAS links")
+		assert.Contains(t, foundRegression.Links, "test_details", "regression should have test_details link")
+		testDetailsLink := foundRegression.Links["test_details"]
+		assert.Contains(t, testDetailsLink, fmt.Sprintf("http://%s:%s/api/component_readiness/test_details", os.Getenv("SIPPY_ENDPOINT"), os.Getenv("SIPPY_API_PORT")), "test_details link should point to correct endpoint")
+		// Note: testId will be URL encoded, so we check for the encoded version
+		assert.Contains(t, testDetailsLink, "testId=", "test_details link should contain testId parameter")
+	})
+	t.Run("list regressions with view filter", func(t *testing.T) {
+		defer cleanupAllTriages(dbc)
+		_ = createAndValidateTriageRecord(t, jiraBug.URL, testRegression1)
+
+		// Test listing regressions filtered by view
+		var filteredRegressions []models.TestRegression
+		err := util.SippyGet("/api/component_readiness/regressions?view="+view.Name, &filteredRegressions)
+		require.NoError(t, err)
+
+		// Should find our test regression
+		var foundRegression *models.TestRegression
+		for i, regression := range filteredRegressions {
+			if regression.ID == testRegression1.ID {
+				foundRegression = &filteredRegressions[i]
+				break
+			}
+		}
+		require.NotNil(t, foundRegression, "expected regression was not found in filtered list")
+		assert.Equal(t, view.Name, foundRegression.View)
+	})
+	t.Run("list regressions with release filter", func(t *testing.T) {
+		defer cleanupAllTriages(dbc)
+		_ = createAndValidateTriageRecord(t, jiraBug.URL, testRegression1)
+
+		// Test listing regressions filtered by release
+		var filteredRegressions []models.TestRegression
+		err := util.SippyGet("/api/component_readiness/regressions?release="+view.SampleRelease.Name, &filteredRegressions)
+		require.NoError(t, err)
+
+		// Should find our test regression
+		var foundRegression *models.TestRegression
+		for i, regression := range filteredRegressions {
+			if regression.ID == testRegression1.ID {
+				foundRegression = &filteredRegressions[i]
+				break
+			}
+		}
+		require.NotNil(t, foundRegression, "expected regression was not found in release filtered list")
+		assert.Equal(t, view.SampleRelease.Release.Name, foundRegression.Release)
+	})
+	t.Run("error when both view and release are specified", func(t *testing.T) {
+		defer cleanupAllTriages(dbc)
+		_ = createAndValidateTriageRecord(t, jiraBug.URL, testRegression1)
+
+		// Test that specifying both view and release parameters returns an error
+		var regressions []models.TestRegression
+		err := util.SippyGet("/api/component_readiness/regressions?view="+view.Name+"&release="+view.SampleRelease.Name, &regressions)
+		require.Error(t, err, "Expected error when both view and release are specified")
 	})
 }
 
@@ -1016,10 +1017,11 @@ func Test_TriagePotentialMatchingRegressions(t *testing.T) {
 		assert.True(t, len(potentialMatches) > 0, "Should find some potential matches")
 
 		// Verify HATEOAS links are present in potential match responses
+		baseURL := fmt.Sprintf("http://%s:%s", os.Getenv("SIPPY_ENDPOINT"), os.Getenv("SIPPY_API_PORT"))
 		for _, match := range potentialMatches {
-			assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d/matches", triageResponse.ID),
+			assert.Equal(t, fmt.Sprintf("%s/api/component_readiness/triages/%d/matches", baseURL, triageResponse.ID),
 				match.Links["self"], "Potential match should have self link")
-			assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d", triageResponse.ID),
+			assert.Equal(t, fmt.Sprintf("%s/api/component_readiness/triages/%d", baseURL, triageResponse.ID),
 				match.Links["triage"], "Potential match should have triage link")
 		}
 

--- a/test/e2e/componentreadiness/triage/triageapi_test.go
+++ b/test/e2e/componentreadiness/triage/triageapi_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -114,7 +115,7 @@ func Test_TriageAPI(t *testing.T) {
 		triageResponse := createAndValidateTriageRecord(t, jiraBug.URL, testRegression1)
 
 		// ensure hateoas links are present
-		assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d", triageResponse.ID),
+		assert.Equal(t, fmt.Sprintf("http://%s:%s/api/component_readiness/triages/%d", os.Getenv("SIPPY_ENDPOINT"), os.Getenv("SIPPY_API_PORT"), triageResponse.ID),
 			triageResponse.Links["self"])
 		assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d/matches", triageResponse.ID),
 			triageResponse.Links["potential_matches"])
@@ -198,7 +199,7 @@ func Test_TriageAPI(t *testing.T) {
 
 		// ensure hateoas links are present
 		for _, triage := range allTriages {
-			assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d", triage.ID),
+			assert.Equal(t, fmt.Sprintf("http://%s:%s/api/component_readiness/triages/%d", os.Getenv("SIPPY_ENDPOINT"), os.Getenv("SIPPY_API_PORT"), triage.ID),
 				triage.Links["self"])
 			assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d/matches", triage.ID),
 				triage.Links["potential_matches"])
@@ -220,7 +221,7 @@ func Test_TriageAPI(t *testing.T) {
 		assert.NotEqual(t, triageResponse.UpdatedAt, triageResponse2.UpdatedAt)
 
 		// ensure hateoas links are present
-		assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d", triageResponse2.ID),
+		assert.Equal(t, fmt.Sprintf("http://%s:%s/api/component_readiness/triages/%d", os.Getenv("SIPPY_ENDPOINT"), os.Getenv("SIPPY_API_PORT"), triageResponse2.ID),
 			triageResponse2.Links["self"])
 		assert.Equal(t, fmt.Sprintf("/api/component_readiness/triages/%d/matches", triageResponse2.ID),
 			triageResponse2.Links["potential_matches"])
@@ -306,6 +307,101 @@ func Test_TriageAPI(t *testing.T) {
 		var triageResponse2 models.Triage
 		err := util.SippyPut("/api/component_readiness/triages/128736182736128736", &triageResponse, &triageResponse2)
 		require.Error(t, err)
+	})
+
+}
+
+func Test_RegressionAPI(t *testing.T) {
+	dbc := util.CreateE2EPostgresConnection(t)
+	tracker := componentreadiness.NewPostgresRegressionStore(dbc)
+
+	testRegression1 := createTestRegression(t, tracker, view, "faketestid1")
+	defer dbc.DB.Delete(testRegression1)
+
+	testRegression2 := createTestRegression(t, tracker, view, "faketestid2")
+	defer dbc.DB.Delete(testRegression2)
+
+	jiraBug := createBug(t, dbc.DB)
+	defer dbc.DB.Delete(jiraBug)
+
+	t.Run("list regressions", func(t *testing.T) {
+		defer cleanupAllTriages(dbc)
+		_ = createAndValidateTriageRecord(t, jiraBug.URL, testRegression1)
+
+		// Test listing all regressions
+		var allRegressions []models.TestRegression
+		err := util.SippyGet("/api/component_readiness/regressions", &allRegressions)
+		require.NoError(t, err)
+
+		// Should find at least our test regression
+		var foundRegression *models.TestRegression
+		for i, regression := range allRegressions {
+			if regression.ID == testRegression1.ID {
+				foundRegression = &allRegressions[i]
+				break
+			}
+		}
+		require.NotNil(t, foundRegression, "expected regression was not found in list")
+		assert.Equal(t, testRegression1.TestName, foundRegression.TestName)
+		assert.Equal(t, testRegression1.View, foundRegression.View)
+		assert.Equal(t, testRegression1.Release, foundRegression.Release)
+
+		// Verify HATEOAS links are present
+		assert.NotNil(t, foundRegression.Links, "regression should have HATEOAS links")
+		assert.Contains(t, foundRegression.Links, "test_details", "regression should have test_details link")
+		testDetailsLink := foundRegression.Links["test_details"]
+		assert.Contains(t, testDetailsLink, "/api/component_readiness/test_details", "test_details link should point to correct endpoint")
+		// Note: testId will be URL encoded, so we check for the encoded version
+		assert.Contains(t, testDetailsLink, "testId=", "test_details link should contain testId parameter")
+	})
+	t.Run("list regressions with view filter", func(t *testing.T) {
+		defer cleanupAllTriages(dbc)
+		_ = createAndValidateTriageRecord(t, jiraBug.URL, testRegression1)
+
+		// Test listing regressions filtered by view
+		var filteredRegressions []models.TestRegression
+		err := util.SippyGet("/api/component_readiness/regressions?view="+view.Name, &filteredRegressions)
+		require.NoError(t, err)
+
+		// Should find our test regression
+		var foundRegression *models.TestRegression
+		for i, regression := range filteredRegressions {
+			if regression.ID == testRegression1.ID {
+				foundRegression = &filteredRegressions[i]
+				break
+			}
+		}
+		require.NotNil(t, foundRegression, "expected regression was not found in filtered list")
+		assert.Equal(t, view.Name, foundRegression.View)
+	})
+	t.Run("list regressions with release filter", func(t *testing.T) {
+		defer cleanupAllTriages(dbc)
+		_ = createAndValidateTriageRecord(t, jiraBug.URL, testRegression1)
+
+		// Test listing regressions filtered by release
+		var filteredRegressions []models.TestRegression
+		err := util.SippyGet("/api/component_readiness/regressions?release="+view.SampleRelease.Name, &filteredRegressions)
+		require.NoError(t, err)
+
+		// Should find our test regression
+		var foundRegression *models.TestRegression
+		for i, regression := range filteredRegressions {
+			if regression.ID == testRegression1.ID {
+				foundRegression = &filteredRegressions[i]
+				break
+			}
+		}
+		require.NotNil(t, foundRegression, "expected regression was not found in release filtered list")
+		assert.Equal(t, view.SampleRelease.Release.Name, foundRegression.Release)
+	})
+	t.Run("error when both view and release are specified", func(t *testing.T) {
+		defer cleanupAllTriages(dbc)
+		_ = createAndValidateTriageRecord(t, jiraBug.URL, testRegression1)
+
+		// Test that specifying both view and release parameters returns an error
+		var regressions []models.TestRegression
+		err := util.SippyGet("/api/component_readiness/regressions?view="+view.Name+"&release="+view.SampleRelease.Name, &regressions)
+		require.Error(t, err, "Expected error when both view and release are specified")
 	})
 	t.Run("update generates audit_log record", func(t *testing.T) {
 		defer cleanupAllTriages(dbc)
@@ -777,6 +873,11 @@ func Test_TriageRawDB(t *testing.T) {
 
 func createTestRegression(t *testing.T, tracker componentreadiness.RegressionStore, view crview.View, testID string) *models.TestRegression {
 	newRegression := componentreport.ReportTestSummary{
+		TestComparison: testdetails.TestComparison{
+			BaseStats: &testdetails.ReleaseStats{
+				Release: "4.18",
+			},
+		},
 		Identification: crtest.Identification{
 			RowIdentification: crtest.RowIdentification{
 				Component:  "comp",

--- a/test/e2e/util/e2erequest.go
+++ b/test/e2e/util/e2erequest.go
@@ -19,7 +19,7 @@ const (
 	APIPort = 18080
 )
 
-func buildURL(apiPath string) string {
+func BuildE2EURL(apiPath string) string {
 	envSippyAPIPort := os.Getenv("SIPPY_API_PORT")
 	envSippyEndpoint := os.Getenv("SIPPY_ENDPOINT")
 
@@ -38,7 +38,7 @@ func buildURL(apiPath string) string {
 }
 
 func SippyGet(path string, data interface{}) error {
-	req, err := http.Get(buildURL(path))
+	req, err := http.Get(BuildE2EURL(path))
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func sippyMutatingRequest(method, path string, bodyData, responseData interface{
 		bodyReader = strings.NewReader(string(bodyBytes))
 	}
 
-	req, err := http.NewRequest(method, buildURL(path), bodyReader)
+	req, err := http.NewRequest(method, BuildE2EURL(path), bodyReader)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This replaces https://github.com/openshift/sippy/pull/2953 with a rebase and a few changes. Original description:

> * **Reapply "[TRT-2210](https://issues.redhat.com//browse/TRT-2210): Include test details report links in server response, add regression APIs"**
> * **Fix a nil pointer for pre-existing new test regressions with no base stats**
> * **WIP fix for env_test separate test details url generation merger**
> * **Fix some merge issues due to function rename**
> * **Get links rendering at bottom level test table in CR**
> 
> At one point I thought I saw the low level drilldown link to a test details report cache miss, today I cannot reproduce it. We can live with it as this will be a rare case anyhow but it's something to keep an eye on.
> 
> I got into merge conflicts with the hateoas link injection and Stephen's PR, specifically I had them set up to include fully qualified links with http https whenever possible, so they are clickable and copyable. I migrated your work Stephen but I'm worried there's something out there expecting them to be relative, probably in the new triage regression matcher. However, I tested both directions, and it seemed to work.
> 
> Apologies I ran out of time to test as much as I'd like so this PR may need someone to take over, but it looks good from what I've tested. (cache load, regression tracker, main report, drilldown, test details reports, triage, and scan for regressions matching triage)