### PR TITLE
Drop rhcos10 from 4.22 main, covered by aux view

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -66,6 +66,10 @@ component_readiness:
       ContainerRuntime:
       - runc
       - crun
+      Upgrade:
+      - micro
+      - minor
+      - none
   advanced_options:
     minimum_failure: 3
     confidence: 95

--- a/config/views.yaml
+++ b/config/views.yaml
@@ -45,6 +45,8 @@ component_readiness:
       - virt
       Network:
       - ovn
+      OS:
+      - rhcos9
       Owner:
       - eng
       - service-delivery


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for RHCOS9 operating system variant in version 4.22-main, providing an additional OS selection option.
  * Added Upgrade variant options (micro, minor, none) for version 4.22-main to give more upgrade flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->