### PR TITLE
TRT-1989: remove ProwJobRunTest during partition migration

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -102,6 +102,29 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 		}
 	}
 
+	// while we are in the transition phase we have to check to see if the table exists for the models we are migrating
+	// if not then this is a new db so we should create the old non-partitioned tables
+	modelsToInitialize := []struct {
+		model     interface{}
+		tableName string
+	}{
+		{
+			model:     &models.ProwJobRunTest{},
+			tableName: "prow_job_run_tests",
+		},
+		{
+			model:     &models.ProwJobRunTestOutput{},
+			tableName: "prow_job_run_test_outputs",
+		},
+	}
+	for _, model := range modelsToInitialize {
+		if !d.DB.Migrator().HasTable(model.tableName) {
+			if err := d.DB.AutoMigrate(model.model); err != nil {
+				return err
+			}
+		}
+	}
+
 	// TODO(sgoeddel): This migration logic can be removed once we have a migration that drops the view column from test_regressions
 	if d.DB.Migrator().HasColumn(&models.TestRegression{}, "view") {
 		if err := d.DB.Migrator().DropColumn(&models.TestRegression{}, "view"); err != nil {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -77,8 +77,6 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 		&models.ProwJobRunAnnotation{},
 		&models.Test{},
 		&models.Suite{},
-		&models.ProwJobRunTest{},
-		&models.ProwJobRunTestOutput{},
 		&models.APISnapshot{},
 		&models.Bug{},
 		&models.ProwPullRequest{},
@@ -110,6 +108,10 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 			return err
 		}
 	}
+
+	// TODO(fbabcock): Add support for migrating partitioned table
+	// &models.ProwJobRunTest{},
+	// &models.ProwJobRunTestOutput{},
 
 	if err := createAuditLogIndexes(d.DB); err != nil {
 		return err

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -83,6 +83,7 @@ type Test struct {
 
 // ProwJobRunTest defines a join table linking tests to the job runs they execute in, along with the status for
 // that execution.
+// Do not update until after partitions have been enabled
 type ProwJobRunTest struct {
 	gorm.Model
 	ProwJobRunID uint `gorm:"index"`
@@ -102,6 +103,7 @@ type ProwJobRunTest struct {
 	ProwJobRunTestOutput *ProwJobRunTestOutput `gorm:"constraint:OnDelete:CASCADE;"`
 }
 
+// Do not update until after partitions have been enabled
 type ProwJobRunTestOutput struct {
 	gorm.Model
 	ProwJobRunTestID uint `gorm:"index"`


### PR DESCRIPTION
Removes tables targeted for partitioning from being managed automatically via gorm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted database migration flow to exclude specific test tables from the primary auto-migrate path and added a transitional initialization that conditionally creates legacy non‑partitioned test tables for new/unknown databases.
  * Preserved existing migration behavior and error handling; added a TODO placeholder for upcoming partitioned-table migration work.

* **Documentation**
  * Added inline comments clarifying migration intent for the affected test models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->