### PR TITLE
Stop updating triaged Jiras when all regressions resolve

### DIFF
--- a/pkg/api/componentreadiness/regressiontracker.go
+++ b/pkg/api/componentreadiness/regressiontracker.go
@@ -156,7 +156,6 @@ func (prs *PostgresRegressionStore) ResolveTriages() error {
 			continue
 		}
 
-		ReportTriageResolved(prs.jiraClient, triage)
 		log.Infof("Resolved triage %d with resolution time %v", triage.ID, triage.Resolved.Time)
 	}
 

--- a/pkg/api/componentreadiness/triage.go
+++ b/pkg/api/componentreadiness/triage.go
@@ -110,13 +110,6 @@ func CreateTriage(dbc *gorm.DB, jiraClient *jira.Client, triage models.Triage, r
 
 const jiraPrefix = "https://issues.redhat.com/browse/"
 
-// ReportTriageResolved comments on the associated jira that the regressions have been resolved, including a link
-// to the triage details
-func ReportTriageResolved(jiraClient *jira.Client, triage models.Triage) {
-	message := "All regressions associated with this triage record have been resolved."
-	reportOnJiraUsedForTriage(jiraClient, triage, message, nil)
-}
-
 // ReportTriageAddedForJira comments on the associated jira with a link to the triage details
 func ReportTriageAddedForJira(jiraClient *jira.Client, triage models.Triage, req *http.Request) {
 	message := "This bug has been triaged to one or more component readiness regressions."


### PR DESCRIPTION
While helpful in the happy path, the reality is that many regressions come and go on the board over time. We treat regressions as release blockers, but when they drop off the board the case gets murkier to push for a fix and prevent it the next time. This message appearing on such bugs immediately triggers ambiguity and debate with engineering about whether or not the issue should be fixed, which burns time and when unsuccessful leaves us exposed to the whole cycle repeating again later when the unfixed issue returns. 

I would argue we're better off making it harder to notice this, and letting eng teams work through the fixes regardless rather than reopening the debate. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed Jira notifications that were being sent when triages are resolved. The triage resolution process continues to function normally without posting status updates to Jira.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->