### PR TITLE
TRT-2249: obtain release_blocker status on bugs and display it on linked triage in the UI

### DIFF
--- a/pkg/dataloader/bugloader/bugloader.go
+++ b/pkg/dataloader/bugloader/bugloader.go
@@ -50,7 +50,8 @@ SELECT
   ARRAY(SELECT name FROM UNNEST(fix_versions)) as fix_versions,
   ARRAY(SELECT name FROM UNNEST(target_versions)) as target_versions,
   ARRAY(SELECT name FROM UNNEST(components)) as components,
-  t.labels as labels
+  t.labels as labels,
+  t.release_blocker.value as release_blocker
 FROM
   TicketData t`
 )
@@ -74,6 +75,7 @@ type bigQueryBug struct {
 	Labels          []string           `json:"labels" bigquery:"labels"`
 	JiraID          string             `bigquery:"jira_id"`
 	LinkName        string             `bigquery:"link_name"`
+	ReleaseBlocker  string             `bigquery:"release_blocker"`
 }
 
 func New(dbc *db.DB, bqc *bigquery.Client) *BugLoader {
@@ -512,6 +514,7 @@ func bigQueryBugToModel(bqBug bigQueryBug) *models.Bug {
 		TargetVersions:  pq.StringArray(bqBug.TargetVersions),
 		Components:      pq.StringArray(bqBug.Components),
 		Labels:          pq.StringArray(bqBug.Labels),
+		ReleaseBlocker:  bqBug.ReleaseBlocker,
 		URL:             fmt.Sprintf("https://issues.redhat.com/browse/%s", bqBug.Key),
 	}
 }

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -131,6 +131,7 @@ type Bug struct {
 	Components      pq.StringArray `json:"components" gorm:"type:text[]"`
 	Labels          pq.StringArray `json:"labels" gorm:"type:text[]"`
 	URL             string         `json:"url"`
+	ReleaseBlocker  string         `json:"release_blocker"`
 	Tests           []Test         `json:"-" gorm:"many2many:bug_tests;constraint:OnDelete:CASCADE;"`
 	Jobs            []ProwJob      `json:"-" gorm:"many2many:bug_jobs;constraint:OnDelete:CASCADE;"`
 }

--- a/sippy-ng/src/component_readiness/Triage.js
+++ b/sippy-ng/src/component_readiness/Triage.js
@@ -230,6 +230,10 @@ export default function Triage({ id }) {
             </TableCell>
           </TableRow>
           <TableRow>
+            <TableCell>Jira Release Blocker</TableCell>
+            <TableCell>{triage.bug?.release_blocker}</TableCell>
+          </TableRow>
+          <TableRow>
             <TableCell>Jira updated</TableCell>
             <TableCell>
               {triage.bug?.last_change_time ? (

--- a/sippy-ng/src/component_readiness/TriagedRegressions.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressions.js
@@ -146,7 +146,6 @@ export default function TriagedRegressions({
         </a>
       ),
     },
-
     {
       field: 'bug_state',
       valueGetter: (value) => {
@@ -166,6 +165,15 @@ export default function TriagedRegressions({
         )
       },
       headerName: 'Version',
+      flex: 5,
+      renderCell: (param) => <div className="test-name">{param.value}</div>,
+    },
+    {
+      field: 'release_blocker',
+      valueGetter: (value) => {
+        return value.row.bug?.release_blocker || ''
+      },
+      headerName: 'Release Blocker',
       flex: 5,
       renderCell: (param) => <div className="test-name">{param.value}</div>,
     },


### PR DESCRIPTION
I have already update the `openshift-ci-data-analysis.jira_data.tickets_dedup` view to include the new field.

<img width="1811" height="772" alt="Screenshot 2025-09-24 at 1 42 18 PM" src="https://github.com/user-attachments/assets/c5624dcd-0e86-4dfd-929e-2e525e493791" />

<img width="2484" height="198" alt="Screenshot 2025-09-24 at 1 42 10 PM" src="https://github.com/user-attachments/assets/285c5b81-b459-444e-bdff-1d8d6a994319" />
