### PR TITLE
Drop hypershift from main views for 4.20 and 4.21

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -34,7 +34,6 @@ component_readiness:
         Installer:
           - ipi
           - upi
-          - hypershift
         JobTier:
           - blocking
           - informing
@@ -57,7 +56,6 @@ component_readiness:
         Topology:
           - ha
           - microshift
-          - external
         CGroupMode:
           - v2
         ContainerRuntime:
@@ -516,7 +514,6 @@ component_readiness:
         Installer:
           - ipi
           - upi
-          - hypershift
         JobTier:
           - blocking
           - informing
@@ -539,7 +536,6 @@ component_readiness:
         Topology:
           - ha
           - microshift
-          - external
         CGroupMode:
           - v2
         ContainerRuntime:


### PR DESCRIPTION
After discussion with leadership we are pulling hypershift until they can fix some issues and stabilize their CI signal. We will try again in 4.21 once signal is clean.
