### PR TITLE
TRT-2150: better debug info for cache primer issue

### DIFF
--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -180,7 +180,12 @@ func (c *ComponentReportGenerator) GenerateTestDetailsReportMultiTest(ctx contex
 }
 
 // GenerateDetailsReportForTest generates a test detail report for a per-test + variant combo.
-func (c *ComponentReportGenerator) GenerateDetailsReportForTest(ctx context.Context, testIDOption reqopts.TestIdentification, componentJobRunTestReportStatus bq.TestJobRunStatuses, allowUnregressedReports bool) (testdetails.Report, []error) {
+func (c *ComponentReportGenerator) GenerateDetailsReportForTest(
+	ctx context.Context,
+	testIDOption reqopts.TestIdentification,
+	componentJobRunTestReportStatus bq.TestJobRunStatuses,
+	allowUnregressedReports bool,
+) (testdetails.Report, []error) {
 
 	if testIDOption.TestID == "" {
 		return testdetails.Report{}, []error{fmt.Errorf("test_id has to be defined for test details")}
@@ -257,7 +262,9 @@ func (c *ComponentReportGenerator) GenerateDetailsReportForTest(ctx context.Cont
 			}
 		}
 		if !regressed {
-			return testdetails.Report{}, []error{fmt.Errorf("report for test: %s is not showing as regressed", report.TestID)}
+			return testdetails.Report{}, []error{fmt.Errorf(
+				"report for test is not regressed as expected in release %s; ID=%v", c.ReqOptions.SampleRelease.Name, testIDOption,
+			)}
 		}
 	}
 

--- a/pkg/dataloader/crcacheloader/crcacheloader.go
+++ b/pkg/dataloader/crcacheloader/crcacheloader.go
@@ -169,6 +169,9 @@ func (l *ComponentReadinessCacheLoader) primeCacheForView(ctx context.Context, v
 		return fmt.Errorf("multi test details report generation encountered errors: %s", strings.Join(strErrors, "; "))
 	}
 	rLog.Infof("got %d test details reports", len(tdReports))
+	if len(testIDOptions) != len(tdReports) {
+		rLog.Warnf("test details report generation returned %d reports, but %d test details requests were made", len(tdReports), len(testIDOptions))
+	}
 
 	// Now we cache each test details report:
 	for _, report := range tdReports {


### PR DESCRIPTION
The debug message for this issue where regressed tests aren't regressed could use some helpful info, like for what release and variants.