### PR TITLE
TRT-2228: load bugs that are older than 14 days if they are not yet closed

### DIFF
--- a/pkg/dataloader/bugloader/bugloader.go
+++ b/pkg/dataloader/bugloader/bugloader.go
@@ -37,7 +37,12 @@ const (
   FROM
     openshift-ci-data-analysis.jira_data.tickets_dedup t
   LEFT JOIN UNNEST(t.comments) AS c
-  WHERE t.summary IS NOT NULL AND last_changed_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+  WHERE t.summary IS NOT NULL 
+    AND (
+      (last_changed_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY))
+      OR
+      (t.status.name != "Closed" AND last_changed_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY))
+    )
 )
 SELECT
   t.issue.key as key,


### PR DESCRIPTION
This will keep bugs in the system for 90 days as long as they are not `Closed`. We don't want to filter out bugs that haven't been touched for 14 days when they are still active.