### PR TITLE
TRT-2263: Indicate when feature gate test results are coming from included/excluded jobtiers

### DIFF
--- a/cmd/sippy/seed_data.go
+++ b/cmd/sippy/seed_data.go
@@ -131,20 +131,19 @@ rolled off the 1 week window.
 }
 
 func createProwJobsForRelease(dbc *db.DB, release string, jobsPerRelease int) error {
-	// JobTier values to randomly choose from
-	jobTiers := []string{"standard", "candidate", "informing", "blocking", "hidden"}
-
 	for i := 1; i <= jobsPerRelease; i++ {
-		// Randomly select a JobTier
-		// nolint: gosec
-		randomJobTier := jobTiers[rand.Intn(len(jobTiers))]
+		// Choose JobTier based on whether i is even or odd
+		var jobTier = "JobTier:standard" // even number job index = standard
+		if i%2 != 0 {
+			jobTier = "JobTier:hidden" // odd = hidden
+		}
 
 		prowJob := models.ProwJob{
 			Kind:    models.ProwKind("periodic"),
 			Name:    fmt.Sprintf("sippy-test-job-%s-test-%d", release, i),
 			Release: release,
 			// TestGridURL, Bugs, and JobRuns are left empty as requested
-			Variants: []string{"Platform:aws", "Upgrade:none", fmt.Sprintf("JobTier:%s", randomJobTier)},
+			Variants: []string{"Platform:aws", "Upgrade:none", jobTier},
 		}
 
 		// Use FirstOrCreate to avoid duplicates - only creates if a ProwJob with this name doesn't exist

--- a/cmd/sippy/seed_data.go
+++ b/cmd/sippy/seed_data.go
@@ -131,13 +131,20 @@ rolled off the 1 week window.
 }
 
 func createProwJobsForRelease(dbc *db.DB, release string, jobsPerRelease int) error {
+	// JobTier values to randomly choose from
+	jobTiers := []string{"standard", "candidate", "informing", "blocking", "hidden"}
+
 	for i := 1; i <= jobsPerRelease; i++ {
+		// Randomly select a JobTier
+		// nolint: gosec
+		randomJobTier := jobTiers[rand.Intn(len(jobTiers))]
+
 		prowJob := models.ProwJob{
 			Kind:    models.ProwKind("periodic"),
 			Name:    fmt.Sprintf("sippy-test-job-%s-test-%d", release, i),
 			Release: release,
 			// TestGridURL, Bugs, and JobRuns are left empty as requested
-			Variants: []string{"Platform:aws", "Upgrade:none"},
+			Variants: []string{"Platform:aws", "Upgrade:none", fmt.Sprintf("JobTier:%s", randomJobTier)},
 		}
 
 		// Use FirstOrCreate to avoid duplicates - only creates if a ProwJob with this name doesn't exist

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -43,6 +43,66 @@ const bookmarks = [
   },
 ]
 
+/**
+ * Chooses which variants to display in the table based on priority and limits.
+ * @param {Array<string>} variants - Array of variant strings in "key:value" format
+ * @returns {Array<string>} - Up to 8 selected variants
+ */
+function chooseVariantsToDisplay(variants) {
+  if (!variants || variants.length === 0) {
+    return []
+  }
+
+  // Filter out default variants first
+  const filteredVariants = variants.filter((item) => !item.endsWith(':default'))
+
+  // Priority order for variant keys
+  const priorityKeys = [
+    'JobTier',
+    'Platform',
+    'Architecture',
+    'NetworkStack',
+    'Topology',
+    'FeatureSet',
+    'Upgrade',
+  ]
+
+  // Parse variants into key-value pairs
+  const variantMap = new Map()
+  const remainingVariants = []
+
+  filteredVariants.forEach((variant) => {
+    const colonIndex = variant.indexOf(':')
+    if (colonIndex > 0) {
+      const key = variant.substring(0, colonIndex)
+      if (priorityKeys.includes(key)) {
+        variantMap.set(key, variant)
+      } else {
+        remainingVariants.push(variant)
+      }
+    } else {
+      remainingVariants.push(variant)
+    }
+  })
+
+  // Build result array starting with priority keys
+  const result = []
+  priorityKeys.forEach((key) => {
+    if (variantMap.has(key) && result.length < 8) {
+      result.push(variantMap.get(key))
+    }
+  })
+
+  // Fill remaining slots with other variants
+  let i = 0
+  while (result.length < 8 && i < remainingVariants.length) {
+    result.push(remainingVariants[i])
+    i++
+  }
+
+  return result
+}
+
 const useStyles = makeStyles((theme) => ({
   backdrop: {
     zIndex: 999999,
@@ -429,21 +489,17 @@ function TestTable(props) {
       headerName: 'Variants',
       autocomplete: 'variants',
       type: 'array',
-      renderCell: (params) => (
-        <Tooltip
-          sx={{ whiteSpace: 'pre' }}
-          title={params.value ? params.value.join('\n') : ''}
-        >
-          <div className="variants-list">
-            {params.value
-              ? params.value
-                  .slice(0, 8)
-                  .filter((item) => !item.endsWith(':default'))
-                  .join('\n')
-              : ''}
-          </div>
-        </Tooltip>
-      ),
+      renderCell: (params) => {
+        const displayVariants = chooseVariantsToDisplay(params.value)
+        return (
+          <Tooltip
+            sx={{ whiteSpace: 'pre' }}
+            title={params.value ? params.value.join('\n') : ''}
+          >
+            <div className="variants-list">{displayVariants.join('\n')}</div>
+          </Tooltip>
+        )
+      },
     },
     delta_from_working_average: {
       field: 'delta_from_working_average',

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -93,7 +93,8 @@ function chooseVariantsToDisplay(variants) {
     }
   })
 
-  // Fill remaining slots with other variants
+  // Fill remaining slots with other variants, for non OCP sippy users it will
+  // just be whatever order their variants appear in the prow_jobs table.
   let i = 0
   while (result.length < 8 && i < remainingVariants.length) {
     result.push(remainingVariants[i])
@@ -447,6 +448,20 @@ function TestTable(props) {
     </div>
   )
 
+  const getVariantStyle = (variant) => {
+    // Special treatment for JobTier to help users better understand if their test is feeding component readiness or not
+    if (
+      variant === 'JobTier:blocking' ||
+      variant === 'JobTier:informing' ||
+      variant === 'JobTier:standard'
+    ) {
+      return { color: 'green' }
+    } else if (variant.startsWith('JobTier:')) {
+      return { color: 'darkred' }
+    }
+    return {}
+  }
+
   const columns = {
     name: {
       field: 'name',
@@ -491,12 +506,19 @@ function TestTable(props) {
       type: 'array',
       renderCell: (params) => {
         const displayVariants = chooseVariantsToDisplay(params.value)
+
         return (
           <Tooltip
             sx={{ whiteSpace: 'pre' }}
             title={params.value ? params.value.join('\n') : ''}
           >
-            <div className="variants-list">{displayVariants.join('\n')}</div>
+            <div className="variants-list">
+              {displayVariants.map((variant, index) => (
+                <div key={index} style={getVariantStyle(variant)}>
+                  {variant}
+                </div>
+              ))}
+            </div>
           </Tooltip>
         )
       },

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -22,7 +22,7 @@ import {
 import { generateClasses } from '../datagrid/utils'
 import { GridView } from '../datagrid/GridView'
 import { Link, useLocation } from 'react-router-dom'
-import { makeStyles } from '@mui/styles'
+import { makeStyles, useTheme } from '@mui/styles'
 import { NumberParam, StringParam, useQueryParam } from 'use-query-params'
 import { StyledDataGrid } from '../datagrid/StyledDataGrid'
 import { useCookies } from 'react-cookie'
@@ -122,6 +122,7 @@ const useStyles = makeStyles((theme) => ({
 function TestTable(props) {
   const { classes } = props
   const gridClasses = useStyles()
+  const theme = useTheme()
   const location = useLocation().pathname
 
   const [testDetails, setTestDetails] = React.useState({ bugs: [] })
@@ -459,9 +460,9 @@ function TestTable(props) {
   const getVariantStyle = (variant) => {
     // Special treatment for JobTier to help users better understand if their test is feeding component readiness or not
     if (isComponentReadinessIncludedJobTier(variant)) {
-      return { color: 'green' }
+      return { color: theme.palette.success.dark }
     } else if (variant.startsWith('JobTier:')) {
-      return { color: 'darkred' }
+      return { color: theme.palette.error.dark }
     }
     return {}
   }

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -520,15 +520,28 @@ function TestTable(props) {
               !isComponentReadinessIncludedJobTier(variant)
           )
 
-        const tooltipTitle = params.value
-          ? params.value.join('\n') +
-            (hasExcludedJobTier
-              ? '\n\nWARNING: Test results from jobs with this JobTier are not included in the main release blocking views for component readiness, and will not be monitored for regressions.'
-              : '')
-          : ''
+        const tooltipContent = params.value ? (
+          <div>
+            {params.value.map((variant, index) => (
+              <div key={index}>{variant}</div>
+            ))}
+            {hasExcludedJobTier && (
+              <>
+                <br />
+                <div>
+                  <b>WARNING:</b> Test results from jobs with this JobTier are
+                  not included in the main release blocking views for component
+                  readiness, and will not be monitored for regressions.
+                </div>
+              </>
+            )}
+          </div>
+        ) : (
+          ''
+        )
 
         return (
-          <Tooltip sx={{ whiteSpace: 'pre' }} title={tooltipTitle}>
+          <Tooltip sx={{ whiteSpace: 'pre' }} title={tooltipContent}>
             <div className="variants-list">
               {displayVariants.map((variant, index) => (
                 <div key={index} style={getVariantStyle(variant)}>


### PR DESCRIPTION
This does not enforce that feature gate test results are coming from component readiness included job tiers, but it does help display to the user whether they are or not in the default view presented when clicking through to the fg tests table.

JobTier is now first in the list, previously it was typically hidden as it wasn't in the first 8. It will be green if an included jobtier, red otherwise.
Hide Network (always ovn now)
Hide Owner (still visible in tooltip)

Tooltip will also get a warning if the result is from an excluded jobtier to help explain.

In future, a dropdown view for included/excluded CR would be nice both on this table, and the jobs table.

Assisted-by: Cursor AI