### PR TITLE
TRT-2210: fix panic in regression tracker when BaseStats is nil

### DIFF
--- a/pkg/api/componentreadiness/regressiontracker.go
+++ b/pkg/api/componentreadiness/regressiontracker.go
@@ -300,10 +300,10 @@ func (rt *RegressionTracker) SyncRegressionsForReport(ctx context.Context, view 
 			baseRelease := view.BaseRelease.Name
 			if regTest.BaseStats != nil {
 				baseRelease = regTest.BaseStats.Release
-				if baseRelease != openReg.BaseRelease {
-					openReg.BaseRelease = regTest.BaseStats.Release
-					modifiedRegression = true
-				}
+			}
+			if baseRelease != openReg.BaseRelease {
+				openReg.BaseRelease = baseRelease
+				modifiedRegression = true
 			}
 
 			// Technically component and capability could get remapped during the time the regression is open,

--- a/pkg/api/componentreadiness/regressiontracker.go
+++ b/pkg/api/componentreadiness/regressiontracker.go
@@ -300,10 +300,10 @@ func (rt *RegressionTracker) SyncRegressionsForReport(ctx context.Context, view 
 			baseRelease := view.BaseRelease.Name
 			if regTest.BaseStats != nil {
 				baseRelease = regTest.BaseStats.Release
-			}
-			if baseRelease != openReg.BaseRelease {
-				openReg.BaseRelease = regTest.BaseStats.Release
-				modifiedRegression = true
+				if baseRelease != openReg.BaseRelease {
+					openReg.BaseRelease = regTest.BaseStats.Release
+					modifiedRegression = true
+				}
 			}
 
 			// Technically component and capability could get remapped during the time the regression is open,


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x11559ee]
goroutine 1 [running]:
github.com/openshift/sippy/pkg/api/componentreadiness.(*RegressionTracker).SyncRegressionsForReport(_, {_, _}, {{0xc0008ddc50, 0x9}, {{{0xc0008ddcd0, 0x4}, 0x0, 0x0, {0x0, ...}, ...}, ...}, ...}, ...)
/go/src/sippy/pkg/api/componentreadiness/regressiontracker.go:305 +0x46e
```