### PR TITLE
TRT-2228: Additional updates for retaining open bugs longer

### DIFF
--- a/pkg/dataloader/bugloader/bugloader.go
+++ b/pkg/dataloader/bugloader/bugloader.go
@@ -41,7 +41,7 @@ const (
     AND (
       (last_changed_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY))
       OR
-      (t.status.name != "Closed" AND last_changed_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY))
+      (UPPER(t.status.name) NOT IN ('CLOSED', 'VERIFIED') AND last_changed_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY))
     )
 )
 SELECT


### PR DESCRIPTION
Follows up on https://github.com/openshift/sippy/pull/2988 to ensure bugs in Verified status should be limited to 14 days from last change (instead of 90), and bugs loaded for jobs should extend to 90 days when they aren't in Closed or Verified