### PR TITLE
TRT-2284: informational comment on OCPBUGS cards used for triage

### DIFF
--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1371,7 +1371,7 @@ func (s *Server) jsonCreateTriage(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	ctx := context.WithValue(req.Context(), models.CurrentUserKey, user)
-	triage, err := componentreadiness.CreateTriage(s.db.DB.WithContext(ctx), triage, req)
+	triage, err := componentreadiness.CreateTriage(s.db.DB.WithContext(ctx), s.jiraClient, triage, req)
 	if err != nil {
 		failureResponse(w, http.StatusBadRequest, err.Error())
 		return
@@ -1401,7 +1401,7 @@ func (s *Server) jsonUpdateTriage(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	ctx := context.WithValue(req.Context(), models.CurrentUserKey, user)
-	triage, err = componentreadiness.UpdateTriage(s.db.DB.WithContext(ctx), triage, req)
+	triage, err = componentreadiness.UpdateTriage(s.db.DB.WithContext(ctx), s.jiraClient, triage, req)
 	if err != nil {
 		log.WithError(err).Error("error updating triage")
 		failureResponse(w, http.StatusBadRequest, err.Error())


### PR DESCRIPTION
Adds a simple comment to any OCPBUGS cards that are utilized for a triage record. This happens on initial creation, and when the triage is updated to point to a new Jira URL. We cannot comment on cards outside the OCPBUGS project, so there is simple validation there.

/hold merge after https://github.com/openshift/sippy/pull/2969