### PR TITLE
TRT-2310: Display triaged jira details in test details triage table

### DIFF
--- a/pkg/db/query/triage_queries.go
+++ b/pkg/db/query/triage_queries.go
@@ -19,7 +19,7 @@ func ListOpenRegressions(dbc *db.DB, release string) ([]*models.TestRegression, 
 	var openRegressions []*models.TestRegression
 	res := dbc.DB.
 		Model(&models.TestRegression{}).
-		Preload("Triages").
+		Preload("Triages.Bug").
 		Where("test_regressions.release = ?", release).
 		Where("test_regressions.closed IS NULL").
 		Find(&openRegressions)


### PR DESCRIPTION
Bug details were always empty in test details triage table, but present if you went to the triage tab indicating we have the data, it's just not being returned from the API.