### PR TITLE
TRT-2235: include LayeredProduct in DBGroupBy (4.21 views)

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -24,6 +24,7 @@ component_readiness:
         Suite: { }
         Topology: { }
         Upgrade: { }
+        LayeredProduct: { }
       include_variants:
         Architecture:
           - amd64
@@ -103,6 +104,7 @@ component_readiness:
         Suite: { }
         Topology: { }
         Upgrade: { }
+        LayeredProduct: { }
       include_variants:
         Architecture:
           - amd64
@@ -165,6 +167,7 @@ component_readiness:
         Suite: { }
         Topology: { }
         Upgrade: { }
+        LayeredProduct: { }
       include_variants:
         Architecture:
           - amd64
@@ -243,6 +246,7 @@ component_readiness:
         Suite: { }
         Topology: { }
         Upgrade: { }
+        LayeredProduct: { }
       include_variants:
         Architecture:
           - amd64
@@ -320,6 +324,7 @@ component_readiness:
         Platform: { }
         Suite: { }
         Upgrade: { }
+        LayeredProduct: { }
       include_variants:
         Architecture:
           - amd64
@@ -440,6 +445,7 @@ component_readiness:
         Upgrade: { }
         Procedure: { }
         JobTier: { }
+        LayeredProduct: { }
       include_variants:
         Architecture:
           - amd64

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -55,7 +55,7 @@ var (
 	// TODO: centralize these configurations for consumption by both the front and backends
 
 	DefaultColumnGroupBy = "Platform,Architecture,Network"
-	DefaultDBGroupBy     = "Platform,Architecture,Network,Topology,FeatureSet,Upgrade,Suite,Installer"
+	DefaultDBGroupBy     = "Platform,Architecture,Network,Topology,FeatureSet,Upgrade,Suite,Installer,LayeredProduct"
 )
 
 func getSingleColumnResultToSlice(ctx context.Context, q *bigquery.Query) ([]string, error) {

--- a/pkg/api/componentreadiness/queryparamparser_test.go
+++ b/pkg/api/componentreadiness/queryparamparser_test.go
@@ -235,7 +235,7 @@ func TestParseComponentReportRequest(t *testing.T) {
 			},
 			variantOption: reqopts.Variants{
 				ColumnGroupBy: sets.NewString("Platform", "Architecture", "Network"),
-				DBGroupBy:     sets.NewString("Platform", "Architecture", "Network", "Topology", "Suite", "FeatureSet", "Upgrade", "Installer"),
+				DBGroupBy:     sets.NewString("Platform", "Architecture", "Network", "Topology", "Suite", "FeatureSet", "Upgrade", "Installer", "LayeredProduct"),
 				IncludeVariants: map[string][]string{
 					"Architecture": {"amd64"},
 					"FeatureSet":   {"default", "techpreview"},


### PR DESCRIPTION
I can't see any reason this wouldn't work correctly now. Everything seems to be getting dbGroupBy from a view (the default would only be used in the absence of views) and passing it around as a parameter. I ran the cache primer with this locally and test_details linked from the CR modal came from cache.