### PR TITLE
Trt-1989: partition management

### DIFF
--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -11,7 +11,6 @@ import (
 	"reflect"
 	"regexp"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -174,10 +173,74 @@ func (pl *ProwLoader) Errors() []error {
 	return pl.errors
 }
 
+// PartitionManagementConfig defines partition lifecycle settings for a table
+type PartitionManagementConfig struct {
+	TableName             string        // Name of the partitioned table
+	FuturePartitionWindow time.Duration // How far in the future to create partitions
+	DetachAfter           int           // Detach partitions older than this many days
+	DropDetachedAfter     int           // Drop detached partitions older than this many days
+	InitialLookbackDays   int           // Days to look back when initializing a new table
+}
+
+// sippy_backup currently deletes data older than 90 days
+// this adds grace of 5 days before detaching and
+// 10 before deleting. test_analysis_by_job_by_dates
+// is not currently managed by sippy_backup
+var partitionConfigs = []PartitionManagementConfig{
+	{
+		TableName:             "test_analysis_by_job_by_dates",
+		FuturePartitionWindow: 48 * time.Hour,
+		DetachAfter:           95,
+		DropDetachedAfter:     100,
+		InitialLookbackDays:   15,
+	},
+	{
+		TableName:             "prow_job_run_tests",
+		FuturePartitionWindow: 48 * time.Hour,
+		DetachAfter:           95,
+		DropDetachedAfter:     100,
+		InitialLookbackDays:   15,
+	},
+	{
+		TableName:             "prow_job_run_test_outputs",
+		FuturePartitionWindow: 48 * time.Hour,
+		DetachAfter:           95,
+		DropDetachedAfter:     100,
+		InitialLookbackDays:   15,
+	},
+}
+
+func (pl *ProwLoader) updatePartitions(config PartitionManagementConfig) error {
+	err := pl.agePartitions(config)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error aging %s", config.TableName))
+	}
+
+	err = pl.preparePartitions(config)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error preparing %s", config.TableName))
+	}
+
+	return nil
+}
+
 func (pl *ProwLoader) Load() {
 	start := time.Now()
 
 	log.Infof("started loading prow jobs to DB...")
+
+	for _, config := range partitionConfigs {
+		err := pl.updatePartitions(config)
+		if err != nil {
+			pl.errors = append(pl.errors, err)
+
+			// if we have errors with partition management we can't be sure that we have created
+			// the necessary partitions to proceed with loading
+			// we could possibly differentiate between removing old and creating new but for now
+			// any failures here block any loading
+			return
+		}
+	}
 
 	// Update unmerged PR statuses in case any have merged
 	if err := pl.syncPRStatus(); err != nil {
@@ -338,19 +401,62 @@ func DaysBetween(start, end time.Time) []string {
 	return days
 }
 
-// NextDay takes a date string in YYYY-MM-DD format and returns the date string for the following day.
-func NextDay(dateStr string) (string, error) {
-	// Parse the input date string
-	date, err := time.Parse("2006-01-02", dateStr)
+// agePartitions detaches and drops old partitions based on configuration
+func (pl *ProwLoader) agePartitions(config PartitionManagementConfig) error {
+	detached, err := pl.dbc.DetachOldPartitions(config.TableName, config.DetachAfter, false)
 	if err != nil {
-		return "", fmt.Errorf("invalid date format: %v", err)
+		log.WithError(err).Errorf("error detaching partitions for %s", config.TableName)
+		return err
+	}
+	log.Infof("detached %d partitions from %s", detached, config.TableName)
+	dropped, err := pl.dbc.DropOldDetachedPartitions(config.TableName, config.DropDetachedAfter, false)
+	if err != nil {
+		log.WithError(err).Errorf("error dropping detached partitions for %s", config.TableName)
+		return err
+	}
+	log.Infof("dropped %d detached partitions from %s", dropped, config.TableName)
+
+	return nil
+}
+
+// preparePartitions creates missing partitions for future data based on configuration
+func (pl *ProwLoader) preparePartitions(config PartitionManagementConfig) error {
+	log.Infof("preparing partitions for %s", config.TableName)
+	stats, err := pl.dbc.GetAttachedPartitionStats(config.TableName)
+
+	if err != nil {
+		log.WithError(err).Errorf("error getting partition stats for %s", config.TableName)
+		return err
+	}
+	fmt.Printf("  Total: %d partitions (%s)\n", stats.TotalPartitions, stats.TotalSizePretty)
+
+	// When initializing a new table, look back the configured number of days
+	oldestDate := time.Now().Add(-time.Duration(config.InitialLookbackDays) * 24 * time.Hour)
+	if stats.TotalPartitions > 0 {
+
+		var startRange, endRange string
+		if stats.OldestDate.Valid {
+			startRange = stats.OldestDate.Time.Format("2006-01-02")
+			oldestDate = stats.OldestDate.Time
+		}
+		if stats.NewestDate.Valid {
+			endRange = stats.OldestDate.Time.Format("2006-01-02")
+		}
+		fmt.Printf("  Range: %s to %s\n",
+			startRange,
+			endRange)
+
 	}
 
-	// Add one day to the parsed date
-	nextDay := date.Add(24 * time.Hour)
+	futureDate := time.Now().Add(config.FuturePartitionWindow)
+	created, err := pl.dbc.CreateMissingPartitions(config.TableName, oldestDate, futureDate, false)
+	if err != nil {
+		log.WithError(err).Errorf("error creating partitions for %s", config.TableName)
+		return err
+	}
 
-	// Format the next day back to YYYY-MM-DD
-	return nextDay.Format("2006-01-02"), nil
+	log.Infof("created %d partitions for %s", created, config.TableName)
+	return nil
 }
 
 // loadDailyTestAnalysisByJob loads test analysis data into partitioned tables in postgres, one per
@@ -389,21 +495,6 @@ func (pl *ProwLoader) loadDailyTestAnalysisByJob(ctx context.Context) error {
 		dLog := log.WithField("date", dateToImport)
 
 		dLog.Infof("Loading test analysis by job daily summaries")
-		nextDay, err := NextDay(dateToImport)
-		if err != nil {
-			return errors.Wrapf(err, "error parsing next day from %s", dateToImport)
-		}
-
-		// create a partition for this date
-		partitionSQL := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS test_analysis_by_job_by_dates_%s PARTITION OF test_analysis_by_job_by_dates
-    		FOR VALUES FROM ('%s') TO ('%s');`, strings.ReplaceAll(dateToImport, "-", "_"), dateToImport, nextDay)
-		dLog.Info(partitionSQL)
-
-		if res := pl.dbc.DB.Exec(partitionSQL); res.Error != nil {
-			log.WithError(res.Error).Error("error creating partition")
-			return res.Error
-		}
-		dLog.Warnf("partition created for releases %v", pl.releases)
 
 		q := pl.bigQueryClient.Query(ctx, bqlabel.ProwLoaderTestAnalysis, fmt.Sprintf(`WITH
   deduped_testcases AS (
@@ -1265,6 +1356,7 @@ func (pl *ProwLoader) extractTestCases(suite *junit.TestSuite, suiteID *uint, te
 				continue
 			}
 
+			// interesting that we rely on created_at here which is when we imported the test, not when the test ran
 			testCases[testCacheKey] = &models.ProwJobRunTest{
 				TestID:               testID,
 				SuiteID:              suiteID,

--- a/pkg/db/migration.go
+++ b/pkg/db/migration.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lib/pq"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -53,7 +54,7 @@ func (dbc *DB) MigrateToPartitionedTable(model interface{}, sourceTable, dateCol
 	// Step 2: Determine date range and create partitions
 	l.Info("step 2: determining date range for partitions")
 	var minDate time.Time
-	query := fmt.Sprintf("SELECT MIN(%s) FROM %s", dateColumn, sourceTable)
+	query := fmt.Sprintf("SELECT MIN(%s) FROM %s", pq.QuoteIdentifier(dateColumn), pq.QuoteIdentifier(sourceTable))
 	result := dbc.DB.Raw(query).Scan(&minDate)
 	if result.Error != nil {
 		return fmt.Errorf("failed to get min %s from %s: %w", dateColumn, sourceTable, result.Error)
@@ -131,7 +132,7 @@ func (dbc *DB) UpdatePartitionedTableMigration(sourceTable, dateColumn string, m
 	// Step 1: Find the newest date already migrated
 	l.Info("step 1: finding newest migrated date")
 	var maxDate time.Time
-	query := fmt.Sprintf("SELECT COALESCE(MAX(%s), '0001-01-01'::timestamp) FROM %s", dateColumn, targetTable)
+	query := fmt.Sprintf("SELECT COALESCE(MAX(%s), '0001-01-01'::timestamp) FROM %s", pq.QuoteIdentifier(dateColumn), pq.QuoteIdentifier(targetTable))
 	result := dbc.DB.Raw(query).Scan(&maxDate)
 	if result.Error != nil {
 		return fmt.Errorf("failed to get max %s from %s: %w", dateColumn, targetTable, result.Error)
@@ -167,7 +168,7 @@ func (dbc *DB) UpdatePartitionedTableMigration(sourceTable, dateColumn string, m
 
 	// Step 3: Migrate data from the day after the newest migrated date through migrateUpTo
 	l.Info("step 3: migrating new data")
-	migrateFrom := maxDate.UTC().Truncate(24*time.Hour).AddDate(0, 0, 1)
+	migrateFrom := maxDate.Add(time.Microsecond)
 	rows, err := dbc.MigrateTableDataRange(sourceTable, targetTable, dateColumn, migrateFrom, migrateUpTo, nil, dryRun)
 	if err != nil {
 		return fmt.Errorf("failed to migrate data: %w", err)
@@ -227,7 +228,7 @@ func (dbc *DB) FinalizePartitionedTableMigration(sourceTable, dateColumn string,
 	// Step 1: Find the newest date already migrated
 	l.Info("step 1: checking for new data to migrate")
 	var maxDate time.Time
-	query := fmt.Sprintf("SELECT COALESCE(MAX(%s), '0001-01-01'::timestamp) FROM %s", dateColumn, partitionedTable)
+	query := fmt.Sprintf("SELECT COALESCE(MAX(%s), '0001-01-01'::timestamp) FROM %s", pq.QuoteIdentifier(dateColumn), pq.QuoteIdentifier(partitionedTable))
 	result := dbc.DB.Raw(query).Scan(&maxDate)
 	if result.Error != nil {
 		return fmt.Errorf("failed to get max %s from %s: %w", dateColumn, partitionedTable, result.Error)
@@ -256,7 +257,7 @@ func (dbc *DB) FinalizePartitionedTableMigration(sourceTable, dateColumn string,
 
 	// Step 3: Migrate remaining data from the day after the newest migrated date
 	l.Info("step 3: migrating remaining data")
-	migrateFromNext := migrateFrom.UTC().Truncate(24*time.Hour).AddDate(0, 0, 1)
+	migrateFromNext := migrateFrom.Add(time.Microsecond)
 	rows, err := dbc.MigrateTableDataRange(sourceTable, partitionedTable, dateColumn, migrateFromNext, migrateUpTo, nil, dryRun)
 	if err != nil {
 		return fmt.Errorf("failed to migrate remaining data: %w", err)

--- a/pkg/db/migration.go
+++ b/pkg/db/migration.go
@@ -165,9 +165,10 @@ func (dbc *DB) UpdatePartitionedTableMigration(sourceTable, dateColumn string, m
 	}
 	l.WithField("partitions_created", created).Info("partition verification complete")
 
-	// Step 3: Migrate data from newest migrated through migrateUpTo
+	// Step 3: Migrate data from the day after the newest migrated date through migrateUpTo
 	l.Info("step 3: migrating new data")
-	rows, err := dbc.MigrateTableDataRange(sourceTable, targetTable, dateColumn, maxDate, migrateUpTo, nil, dryRun)
+	migrateFrom := maxDate.UTC().Truncate(24*time.Hour).AddDate(0, 0, 1)
+	rows, err := dbc.MigrateTableDataRange(sourceTable, targetTable, dateColumn, migrateFrom, migrateUpTo, nil, dryRun)
 	if err != nil {
 		return fmt.Errorf("failed to migrate data: %w", err)
 	}
@@ -253,9 +254,10 @@ func (dbc *DB) FinalizePartitionedTableMigration(sourceTable, dateColumn string,
 	}
 	l.WithField("partitions_created", created).Info("partitions created")
 
-	// Step 3: Migrate remaining data
+	// Step 3: Migrate remaining data from the day after the newest migrated date
 	l.Info("step 3: migrating remaining data")
-	rows, err := dbc.MigrateTableDataRange(sourceTable, partitionedTable, dateColumn, migrateFrom, migrateUpTo, nil, dryRun)
+	migrateFromNext := migrateFrom.UTC().Truncate(24*time.Hour).AddDate(0, 0, 1)
+	rows, err := dbc.MigrateTableDataRange(sourceTable, partitionedTable, dateColumn, migrateFromNext, migrateUpTo, nil, dryRun)
 	if err != nil {
 		return fmt.Errorf("failed to migrate remaining data: %w", err)
 	}

--- a/pkg/db/migration.go
+++ b/pkg/db/migration.go
@@ -1,0 +1,537 @@
+package db
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// MigrateToPartitionedTable creates a new partitioned table from a GORM model,
+// creates daily partitions covering the source table's date range, and migrates
+// data from the source table up to the specified date.  Keeping the migrateUpTo
+// date behind the current date allows follow-up Update and Finalize migration
+// to fill in data incrementally picking up from the previous migrateUpTo date.
+//
+// Parameters:
+//   - model: GORM model struct pointer defining the target schema (e.g., &models.ProwJobRunTest{})
+//   - sourceTable: name of the existing non-partitioned table to migrate from
+//   - dateColumn: the column used for partitioning and date-range migration
+//   - migrateUpTo: migrate data with dateColumn < migrateUpTo
+//   - dryRun: if true, logs all steps without executing
+//
+// The target table name is derived as sourceTable + "_partitioned".
+//
+// Steps performed:
+//  1. Create the partitioned table from the model
+//  2. Create daily partitions from the earliest data date through migrateUpTo + 7 days
+//  3. Migrate data from sourceTable where dateColumn >= earliest and dateColumn < migrateUpTo
+//  4. Sync identity columns so new inserts get correct IDs
+func (dbc *DB) MigrateToPartitionedTable(model interface{}, sourceTable, dateColumn string, migrateUpTo time.Time, dryRun bool) error {
+	targetTable := sourceTable + "_partitioned"
+
+	l := log.WithFields(log.Fields{
+		"source":        sourceTable,
+		"target":        targetTable,
+		"date_column":   dateColumn,
+		"migrate_up_to": migrateUpTo.Format("2006-01-02"),
+		"dry_run":       dryRun,
+	})
+
+	l.Info("starting migration to partitioned table")
+
+	// Step 1: Create the partitioned table
+	l.Info("step 1: creating partitioned table")
+	config := NewRangePartitionConfig(dateColumn)
+	sql, err := dbc.CreatePartitionedTable(model, targetTable, config, dryRun)
+	if err != nil {
+		return fmt.Errorf("failed to create partitioned table: %w", err)
+	}
+	l.WithField("sql", sql).Info("partitioned table created")
+
+	// Step 2: Determine date range and create partitions
+	l.Info("step 2: determining date range for partitions")
+	var minDate time.Time
+	query := fmt.Sprintf("SELECT MIN(%s) FROM %s", dateColumn, sourceTable)
+	result := dbc.DB.Raw(query).Scan(&minDate)
+	if result.Error != nil {
+		return fmt.Errorf("failed to get min %s from %s: %w", dateColumn, sourceTable, result.Error)
+	}
+
+	if minDate.IsZero() {
+		return fmt.Errorf("source table %s is empty or %s has no values", sourceTable, dateColumn)
+	}
+
+	// Create partitions from earliest data through migrateUpTo + 7 days buffer
+	partitionEnd := migrateUpTo.AddDate(0, 0, 7)
+	partitionStart := minDate.UTC().Truncate(24 * time.Hour)
+
+	l.WithFields(log.Fields{
+		"partition_start": partitionStart.Format("2006-01-02"),
+		"partition_end":   partitionEnd.Format("2006-01-02"),
+	}).Info("creating partitions")
+
+	created, err := dbc.CreateMissingPartitions(targetTable, partitionStart.AddDate(0, 0, -1), partitionEnd, dryRun)
+	if err != nil {
+		return fmt.Errorf("failed to create partitions: %w", err)
+	}
+	l.WithField("partitions_created", created).Info("partitions created")
+
+	// can't go any further if we haven't created the table
+	if !dryRun {
+		// Step 3: Migrate data
+		l.Info("step 3: migrating data")
+		rows, err := dbc.MigrateTableDataRange(sourceTable, targetTable, dateColumn, partitionStart, migrateUpTo, nil, dryRun)
+		if err != nil {
+			return fmt.Errorf("failed to migrate data: %w", err)
+		}
+		l.WithField("rows_migrated", rows).Info("data migration complete")
+
+		// Step 4: Sync identity column
+		l.Info("step 4: syncing identity column")
+		if err := dbc.SyncIdentityColumn(targetTable, "id"); err != nil {
+			return fmt.Errorf("failed to sync identity column: %w", err)
+		}
+		l.Info("identity column synced")
+	}
+
+	l.Info("migration to partitioned table complete")
+	return nil
+}
+
+// UpdatePartitionedTableMigration migrates additional data from the source table to
+// the partitioned table created by MigrateToPartitionedTable. Call this one or more
+// times to incrementally catch up before calling FinalizePartitionedTableMigration.
+//
+// Parameters:
+//   - sourceTable: name of the original non-partitioned table
+//   - dateColumn: the column used for partitioning and date-range migration
+//   - migrateUpTo: migrate data with dateColumn < migrateUpTo
+//   - dryRun: if true, logs all steps without executing
+//
+// Steps performed:
+//  1. Find the newest date already migrated in the partitioned table
+//  2. Verify partitions exist for the range; create any that are missing
+//  3. Migrate data from sourceTable where dateColumn > newest migrated and dateColumn < migrateUpTo
+//  4. Sync identity column so new inserts get correct IDs
+func (dbc *DB) UpdatePartitionedTableMigration(sourceTable, dateColumn string, migrateUpTo time.Time, dryRun bool) error {
+	targetTable := sourceTable + "_partitioned"
+
+	l := log.WithFields(log.Fields{
+		"source":        sourceTable,
+		"target":        targetTable,
+		"date_column":   dateColumn,
+		"migrate_up_to": migrateUpTo.Format("2006-01-02"),
+		"dry_run":       dryRun,
+	})
+
+	l.Info("starting incremental migration update")
+
+	// Step 1: Find the newest date already migrated
+	l.Info("step 1: finding newest migrated date")
+	var maxDate time.Time
+	query := fmt.Sprintf("SELECT COALESCE(MAX(%s), '0001-01-01'::timestamp) FROM %s", dateColumn, targetTable)
+	result := dbc.DB.Raw(query).Scan(&maxDate)
+	if result.Error != nil {
+		return fmt.Errorf("failed to get max %s from %s: %w", dateColumn, targetTable, result.Error)
+	}
+
+	if maxDate.IsZero() || maxDate.Year() == 1 {
+		return fmt.Errorf("partitioned table %s has no data; run MigrateToPartitionedTable first", targetTable)
+	}
+
+	if !migrateUpTo.After(maxDate) {
+		l.WithFields(log.Fields{
+			"newest_migrated": maxDate.Format("2006-01-02 15:04:05"),
+			"migrate_up_to":   migrateUpTo.Format("2006-01-02"),
+		}).Info("no new data to migrate; migrateUpTo is not after newest migrated date")
+		return nil
+	}
+
+	l.WithFields(log.Fields{
+		"migrate_from":  maxDate.Format("2006-01-02 15:04:05"),
+		"migrate_up_to": migrateUpTo.Format("2006-01-02"),
+	}).Info("determined migration range")
+
+	// Step 2: Verify and create missing partitions
+	l.Info("step 2: verifying partitions")
+	partitionStart := maxDate.UTC().Truncate(24 * time.Hour)
+	partitionEnd := migrateUpTo.AddDate(0, 0, 7)
+
+	created, err := dbc.CreateMissingPartitions(targetTable, partitionStart, partitionEnd, dryRun)
+	if err != nil {
+		return fmt.Errorf("failed to create missing partitions: %w", err)
+	}
+	l.WithField("partitions_created", created).Info("partition verification complete")
+
+	// Step 3: Migrate data from newest migrated through migrateUpTo
+	l.Info("step 3: migrating new data")
+	rows, err := dbc.MigrateTableDataRange(sourceTable, targetTable, dateColumn, maxDate, migrateUpTo, nil, dryRun)
+	if err != nil {
+		return fmt.Errorf("failed to migrate data: %w", err)
+	}
+	l.WithField("rows_migrated", rows).Info("data migration complete")
+
+	// Step 4: Sync identity column
+	if !dryRun {
+		l.Info("step 4: syncing identity column")
+		if err := dbc.SyncIdentityColumn(targetTable, "id"); err != nil {
+			return fmt.Errorf("failed to sync identity column: %w", err)
+		}
+		l.Info("identity column synced")
+	}
+
+	l.Info("incremental migration update complete")
+	return nil
+}
+
+// FinalizePartitionedTableMigration migrates any remaining data from the source table
+// to the partitioned table, syncs identity columns, swaps the tables so the partitioned
+// table takes the original name, and handles foreign keys.
+//
+// Parameters:
+//   - sourceTable: name of the original non-partitioned table
+//   - dateColumn: the column used for partitioning and date-range migration
+//   - migrateUpTo: migrate data with dateColumn < migrateUpTo
+//   - moveForeignKeys: if true, foreign keys are moved from the old table to the new
+//     partitioned table; if false, foreign keys are dropped (necessary when the
+//     partitioned table cannot support the FK constraints)
+//   - dryRun: if true, logs all steps without executing
+//
+// Assumes MigrateToPartitionedTable was previously called to create sourceTable + "_partitioned".
+//
+// Steps performed:
+//  1. Determine the newest date already migrated in the partitioned table
+//  2. Create any missing partitions up to migrateUpTo + 7 days
+//  3. Migrate remaining data from sourceTable where dateColumn >= newest migrated and dateColumn < migrateUpTo
+//  4. Sync identity columns
+//  5. Swap tables: sourceTable → sourceTable_old, sourceTable_partitioned → sourceTable
+//  6. Move or drop foreign keys from sourceTable_old
+func (dbc *DB) FinalizePartitionedTableMigration(sourceTable, dateColumn string, migrateUpTo time.Time, moveForeignKeys, dryRun bool) error {
+	partitionedTable := sourceTable + "_partitioned"
+	oldTable := sourceTable + "_old"
+
+	l := log.WithFields(log.Fields{
+		"source":            sourceTable,
+		"partitioned_table": partitionedTable,
+		"date_column":       dateColumn,
+		"migrate_up_to":     migrateUpTo.Format("2006-01-02"),
+		"move_foreign_keys": moveForeignKeys,
+		"dry_run":           dryRun,
+	})
+
+	l.Info("starting finalization of partitioned table migration")
+
+	// Step 1: Find the newest date already migrated
+	l.Info("step 1: checking for new data to migrate")
+	var maxDate time.Time
+	query := fmt.Sprintf("SELECT COALESCE(MAX(%s), '0001-01-01'::timestamp) FROM %s", dateColumn, partitionedTable)
+	result := dbc.DB.Raw(query).Scan(&maxDate)
+	if result.Error != nil {
+		return fmt.Errorf("failed to get max %s from %s: %w", dateColumn, partitionedTable, result.Error)
+	}
+
+	migrateFrom := maxDate
+	if maxDate.IsZero() || maxDate.Year() == 1 {
+		return fmt.Errorf("partitioned table %s has no data; run MigrateToPartitionedTable first", partitionedTable)
+	}
+
+	l.WithFields(log.Fields{
+		"newest_migrated": migrateFrom.Format("2006-01-02 15:04:05"),
+		"migrate_up_to":   migrateUpTo.Format("2006-01-02"),
+	}).Info("determined migration range")
+
+	// Step 2: Create any missing partitions
+	l.Info("step 2: creating missing partitions")
+	partitionEnd := migrateUpTo.AddDate(0, 0, 7)
+	partitionStart := migrateFrom.UTC().Truncate(24 * time.Hour)
+
+	created, err := dbc.CreateMissingPartitions(partitionedTable, partitionStart, partitionEnd, dryRun)
+	if err != nil {
+		return fmt.Errorf("failed to create partitions: %w", err)
+	}
+	l.WithField("partitions_created", created).Info("partitions created")
+
+	// Step 3: Migrate remaining data
+	l.Info("step 3: migrating remaining data")
+	rows, err := dbc.MigrateTableDataRange(sourceTable, partitionedTable, dateColumn, migrateFrom, migrateUpTo, nil, dryRun)
+	if err != nil {
+		return fmt.Errorf("failed to migrate remaining data: %w", err)
+	}
+	l.WithField("rows_migrated", rows).Info("remaining data migration complete")
+
+	// Step 4: Sync identity column
+	l.Info("step 4: syncing identity column")
+	if !dryRun {
+		if err := dbc.SyncIdentityColumn(partitionedTable, "id"); err != nil {
+			return fmt.Errorf("failed to sync identity column: %w", err)
+		}
+		l.Info("identity column synced")
+	}
+
+	// Step 5: Swap tables atomically
+	l.Info("step 5: swapping tables")
+	renames := []TableRename{
+		{From: sourceTable, To: oldTable},
+		{From: partitionedTable, To: sourceTable},
+	}
+
+	count, err := dbc.RenameTables(renames, true, true, true, true, dryRun)
+	if err != nil {
+		return fmt.Errorf("failed to swap tables: %w", err)
+	}
+	l.WithField("renames", count).Info("tables swapped")
+
+	// Step 6: Move or drop foreign keys
+	fkTarget := sourceTable
+	if !moveForeignKeys {
+		fkTarget = ""
+	}
+	if moveForeignKeys {
+		l.Info("step 6: moving foreign keys")
+	} else {
+		l.Info("step 6: dropping foreign keys")
+	}
+	moved, err := dbc.MoveForeignKeys(oldTable, fkTarget, dryRun)
+	if err != nil {
+		return fmt.Errorf("failed to process foreign keys: %w", err)
+	}
+	if moveForeignKeys {
+		l.WithField("fks_moved", moved).Info("foreign keys moved")
+	} else {
+		l.WithField("fks_dropped", moved).Info("foreign keys dropped")
+	}
+
+	l.Info("partitioned table migration finalized successfully")
+	return nil
+}
+
+// AnalyzePartitioningImpact examines the foreign key relationships for a table and
+// logs the impact of migrating it to a partitioned table. For each FK, it reports:
+//   - Direction (inbound or outbound)
+//   - Whether the related table is already partitioned
+//   - Whether the FK can be preserved, must be expanded, or must be dropped
+//   - Whether the source table has the necessary partition key columns for expansion
+//
+// This is a read-only analysis function that makes no changes to the database.
+func (dbc *DB) AnalyzePartitioningImpact(tableName string) error {
+	l := log.WithField("table", tableName)
+	l.Info("analyzing partitioning impact")
+
+	// Check if the table is already partitioned
+	tablePartCols, _ := dbc.getPartitionColumns(tableName)
+	if len(tablePartCols) > 0 {
+		l.WithField("partition_columns", tablePartCols).Info("table is already partitioned")
+	}
+
+	// Get all FK relationships
+	fks, err := dbc.GetFKRelationships(tableName)
+	if err != nil {
+		return fmt.Errorf("failed to get FK relationships: %w", err)
+	}
+
+	if len(fks) == 0 {
+		l.Info("no foreign key relationships found")
+		return nil
+	}
+
+	l.WithField("count", len(fks)).Info("found foreign key relationships")
+
+	for _, fk := range fks {
+		fields := log.Fields{
+			"constraint":         fk.ConstraintName,
+			"source_table":       fk.SourceTable,
+			"source_columns":     fk.SourceColumns,
+			"referenced_table":   fk.ReferencedTable,
+			"referenced_columns": fk.ReferencedColumns,
+		}
+
+		if fk.SourceTable == tableName {
+			// Outbound FK: this table references another table
+			fields["direction"] = "outbound"
+
+			refPartCols, _ := dbc.getPartitionColumns(fk.ReferencedTable)
+			fields["referenced_table_partitioned"] = len(refPartCols) > 0
+
+			if len(refPartCols) == 0 {
+				// Referenced table is not partitioned — FK can be preserved
+				fields["action"] = "KEEP"
+				fields["reason"] = "referenced table is not partitioned; outbound FKs from partitioned tables are allowed"
+			} else {
+				// Referenced table is partitioned — FK requires unique constraint
+				// on the referenced columns which must include partition key
+				fields["action"] = "DROP"
+				fields["reason"] = "referenced table is partitioned; unique constraints on partitioned tables must include partition key, making single-column FK references problematic"
+				fields["referenced_partition_columns"] = refPartCols
+			}
+
+			l.WithFields(fields).Info("outbound FK analysis")
+		} else {
+			// Inbound FK: another table references this table
+			fields["direction"] = "inbound"
+
+			srcPartCols, _ := dbc.getPartitionColumns(fk.SourceTable)
+			fields["source_table_partitioned"] = len(srcPartCols) > 0
+
+			// When this table becomes partitioned, its PK will include the partition
+			// key. Inbound FKs must reference the full PK (or a unique constraint
+			// that includes the partition key).
+			srcColumns, err := dbc.GetTableColumns(fk.SourceTable)
+			if err != nil {
+				l.WithError(err).WithFields(fields).Warn("could not inspect source table columns")
+				continue
+			}
+
+			srcColSet := make(map[string]bool)
+			for _, col := range srcColumns {
+				srcColSet[col.ColumnName] = true
+			}
+
+			// Assume partitioning on created_at (most common case) — check if source has it
+			hasCreatedAt := srcColSet["created_at"]
+			fields["source_has_created_at"] = hasCreatedAt
+
+			if len(srcPartCols) > 0 {
+				// Source table is also partitioned
+				fields["action"] = "DROP"
+				fields["reason"] = "both tables are partitioned; FK constraints between partitioned tables are not supported"
+			} else if !hasCreatedAt {
+				// Source table lacks the partition key column — FK must be dropped
+				fields["action"] = "DROP"
+				fields["reason"] = fmt.Sprintf("source table %s lacks created_at column needed to reference partitioned %s; FK cannot be expanded",
+					fk.SourceTable, tableName)
+			} else {
+				// Source table has the partition key — FK could be expanded
+				fields["action"] = "EXPAND or DROP"
+				fields["reason"] = fmt.Sprintf("source table %s has created_at column; FK could be expanded to include partition key, "+
+					"but this requires a UNIQUE constraint on %s(%s, created_at) and adds complexity",
+					fk.SourceTable, tableName, fk.ReferencedColumns)
+			}
+
+			l.WithFields(fields).Info("inbound FK analysis")
+		}
+	}
+
+	l.Info("partitioning impact analysis complete")
+	return nil
+}
+
+// DeleteTestsByName deletes all data associated with tests whose name matches the
+// given SQL LIKE pattern. This handles the full dependency chain across partitioned
+// tables where FK cascades are not available.
+//
+// Deletion order (leaf to root):
+//  1. prow_job_run_test_outputs (references prow_job_run_tests)
+//  2. test_analysis_by_job_by_dates (references tests)
+//  3. prow_job_run_tests (references tests)
+//  4. bug_tests (join table between bugs and tests)
+//  5. test_ownerships (references tests)
+//  6. tests
+//
+// The namePattern uses SQL LIKE syntax (e.g., "%shouldn't use random names%").
+func (dbc *DB) DeleteTestsByName(namePattern string, dryRun bool) (int64, error) {
+	if strings.TrimSpace(namePattern) == "" {
+		return 0, fmt.Errorf("namePattern cannot be empty")
+	}
+
+	l := log.WithFields(log.Fields{
+		"name_pattern": namePattern,
+		"dry_run":      dryRun,
+	})
+
+	// Preview matching tests
+	var matchCount int64
+	if err := dbc.DB.Raw("SELECT COUNT(*) FROM tests WHERE name LIKE ?", namePattern).Scan(&matchCount).Error; err != nil {
+		return 0, fmt.Errorf("failed to count matching tests: %w", err)
+	}
+
+	if matchCount == 0 {
+		l.Info("no tests match the pattern")
+		return 0, nil
+	}
+
+	l.WithField("matching_tests", matchCount).Info("found tests matching pattern")
+
+	if dryRun {
+		type tableCount struct {
+			name  string
+			query string
+		}
+		counts := []tableCount{
+			{"prow_job_run_test_outputs", "SELECT COUNT(*) FROM prow_job_run_test_outputs WHERE prow_job_run_test_id IN (SELECT pjrt.id FROM prow_job_run_tests pjrt JOIN tests t ON t.id = pjrt.test_id WHERE t.name LIKE ?)"},
+			{"test_analysis_by_job_by_dates", "SELECT COUNT(*) FROM test_analysis_by_job_by_dates WHERE test_id IN (SELECT id FROM tests WHERE name LIKE ?)"},
+			{"prow_job_run_tests", "SELECT COUNT(*) FROM prow_job_run_tests WHERE test_id IN (SELECT id FROM tests WHERE name LIKE ?)"},
+			{"bug_tests", "SELECT COUNT(*) FROM bug_tests WHERE test_id IN (SELECT id FROM tests WHERE name LIKE ?)"},
+			{"test_ownerships", "SELECT COUNT(*) FROM test_ownerships WHERE test_id IN (SELECT id FROM tests WHERE name LIKE ?)"},
+			{"tests", "SELECT COUNT(*) FROM tests WHERE name LIKE ?"},
+		}
+
+		for _, tc := range counts {
+			var c int64
+			if err := dbc.DB.Raw(tc.query, namePattern).Scan(&c).Error; err != nil {
+				l.WithError(err).WithField("table", tc.name).Warn("failed to count rows")
+				continue
+			}
+			l.WithFields(log.Fields{"table": tc.name, "rows": c}).Info("would delete")
+		}
+
+		return matchCount, nil
+	}
+
+	// Execute deletes in a transaction
+	tx := dbc.DB.Begin()
+	if tx.Error != nil {
+		return 0, fmt.Errorf("failed to begin transaction: %w", tx.Error)
+	}
+	defer tx.Rollback()
+
+	type deleteStep struct {
+		name string
+		sql  string
+	}
+
+	steps := []deleteStep{
+		{
+			"prow_job_run_test_outputs",
+			"DELETE FROM prow_job_run_test_outputs WHERE prow_job_run_test_id IN (SELECT pjrt.id FROM prow_job_run_tests pjrt JOIN tests t ON t.id = pjrt.test_id WHERE t.name LIKE ?)",
+		},
+		{
+			"test_analysis_by_job_by_dates",
+			"DELETE FROM test_analysis_by_job_by_dates WHERE test_id IN (SELECT id FROM tests WHERE name LIKE ?)",
+		},
+		{
+			"prow_job_run_tests",
+			"DELETE FROM prow_job_run_tests WHERE test_id IN (SELECT id FROM tests WHERE name LIKE ?)",
+		},
+		{
+			"bug_tests",
+			"DELETE FROM bug_tests WHERE test_id IN (SELECT id FROM tests WHERE name LIKE ?)",
+		},
+		{
+			"test_ownerships",
+			"DELETE FROM test_ownerships WHERE test_id IN (SELECT id FROM tests WHERE name LIKE ?)",
+		},
+		{
+			"tests",
+			"DELETE FROM tests WHERE name LIKE ?",
+		},
+	}
+
+	var totalDeleted int64
+	for _, step := range steps {
+		result := tx.Exec(step.sql, namePattern)
+		if result.Error != nil {
+			return 0, fmt.Errorf("failed to delete from %s: %w", step.name, result.Error)
+		}
+		l.WithFields(log.Fields{"table": step.name, "rows": result.RowsAffected}).Info("deleted rows")
+		totalDeleted += result.RowsAffected
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		return 0, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	l.WithField("total_deleted", totalDeleted).Info("test deletion complete")
+	return matchCount, nil
+}

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -84,19 +84,22 @@ type Test struct {
 // ProwJobRunTest defines a join table linking tests to the job runs they execute in, along with the status for
 // that execution.
 // Do not update until after partitions have been enabled
+// Remove gorm.model on Partitioned tables so we can manage the primary key and index
 type ProwJobRunTest struct {
-	gorm.Model
-	ProwJobRunID uint `gorm:"index"`
+	ID        uint      `gorm:"primaryKey;autoIncrement"`
+	CreatedAt time.Time `gorm:"primaryKey;index"`
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt
+
+	ProwJobRunID uint `gorm:"index;index:idx_pjrt_run_test_status,priority:1"`
 	ProwJobRun   ProwJobRun
 	TestID       uint `gorm:"index;index:idx_prow_job_run_tests_test_id_status"`
 	Test         Test
 	// SuiteID may be nil if no suite name could be parsed from the testgrid test name.
-	SuiteID   *uint `gorm:"index"`
-	Suite     Suite
-	Status    int `gorm:"index;index:idx_prow_job_run_tests_test_id_status"`
-	Duration  float64
-	CreatedAt time.Time `gorm:"index"`
-	DeletedAt gorm.DeletedAt
+	SuiteID  *uint `gorm:"index"`
+	Suite    Suite
+	Status   int `gorm:"index;index:idx_prow_job_run_tests_test_id_status;index:idx_pjrt_run_test_status,priority:3"`
+	Duration float64
 
 	// ProwJobRunTestOutput collect the output of a failed test run. This is stored as a separate object in the DB, so
 	// we can keep the test result for a longer period of time than we keep the full failure output.
@@ -104,8 +107,13 @@ type ProwJobRunTest struct {
 }
 
 // Do not update until after partitions have been enabled
+// Remove gorm.model on Partitioned tables so we can manage the primary key and index
 type ProwJobRunTestOutput struct {
-	gorm.Model
+	ID        uint      `gorm:"primaryKey;autoIncrement"`
+	CreatedAt time.Time `gorm:"primaryKey"`
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt
+
 	ProwJobRunTestID uint `gorm:"index"`
 	// Output stores the output of a ProwJobRunTest.
 	Output string

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -83,6 +83,7 @@ type Test struct {
 
 // ProwJobRunTest defines a join table linking tests to the job runs they execute in, along with the status for
 // that execution.
+// Do not update until after partitions have been enabled
 type ProwJobRunTest struct {
 	gorm.Model
 	ProwJobRunID uint `gorm:"index"`
@@ -102,6 +103,7 @@ type ProwJobRunTest struct {
 	ProwJobRunTestOutput *ProwJobRunTestOutput `gorm:"constraint:OnDelete:CASCADE;"`
 }
 
+// Do not update until after partitions have been enabled
 type ProwJobRunTestOutput struct {
 	gorm.Model
 	ProwJobRunTestID uint `gorm:"index"`

--- a/pkg/db/partitions.go
+++ b/pkg/db/partitions.go
@@ -1297,7 +1297,7 @@ type indexInfo struct {
 // Note: Cannot modify partition keys or add unique constraints without partition keys
 //
 //nolint:gocyclo
-func (dbc *DB) UpdatePartitionedTable(model interface{}, tableName string, config PartitionConfig, dryRun bool, dropColumns bool) (string, error) {
+func (dbc *DB) UpdatePartitionedTable(model interface{}, tableName string, config PartitionConfig, dryRun, dropColumns bool) (string, error) {
 	start := time.Now()
 
 	// If table doesn't exist, create it

--- a/pkg/db/partitions.go
+++ b/pkg/db/partitions.go
@@ -1,0 +1,2108 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+// escapeForLike escapes characters that have special meaning in SQL LIKE patterns.
+func escapeForLike(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
+}
+
+// PartitionInfo holds metadata about a partition
+type PartitionInfo struct {
+	TableName     string    `gorm:"column:tablename"`
+	SchemaName    string    `gorm:"column:schemaname"`
+	PartitionDate time.Time `gorm:"column:partition_date"`
+	Age           int       `gorm:"column:age_days"`
+	SizeBytes     int64     `gorm:"column:size_bytes"`
+	SizePretty    string    `gorm:"column:size_pretty"`
+	RowEstimate   int64     `gorm:"column:row_estimate"`
+}
+
+// PartitionedTableInfo holds metadata about a partitioned parent table
+type PartitionedTableInfo struct {
+	TableName         string `gorm:"column:tablename"`
+	SchemaName        string `gorm:"column:schemaname"`
+	PartitionCount    int    `gorm:"column:partition_count"`
+	PartitionStrategy string `gorm:"column:partition_strategy"`
+}
+
+// PartitionStats holds aggregate statistics about partitions
+type PartitionStats struct {
+	TotalPartitions int
+	TotalSizeBytes  int64
+	TotalSizePretty string
+	OldestDate      sql.NullTime
+	NewestDate      sql.NullTime
+	AvgSizeBytes    int64
+	AvgSizePretty   string
+}
+
+// RetentionSummary provides a summary of what would be affected by a retention policy
+type RetentionSummary struct {
+	RetentionDays      int
+	CutoffDate         time.Time
+	PartitionsToRemove int
+	StorageToReclaim   int64
+	StoragePretty      string
+	OldestPartition    string
+	NewestPartition    string
+}
+
+// PartitionConfig defines the configuration for creating a partitioned table
+type PartitionConfig struct {
+	// Strategy is the partitioning strategy (RANGE, LIST, or HASH)
+	Strategy PartitionStrategy
+
+	// Columns are the column(s) to partition by
+	// For RANGE and LIST: typically one column (e.g., "date", "created_at")
+	// For HASH: can be one or more columns
+	Columns []string
+
+	// Modulus is required for HASH partitioning (number of partitions)
+	// Not used for RANGE or LIST
+	Modulus int
+}
+
+// NewRangePartitionConfig creates a partition config for RANGE partitioning
+func NewRangePartitionConfig(column string) PartitionConfig {
+	return PartitionConfig{
+		Strategy: PartitionStrategyRange,
+		Columns:  []string{column},
+	}
+}
+
+// NewListPartitionConfig creates a partition config for LIST partitioning
+func NewListPartitionConfig(column string) PartitionConfig {
+	return PartitionConfig{
+		Strategy: PartitionStrategyList,
+		Columns:  []string{column},
+	}
+}
+
+// NewHashPartitionConfig creates a partition config for HASH partitioning
+func NewHashPartitionConfig(modulus int, columns ...string) PartitionConfig {
+	return PartitionConfig{
+		Strategy: PartitionStrategyHash,
+		Columns:  columns,
+		Modulus:  modulus,
+	}
+}
+
+// Validate checks if the partition configuration is valid
+func (pc PartitionConfig) Validate() error {
+	if pc.Strategy == "" {
+		return fmt.Errorf("partition strategy must be specified")
+	}
+
+	if len(pc.Columns) == 0 {
+		return fmt.Errorf("at least one partition column must be specified")
+	}
+
+	switch pc.Strategy {
+	case PartitionStrategyRange, PartitionStrategyList:
+		if len(pc.Columns) != 1 {
+			return fmt.Errorf("%s partitioning requires exactly one column, got %d", pc.Strategy, len(pc.Columns))
+		}
+	case PartitionStrategyHash:
+		if pc.Modulus <= 0 {
+			return fmt.Errorf("HASH partitioning requires modulus > 0, got %d", pc.Modulus)
+		}
+	default:
+		return fmt.Errorf("unknown partition strategy: %s (valid: RANGE, LIST, HASH)", pc.Strategy)
+	}
+
+	return nil
+}
+
+// ToSQL generates the PARTITION BY clause for the CREATE TABLE statement
+func (pc PartitionConfig) ToSQL() string {
+	columnList := strings.Join(pc.Columns, ", ")
+
+	switch pc.Strategy {
+	case PartitionStrategyRange:
+		return fmt.Sprintf("PARTITION BY RANGE (%s)", columnList)
+	case PartitionStrategyList:
+		return fmt.Sprintf("PARTITION BY LIST (%s)", columnList)
+	case PartitionStrategyHash:
+		return fmt.Sprintf("PARTITION BY HASH (%s)", columnList)
+	default:
+		return ""
+	}
+}
+
+// ListPartitionedTables returns all partitioned parent tables in the database
+func (dbc *DB) ListPartitionedTables() ([]PartitionedTableInfo, error) {
+	start := time.Now()
+	var tables []PartitionedTableInfo
+
+	query := `
+		SELECT
+			c.relname AS tablename,
+			n.nspname AS schemaname,
+			COUNT(i.inhrelid)::INT AS partition_count,
+			CASE pp.partstrat
+				WHEN 'r' THEN 'RANGE'
+				WHEN 'l' THEN 'LIST'
+				WHEN 'h' THEN 'HASH'
+				ELSE 'UNKNOWN'
+			END AS partition_strategy
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		JOIN pg_partitioned_table pp ON pp.partrelid = c.oid
+		LEFT JOIN pg_inherits i ON i.inhparent = c.oid
+		WHERE n.nspname = 'public'
+		GROUP BY c.relname, n.nspname, pp.partstrat
+		ORDER BY c.relname
+	`
+
+	result := dbc.DB.Raw(query).Scan(&tables)
+	if result.Error != nil {
+		log.WithError(result.Error).Error("failed to list partitioned tables")
+		return nil, result.Error
+	}
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"count":   len(tables),
+		"elapsed": elapsed,
+	}).Info("listed partitioned tables")
+
+	return tables, nil
+}
+
+// ListTablePartitions returns all partitions for a given table
+func (dbc *DB) ListTablePartitions(tableName string) ([]PartitionInfo, error) {
+	start := time.Now()
+	var partitions []PartitionInfo
+
+	query := `
+		SELECT
+			tablename,
+			'public' as schemaname,
+			TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD') AS partition_date,
+			(CURRENT_DATE - TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD'))::INT AS age_days,
+			pg_total_relation_size('public.'||tablename) AS size_bytes,
+			pg_size_pretty(pg_total_relation_size('public.'||tablename)) AS size_pretty,
+			COALESCE(n_live_tup, 0) AS row_estimate
+		FROM pg_tables
+		LEFT JOIN pg_stat_user_tables ON pg_stat_user_tables.relname = pg_tables.tablename
+			AND pg_stat_user_tables.schemaname = pg_tables.schemaname
+		WHERE pg_tables.schemaname = 'public'
+			AND pg_tables.tablename LIKE @table_pattern ESCAPE '\'
+		ORDER BY partition_date ASC
+	`
+
+	tablePattern := escapeForLike(tableName) + `\_20%`
+	result := dbc.DB.Raw(query, sql.Named("table_pattern", tablePattern)).Scan(&partitions)
+	if result.Error != nil {
+		log.WithError(result.Error).WithField("table", tableName).Error("failed to list table partitions")
+		return nil, result.Error
+	}
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"table":   tableName,
+		"count":   len(partitions),
+		"elapsed": elapsed,
+	}).Info("listed table partitions")
+
+	return partitions, nil
+}
+
+// GetPartitionStats returns aggregate statistics about partitions for a given table
+func (dbc *DB) GetPartitionStats(tableName string) (*PartitionStats, error) {
+	start := time.Now()
+	var stats PartitionStats
+
+	query := `
+		WITH partition_info AS (
+			SELECT
+				tablename,
+				TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD') AS partition_date,
+				pg_total_relation_size('public.'||tablename) AS size_bytes
+			FROM pg_tables
+			WHERE schemaname = 'public'
+				AND tablename LIKE @table_pattern ESCAPE '\'
+		)
+		SELECT
+			COUNT(*)::INT AS total_partitions,
+			SUM(size_bytes)::BIGINT AS total_size_bytes,
+			pg_size_pretty(SUM(size_bytes)) AS total_size_pretty,
+			MIN(partition_date) AS oldest_date,
+			MAX(partition_date) AS newest_date,
+			AVG(size_bytes)::BIGINT AS avg_size_bytes,
+			pg_size_pretty(AVG(size_bytes)::BIGINT) AS avg_size_pretty
+		FROM partition_info
+	`
+
+	tablePattern := escapeForLike(tableName) + `\_20%`
+	result := dbc.DB.Raw(query, sql.Named("table_pattern", tablePattern)).Scan(&stats)
+	if result.Error != nil {
+		log.WithError(result.Error).WithField("table", tableName).Error("failed to get partition statistics")
+		return nil, result.Error
+	}
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"table":            tableName,
+		"total_partitions": stats.TotalPartitions,
+		"total_size":       stats.TotalSizePretty,
+		"elapsed":          elapsed,
+	}).Info("retrieved partition statistics")
+
+	return &stats, nil
+}
+
+// GetPartitionsForRemoval identifies partitions older than the retention period for a given table
+// This is a read-only operation (dry-run) that shows what would be removed (deleted or detached)
+// If attachedOnly is true, only returns attached partitions (useful for detach operations)
+// If attachedOnly is false, returns all partitions (useful for drop operations on both attached and detached)
+func (dbc *DB) GetPartitionsForRemoval(tableName string, retentionDays int, attachedOnly bool) ([]PartitionInfo, error) {
+	start := time.Now()
+	var partitions []PartitionInfo
+
+	cutoffDate := time.Now().AddDate(0, 0, -retentionDays)
+
+	var query string
+	if attachedOnly {
+		// Only return attached partitions
+		query = `
+			WITH attached_partitions AS (
+				SELECT c.relname AS tablename
+				FROM pg_inherits i
+				JOIN pg_class c ON i.inhrelid = c.oid
+				JOIN pg_class p ON i.inhparent = p.oid
+				WHERE p.relname = @table_name
+			)
+			SELECT
+				tablename,
+				'public' as schemaname,
+				TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD') AS partition_date,
+				(CURRENT_DATE - TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD'))::INT AS age_days,
+				pg_total_relation_size('public.'||tablename) AS size_bytes,
+				pg_size_pretty(pg_total_relation_size('public.'||tablename)) AS size_pretty,
+				COALESCE(n_live_tup, 0) AS row_estimate
+			FROM pg_tables
+			LEFT JOIN pg_stat_user_tables ON pg_stat_user_tables.relname = pg_tables.tablename
+				AND pg_stat_user_tables.schemaname = pg_tables.schemaname
+			WHERE pg_tables.schemaname = 'public'
+				AND pg_tables.tablename LIKE @table_pattern ESCAPE '\'
+				AND pg_tables.tablename IN (SELECT tablename FROM attached_partitions)
+				AND TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD') < @cutoff_date
+			ORDER BY partition_date ASC
+		`
+	} else {
+		// Return all partitions (attached + detached)
+		query = `
+			SELECT
+				tablename,
+				'public' as schemaname,
+				TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD') AS partition_date,
+				(CURRENT_DATE - TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD'))::INT AS age_days,
+				pg_total_relation_size('public.'||tablename) AS size_bytes,
+				pg_size_pretty(pg_total_relation_size('public.'||tablename)) AS size_pretty,
+				COALESCE(n_live_tup, 0) AS row_estimate
+			FROM pg_tables
+			LEFT JOIN pg_stat_user_tables ON pg_stat_user_tables.relname = pg_tables.tablename
+				AND pg_stat_user_tables.schemaname = pg_tables.schemaname
+			WHERE pg_tables.schemaname = 'public'
+				AND pg_tables.tablename LIKE @table_pattern ESCAPE '\'
+				AND TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD') < @cutoff_date
+			ORDER BY partition_date ASC
+		`
+	}
+
+	tablePattern := escapeForLike(tableName) + `\_20%`
+	result := dbc.DB.Raw(query,
+		sql.Named("table_name", tableName),
+		sql.Named("table_pattern", tablePattern),
+		sql.Named("cutoff_date", cutoffDate)).Scan(&partitions)
+	if result.Error != nil {
+		log.WithError(result.Error).WithField("table", tableName).Error("failed to get partitions for removal")
+		return nil, result.Error
+	}
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"table":          tableName,
+		"retention_days": retentionDays,
+		"cutoff_date":    cutoffDate.Format("2006-01-02"),
+		"attached_only":  attachedOnly,
+		"count":          len(partitions),
+		"elapsed":        elapsed,
+	}).Info("identified partitions for removal")
+
+	return partitions, nil
+}
+
+// GetRetentionSummary provides a summary of what would be affected by a retention policy for a given table
+// If attachedOnly is true, only considers attached partitions (useful for detach operations)
+// If attachedOnly is false, considers all partitions (useful for drop operations on both attached and detached)
+func (dbc *DB) GetRetentionSummary(tableName string, retentionDays int, attachedOnly bool) (*RetentionSummary, error) {
+	start := time.Now()
+
+	cutoffDate := time.Now().AddDate(0, 0, -retentionDays)
+
+	var summary RetentionSummary
+	summary.RetentionDays = retentionDays
+	summary.CutoffDate = cutoffDate
+
+	var query string
+	if attachedOnly {
+		// Only consider attached partitions
+		query = `
+			WITH attached_partitions AS (
+				SELECT c.relname AS tablename
+				FROM pg_inherits i
+				JOIN pg_class c ON i.inhrelid = c.oid
+				JOIN pg_class p ON i.inhparent = p.oid
+				WHERE p.relname = @table_name
+			)
+			SELECT
+				COUNT(*)::INT AS partitions_to_remove,
+				COALESCE(SUM(pg_total_relation_size('public.'||tablename)), 0)::BIGINT AS storage_to_reclaim,
+				COALESCE(pg_size_pretty(SUM(pg_total_relation_size('public.'||tablename))), '0 bytes') AS storage_pretty,
+				MIN(tablename) AS oldest_partition,
+				MAX(tablename) AS newest_partition
+			FROM pg_tables
+			WHERE schemaname = 'public'
+				AND tablename LIKE @table_pattern ESCAPE '\'
+				AND tablename IN (SELECT tablename FROM attached_partitions)
+				AND TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD') < @cutoff_date
+		`
+	} else {
+		// Consider all partitions (attached + detached)
+		query = `
+			SELECT
+				COUNT(*)::INT AS partitions_to_remove,
+				COALESCE(SUM(pg_total_relation_size('public.'||tablename)), 0)::BIGINT AS storage_to_reclaim,
+				COALESCE(pg_size_pretty(SUM(pg_total_relation_size('public.'||tablename))), '0 bytes') AS storage_pretty,
+				MIN(tablename) AS oldest_partition,
+				MAX(tablename) AS newest_partition
+			FROM pg_tables
+			WHERE schemaname = 'public'
+				AND tablename LIKE @table_pattern ESCAPE '\'
+				AND TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD') < @cutoff_date
+		`
+	}
+
+	tablePattern := escapeForLike(tableName) + `\_20%`
+	result := dbc.DB.Raw(query,
+		sql.Named("table_name", tableName),
+		sql.Named("table_pattern", tablePattern),
+		sql.Named("cutoff_date", cutoffDate)).Scan(&summary)
+	if result.Error != nil {
+		log.WithError(result.Error).WithField("table", tableName).Error("failed to get retention summary")
+		return nil, result.Error
+	}
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"table":                tableName,
+		"retention_days":       retentionDays,
+		"attached_only":        attachedOnly,
+		"partitions_to_remove": summary.PartitionsToRemove,
+		"storage_to_reclaim":   summary.StoragePretty,
+		"elapsed":              elapsed,
+	}).Info("calculated retention summary")
+
+	return &summary, nil
+}
+
+// ValidateRetentionPolicy checks if a retention policy would be safe to apply for a given table
+// Returns an error if the policy would delete critical data or too much data
+// Only considers attached partitions when validating thresholds
+func (dbc *DB) ValidateRetentionPolicy(tableName string, retentionDays int) error {
+	// Minimum retention is 90 days
+	if retentionDays < 90 {
+		return fmt.Errorf("retention policy too aggressive: minimum 90 days required, got %d", retentionDays)
+	}
+
+	// Get summary for attached partitions only to match stats below
+	summary, err := dbc.GetRetentionSummary(tableName, retentionDays, true)
+	if err != nil {
+		return fmt.Errorf("failed to get retention summary: %w", err)
+	}
+
+	// Get stats for attached partitions only (detached partitions are not considered)
+	stats, err := dbc.GetAttachedPartitionStats(tableName)
+	if err != nil {
+		return fmt.Errorf("failed to get attached partition stats: %w", err)
+	}
+
+	// Check if we'd delete more than 75% of attached partitions
+	if stats.TotalPartitions > 0 {
+		deletePercentage := float64(summary.PartitionsToRemove) / float64(stats.TotalPartitions) * 100
+		if deletePercentage > 75 {
+			return fmt.Errorf("retention policy would delete %.1f%% of attached partitions (%d of %d) - exceeds 75%% safety threshold",
+				deletePercentage, summary.PartitionsToRemove, stats.TotalPartitions)
+		}
+	}
+
+	// Check if we'd delete more than 80% of storage from attached partitions
+	if stats.TotalSizeBytes > 0 {
+		deletePercentage := float64(summary.StorageToReclaim) / float64(stats.TotalSizeBytes) * 100
+		if deletePercentage > 80 {
+			return fmt.Errorf("retention policy would delete %.1f%% of attached storage (%s of %s) - exceeds 80%% safety threshold",
+				deletePercentage, summary.StoragePretty, stats.TotalSizePretty)
+		}
+	}
+
+	log.WithFields(log.Fields{
+		"table":                tableName,
+		"retention_days":       retentionDays,
+		"partitions_to_remove": summary.PartitionsToRemove,
+		"attached_partitions":  stats.TotalPartitions,
+		"attached_storage":     stats.TotalSizePretty,
+		"storage_to_reclaim":   summary.StoragePretty,
+	}).Info("retention policy validated")
+
+	return nil
+}
+
+// DropPartition drops a single partition (DESTRUCTIVE - requires write access)
+// This is a wrapper around DROP TABLE for safety and logging
+func (dbc *DB) DropPartition(partitionName string, dryRun bool) error {
+	start := time.Now()
+
+	// Extract table name from partition name
+	tableName, err := extractTableNameFromPartition(partitionName)
+	if err != nil {
+		return fmt.Errorf("invalid partition name: %w", err)
+	}
+
+	// Validate partition name format for safety
+	if !isValidPartitionName(tableName, partitionName) {
+		return fmt.Errorf("invalid partition name: %s - must match %s_YYYY_MM_DD", partitionName, tableName)
+	}
+
+	if dryRun {
+		log.WithFields(log.Fields{
+			"partition": partitionName,
+			"table":     tableName,
+		}).Info("[DRY RUN] would drop partition")
+		return nil
+	}
+
+	query := "DROP TABLE IF EXISTS " + pq.QuoteIdentifier(partitionName)
+	result := dbc.DB.Exec(query)
+	if result.Error != nil {
+		log.WithError(result.Error).WithFields(log.Fields{
+			"partition": partitionName,
+			"table":     tableName,
+		}).Error("failed to drop partition")
+		return result.Error
+	}
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"partition": partitionName,
+		"table":     tableName,
+		"elapsed":   elapsed,
+	}).Info("dropped partition")
+
+	return nil
+}
+
+// DetachPartition detaches a partition from the parent table (safer alternative to DROP)
+// The detached table can be archived or dropped later
+func (dbc *DB) DetachPartition(partitionName string, dryRun bool) error {
+	start := time.Now()
+
+	// Extract table name from partition name
+	tableName, err := extractTableNameFromPartition(partitionName)
+	if err != nil {
+		return fmt.Errorf("invalid partition name: %w", err)
+	}
+
+	// Validate partition name format for safety
+	if !isValidPartitionName(tableName, partitionName) {
+		return fmt.Errorf("invalid partition name: %s - must match %s_YYYY_MM_DD", partitionName, tableName)
+	}
+
+	if dryRun {
+		log.WithFields(log.Fields{
+			"partition": partitionName,
+			"table":     tableName,
+		}).Info("[DRY RUN] would detach partition")
+		return nil
+	}
+
+	query := fmt.Sprintf("ALTER TABLE %s DETACH PARTITION %s", pq.QuoteIdentifier(tableName), pq.QuoteIdentifier(partitionName))
+	result := dbc.DB.Exec(query)
+	if result.Error != nil {
+		log.WithError(result.Error).WithFields(log.Fields{
+			"partition": partitionName,
+			"table":     tableName,
+		}).Error("failed to detach partition")
+		return result.Error
+	}
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"partition": partitionName,
+		"table":     tableName,
+		"elapsed":   elapsed,
+	}).Info("detached partition")
+
+	return nil
+}
+
+// DropOldDetachedPartitions drops detached partitions older than retentionDays (DESTRUCTIVE)
+// This removes detached partitions that are no longer needed
+// Use this after archiving detached partitions or when you're sure the data is no longer needed
+func (dbc *DB) DropOldDetachedPartitions(tableName string, retentionDays int, dryRun bool) (int, error) {
+	start := time.Now()
+
+	// Get all detached partitions
+	detached, err := dbc.ListDetachedPartitions(tableName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list detached partitions: %w", err)
+	}
+
+	if len(detached) == 0 {
+		log.WithField("table", tableName).Info("no detached partitions found")
+		return 0, nil
+	}
+
+	// Filter by retention period
+	cutoffDate := time.Now().AddDate(0, 0, -retentionDays)
+	var toRemove []PartitionInfo
+
+	for _, partition := range detached {
+		if partition.PartitionDate.Before(cutoffDate) {
+			toRemove = append(toRemove, partition)
+		}
+	}
+
+	if len(toRemove) == 0 {
+		log.WithFields(log.Fields{
+			"table":          tableName,
+			"retention_days": retentionDays,
+			"cutoff_date":    cutoffDate.Format("2006-01-02"),
+		}).Info("no detached partitions older than retention period")
+		return 0, nil
+	}
+
+	if dryRun {
+		for _, partition := range toRemove {
+			if err := dbc.DropPartition(partition.TableName, true); err != nil {
+				return 0, fmt.Errorf("failed to dry-run drop partition %s: %w", partition.TableName, err)
+			}
+		}
+		return len(toRemove), nil
+	}
+
+	// Drop all old detached partitions in a transaction
+	droppedCount := 0
+	var totalSize int64
+
+	err = dbc.DB.Transaction(func(tx *gorm.DB) error {
+		txDBC := &DB{DB: tx}
+		for _, partition := range toRemove {
+			if err := txDBC.DropPartition(partition.TableName, false); err != nil {
+				return fmt.Errorf("failed to drop partition %s: %w", partition.TableName, err)
+			}
+			droppedCount++
+			totalSize += partition.SizeBytes
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"table":             tableName,
+		"retention_days":    retentionDays,
+		"total_dropped":     droppedCount,
+		"storage_reclaimed": fmt.Sprintf("%d bytes", totalSize),
+		"elapsed":           elapsed,
+	}).Info("completed dropping old detached partitions")
+
+	return droppedCount, nil
+}
+
+// ListDetachedPartitions returns partitions that have been detached from the parent table
+// Detached partitions are standalone tables that match the naming pattern but are no longer
+// part of the partitioned table hierarchy
+func (dbc *DB) ListDetachedPartitions(tableName string) ([]PartitionInfo, error) {
+	start := time.Now()
+	var partitions []PartitionInfo
+
+	query := `
+		WITH attached_partitions AS (
+			-- Get all currently attached partitions using pg_inherits
+			SELECT c.relname AS tablename
+			FROM pg_inherits i
+			JOIN pg_class c ON i.inhrelid = c.oid
+			JOIN pg_class p ON i.inhparent = p.oid
+			WHERE p.relname = @table_name
+		)
+		SELECT
+			tablename,
+			'public' as schemaname,
+			TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD') AS partition_date,
+			(CURRENT_DATE - TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD'))::INT AS age_days,
+			pg_total_relation_size('public.'||tablename) AS size_bytes,
+			pg_size_pretty(pg_total_relation_size('public.'||tablename)) AS size_pretty,
+			COALESCE(n_live_tup, 0) AS row_estimate
+		FROM pg_tables
+		LEFT JOIN pg_stat_user_tables ON pg_stat_user_tables.relname = pg_tables.tablename
+			AND pg_stat_user_tables.schemaname = pg_tables.schemaname
+		WHERE pg_tables.schemaname = 'public'
+			AND pg_tables.tablename LIKE @table_pattern ESCAPE '\'
+			AND pg_tables.tablename NOT IN (SELECT tablename FROM attached_partitions)
+		ORDER BY partition_date ASC
+	`
+
+	tablePattern := escapeForLike(tableName) + `\_20%`
+	result := dbc.DB.Raw(query,
+		sql.Named("table_name", tableName),
+		sql.Named("table_pattern", tablePattern)).Scan(&partitions)
+	if result.Error != nil {
+		log.WithError(result.Error).WithField("table", tableName).Error("failed to list detached partitions")
+		return nil, result.Error
+	}
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"table":   tableName,
+		"count":   len(partitions),
+		"elapsed": elapsed,
+	}).Info("listed detached partitions")
+
+	return partitions, nil
+}
+
+// ListAttachedPartitions returns partitions that are currently attached to the parent table
+// These are partitions that are part of the active partitioned table hierarchy
+func (dbc *DB) ListAttachedPartitions(tableName string) ([]PartitionInfo, error) {
+	start := time.Now()
+	var partitions []PartitionInfo
+
+	query := `
+		WITH attached_partitions AS (
+			-- Get all currently attached partitions using pg_inherits
+			SELECT c.relname AS tablename
+			FROM pg_inherits i
+			JOIN pg_class c ON i.inhrelid = c.oid
+			JOIN pg_class p ON i.inhparent = p.oid
+			WHERE p.relname = @table_name
+		)
+		SELECT
+			tablename,
+			'public' as schemaname,
+			TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD') AS partition_date,
+			(CURRENT_DATE - TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD'))::INT AS age_days,
+			pg_total_relation_size('public.'||tablename) AS size_bytes,
+			pg_size_pretty(pg_total_relation_size('public.'||tablename)) AS size_pretty,
+			COALESCE(n_live_tup, 0) AS row_estimate
+		FROM pg_tables
+		LEFT JOIN pg_stat_user_tables ON pg_stat_user_tables.relname = pg_tables.tablename
+			AND pg_stat_user_tables.schemaname = pg_tables.schemaname
+		WHERE pg_tables.schemaname = 'public'
+			AND pg_tables.tablename IN (SELECT tablename FROM attached_partitions)
+		ORDER BY partition_date ASC
+	`
+
+	result := dbc.DB.Raw(query, sql.Named("table_name", tableName)).Scan(&partitions)
+	if result.Error != nil {
+		log.WithError(result.Error).WithField("table", tableName).Error("failed to list attached partitions")
+		return nil, result.Error
+	}
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"table":   tableName,
+		"count":   len(partitions),
+		"elapsed": elapsed,
+	}).Info("listed attached partitions")
+
+	return partitions, nil
+}
+
+// GetAttachedPartitionStats returns statistics about attached partitions for a given table
+func (dbc *DB) GetAttachedPartitionStats(tableName string) (*PartitionStats, error) {
+	start := time.Now()
+	var stats PartitionStats
+
+	query := `
+		WITH attached_partitions AS (
+			SELECT c.relname AS tablename
+			FROM pg_inherits i
+			JOIN pg_class c ON i.inhrelid = c.oid
+			JOIN pg_class p ON i.inhparent = p.oid
+			WHERE p.relname = @table_name
+		),
+		attached_info AS (
+			SELECT
+				tablename,
+				TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD') AS partition_date,
+				pg_total_relation_size('public.'||tablename) AS size_bytes
+			FROM pg_tables
+			WHERE schemaname = 'public'
+				AND tablename IN (SELECT tablename FROM attached_partitions)
+		)
+		SELECT
+			COALESCE(COUNT(*), 0)::INT AS total_partitions,
+			COALESCE(SUM(size_bytes), 0)::BIGINT AS total_size_bytes,
+			pg_size_pretty(COALESCE(SUM(size_bytes), 0)) AS total_size_pretty,
+			MIN(partition_date) AS oldest_date,
+			MAX(partition_date) AS newest_date,
+			COALESCE(AVG(size_bytes), 0)::BIGINT AS avg_size_bytes,
+			pg_size_pretty(COALESCE(AVG(size_bytes), 0)::BIGINT) AS avg_size_pretty
+		FROM attached_info
+	`
+
+	result := dbc.DB.Raw(query, sql.Named("table_name", tableName)).Scan(&stats)
+	if result.Error != nil {
+		log.WithError(result.Error).WithField("table", tableName).Error("failed to get attached partition statistics")
+		return nil, result.Error
+	}
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"table":            tableName,
+		"total_partitions": stats.TotalPartitions,
+		"total_size":       stats.TotalSizePretty,
+		"elapsed":          elapsed,
+	}).Info("retrieved attached partition statistics")
+
+	return &stats, nil
+}
+
+// CreateMissingPartitions creates partitions for a date range if they don't already exist
+// Assumes daily partitions (one partition per day) based on the naming convention: tablename_YYYY_MM_DD
+// Each partition covers a 24-hour period from midnight to midnight
+//
+// Workflow:
+//  1. Lists all existing partitions (both attached and detached)
+//  2. Generates list of missing dates in the specified range
+//  3. For each missing date: creates table and attaches it as partition
+//  4. Skips dates that already have partitions (attached or detached)
+//
+// Parameters:
+//   - tableName: Name of the partitioned parent table
+//   - startDate: Start of date range (inclusive)
+//   - endDate: End of date range (inclusive)
+//   - dryRun: If true, logs what would be created without executing
+//
+// Returns: Count of partitions created (or would be created in dry-run mode)
+func (dbc *DB) CreateMissingPartitions(tableName string, startDate, endDate time.Time, dryRun bool) (int, error) {
+	start := time.Now()
+
+	// Validate date range
+	if endDate.Before(startDate) {
+		return 0, fmt.Errorf("end date (%s) cannot be before start date (%s)",
+			endDate.Format("2006-01-02"), startDate.Format("2006-01-02"))
+	}
+
+	// Get list of all existing partitions (attached + detached)
+	existingPartitions, err := dbc.ListTablePartitions(tableName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list existing partitions: %w", err)
+	}
+
+	// Create a map of existing partition dates for quick lookup
+	existingDates := make(map[string]bool)
+	for _, p := range existingPartitions {
+		dateStr := p.PartitionDate.Format("2006_01_02")
+		existingDates[dateStr] = true
+	}
+
+	// Generate list of partitions to create and detached partitions to reattach
+	var partitionsToCreate []time.Time
+	var partitionsToReattach []string
+	currentDate := startDate
+	for !currentDate.After(endDate) {
+		dateStr := currentDate.Format("2006_01_02")
+		if !existingDates[dateStr] {
+			partitionsToCreate = append(partitionsToCreate, currentDate)
+		} else {
+			// Partition exists — verify it is attached
+			partitionName := fmt.Sprintf("%s_%s", tableName, dateStr)
+			attached, err := dbc.IsPartitionAttached(partitionName)
+			if err != nil {
+				return 0, fmt.Errorf("failed to check if partition %s is attached: %w", partitionName, err)
+			}
+			if !attached {
+				partitionsToReattach = append(partitionsToReattach, partitionName)
+			}
+		}
+		currentDate = currentDate.AddDate(0, 0, 1) // Move to next day
+	}
+
+	if len(partitionsToCreate) == 0 && len(partitionsToReattach) == 0 {
+		log.WithFields(log.Fields{
+			"table":      tableName,
+			"start_date": startDate.Format("2006-01-02"),
+			"end_date":   endDate.Format("2006-01-02"),
+		}).Info("no missing partitions to create")
+		return 0, nil
+	}
+
+	if dryRun {
+		for _, partitionDate := range partitionsToCreate {
+			partitionName := fmt.Sprintf("%s_%s", tableName, partitionDate.Format("2006_01_02"))
+			log.WithFields(log.Fields{
+				"partition": partitionName,
+				"table":     tableName,
+			}).Info("[DRY RUN] would create partition")
+		}
+		for _, partitionName := range partitionsToReattach {
+			log.WithFields(log.Fields{
+				"partition": partitionName,
+				"table":     tableName,
+			}).Info("[DRY RUN] would reattach partition")
+		}
+		return len(partitionsToCreate), nil
+	}
+
+	createdCount := 0
+	err = dbc.DB.Transaction(func(tx *gorm.DB) error {
+		txDBC := &DB{DB: tx}
+
+		for _, partitionName := range partitionsToReattach {
+			if err := txDBC.AttachPartition(tableName, partitionName, false); err != nil {
+				return fmt.Errorf("failed to reattach partition %s: %w", partitionName, err)
+			}
+		}
+
+		for _, partitionDate := range partitionsToCreate {
+			partitionName := fmt.Sprintf("%s_%s", tableName, partitionDate.Format("2006_01_02"))
+
+			createTableQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (LIKE %s INCLUDING ALL)", pq.QuoteIdentifier(partitionName), pq.QuoteIdentifier(tableName))
+			if result := tx.Exec(createTableQuery); result.Error != nil {
+				return fmt.Errorf("failed to create partition table %s: %w", partitionName, result.Error)
+			}
+
+			if err := txDBC.AttachPartition(tableName, partitionName, false); err != nil {
+				return fmt.Errorf("failed to attach partition %s: %w", partitionName, err)
+			}
+
+			createdCount++
+		}
+
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"table":      tableName,
+		"start_date": startDate.Format("2006-01-02"),
+		"end_date":   endDate.Format("2006-01-02"),
+		"created":    createdCount,
+		"reattached": len(partitionsToReattach),
+		"dry_run":    dryRun,
+		"elapsed":    elapsed,
+	}).Info("completed creating missing partitions")
+
+	return createdCount, nil
+}
+
+// gormTypeToPostgresType converts GORM/Go data types to PostgreSQL types
+func gormTypeToPostgresType(dataType string) string {
+	dataType = strings.ToLower(strings.TrimSpace(dataType))
+
+	// Map GORM/Go types to PostgreSQL types
+	typeMap := map[string]string{
+		// Integer types
+		"uint":    "bigint",
+		"uint8":   "smallint",
+		"uint16":  "integer",
+		"uint32":  "bigint",
+		"uint64":  "bigint",
+		"int":     "bigint",
+		"int8":    "smallint",
+		"int16":   "smallint",
+		"int32":   "integer",
+		"int64":   "bigint",
+		"integer": "integer",
+		"bigint":  "bigint",
+
+		// Float types
+		"float":   "double precision",
+		"float32": "real",
+		"float64": "double precision",
+
+		// String types
+		"string": "text",
+		"text":   "text",
+
+		// Boolean
+		"bool":    "boolean",
+		"boolean": "boolean",
+
+		// Time types
+		"time.time": "timestamp with time zone",
+		"time":      "timestamp with time zone",
+		"timestamp": "timestamp with time zone",
+		"date":      "date",
+
+		// Binary
+		"[]byte": "bytea",
+		"bytes":  "bytea",
+		"bytea":  "bytea",
+
+		// JSON
+		"json":  "jsonb",
+		"jsonb": "jsonb",
+
+		// UUID
+		"uuid": "uuid",
+	}
+
+	// Check if we have a direct mapping
+	if pgType, exists := typeMap[dataType]; exists {
+		return pgType
+	}
+
+	// If it's already a PostgreSQL type, return as-is
+	// Common PostgreSQL types that might pass through
+	postgresTypes := []string{
+		"varchar", "character varying",
+		"smallint", "bigserial", "serial",
+		"numeric", "decimal", "real", "double precision",
+		"timestamptz", "timestamp without time zone",
+		"interval", "money",
+		"inet", "cidr", "macaddr",
+		"point", "line", "lseg", "box", "path", "polygon", "circle",
+		"xml", "array",
+	}
+
+	for _, pgType := range postgresTypes {
+		if strings.Contains(dataType, pgType) {
+			return dataType
+		}
+	}
+
+	// If we can't map it, log a warning and return as-is
+	// This allows for custom types or types we haven't mapped yet
+	log.WithField("data_type", dataType).Warn("unmapped data type - using as-is (may cause PostgreSQL error)")
+	return dataType
+}
+
+// CreatePartitionedTable creates a new partitioned table based on a GORM model struct
+// If the table already exists, it returns without error
+//
+// Parameters:
+//   - model: GORM model struct (must be a pointer, e.g., &models.MyModel{})
+//   - tableName: Name for the partitioned table
+//   - config: Partition configuration (strategy, columns, etc.)
+//   - dryRun: If true, prints SQL without executing
+//
+// Returns: The SQL statement that was (or would be) executed
+//
+// Example:
+//
+//	config := partitions.NewRangePartitionConfig("created_at")
+//	sql, err := partitions.CreatePartitionedTable(dbc, &MyModel{}, "my_table", config, true)
+func (dbc *DB) CreatePartitionedTable(model interface{}, tableName string, config PartitionConfig, dryRun bool) (string, error) {
+	start := time.Now()
+
+	// Validate partition configuration
+	if err := config.Validate(); err != nil {
+		return "", fmt.Errorf("invalid partition config: %w", err)
+	}
+
+	// Check if table already exists
+	if dbc.DB.Migrator().HasTable(tableName) {
+		log.WithField("table", tableName).Info("partitioned table already exists, skipping creation")
+		return "", nil
+	}
+
+	// Use GORM statement parser to get the table structure from the model
+	stmt := &gorm.Statement{DB: dbc.DB}
+	if err := stmt.Parse(model); err != nil {
+		return "", fmt.Errorf("failed to parse model: %w", err)
+	}
+
+	// Build the CREATE TABLE statement manually from the GORM schema
+	var columns []string
+	var primaryKeyColumns []string
+
+	// Create a map of fields with default database values for quick lookup
+	hasDefaultDBValue := make(map[string]bool)
+	for _, field := range stmt.Schema.FieldsWithDefaultDBValue {
+		hasDefaultDBValue[field.Name] = true
+	}
+
+	// Track which columns we've already added to prevent duplicates
+	addedColumns := make(map[string]bool)
+
+	for _, field := range stmt.Schema.Fields {
+		// Skip fields that shouldn't be in the database
+		if field.IgnoreMigration {
+			continue
+		}
+
+		// Skip fields with empty DBName or DataType
+		if field.DBName == "" || field.DataType == "" {
+			log.WithFields(log.Fields{
+				"table":     tableName,
+				"field":     field.Name,
+				"db_name":   field.DBName,
+				"data_type": field.DataType,
+			}).Warn("skipping field with empty DBName or DataType")
+			continue
+		}
+
+		// Skip duplicate columns (GORM can include same field multiple times)
+		if addedColumns[field.DBName] {
+			log.WithFields(log.Fields{
+				"table":  tableName,
+				"column": field.DBName,
+				"field":  field.Name,
+			}).Debug("skipping duplicate column")
+			continue
+		}
+		addedColumns[field.DBName] = true
+
+		// Convert GORM/Go type to PostgreSQL type
+		pgType := gormTypeToPostgresType(string(field.DataType))
+		columnDef := fmt.Sprintf("%s %s", field.DBName, pgType)
+
+		// Handle AUTO_INCREMENT using GENERATED BY DEFAULT AS IDENTITY
+		// This must be done before NOT NULL and DEFAULT clauses
+		if field.AutoIncrement {
+			// IDENTITY columns are always NOT NULL, so we add GENERATED BY DEFAULT AS IDENTITY
+			if field.AutoIncrementIncrement > 0 {
+				columnDef += fmt.Sprintf(" GENERATED BY DEFAULT AS IDENTITY (INCREMENT BY %d)", field.AutoIncrementIncrement)
+			} else {
+				columnDef += " GENERATED BY DEFAULT AS IDENTITY"
+			}
+			// IDENTITY columns are automatically NOT NULL, no need to add it explicitly
+		} else {
+			// Add NOT NULL constraint if applicable
+			// Primary keys are always NOT NULL in PostgreSQL
+			if field.PrimaryKey || field.NotNull {
+				columnDef += " NOT NULL"
+			}
+
+			// Add DEFAULT if specified
+			// Check both field.DefaultValue and if field is in FieldsWithDefaultDBValue
+			if field.DefaultValue != "" {
+				columnDef += fmt.Sprintf(" DEFAULT %s", field.DefaultValue)
+			} else if hasDefaultDBValue[field.Name] && field.DefaultValueInterface != nil {
+				// Field has a database-level default value
+				columnDef += fmt.Sprintf(" DEFAULT %v", field.DefaultValueInterface)
+			}
+		}
+
+		columns = append(columns, columnDef)
+
+		// Track primary key columns
+		if field.PrimaryKey {
+			primaryKeyColumns = append(primaryKeyColumns, field.DBName)
+		}
+	}
+
+	// Add PRIMARY KEY constraint if we have primary keys
+	// For partitioned tables, the primary key must include all partition columns
+	if len(primaryKeyColumns) > 0 {
+		// Check if primary key includes all partition columns
+		pkMap := make(map[string]bool)
+		for _, pk := range primaryKeyColumns {
+			pkMap[pk] = true
+		}
+
+		// Add missing partition columns to primary key
+		missingPartCols := []string{}
+		for _, partCol := range config.Columns {
+			if !pkMap[partCol] {
+				missingPartCols = append(missingPartCols, partCol)
+			}
+		}
+
+		if len(missingPartCols) > 0 {
+			log.WithFields(log.Fields{
+				"table":             tableName,
+				"primary_keys":      primaryKeyColumns,
+				"partition_columns": config.Columns,
+				"missing_in_pk":     missingPartCols,
+			}).Warn("primary key must include all partition columns - adding partition columns to primary key")
+			primaryKeyColumns = append(primaryKeyColumns, missingPartCols...)
+		}
+
+		primaryKeyConstraint := fmt.Sprintf("PRIMARY KEY (%s)", strings.Join(primaryKeyColumns, ", "))
+		columns = append(columns, primaryKeyConstraint)
+	}
+
+	// Build the CREATE TABLE statement with partition strategy
+	partitionClause := config.ToSQL()
+	createTableSQL := fmt.Sprintf(
+		"CREATE TABLE IF NOT EXISTS %s (\n    %s\n) %s",
+		pq.QuoteIdentifier(tableName),
+		strings.Join(columns, ",\n    "),
+		partitionClause,
+	)
+
+	// Create a map of partition columns for easy lookup
+	partitionColMap := make(map[string]bool)
+	for _, col := range config.Columns {
+		partitionColMap[col] = true
+	}
+
+	// Add indexes if they exist in the schema
+	var indexSQL strings.Builder
+	for _, idx := range stmt.Schema.ParseIndexes() {
+		// Skip unique indexes that don't include ALL partition keys
+		// (they're not allowed in partitioned tables)
+		if idx.Class == "UNIQUE" {
+			hasAllPartitionKeys := true
+			for _, partCol := range config.Columns {
+				found := false
+				for _, field := range idx.Fields {
+					if field.DBName == partCol {
+						found = true
+						break
+					}
+				}
+				if !found {
+					hasAllPartitionKeys = false
+					break
+				}
+			}
+			if !hasAllPartitionKeys {
+				// Generate table-specific name for logging
+				indexName := makeTableSpecificIndexName(tableName, idx.Fields)
+				log.WithFields(log.Fields{
+					"table":          tableName,
+					"index":          indexName,
+					"model_index":    idx.Name,
+					"partition_keys": config.Columns,
+				}).Warn("skipping unique index without all partition keys (not allowed on partitioned tables)")
+				continue
+			}
+		}
+
+		// Generate table-specific index name to avoid conflicts when creating multiple tables from same model
+		indexName := makeTableSpecificIndexName(tableName, idx.Fields)
+
+		indexSQL.WriteString("\n")
+		if idx.Class == "UNIQUE" {
+			indexSQL.WriteString(fmt.Sprintf("CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s (", indexName, tableName))
+		} else {
+			indexSQL.WriteString(fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s (", indexName, tableName))
+		}
+
+		var fieldNames []string
+		for _, field := range idx.Fields {
+			fieldNames = append(fieldNames, field.DBName)
+		}
+		indexSQL.WriteString(strings.Join(fieldNames, ", "))
+		indexSQL.WriteString(");")
+	}
+
+	fullSQL := createTableSQL + ";" + indexSQL.String()
+
+	if dryRun {
+		log.WithField("table", tableName).Info("[DRY RUN] would execute SQL:")
+		fmt.Println("\n" + strings.Repeat("-", 80))
+		fmt.Println(fullSQL)
+		fmt.Println(strings.Repeat("-", 80) + "\n")
+		return fullSQL, nil
+	}
+
+	// Execute table creation and index creation in a transaction
+	tx := dbc.DB.Begin()
+	if tx.Error != nil {
+		return "", fmt.Errorf("failed to begin transaction: %w", tx.Error)
+	}
+
+	// Ensure transaction is properly handled
+	committed := false
+	defer func() {
+		if !committed {
+			tx.Rollback()
+		}
+	}()
+
+	// Execute the CREATE TABLE statement
+	result := tx.Exec(createTableSQL)
+	if result.Error != nil {
+		return "", fmt.Errorf("failed to create partitioned table: %w", result.Error)
+	}
+
+	// Execute index creation statements
+	if indexSQL.Len() > 0 {
+		result = tx.Exec(indexSQL.String())
+		if result.Error != nil {
+			return "", fmt.Errorf("failed to create indexes: %w", result.Error)
+		}
+	}
+
+	// Commit the transaction
+	if err := tx.Commit().Error; err != nil {
+		return "", fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	committed = true
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"table":              tableName,
+		"partition_strategy": string(config.Strategy),
+		"partition_columns":  strings.Join(config.Columns, ", "),
+		"elapsed":            elapsed,
+	}).Info("created partitioned table")
+
+	return fullSQL, nil
+}
+
+// indexInfo holds information about a database index
+type indexInfo struct {
+	IndexName string
+	IsUnique  bool
+	Columns   []string
+}
+
+// UpdatePartitionedTable updates an existing partitioned table schema based on a GORM model
+// Detects differences between the model and current database schema and generates ALTER statements
+//
+// Parameters:
+//   - model: GORM model struct (must be a pointer, e.g., &models.MyModel{})
+//   - tableName: Name of the existing partitioned table
+//   - dryRun: If true, prints SQL without executing
+//   - dropColumns: If true, columns present in the database but absent from the model will be dropped
+//
+// Returns: The SQL statements that were (or would be) executed
+//
+// Example:
+//
+//	sql, err := partitions.UpdatePartitionedTable(dbc, &MyModel{}, "my_table", true, false)
+//
+// Note: Cannot modify partition keys or add unique constraints without partition keys
+func (dbc *DB) UpdatePartitionedTable(model interface{}, tableName string, dryRun bool, dropColumns bool) (string, error) {
+	start := time.Now()
+
+	// Check if table exists
+	if !dbc.DB.Migrator().HasTable(tableName) {
+		return "", fmt.Errorf("table %s does not exist", tableName)
+	}
+
+	// Parse the GORM model to get desired schema
+	stmt := &gorm.Statement{DB: dbc.DB}
+	if err := stmt.Parse(model); err != nil {
+		return "", fmt.Errorf("failed to parse model: %w", err)
+	}
+
+	// Get current schema from database
+	currentColumns, err := dbc.GetTableColumns(tableName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get current columns: %w", err)
+	}
+
+	currentIndexes, err := dbc.getCurrentIndexes(tableName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get current indexes: %w", err)
+	}
+
+	// Get partition columns to validate unique indexes
+	partitionColumns, err := dbc.getPartitionColumns(tableName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get partition columns: %w", err)
+	}
+
+	// Get primary key columns to prevent dropping NOT NULL from them
+	primaryKeyColumns, err := dbc.getPrimaryKeyColumns(tableName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get primary key columns: %w", err)
+	}
+
+	log.WithFields(log.Fields{
+		"table":               tableName,
+		"partition_columns":   partitionColumns,
+		"primary_key_columns": primaryKeyColumns,
+	}).Info("table structure for update validation")
+
+	// Build a set of partition columns for quick lookup
+	partitionColMap := make(map[string]bool)
+	for _, col := range partitionColumns {
+		partitionColMap[col] = true
+	}
+
+	// Build a set of primary key columns for quick lookup
+	primaryKeyColMap := make(map[string]bool)
+	for _, col := range primaryKeyColumns {
+		primaryKeyColMap[col] = true
+	}
+
+	// Build maps for comparison
+	currentColMap := make(map[string]ColumnInfo)
+	for _, col := range currentColumns {
+		currentColMap[col.ColumnName] = col
+	}
+
+	currentIdxMap := make(map[string]indexInfo)
+	for _, idx := range currentIndexes {
+		currentIdxMap[idx.IndexName] = idx
+	}
+
+	// Create a map of fields with default database values for quick lookup
+	hasDefaultDBValue := make(map[string]bool)
+	for _, field := range stmt.Schema.FieldsWithDefaultDBValue {
+		hasDefaultDBValue[field.Name] = true
+	}
+
+	// Track which columns we've already processed to prevent duplicates
+	processedColumns := make(map[string]bool)
+
+	// Generate ALTER statements
+	var alterStatements []string
+
+	// Check for new or modified columns
+	for _, field := range stmt.Schema.Fields {
+		if field.IgnoreMigration {
+			continue
+		}
+
+		// Skip fields with empty DBName or DataType
+		if field.DBName == "" || field.DataType == "" {
+			log.WithFields(log.Fields{
+				"table":     tableName,
+				"field":     field.Name,
+				"db_name":   field.DBName,
+				"data_type": field.DataType,
+			}).Warn("skipping field with empty DBName or DataType")
+			continue
+		}
+
+		// Skip duplicate columns (GORM can include same field multiple times)
+		if processedColumns[field.DBName] {
+			log.WithFields(log.Fields{
+				"table":  tableName,
+				"column": field.DBName,
+				"field":  field.Name,
+			}).Debug("skipping duplicate column")
+			continue
+		}
+		processedColumns[field.DBName] = true
+
+		currentCol, exists := currentColMap[field.DBName]
+
+		// Convert GORM/Go type to PostgreSQL type
+		pgType := gormTypeToPostgresType(string(field.DataType))
+
+		if !exists {
+			// New column - add it
+			columnDef := fmt.Sprintf("%s %s", field.DBName, pgType)
+
+			// Handle AUTO_INCREMENT using GENERATED BY DEFAULT AS IDENTITY
+			if field.AutoIncrement {
+				// IDENTITY columns are always NOT NULL, so we add GENERATED BY DEFAULT AS IDENTITY
+				if field.AutoIncrementIncrement > 0 {
+					columnDef += fmt.Sprintf(" GENERATED BY DEFAULT AS IDENTITY (INCREMENT BY %d)", field.AutoIncrementIncrement)
+				} else {
+					columnDef += " GENERATED BY DEFAULT AS IDENTITY"
+				}
+				// IDENTITY columns are automatically NOT NULL, no need to add it explicitly
+			} else {
+				// Primary keys are always NOT NULL in PostgreSQL
+				if field.PrimaryKey || field.NotNull {
+					columnDef += " NOT NULL"
+				}
+				// Add DEFAULT if specified
+				// Check both field.DefaultValue and if field is in FieldsWithDefaultDBValue
+				if field.DefaultValue != "" {
+					columnDef += fmt.Sprintf(" DEFAULT %s", field.DefaultValue)
+				} else if hasDefaultDBValue[field.Name] && field.DefaultValueInterface != nil {
+					// Field has a database-level default value
+					columnDef += fmt.Sprintf(" DEFAULT %v", field.DefaultValueInterface)
+				}
+			}
+
+			alterStatements = append(alterStatements,
+				fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s", pq.QuoteIdentifier(tableName), columnDef))
+		} else {
+			// Existing column - check for modifications
+			modifications := []string{}
+
+			// Check data type
+			if !strings.EqualFold(normalizeDataType(currentCol.DataType), normalizeDataType(pgType)) {
+				modifications = append(modifications,
+					fmt.Sprintf("ALTER COLUMN %s TYPE %s", field.DBName, pgType))
+			}
+
+			// Check NOT NULL constraint
+			// Primary keys, partition keys, and columns in primary key are always NOT NULL in PostgreSQL
+			currentNotNull := currentCol.IsNullable == "NO"
+
+			// Check if column is part of primary key or partition key
+			isPartOfPrimaryKey := primaryKeyColMap[field.DBName]
+			isPartOfPartitionKey := partitionColMap[field.DBName]
+
+			// Desired NOT NULL state: explicit primary key, explicit not null, or part of actual primary key
+			desiredNotNull := field.PrimaryKey || field.NotNull || isPartOfPrimaryKey
+
+			if desiredNotNull != currentNotNull {
+				if desiredNotNull {
+					modifications = append(modifications,
+						fmt.Sprintf("ALTER COLUMN %s SET NOT NULL", field.DBName))
+				} else {
+					// Cannot drop NOT NULL from primary key or partition key columns
+					if isPartOfPrimaryKey {
+						log.WithFields(log.Fields{
+							"table":  tableName,
+							"column": field.DBName,
+						}).Warn("cannot drop NOT NULL from primary key column - skipping")
+					} else if isPartOfPartitionKey {
+						log.WithFields(log.Fields{
+							"table":  tableName,
+							"column": field.DBName,
+						}).Warn("cannot drop NOT NULL from partition key column - skipping")
+					} else {
+						// Safe to drop NOT NULL
+						modifications = append(modifications,
+							fmt.Sprintf("ALTER COLUMN %s DROP NOT NULL", field.DBName))
+					}
+				}
+			}
+
+			// Check DEFAULT value
+			currentDefault := ""
+			if currentCol.ColumnDefault.Valid {
+				currentDefault = currentCol.ColumnDefault.String
+			}
+			if field.DefaultValue != currentDefault {
+				if field.DefaultValue != "" {
+					modifications = append(modifications,
+						fmt.Sprintf("ALTER COLUMN %s SET DEFAULT %s", field.DBName, field.DefaultValue))
+				} else if currentDefault != "" {
+					modifications = append(modifications,
+						fmt.Sprintf("ALTER COLUMN %s DROP DEFAULT", field.DBName))
+				}
+			}
+
+			// Add modifications as separate ALTER TABLE statements
+			for _, mod := range modifications {
+				alterStatements = append(alterStatements,
+					fmt.Sprintf("ALTER TABLE %s %s", pq.QuoteIdentifier(tableName), mod))
+			}
+		}
+
+		// Remove from map to track processed columns
+		delete(currentColMap, field.DBName)
+	}
+
+	// Remaining columns in map are not in the model
+	if dropColumns {
+		for colName := range currentColMap {
+			alterStatements = append(alterStatements,
+				fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", pq.QuoteIdentifier(tableName), colName))
+		}
+	}
+
+	// Check indexes
+	// (partitionColMap already created earlier)
+	for _, idx := range stmt.Schema.ParseIndexes() {
+		// Skip unique indexes that don't include all partition keys
+		if idx.Class == "UNIQUE" {
+			hasAllPartitionKeys := true
+			for _, partCol := range partitionColumns {
+				found := false
+				for _, field := range idx.Fields {
+					if field.DBName == partCol {
+						found = true
+						break
+					}
+				}
+				if !found {
+					hasAllPartitionKeys = false
+					break
+				}
+			}
+			if !hasAllPartitionKeys {
+				// Generate table-specific name for logging
+				indexName := makeTableSpecificIndexName(tableName, idx.Fields)
+				log.WithFields(log.Fields{
+					"table":          tableName,
+					"index":          indexName,
+					"model_index":    idx.Name,
+					"partition_keys": partitionColumns,
+				}).Warn("skipping unique index without all partition keys")
+				continue
+			}
+		}
+
+		// Generate table-specific index name to avoid conflicts when creating multiple tables from same model
+		indexName := makeTableSpecificIndexName(tableName, idx.Fields)
+
+		currentIdx, exists := currentIdxMap[indexName]
+		if !exists {
+			// New index - create it
+			var fieldNames []string
+			for _, field := range idx.Fields {
+				fieldNames = append(fieldNames, field.DBName)
+			}
+
+			if idx.Class == "UNIQUE" {
+				alterStatements = append(alterStatements,
+					fmt.Sprintf("CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s (%s)",
+						indexName, tableName, strings.Join(fieldNames, ", ")))
+			} else {
+				alterStatements = append(alterStatements,
+					fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s (%s)",
+						indexName, tableName, strings.Join(fieldNames, ", ")))
+			}
+		} else {
+			// Index exists - check if it needs to be recreated
+			var desiredCols []string
+			for _, field := range idx.Fields {
+				desiredCols = append(desiredCols, field.DBName)
+			}
+
+			colsMatch := len(currentIdx.Columns) == len(desiredCols)
+			if colsMatch {
+				for i, col := range currentIdx.Columns {
+					if col != desiredCols[i] {
+						colsMatch = false
+						break
+					}
+				}
+			}
+
+			uniqueMatch := (idx.Class == "UNIQUE") == currentIdx.IsUnique
+
+			if !colsMatch || !uniqueMatch {
+				// Drop and recreate index
+				alterStatements = append(alterStatements,
+					fmt.Sprintf("DROP INDEX IF EXISTS %s", indexName))
+
+				if idx.Class == "UNIQUE" {
+					alterStatements = append(alterStatements,
+						fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s (%s)",
+							indexName, tableName, strings.Join(desiredCols, ", ")))
+				} else {
+					alterStatements = append(alterStatements,
+						fmt.Sprintf("CREATE INDEX %s ON %s (%s)",
+							indexName, tableName, strings.Join(desiredCols, ", ")))
+				}
+			}
+		}
+
+		delete(currentIdxMap, indexName)
+	}
+
+	// Drop indexes that are no longer in the model
+	for idxName := range currentIdxMap {
+		// Skip primary key and system indexes
+		if strings.HasSuffix(idxName, "_pkey") {
+			continue
+		}
+		alterStatements = append(alterStatements,
+			fmt.Sprintf("DROP INDEX IF EXISTS %s", idxName))
+	}
+
+	// If no changes, return early
+	if len(alterStatements) == 0 {
+		log.WithField("table", tableName).Info("schema is up to date, no changes needed")
+		return "", nil
+	}
+
+	fullSQL := strings.Join(alterStatements, ";\n") + ";"
+
+	if dryRun {
+		log.WithField("table", tableName).Info("[DRY RUN] would execute SQL:")
+		fmt.Println("\n" + strings.Repeat("-", 80))
+		fmt.Println(fullSQL)
+		fmt.Println(strings.Repeat("-", 80) + "\n")
+		return fullSQL, nil
+	}
+
+	// Execute ALTER statements in a transaction for atomicity
+	tx := dbc.DB.Begin()
+	if tx.Error != nil {
+		return "", fmt.Errorf("failed to begin transaction: %w", tx.Error)
+	}
+
+	// Ensure transaction is properly handled
+	committed := false
+	defer func() {
+		if !committed {
+			tx.Rollback()
+		}
+	}()
+
+	for i, stmt := range alterStatements {
+		result := tx.Exec(stmt)
+		if result.Error != nil {
+			log.WithError(result.Error).WithFields(log.Fields{
+				"table":     tableName,
+				"statement": stmt,
+				"index":     i + 1,
+				"total":     len(alterStatements),
+			}).Error("failed to execute ALTER statement")
+			return "", fmt.Errorf("failed to execute ALTER statement %d of %d: %w", i+1, len(alterStatements), result.Error)
+		}
+	}
+
+	// Commit the transaction
+	if err := tx.Commit().Error; err != nil {
+		return "", fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	committed = true
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"table":      tableName,
+		"statements": len(alterStatements),
+		"elapsed":    elapsed,
+	}).Info("updated partitioned table schema")
+
+	return fullSQL, nil
+}
+
+// getCurrentColumns retrieves the current column schema from the database
+// getCurrentIndexes retrieves the current indexes from the database
+func (dbc *DB) getCurrentIndexes(tableName string) ([]indexInfo, error) {
+	type indexRow struct {
+		IndexName string
+		IsUnique  bool
+		Column    string
+	}
+
+	var rows []indexRow
+
+	query := `
+		SELECT
+			i.indexname AS index_name,
+			ix.indisunique AS is_unique,
+			a.attname AS column
+		FROM pg_indexes i
+		JOIN pg_class c ON c.relname = i.indexname
+		JOIN pg_index ix ON ix.indexrelid = c.oid
+		JOIN unnest(ix.indkey) WITH ORDINALITY AS u(attnum, ord) ON true
+		JOIN pg_attribute a ON a.attrelid = ix.indrelid AND a.attnum = u.attnum
+		WHERE i.schemaname = 'public'
+			AND i.tablename = @table_name
+		ORDER BY i.indexname, u.ord
+	`
+
+	result := dbc.DB.Raw(query, sql.Named("table_name", tableName)).Scan(&rows)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	// Group by index name
+	indexMap := make(map[string]*indexInfo)
+	for _, row := range rows {
+		if idx, exists := indexMap[row.IndexName]; exists {
+			idx.Columns = append(idx.Columns, row.Column)
+		} else {
+			indexMap[row.IndexName] = &indexInfo{
+				IndexName: row.IndexName,
+				IsUnique:  row.IsUnique,
+				Columns:   []string{row.Column},
+			}
+		}
+	}
+
+	var indexes []indexInfo
+	for _, idx := range indexMap {
+		indexes = append(indexes, *idx)
+	}
+
+	return indexes, nil
+}
+
+// getPartitionColumns retrieves the partition key columns for a table
+func (dbc *DB) getPartitionColumns(tableName string) ([]string, error) {
+	var columns []string
+
+	query := `
+		SELECT a.attname
+		FROM pg_class c
+		JOIN pg_partitioned_table pt ON pt.partrelid = c.oid
+		JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(pt.partattrs)
+		WHERE c.relname = @table_name
+			AND c.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+		ORDER BY array_position(pt.partattrs, a.attnum)
+	`
+
+	result := dbc.DB.Raw(query, sql.Named("table_name", tableName)).Scan(&columns)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return columns, nil
+}
+
+// makeTableSpecificIndexName creates a table-specific index name from index fields
+// This prevents index name collisions when creating multiple tables from the same model
+//
+// GORM often generates index names like "idx_{original_table_name}_{column_names}"
+// (e.g., "idx_prow_job_run_tests_suite_id"). When creating a different table like
+// "prow_job_run_tests_copy_1", we need to avoid the redundant name like
+// "prow_job_run_tests_copy_1_idx_prow_job_run_tests_suite_id".
+//
+// Instead, we extract the column names from the index fields and generate:
+// "{table_name}_idx_{column_names}"
+//
+// Examples:
+//   - Index fields: [suite_id] -> "prow_job_run_tests_copy_1_idx_suite_id"
+//   - Index fields: [created_at] -> "orders_copy_1_idx_created_at"
+//   - Index fields: [user_id, org_id] -> "users_backup_idx_user_id_org_id"
+func makeTableSpecificIndexName(tableName string, indexFields []schema.IndexOption) string {
+	// Extract column names from index fields
+	var columnNames []string
+	for _, field := range indexFields {
+		columnNames = append(columnNames, field.DBName)
+	}
+
+	// Generate table-specific index name: {table}_idx_{columns}
+	columnSuffix := strings.Join(columnNames, "_")
+	return fmt.Sprintf("%s_idx_%s", tableName, columnSuffix)
+}
+
+// getPrimaryKeyColumns retrieves the columns that are part of the primary key for a table
+func (dbc *DB) getPrimaryKeyColumns(tableName string) ([]string, error) {
+	var columns []string
+
+	query := `
+		SELECT a.attname
+		FROM pg_index i
+		JOIN pg_class c ON c.oid = i.indrelid
+		JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(i.indkey)
+		WHERE c.relname = @table_name
+			AND c.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+			AND i.indisprimary = true
+		ORDER BY array_position(i.indkey, a.attnum)
+	`
+
+	result := dbc.DB.Raw(query, sql.Named("table_name", tableName)).Scan(&columns)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return columns, nil
+}
+
+// normalizeDataType normalizes data type strings for comparison
+// Preserves type modifiers (length, precision, scale) while normalizing base type names
+// Examples:
+//   - "character varying(64)" -> "varchar(64)"
+//   - "integer" -> "int"
+//   - "numeric(8,2)" -> "numeric(8,2)" (preserved)
+func normalizeDataType(dataType string) string {
+	dataType = strings.ToLower(strings.TrimSpace(dataType))
+
+	// Map common type variations to standard forms (preserving any modifiers).
+	// Uses a slice for deterministic matching order — longer prefixes must come
+	// before shorter ones (e.g., "character varying" before "character").
+	replacements := []struct{ old, new string }{
+		{"character varying", "varchar"},
+		{"timestamp without time zone", "timestamp"},
+		{"timestamp with time zone", "timestamptz"},
+		{"time without time zone", "time"},
+		{"time with time zone", "timetz"},
+		{"double precision", "float8"},
+		{"character", "char"},
+		{"integer", "int"},
+		{"int4", "int"},
+		{"int8", "bigint"},
+		{"bigserial", "bigint"},
+		{"serial", "int"},
+		{"smallint", "int2"},
+		{"boolean", "bool"},
+		{"real", "float4"},
+	}
+
+	// Try to replace the base type name while preserving modifiers
+	for _, r := range replacements {
+		if suffix, found := strings.CutPrefix(dataType, r.old); found {
+			return r.new + suffix
+		}
+	}
+
+	return dataType
+}
+
+// GetDetachedPartitionStats returns statistics about detached partitions for a given table
+func (dbc *DB) GetDetachedPartitionStats(tableName string) (*PartitionStats, error) {
+	start := time.Now()
+	var stats PartitionStats
+
+	query := `
+		WITH attached_partitions AS (
+			SELECT c.relname AS tablename
+			FROM pg_inherits i
+			JOIN pg_class c ON i.inhrelid = c.oid
+			JOIN pg_class p ON i.inhparent = p.oid
+			WHERE p.relname = @table_name
+		),
+		detached_info AS (
+			SELECT
+				tablename,
+				TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD') AS partition_date,
+				pg_total_relation_size('public.'||tablename) AS size_bytes
+			FROM pg_tables
+			WHERE schemaname = 'public'
+				AND tablename LIKE @table_pattern ESCAPE '\'
+				AND tablename NOT IN (SELECT tablename FROM attached_partitions)
+		)
+		SELECT
+			COUNT(*)::INT AS total_partitions,
+			COALESCE(SUM(size_bytes), 0)::BIGINT AS total_size_bytes,
+			COALESCE(pg_size_pretty(SUM(size_bytes)), '0 bytes') AS total_size_pretty,
+			MIN(partition_date) AS oldest_date,
+			MAX(partition_date) AS newest_date,
+			COALESCE(AVG(size_bytes), 0)::BIGINT AS avg_size_bytes,
+			COALESCE(pg_size_pretty(AVG(size_bytes)::BIGINT), '0 bytes') AS avg_size_pretty
+		FROM detached_info
+	`
+
+	tablePattern := escapeForLike(tableName) + `\_20%`
+	result := dbc.DB.Raw(query,
+		sql.Named("table_name", tableName),
+		sql.Named("table_pattern", tablePattern)).Scan(&stats)
+	if result.Error != nil {
+		log.WithError(result.Error).WithField("table", tableName).Error("failed to get detached partition statistics")
+		return nil, result.Error
+	}
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"table":            tableName,
+		"total_partitions": stats.TotalPartitions,
+		"total_size":       stats.TotalSizePretty,
+		"elapsed":          elapsed,
+	}).Info("retrieved detached partition statistics")
+
+	return &stats, nil
+}
+
+// AttachPartition attaches a partition to the parent table with the appropriate date range
+// The partition name must follow the convention tableName_YYYY_MM_DD
+func (dbc *DB) AttachPartition(tableName string, partitionName string, dryRun bool) error {
+	start := time.Now()
+
+	// Validate partition name format for safety
+	if !isValidPartitionName(tableName, partitionName) {
+		return fmt.Errorf("invalid partition name: %s - must match %s_YYYY_MM_DD", partitionName, tableName)
+	}
+
+	// Extract date from partition name
+	prefix := tableName + "_"
+	dateStr := partitionName[len(prefix):]
+	partitionDate, err := time.Parse("2006_01_02", dateStr)
+	if err != nil {
+		return fmt.Errorf("invalid partition date format: %w", err)
+	}
+
+	// Calculate date range for the partition
+	rangeStart := partitionDate.Format("2006-01-02")
+	rangeEnd := partitionDate.AddDate(0, 0, 1).Format("2006-01-02")
+
+	if dryRun {
+		log.WithFields(log.Fields{
+			"partition":   partitionName,
+			"table":       tableName,
+			"range_start": rangeStart,
+			"range_end":   rangeEnd,
+		}).Info("[DRY RUN] would attach partition")
+		return nil
+	}
+
+	// Attach the partition with FOR VALUES clause
+	query := fmt.Sprintf(
+		"ALTER TABLE %s ATTACH PARTITION %s FOR VALUES FROM ('%s') TO ('%s')",
+		pq.QuoteIdentifier(tableName),
+		pq.QuoteIdentifier(partitionName),
+		rangeStart,
+		rangeEnd,
+	)
+
+	result := dbc.DB.Exec(query)
+	if result.Error != nil {
+		log.WithError(result.Error).WithFields(log.Fields{
+			"partition": partitionName,
+			"table":     tableName,
+		}).Error("failed to attach partition")
+		return result.Error
+	}
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"partition": partitionName,
+		"table":     tableName,
+		"elapsed":   elapsed,
+	}).Info("attached partition")
+
+	return nil
+}
+
+// IsPartitionAttached checks if a partition is currently attached to the parent table
+func (dbc *DB) IsPartitionAttached(partitionName string) (bool, error) {
+	start := time.Now()
+
+	// Extract table name from partition name
+	tableName, err := extractTableNameFromPartition(partitionName)
+	if err != nil {
+		return false, fmt.Errorf("invalid partition name: %w", err)
+	}
+
+	// Validate partition name format for safety
+	if !isValidPartitionName(tableName, partitionName) {
+		return false, fmt.Errorf("invalid partition name: %s", partitionName)
+	}
+
+	var isAttached bool
+	query := `
+		SELECT EXISTS(
+			SELECT 1
+			FROM pg_inherits i
+			JOIN pg_class c ON i.inhrelid = c.oid
+			JOIN pg_class p ON i.inhparent = p.oid
+			WHERE p.relname = @table_name
+				AND c.relname = @partition_name
+		) AS is_attached
+	`
+
+	result := dbc.DB.Raw(query,
+		sql.Named("table_name", tableName),
+		sql.Named("partition_name", partitionName)).Scan(&isAttached)
+	if result.Error != nil {
+		log.WithError(result.Error).WithFields(log.Fields{
+			"partition": partitionName,
+			"table":     tableName,
+		}).Error("failed to check partition status")
+		return false, result.Error
+	}
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"partition":   partitionName,
+		"table":       tableName,
+		"is_attached": isAttached,
+		"elapsed":     elapsed,
+	}).Debug("checked partition attachment status")
+
+	return isAttached, nil
+}
+
+// DetachOldPartitions detaches all partitions older than the retention period for a given table
+// This is safer than dropping as partitions can be reattached if needed
+func (dbc *DB) DetachOldPartitions(tableName string, retentionDays int, dryRun bool) (int, error) {
+	start := time.Now()
+
+	// Validate retention policy first
+	if err := dbc.ValidateRetentionPolicy(tableName, retentionDays); err != nil {
+		return 0, fmt.Errorf("retention policy validation failed: %w", err)
+	}
+
+	// Get only attached partitions for removal (can only detach what's attached)
+	partitions, err := dbc.GetPartitionsForRemoval(tableName, retentionDays, true)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get partitions for removal: %w", err)
+	}
+
+	if len(partitions) == 0 {
+		log.WithField("table", tableName).Info("no partitions to detach")
+		return 0, nil
+	}
+
+	if dryRun {
+		for _, partition := range partitions {
+			if err := dbc.DetachPartition(partition.TableName, true); err != nil {
+				return 0, fmt.Errorf("failed to dry-run detach partition %s: %w", partition.TableName, err)
+			}
+		}
+		return len(partitions), nil
+	}
+
+	// Detach all old partitions in a transaction
+	detachedCount := 0
+	var totalSize int64
+
+	err = dbc.DB.Transaction(func(tx *gorm.DB) error {
+		txDBC := &DB{DB: tx}
+		for _, partition := range partitions {
+			if err := txDBC.DetachPartition(partition.TableName, false); err != nil {
+				return fmt.Errorf("failed to detach partition %s: %w", partition.TableName, err)
+			}
+			detachedCount++
+			totalSize += partition.SizeBytes
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{
+		"table":            tableName,
+		"retention_days":   retentionDays,
+		"total_detached":   detachedCount,
+		"storage_affected": fmt.Sprintf("%d bytes", totalSize),
+		"elapsed":          elapsed,
+	}).Info("completed detaching old partitions")
+
+	return detachedCount, nil
+}
+
+// extractTableNameFromPartition extracts the table name from a partition name
+// Partition format: {tablename}_YYYY_MM_DD
+func extractTableNameFromPartition(partitionName string) (string, error) {
+	// Must end with _YYYY_MM_DD (10 characters + 1 underscore = 11)
+	if len(partitionName) < 12 {
+		return "", fmt.Errorf("partition name too short: %s", partitionName)
+	}
+
+	// Extract the date portion (last 10 characters should be YYYY_MM_DD)
+	dateStr := partitionName[len(partitionName)-10:]
+
+	// Validate date format
+	_, err := time.Parse("2006_01_02", dateStr)
+	if err != nil {
+		return "", fmt.Errorf("invalid date format in partition name: %s", partitionName)
+	}
+
+	// Table name is everything except the last 11 characters (_YYYY_MM_DD)
+	tableName := partitionName[:len(partitionName)-11]
+
+	return tableName, nil
+}
+
+// isValidPartitionName validates that a partition name matches the expected format for a given table
+// This is a safety check to prevent SQL injection and accidental drops
+func isValidPartitionName(tableName, partitionName string) bool {
+	expectedPrefix := tableName + "_"
+	expectedLen := len(expectedPrefix) + 10 // prefix + "YYYY_MM_DD"
+
+	if len(partitionName) != expectedLen {
+		return false
+	}
+
+	if !strings.HasPrefix(partitionName, expectedPrefix) {
+		return false
+	}
+
+	// Must start with 20xx (year 2000-2099)
+	if len(partitionName) < len(expectedPrefix)+2 || partitionName[len(expectedPrefix):len(expectedPrefix)+2] != "20" {
+		return false
+	}
+
+	// Validate date format by parsing
+	dateStr := partitionName[len(expectedPrefix):] // YYYY_MM_DD format
+	_, err := time.Parse("2006_01_02", dateStr)
+	return err == nil
+}

--- a/pkg/db/partitions.go
+++ b/pkg/db/partitions.go
@@ -1274,12 +1274,14 @@ type indexInfo struct {
 	Columns   []string
 }
 
-// UpdatePartitionedTable updates an existing partitioned table schema based on a GORM model
-// Detects differences between the model and current database schema and generates ALTER statements
+// UpdatePartitionedTable updates an existing partitioned table schema based on a GORM model.
+// If the table does not exist, it is created using CreatePartitionedTable with the provided config.
+// Detects differences between the model and current database schema and generates ALTER statements.
 //
 // Parameters:
 //   - model: GORM model struct (must be a pointer, e.g., &models.MyModel{})
-//   - tableName: Name of the existing partitioned table
+//   - tableName: Name of the partitioned table (created if it does not exist)
+//   - config: Partition configuration (used only when creating a new table)
 //   - dryRun: If true, prints SQL without executing
 //   - dropColumns: If true, columns present in the database but absent from the model will be dropped
 //
@@ -1287,15 +1289,17 @@ type indexInfo struct {
 //
 // Example:
 //
-//	sql, err := partitions.UpdatePartitionedTable(dbc, &MyModel{}, "my_table", true, false)
+//	config := db.NewRangePartitionConfig("created_at")
+//	sql, err := dbc.UpdatePartitionedTable(&MyModel{}, "my_table", config, true, false)
 //
 // Note: Cannot modify partition keys or add unique constraints without partition keys
-func (dbc *DB) UpdatePartitionedTable(model interface{}, tableName string, dryRun bool, dropColumns bool) (string, error) {
+func (dbc *DB) UpdatePartitionedTable(model interface{}, tableName string, config PartitionConfig, dryRun bool, dropColumns bool) (string, error) {
 	start := time.Now()
 
-	// Check if table exists
+	// If table doesn't exist, create it
 	if !dbc.DB.Migrator().HasTable(tableName) {
-		return "", fmt.Errorf("table %s does not exist", tableName)
+		log.WithField("table", tableName).Info("table does not exist, creating partitioned table")
+		return dbc.CreatePartitionedTable(model, tableName, config, dryRun)
 	}
 
 	// Parse the GORM model to get desired schema

--- a/pkg/db/partitions.go
+++ b/pkg/db/partitions.go
@@ -1015,6 +1015,8 @@ func gormTypeToPostgresType(dataType string) string {
 //
 //	config := partitions.NewRangePartitionConfig("created_at")
 //	sql, err := partitions.CreatePartitionedTable(dbc, &MyModel{}, "my_table", config, true)
+//
+//nolint:gocyclo
 func (dbc *DB) CreatePartitionedTable(model interface{}, tableName string, config PartitionConfig, dryRun bool) (string, error) {
 	start := time.Now()
 
@@ -1293,6 +1295,8 @@ type indexInfo struct {
 //	sql, err := dbc.UpdatePartitionedTable(&MyModel{}, "my_table", config, true, false)
 //
 // Note: Cannot modify partition keys or add unique constraints without partition keys
+//
+//nolint:gocyclo
 func (dbc *DB) UpdatePartitionedTable(model interface{}, tableName string, config PartitionConfig, dryRun bool, dropColumns bool) (string, error) {
 	start := time.Now()
 
@@ -1895,7 +1899,7 @@ func (dbc *DB) GetDetachedPartitionStats(tableName string) (*PartitionStats, err
 
 // AttachPartition attaches a partition to the parent table with the appropriate date range
 // The partition name must follow the convention tableName_YYYY_MM_DD
-func (dbc *DB) AttachPartition(tableName string, partitionName string, dryRun bool) error {
+func (dbc *DB) AttachPartition(tableName, partitionName string, dryRun bool) error {
 	start := time.Now()
 
 	// Validate partition name format for safety

--- a/pkg/db/partitions_test.go
+++ b/pkg/db/partitions_test.go
@@ -1,0 +1,540 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsValidTestAnalysisPartitionName(t *testing.T) {
+	tests := []struct {
+		name      string
+		partition string
+		want      bool
+	}{
+		{
+			name:      "valid partition name",
+			partition: "test_analysis_by_job_by_dates_2024_10_29",
+			want:      true,
+		},
+		{
+			name:      "valid partition name 2026",
+			partition: "test_analysis_by_job_by_dates_2026_01_15",
+			want:      true,
+		},
+		{
+			name:      "invalid - too short",
+			partition: "test_analysis_by_job_by_dates",
+			want:      false,
+		},
+		{
+			name:      "invalid - wrong prefix",
+			partition: "wrong_analysis_by_job_by_dates_2024_10_29",
+			want:      false,
+		},
+		{
+			name:      "invalid - wrong date format",
+			partition: "test_analysis_by_job_by_dates_2024_13_40",
+			want:      false,
+		},
+		{
+			name:      "invalid - SQL injection attempt",
+			partition: "test_analysis_by_job_by_dates_2024_10_29; DROP TABLE prow_jobs;",
+			want:      false,
+		},
+		{
+			name:      "invalid - missing date",
+			partition: "test_analysis_by_job_by_dates_",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isValidPartitionName("test_analysis_by_job_by_dates", tt.partition)
+			if got != tt.want {
+				t.Errorf("isValidTestAnalysisPartitionName(%q) = %v, want %v", tt.partition, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPartitionInfo(t *testing.T) {
+	// Test that PartitionInfo struct can be instantiated
+	partition := PartitionInfo{
+		TableName:     "test_analysis_by_job_by_dates_2024_10_29",
+		SchemaName:    "public",
+		PartitionDate: time.Date(2024, 10, 29, 0, 0, 0, 0, time.UTC),
+		Age:           100,
+		SizeBytes:     1073741824, // 1 GB
+		SizePretty:    "1 GB",
+		RowEstimate:   1000000,
+	}
+
+	if partition.TableName != "test_analysis_by_job_by_dates_2024_10_29" {
+		t.Errorf("unexpected table name: %s", partition.TableName)
+	}
+}
+
+func TestRetentionSummary(t *testing.T) {
+	// Test that RetentionSummary struct can be instantiated
+	summary := RetentionSummary{
+		RetentionDays:      180,
+		CutoffDate:         time.Now().AddDate(0, 0, -180),
+		PartitionsToRemove: 50,
+		StorageToReclaim:   53687091200, // ~50 GB
+		StoragePretty:      "50 GB",
+		OldestPartition:    "test_analysis_by_job_by_dates_2024_10_29",
+		NewestPartition:    "test_analysis_by_job_by_dates_2024_12_17",
+	}
+
+	if summary.RetentionDays != 180 {
+		t.Errorf("unexpected retention days: %d", summary.RetentionDays)
+	}
+
+	if summary.PartitionsToRemove != 50 {
+		t.Errorf("unexpected partitions to remove: %d", summary.PartitionsToRemove)
+	}
+}
+
+func TestExtractTableNameFromPartition(t *testing.T) {
+	tests := []struct {
+		name          string
+		partitionName string
+		wantTableName string
+		wantError     bool
+	}{
+		{
+			name:          "valid partition",
+			partitionName: "test_analysis_by_job_by_dates_2024_10_29",
+			wantTableName: "test_analysis_by_job_by_dates",
+			wantError:     false,
+		},
+		{
+			name:          "different table",
+			partitionName: "prow_job_runs_2024_01_15",
+			wantTableName: "prow_job_runs",
+			wantError:     false,
+		},
+		{
+			name:          "too short",
+			partitionName: "short",
+			wantTableName: "",
+			wantError:     true,
+		},
+		{
+			name:          "invalid date",
+			partitionName: "table_name_invalid_date",
+			wantTableName: "",
+			wantError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractTableNameFromPartition(tt.partitionName)
+			if (err != nil) != tt.wantError {
+				t.Errorf("extractTableNameFromPartition() error = %v, wantError %v", err, tt.wantError)
+				return
+			}
+			if got != tt.wantTableName {
+				t.Errorf("extractTableNameFromPartition() = %v, want %v", got, tt.wantTableName)
+			}
+		})
+	}
+}
+
+func TestIsValidPartitionName(t *testing.T) {
+	tests := []struct {
+		name          string
+		tableName     string
+		partitionName string
+		want          bool
+	}{
+		{
+			name:          "valid partition",
+			tableName:     "test_table",
+			partitionName: "test_table_2024_10_29",
+			want:          true,
+		},
+		{
+			name:          "wrong table name",
+			tableName:     "test_table",
+			partitionName: "other_table_2024_10_29",
+			want:          false,
+		},
+		{
+			name:          "invalid date",
+			tableName:     "test_table",
+			partitionName: "test_table_2024_13_40",
+			want:          false,
+		},
+		{
+			name:          "wrong length",
+			tableName:     "test_table",
+			partitionName: "test_table_2024_10",
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isValidPartitionName(tt.tableName, tt.partitionName)
+			if got != tt.want {
+				t.Errorf("isValidPartitionName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPartitionConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  PartitionConfig
+		wantErr bool
+	}{
+		{
+			name:    "valid RANGE config",
+			config:  NewRangePartitionConfig("created_at"),
+			wantErr: false,
+		},
+		{
+			name:    "valid LIST config",
+			config:  NewListPartitionConfig("region"),
+			wantErr: false,
+		},
+		{
+			name:    "valid HASH config",
+			config:  NewHashPartitionConfig(4, "user_id"),
+			wantErr: false,
+		},
+		{
+			name: "invalid - no strategy",
+			config: PartitionConfig{
+				Columns: []string{"created_at"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid - no columns",
+			config: PartitionConfig{
+				Strategy: PartitionStrategyRange,
+				Columns:  []string{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid - RANGE with multiple columns",
+			config: PartitionConfig{
+				Strategy: PartitionStrategyRange,
+				Columns:  []string{"col1", "col2"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid - HASH with no modulus",
+			config: PartitionConfig{
+				Strategy: PartitionStrategyHash,
+				Columns:  []string{"user_id"},
+				Modulus:  0,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PartitionConfig.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPartitionConfigToSQL(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   PartitionConfig
+		expected string
+	}{
+		{
+			name:     "RANGE partition",
+			config:   NewRangePartitionConfig("created_at"),
+			expected: "PARTITION BY RANGE (created_at)",
+		},
+		{
+			name:     "LIST partition",
+			config:   NewListPartitionConfig("region"),
+			expected: "PARTITION BY LIST (region)",
+		},
+		{
+			name:     "HASH partition single column",
+			config:   NewHashPartitionConfig(4, "user_id"),
+			expected: "PARTITION BY HASH (user_id)",
+		},
+		{
+			name:     "HASH partition multiple columns",
+			config:   NewHashPartitionConfig(8, "user_id", "tenant_id"),
+			expected: "PARTITION BY HASH (user_id, tenant_id)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.ToSQL()
+			if got != tt.expected {
+				t.Errorf("PartitionConfig.ToSQL() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPrimaryKeyConstraint(t *testing.T) {
+	// This test documents that primary keys should get PRIMARY KEY constraint
+	// and NOT NULL constraint in the generated SQL
+
+	// In CreatePartitionedTable:
+	// 1. Collect all primary key columns
+	// 2. Add NOT NULL to each primary key column definition
+	// 3. Add PRIMARY KEY (col1, col2, ...) constraint
+	// 4. For partitioned tables, ensure partition columns are in the primary key
+
+	type TestModel struct {
+		ID        uint   `gorm:"primaryKey"` // Should get NOT NULL and be in PRIMARY KEY constraint
+		Name      string `gorm:"not null"`   // Should get NOT NULL from explicit tag
+		Age       int    // Should NOT get NOT NULL
+		CreatedAt string // For partition column
+	}
+
+	// Verify the struct can be instantiated
+	var model TestModel
+	model.ID = 1
+
+	if model.ID != 1 {
+		t.Error("model instantiation failed")
+	}
+
+	// The expected SQL should contain:
+	// - id bigint NOT NULL
+	// - PRIMARY KEY (id, created_at)  -- includes partition column
+	// This is verified in integration tests with actual database
+}
+
+func TestAutoIncrementHandling(t *testing.T) {
+	// This test documents that AutoIncrement fields should get GENERATED BY DEFAULT AS IDENTITY
+	// and AutoIncrementIncrement should be respected
+
+	// In CreatePartitionedTable:
+	// 1. Check if field.AutoIncrement is true
+	// 2. If yes, add GENERATED BY DEFAULT AS IDENTITY
+	// 3. If AutoIncrementIncrement > 0, add INCREMENT BY clause
+	// 4. IDENTITY columns are automatically NOT NULL
+
+	type TestModelWithAutoIncrement struct {
+		ID        uint   `gorm:"primaryKey;autoIncrement"` // Should get GENERATED BY DEFAULT AS IDENTITY
+		Name      string `gorm:"not null"`
+		CreatedAt string // For partition column
+	}
+
+	type TestModelWithIncrementBy struct {
+		ID        uint   `gorm:"primaryKey;autoIncrement;autoIncrementIncrement:10"` // Should get INCREMENT BY 10
+		Name      string `gorm:"not null"`
+		CreatedAt string
+	}
+
+	// Verify the structs can be instantiated
+	var model1 TestModelWithAutoIncrement
+	model1.Name = "test"
+
+	var model2 TestModelWithIncrementBy
+	model2.Name = "test"
+
+	if model1.Name != "test" || model2.Name != "test" {
+		t.Error("model instantiation failed")
+	}
+
+	// The expected SQL should contain:
+	// For TestModelWithAutoIncrement:
+	// - id bigint GENERATED BY DEFAULT AS IDENTITY
+	//
+	// For TestModelWithIncrementBy:
+	// - id bigint GENERATED BY DEFAULT AS IDENTITY (INCREMENT BY 10)
+	//
+	// This is verified in integration tests with actual database
+}
+
+func TestGormTypeToPostgresType(t *testing.T) {
+	tests := []struct {
+		name     string
+		gormType string
+		expected string
+	}{
+		// Integer types
+		{
+			name:     "uint to bigint",
+			gormType: "uint",
+			expected: "bigint",
+		},
+		{
+			name:     "uint8 to smallint",
+			gormType: "uint8",
+			expected: "smallint",
+		},
+		{
+			name:     "uint16 to integer",
+			gormType: "uint16",
+			expected: "integer",
+		},
+		{
+			name:     "uint32 to bigint",
+			gormType: "uint32",
+			expected: "bigint",
+		},
+		{
+			name:     "uint64 to bigint",
+			gormType: "uint64",
+			expected: "bigint",
+		},
+		{
+			name:     "int to bigint",
+			gormType: "int",
+			expected: "bigint",
+		},
+		{
+			name:     "int64 to bigint",
+			gormType: "int64",
+			expected: "bigint",
+		},
+		// Float types
+		{
+			name:     "float to double precision",
+			gormType: "float",
+			expected: "double precision",
+		},
+		{
+			name:     "float32 to real",
+			gormType: "float32",
+			expected: "real",
+		},
+		{
+			name:     "float64 to double precision",
+			gormType: "float64",
+			expected: "double precision",
+		},
+		// String types
+		{
+			name:     "string to text",
+			gormType: "string",
+			expected: "text",
+		},
+		// Boolean
+		{
+			name:     "bool to boolean",
+			gormType: "bool",
+			expected: "boolean",
+		},
+		// Time types
+		{
+			name:     "time.time to timestamptz",
+			gormType: "time.time",
+			expected: "timestamp with time zone",
+		},
+		{
+			name:     "time to timestamptz",
+			gormType: "time",
+			expected: "timestamp with time zone",
+		},
+		// Binary
+		{
+			name:     "[]byte to bytea",
+			gormType: "[]byte",
+			expected: "bytea",
+		},
+		// JSON
+		{
+			name:     "json to jsonb",
+			gormType: "json",
+			expected: "jsonb",
+		},
+		// PostgreSQL types should pass through
+		{
+			name:     "varchar remains varchar",
+			gormType: "varchar",
+			expected: "varchar",
+		},
+		{
+			name:     "character varying remains",
+			gormType: "character varying",
+			expected: "character varying",
+		},
+		{
+			name:     "timestamptz remains",
+			gormType: "timestamptz",
+			expected: "timestamptz",
+		},
+		// Case insensitive
+		{
+			name:     "UINT to bigint",
+			gormType: "UINT",
+			expected: "bigint",
+		},
+		{
+			name:     "String to text",
+			gormType: "String",
+			expected: "text",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gormTypeToPostgresType(tt.gormType)
+			if got != tt.expected {
+				t.Errorf("gormTypeToPostgresType(%q) = %q, want %q", tt.gormType, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestColumnDeduplication(t *testing.T) {
+	// This test documents that CreatePartitionedTable and UpdatePartitionedTable
+	// deduplicate columns to prevent the same column from appearing multiple times
+	// in the generated SQL.
+
+	// GORM's stmt.Schema.Fields can contain duplicate fields in certain cases:
+	// - Embedded structs with same field names
+	// - Field tags that create virtual fields
+	// - Polymorphic associations
+	// - Custom scanners/valuers
+
+	// Example GORM model that might produce duplicates:
+	// type Model struct {
+	//     gorm.Model  // Contains CreatedAt, UpdatedAt, DeletedAt
+	//     CreatedAt time.Time `gorm:"index"`  // Duplicate!
+	//     DeletedAt gorm.DeletedAt
+	// }
+
+	// Without deduplication, this would generate:
+	// CREATE TABLE (...
+	//     created_at timestamp with time zone,
+	//     updated_at timestamp with time zone,
+	//     deleted_at timestamp with time zone,
+	//     created_at timestamp with time zone,  -- DUPLICATE!
+	//     deleted_at timestamp with time zone,  -- DUPLICATE!
+	//     ...
+	// )
+
+	// With deduplication (current implementation):
+	// CREATE TABLE (...
+	//     created_at timestamp with time zone,
+	//     updated_at timestamp with time zone,
+	//     deleted_at timestamp with time zone,
+	//     ... // No duplicates
+	// )
+
+	// The deduplication logic uses a map to track which columns have been added:
+	// - addedColumns[field.DBName] tracks columns in CreatePartitionedTable
+	// - processedColumns[field.DBName] tracks columns in UpdatePartitionedTable
+	// - First occurrence of a column is used, subsequent duplicates are skipped
+
+	t.Log("Column deduplication documented - prevents duplicate columns in generated SQL")
+}

--- a/pkg/db/utils.go
+++ b/pkg/db/utils.go
@@ -1,0 +1,2157 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+	log "github.com/sirupsen/logrus"
+)
+
+// ColumnInfo represents metadata about a database column
+type ColumnInfo struct {
+	ColumnName    string
+	DataType      string
+	IsNullable    string
+	ColumnDefault sql.NullString
+	OrdinalPos    int
+}
+
+// PartitionStrategy defines the partitioning strategy type
+type PartitionStrategy string
+
+const (
+	// PartitionStrategyRange partitions by value ranges (e.g., date ranges)
+	PartitionStrategyRange PartitionStrategy = "RANGE"
+	// PartitionStrategyList partitions by discrete value lists
+	PartitionStrategyList PartitionStrategy = "LIST"
+	// PartitionStrategyHash partitions by hash of partition key
+	PartitionStrategyHash PartitionStrategy = "HASH"
+)
+
+// ColumnVerificationOptions controls which aspects of column definitions to verify
+type ColumnVerificationOptions struct {
+	// CheckNullable verifies that columns have matching nullable constraints
+	CheckNullable bool
+	// CheckDefaults verifies that columns have matching default values
+	CheckDefaults bool
+	// CheckOrder verifies that columns are in the same ordinal position
+	CheckOrder bool
+	// OmitColumns lists column names to exclude from verification
+	OmitColumns []string
+}
+
+// DataMigrationColumnVerificationOptions returns options suitable for data migrations
+// (only checks column names and types, not constraints or defaults)
+func DataMigrationColumnVerificationOptions() ColumnVerificationOptions {
+	return ColumnVerificationOptions{
+		CheckNullable: false,
+		CheckDefaults: false,
+		CheckOrder:    false,
+	}
+}
+
+// VerifyTablesHaveSameColumns verifies that two tables have identical column definitions
+// Returns nil if the tables have the same columns, or an error describing the differences
+//
+// This function checks column names and data types by default. Use options parameter
+// to control whether nullable constraints, default values, and column order are verified.
+func (dbc *DB) VerifyTablesHaveSameColumns(table1, table2 string, opts ColumnVerificationOptions) error {
+	log.WithFields(log.Fields{
+		"table1": table1,
+		"table2": table2,
+	}).Debug("verifying tables have same columns")
+
+	// Get columns for both tables
+	cols1, err := dbc.GetTableColumns(table1)
+	if err != nil {
+		return fmt.Errorf("failed to get columns for table %s: %w", table1, err)
+	}
+
+	cols2, err := dbc.GetTableColumns(table2)
+	if err != nil {
+		return fmt.Errorf("failed to get columns for table %s: %w", table2, err)
+	}
+
+	// Filter out omitted columns
+	if len(opts.OmitColumns) > 0 {
+		omit := make(map[string]bool, len(opts.OmitColumns))
+		for _, col := range opts.OmitColumns {
+			omit[col] = true
+		}
+		cols1 = filterColumns(cols1, omit)
+		cols2 = filterColumns(cols2, omit)
+	}
+
+	// Check if column counts match
+	if len(cols1) != len(cols2) {
+		return fmt.Errorf("column count mismatch: %s has %d columns, %s has %d columns",
+			table1, len(cols1), table2, len(cols2))
+	}
+
+	// Create maps for easier comparison
+	cols1Map := make(map[string]ColumnInfo)
+	for _, col := range cols1 {
+		cols1Map[col.ColumnName] = col
+	}
+
+	cols2Map := make(map[string]ColumnInfo)
+	for _, col := range cols2 {
+		cols2Map[col.ColumnName] = col
+	}
+
+	// Check for missing columns
+	var missingInTable2 []string
+	for colName := range cols1Map {
+		if _, exists := cols2Map[colName]; !exists {
+			missingInTable2 = append(missingInTable2, colName)
+		}
+	}
+
+	var missingInTable1 []string
+	for colName := range cols2Map {
+		if _, exists := cols1Map[colName]; !exists {
+			missingInTable1 = append(missingInTable1, colName)
+		}
+	}
+
+	if len(missingInTable1) > 0 || len(missingInTable2) > 0 {
+		var errMsg strings.Builder
+		errMsg.WriteString("column name mismatch:")
+		if len(missingInTable2) > 0 {
+			errMsg.WriteString(fmt.Sprintf(" columns in %s but not in %s: %v;",
+				table1, table2, missingInTable2))
+		}
+		if len(missingInTable1) > 0 {
+			errMsg.WriteString(fmt.Sprintf(" columns in %s but not in %s: %v",
+				table2, table1, missingInTable1))
+		}
+		return errors.New(errMsg.String())
+	}
+
+	// Compare column definitions for matching columns
+	var differences []string
+	for colName, col1 := range cols1Map {
+		col2 := cols2Map[colName]
+
+		// Normalize data types for comparison
+		type1 := normalizeDataType(col1.DataType)
+		type2 := normalizeDataType(col2.DataType)
+
+		if !strings.EqualFold(type1, type2) {
+			differences = append(differences,
+				fmt.Sprintf("column %s: type mismatch (%s: %s vs %s: %s)",
+					colName, table1, col1.DataType, table2, col2.DataType))
+		}
+
+		// Optional: Check nullable constraints
+		if opts.CheckNullable && col1.IsNullable != col2.IsNullable {
+			differences = append(differences,
+				fmt.Sprintf("column %s: nullable mismatch (%s: %s vs %s: %s)",
+					colName, table1, col1.IsNullable, table2, col2.IsNullable))
+		}
+
+		// Optional: Compare defaults
+		if opts.CheckDefaults {
+			default1 := ""
+			if col1.ColumnDefault.Valid {
+				default1 = col1.ColumnDefault.String
+			}
+			default2 := ""
+			if col2.ColumnDefault.Valid {
+				default2 = col2.ColumnDefault.String
+			}
+
+			if default1 != default2 {
+				differences = append(differences,
+					fmt.Sprintf("column %s: default mismatch (%s: %q vs %s: %q)",
+						colName, table1, default1, table2, default2))
+			}
+		}
+
+		// Optional: Check ordinal position (column order)
+		if opts.CheckOrder && col1.OrdinalPos != col2.OrdinalPos {
+			differences = append(differences,
+				fmt.Sprintf("column %s: position mismatch (%s: pos %d vs %s: pos %d)",
+					colName, table1, col1.OrdinalPos, table2, col2.OrdinalPos))
+		}
+	}
+
+	if len(differences) > 0 {
+		return fmt.Errorf("column definition mismatches:\n  - %s",
+			strings.Join(differences, "\n  - "))
+	}
+
+	log.WithFields(log.Fields{
+		"table1": table1,
+		"table2": table2,
+		"count":  len(cols1),
+	}).Info("tables have identical columns")
+
+	return nil
+}
+
+func filterColumns(cols []ColumnInfo, omit map[string]bool) []ColumnInfo {
+	filtered := make([]ColumnInfo, 0, len(cols))
+	for _, col := range cols {
+		if !omit[col.ColumnName] {
+			filtered = append(filtered, col)
+		}
+	}
+	return filtered
+}
+
+// GetTableColumns retrieves column information for a table from pg_catalog
+// Uses format_type() to preserve precise type definitions including:
+// - Length modifiers: varchar(64) vs varchar(255)
+// - Precision/scale: numeric(8,2) vs numeric(20,10)
+// - Enum type names: user_role instead of USER-DEFINED
+// - Array types: integer[] vs integer
+func (dbc *DB) GetTableColumns(tableName string) ([]ColumnInfo, error) {
+	var columns []ColumnInfo
+
+	// Use pg_catalog to get precise type information including modifiers
+	// format_type() preserves varchar(64) vs varchar(255), numeric(8,2) vs numeric(20,10), etc.
+	query := `
+		SELECT
+			a.attname AS column_name,
+			format_type(a.atttypid, a.atttypmod) AS data_type,
+			CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS is_nullable,
+			pg_get_expr(d.adbin, d.adrelid) AS column_default,
+			a.attnum AS ordinal_position
+		FROM pg_catalog.pg_attribute a
+		JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+		JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+		LEFT JOIN pg_catalog.pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
+		WHERE c.relname = @table_name
+			AND n.nspname = 'public'
+			AND a.attnum > 0
+			AND NOT a.attisdropped
+		ORDER BY a.attnum
+	`
+
+	result := dbc.DB.Raw(query, sql.Named("table_name", tableName)).Scan(&columns)
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to query columns for table %s: %w", tableName, result.Error)
+	}
+
+	if len(columns) == 0 {
+		return nil, fmt.Errorf("table %s does not exist or has no columns", tableName)
+	}
+
+	return columns, nil
+}
+
+func quoteIdentifierList(names []string) string {
+	quoted := make([]string, 0, len(names))
+	for _, n := range names {
+		quoted = append(quoted, pq.QuoteIdentifier(n))
+	}
+	return strings.Join(quoted, ", ")
+}
+
+// MigrateTableData migrates all data from sourceTable to targetTable after verifying schemas match
+// This function performs the following steps:
+// 1. Verifies that both tables have identical column definitions
+// 2. Checks row counts in both tables
+// 3. Copies all data from source to target using INSERT INTO ... SELECT
+// 4. Verifies row counts after migration
+//
+// Parameters:
+// - sourceTable: The table to copy data from
+// - targetTable: The table to copy data to
+// - omitColumns: List of column names to omit from migration (e.g., ["id"] to use target's auto-increment)
+// - dryRun: If true, only verifies schemas and reports what would be migrated without actually copying data
+//
+// Returns:
+// - rowsMigrated: The number of rows successfully migrated (0 if dryRun is true)
+// - error: Any error encountered during migration
+func (dbc *DB) MigrateTableData(sourceTable, targetTable string, omitColumns []string, dryRun bool) (int64, error) {
+	log.WithFields(log.Fields{
+		"source":  sourceTable,
+		"target":  targetTable,
+		"dry_run": dryRun,
+	}).Info("starting table data migration")
+
+	// Step 1: Verify schemas match
+	// For data migration, we only need to verify column names and types
+	// Nullable constraints and defaults don't affect the migration itself
+	if err := dbc.VerifyTablesHaveSameColumns(sourceTable, targetTable, DataMigrationColumnVerificationOptions()); err != nil {
+		return 0, fmt.Errorf("schema verification failed: %w", err)
+	}
+
+	log.Info("schema verification passed - tables have identical column definitions")
+
+	// Step 2: Get row counts before migration
+	sourceCount, err := dbc.GetTableRowCount(sourceTable)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get source table row count: %w", err)
+	}
+
+	targetCountBefore, err := dbc.GetTableRowCount(targetTable)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get target table row count: %w", err)
+	}
+
+	log.WithFields(log.Fields{
+		"source_rows": sourceCount,
+		"target_rows": targetCountBefore,
+	}).Info("row counts before migration")
+
+	if sourceCount == 0 {
+		log.Warn("source table is empty - nothing to migrate")
+		return 0, nil
+	}
+
+	// Step 3: Dry run - report what would be migrated
+	if dryRun {
+		log.WithFields(log.Fields{
+			"source_table":   sourceTable,
+			"target_table":   targetTable,
+			"rows_to_copy":   sourceCount,
+			"target_current": targetCountBefore,
+		}).Info("[DRY RUN] would migrate data")
+		return 0, nil
+	}
+
+	// Step 4: Get column names for the INSERT statement
+	columns, err := dbc.GetTableColumns(sourceTable)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get column list: %w", err)
+	}
+
+	// Create a map of columns to omit for quick lookup
+	omitMap := make(map[string]bool)
+	for _, col := range omitColumns {
+		omitMap[col] = true
+	}
+
+	// Build column list, excluding omitted columns
+	var columnNames []string
+	for _, col := range columns {
+		if !omitMap[col.ColumnName] {
+			columnNames = append(columnNames, col.ColumnName)
+		}
+	}
+
+	if len(columnNames) == 0 {
+		return 0, fmt.Errorf("no columns to migrate after omitting %v", omitColumns)
+	}
+
+	// Step 5: Perform the migration using INSERT INTO ... SELECT
+	// This is done in a single statement for efficiency and atomicity
+	columnList := quoteIdentifierList(columnNames)
+	insertSQL := fmt.Sprintf(
+		"INSERT INTO %s (%s) SELECT %s FROM %s",
+		pq.QuoteIdentifier(targetTable),
+		columnList,
+		columnList,
+		pq.QuoteIdentifier(sourceTable),
+	)
+
+	log.WithFields(log.Fields{
+		"source": sourceTable,
+		"target": targetTable,
+		"rows":   sourceCount,
+	}).Info("migrating data")
+
+	result := dbc.DB.Exec(insertSQL)
+	if result.Error != nil {
+		return 0, fmt.Errorf("data migration failed: %w", result.Error)
+	}
+
+	rowsAffected := result.RowsAffected
+
+	// Step 6: Verify migration success
+	targetCountAfter, err := dbc.GetTableRowCount(targetTable)
+	if err != nil {
+		return rowsAffected, fmt.Errorf("migration completed but failed to verify: %w", err)
+	}
+
+	expectedCount := targetCountBefore + sourceCount
+	if targetCountAfter != expectedCount {
+		log.WithFields(log.Fields{
+			"expected": expectedCount,
+			"actual":   targetCountAfter,
+			"source":   sourceCount,
+			"target":   targetCountBefore,
+		}).Warn("row count mismatch after migration")
+	}
+
+	log.WithFields(log.Fields{
+		"source_table":        sourceTable,
+		"target_table":        targetTable,
+		"rows_migrated":       rowsAffected,
+		"target_count_before": targetCountBefore,
+		"target_count_after":  targetCountAfter,
+	}).Info("data migration completed successfully")
+
+	return rowsAffected, nil
+}
+
+// MigrateTableDataRange migrates data within a specific date range from sourceTable to targetTable
+// This function performs the following steps:
+// 1. Verifies that both tables have identical column definitions
+// 2. Checks if target table is partitioned and verifies partition coverage for the date range
+// 3. Counts rows in the date range
+// 4. Copies data within the date range from source to target using INSERT INTO ... SELECT ... WHERE
+// 5. Verifies row counts after migration
+//
+// If the target table is RANGE partitioned, the function automatically verifies that all necessary
+// partitions exist for the date range being migrated. This prevents migration failures due to missing partitions.
+//
+// Parameters:
+// - sourceTable: The table to copy data from
+// - targetTable: The table to copy data to
+// - dateColumn: The column name to filter by date range (e.g., "created_at")
+// - startDate: Start of date range (inclusive)
+// - endDate: End of date range (exclusive)
+// - omitColumns: List of column names to omit from migration (e.g., ["id"] to use target's auto-increment)
+// - dryRun: If true, only verifies schemas and reports what would be migrated without actually copying data
+//
+// Returns:
+// - rowsMigrated: The number of rows successfully migrated (0 if dryRun is true)
+// - error: Any error encountered during migration
+//
+// Example:
+//
+//	startDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+//	endDate := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+//	rows, err := dbc.MigrateTableDataRange("old_table", "new_table", "created_at", startDate, endDate, nil, false)
+func (dbc *DB) MigrateTableDataRange(sourceTable, targetTable, dateColumn string, startDate, endDate time.Time, omitColumns []string, dryRun bool) (int64, error) {
+	log.WithFields(log.Fields{
+		"source":      sourceTable,
+		"target":      targetTable,
+		"date_column": dateColumn,
+		"start_date":  startDate.Format("2006-01-02"),
+		"end_date":    endDate.Format("2006-01-02"),
+		"dry_run":     dryRun,
+	}).Info("starting table data migration for date range")
+
+	// Validate date range
+	if endDate.Before(startDate) {
+		return 0, fmt.Errorf("end date (%s) cannot be before start date (%s)",
+			endDate.Format("2006-01-02"), startDate.Format("2006-01-02"))
+	}
+
+	// Step 1: Verify schemas match
+	// For data migration, we only need to verify column names and types
+	// Nullable constraints and defaults don't affect the migration itself
+	if err := dbc.VerifyTablesHaveSameColumns(sourceTable, targetTable, DataMigrationColumnVerificationOptions()); err != nil {
+		return 0, fmt.Errorf("schema verification failed: %w", err)
+	}
+
+	log.Info("schema verification passed - tables have identical column definitions")
+
+	// Step 2: Check if target table is partitioned and verify partition coverage
+	partitionStrategy, err := dbc.GetPartitionStrategy(targetTable)
+	if err != nil {
+		return 0, fmt.Errorf("failed to check if target table is partitioned: %w", err)
+	}
+
+	if partitionStrategy != "" {
+		log.WithFields(log.Fields{
+			"table":    targetTable,
+			"strategy": partitionStrategy,
+		}).Info("target table is partitioned - verifying partition coverage")
+
+		// For RANGE partitioned tables, verify that partitions exist for the date range
+		if partitionStrategy == PartitionStrategyRange {
+			if err := dbc.VerifyPartitionCoverage(targetTable, startDate, endDate); err != nil {
+				return 0, fmt.Errorf("partition coverage verification failed: %w", err)
+			}
+			log.Info("partition coverage verified - all required partitions exist")
+		} else {
+			log.WithField("strategy", partitionStrategy).Warn("target table uses non-RANGE partitioning - skipping partition coverage check")
+		}
+	}
+
+	// Step 3: Count rows in the date range in source table
+	var sourceCount int64
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s >= @start_date AND %s < @end_date",
+		pq.QuoteIdentifier(sourceTable), pq.QuoteIdentifier(dateColumn), pq.QuoteIdentifier(dateColumn))
+	result := dbc.DB.Raw(countQuery, sql.Named("start_date", startDate), sql.Named("end_date", endDate)).Scan(&sourceCount)
+	if result.Error != nil {
+		return 0, fmt.Errorf("failed to count rows in date range: %w", result.Error)
+	}
+
+	// Get total target row count before migration
+	targetCountBefore, err := dbc.GetTableRowCount(targetTable)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get target table row count: %w", err)
+	}
+
+	log.WithFields(log.Fields{
+		"source_rows_in_range": sourceCount,
+		"target_rows":          targetCountBefore,
+		"start_date":           startDate.Format("2006-01-02"),
+		"end_date":             endDate.Format("2006-01-02"),
+	}).Info("row counts before migration")
+
+	if sourceCount == 0 {
+		log.Warn("no rows in date range - nothing to migrate")
+		return 0, nil
+	}
+
+	// Step 4: Dry run - report what would be migrated
+	if dryRun {
+		log.WithFields(log.Fields{
+			"source_table":   sourceTable,
+			"target_table":   targetTable,
+			"rows_to_copy":   sourceCount,
+			"target_current": targetCountBefore,
+			"date_range":     fmt.Sprintf("%s to %s", startDate.Format("2006-01-02"), endDate.Format("2006-01-02")),
+		}).Info("[DRY RUN] would migrate data")
+		return 0, nil
+	}
+
+	// Step 5: Get column names for the INSERT statement
+	columns, err := dbc.GetTableColumns(sourceTable)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get column list: %w", err)
+	}
+
+	// Create a map of columns to omit for quick lookup
+	omitMap := make(map[string]bool)
+	for _, col := range omitColumns {
+		omitMap[col] = true
+	}
+
+	// Build column list, excluding omitted columns
+	var columnNames []string
+	for _, col := range columns {
+		if !omitMap[col.ColumnName] {
+			columnNames = append(columnNames, col.ColumnName)
+		}
+	}
+
+	if len(columnNames) == 0 {
+		return 0, fmt.Errorf("no columns to migrate after omitting %v", omitColumns)
+	}
+
+	// Step 6: Perform the migration using INSERT INTO ... SELECT ... WHERE
+	// This is done in a single statement for efficiency and atomicity
+	columnList := quoteIdentifierList(columnNames)
+	insertSQL := fmt.Sprintf(
+		"INSERT INTO %s (%s) SELECT %s FROM %s WHERE %s >= @start_date AND %s < @end_date",
+		pq.QuoteIdentifier(targetTable),
+		columnList,
+		columnList,
+		pq.QuoteIdentifier(sourceTable),
+		pq.QuoteIdentifier(dateColumn),
+		pq.QuoteIdentifier(dateColumn))
+
+	log.WithFields(log.Fields{
+		"source":     sourceTable,
+		"target":     targetTable,
+		"rows":       sourceCount,
+		"start_date": startDate.Format("2006-01-02"),
+		"end_date":   endDate.Format("2006-01-02"),
+	}).Info("migrating data in date range")
+
+	result = dbc.DB.Exec(insertSQL, sql.Named("start_date", startDate), sql.Named("end_date", endDate))
+	if result.Error != nil {
+		return 0, fmt.Errorf("data migration failed: %w", result.Error)
+	}
+
+	rowsAffected := result.RowsAffected
+
+	// Step 7: Verify migration success
+	targetCountAfter, err := dbc.GetTableRowCount(targetTable)
+	if err != nil {
+		return rowsAffected, fmt.Errorf("migration completed but failed to verify: %w", err)
+	}
+
+	expectedCount := targetCountBefore + sourceCount
+	if targetCountAfter != expectedCount {
+		log.WithFields(log.Fields{
+			"expected":             expectedCount,
+			"actual":               targetCountAfter,
+			"source_in_range":      sourceCount,
+			"target_before":        targetCountBefore,
+			"rows_actually_copied": rowsAffected,
+		}).Warn("row count mismatch after migration")
+	}
+
+	log.WithFields(log.Fields{
+		"source_table":        sourceTable,
+		"target_table":        targetTable,
+		"rows_migrated":       rowsAffected,
+		"target_count_before": targetCountBefore,
+		"target_count_after":  targetCountAfter,
+		"start_date":          startDate.Format("2006-01-02"),
+		"end_date":            endDate.Format("2006-01-02"),
+	}).Info("data migration completed successfully")
+
+	return rowsAffected, nil
+}
+
+// GetPartitionStrategy checks if a table is partitioned and returns its partition strategy
+// Returns empty string ("") if table is not partitioned
+// Returns PartitionStrategyRange, PartitionStrategyList, PartitionStrategyHash, or "UNKNOWN" if partitioned
+//
+// Example:
+//
+//	strategy, err := dbc.GetPartitionStrategy("orders")
+//	if err != nil {
+//	    return err
+//	}
+//	if strategy == PartitionStrategyRange {
+//	    // Handle RANGE partitioned table
+//	}
+func (dbc *DB) GetPartitionStrategy(tableName string) (PartitionStrategy, error) {
+	var strategy string
+
+	query := `
+		SELECT
+			CASE pp.partstrat
+				WHEN 'r' THEN 'RANGE'
+				WHEN 'l' THEN 'LIST'
+				WHEN 'h' THEN 'HASH'
+				ELSE 'UNKNOWN'
+			END AS partition_strategy
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		JOIN pg_partitioned_table pp ON pp.partrelid = c.oid
+		WHERE n.nspname = 'public'
+			AND c.relname = @table_name
+	`
+
+	result := dbc.DB.Raw(query, sql.Named("table_name", tableName)).Scan(&strategy)
+	if result.Error != nil {
+		return "", fmt.Errorf("failed to check partition strategy: %w", result.Error)
+	}
+
+	// If no rows returned, table is not partitioned
+	if result.RowsAffected == 0 {
+		return "", nil
+	}
+
+	return PartitionStrategy(strategy), nil
+}
+
+// partitionDateInfo holds date range information for a partition
+type partitionDateInfo struct {
+	PartitionName string
+	PartitionDate time.Time
+}
+
+// getPartitionsInDateRange returns all partitions that cover a date range
+// Assumes daily partitions with naming convention: tablename_YYYY_MM_DD
+func (dbc *DB) getPartitionsInDateRange(tableName string, startDate, endDate time.Time) ([]partitionDateInfo, error) {
+	var partitions []partitionDateInfo
+
+	// Query only attached partitions using pg_inherits
+	// Detached partitions won't appear in pg_inherits
+	query := `
+		WITH attached_partitions AS (
+			SELECT c.relname AS tablename
+			FROM pg_inherits i
+			JOIN pg_class c ON i.inhrelid = c.oid
+			JOIN pg_class p ON i.inhparent = p.oid
+			WHERE p.relname = @table_name
+		)
+		SELECT
+			tablename AS partition_name,
+			TO_DATE(SUBSTRING(tablename FROM '_(\d{4}_\d{2}_\d{2})$'), 'YYYY_MM_DD') AS partition_date
+		FROM pg_tables
+		WHERE schemaname = 'public'
+			AND tablename IN (SELECT tablename FROM attached_partitions)
+			AND tablename ~ @regex_pattern
+		ORDER BY partition_date
+	`
+
+	regexPattern := tableName + "_\\d{4}_\\d{2}_\\d{2}$"
+
+	result := dbc.DB.Raw(query,
+		sql.Named("table_name", tableName),
+		sql.Named("regex_pattern", regexPattern),
+	).Scan(&partitions)
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to query partitions: %w", result.Error)
+	}
+
+	// Normalize bounds to calendar days so that timestamps within a day
+	// don't exclude the partition for that day (PartitionDate is midnight).
+	startDay := startDate.Truncate(24 * time.Hour)
+	endDay := endDate.Truncate(24 * time.Hour)
+
+	// Filter to only partitions in the date range
+	var filtered []partitionDateInfo
+	for _, p := range partitions {
+		if (p.PartitionDate.Equal(startDay) || p.PartitionDate.After(startDay)) &&
+			(p.PartitionDate.Equal(endDay) || p.PartitionDate.Before(endDay)) {
+			filtered = append(filtered, p)
+		}
+	}
+
+	return filtered, nil
+}
+
+// VerifyPartitionCoverage verifies that all necessary partitions exist for a date range
+// Assumes daily partitions with naming convention: tablename_YYYY_MM_DD
+//
+// This function is useful before migrating data to partitioned tables to ensure
+// all required partitions exist, preventing INSERT failures.
+func (dbc *DB) VerifyPartitionCoverage(tableName string, startDate, endDate time.Time) error {
+	partitions, err := dbc.getPartitionsInDateRange(tableName, startDate, endDate)
+	if err != nil {
+		return fmt.Errorf("failed to get partitions: %w", err)
+	}
+
+	// Create a map of existing partition dates for quick lookup
+	existingDates := make(map[string]bool)
+	for _, p := range partitions {
+		dateStr := p.PartitionDate.Format("2006-01-02")
+		existingDates[dateStr] = true
+	}
+
+	// Normalize to calendar days so timestamps within a day are handled correctly
+	startDay := startDate.Truncate(24 * time.Hour)
+	endDay := endDate.Truncate(24 * time.Hour)
+
+	// Check that we have a partition for each day in the range
+	var missingDates []string
+	currentDate := startDay
+	for !currentDate.After(endDay) {
+		dateStr := currentDate.Format("2006-01-02")
+		if !existingDates[dateStr] {
+			missingDates = append(missingDates, dateStr)
+		}
+		currentDate = currentDate.AddDate(0, 0, 1) // Move to next day
+	}
+
+	if len(missingDates) > 0 {
+		return fmt.Errorf("missing partitions for dates: %v", missingDates)
+	}
+
+	log.WithFields(log.Fields{
+		"table":           tableName,
+		"partition_count": len(partitions),
+		"start_date":      startDate.Format("2006-01-02"),
+		"end_date":        endDate.Format("2006-01-02"),
+	}).Info("verified partition coverage for date range")
+
+	return nil
+}
+
+// GetTableRowCount returns the number of rows in a table
+// This is useful for:
+// - Verifying table size before operations
+// - Comparing source and target tables during migration
+// - Monitoring table growth
+func (dbc *DB) GetTableRowCount(tableName string) (int64, error) {
+	var count int64
+
+	query := fmt.Sprintf("SELECT COUNT(*) FROM %s", pq.QuoteIdentifier(tableName))
+	result := dbc.DB.Raw(query).Scan(&count)
+	if result.Error != nil {
+		return 0, fmt.Errorf("failed to count rows in table %s: %w", tableName, result.Error)
+	}
+
+	return count, nil
+}
+
+// SequenceInfo represents information about a sequence associated with a table column
+type SequenceInfo struct {
+	SequenceName string
+	TableName    string
+	ColumnName   string
+}
+
+// PartitionTableInfo represents information about a table partition
+type PartitionTableInfo struct {
+	PartitionName string
+	ParentTable   string
+}
+
+// ConstraintInfo represents information about a table constraint
+type ConstraintInfo struct {
+	ConstraintName string
+	TableName      string
+	ConstraintType string // 'p'=primary key, 'f'=foreign key, 'u'=unique, 'c'=check, 'x'=exclusion
+	Definition     string // Full constraint definition
+}
+
+// GetTableConstraints returns all constraints for a table
+// This includes primary keys, foreign keys, unique constraints, check constraints, and exclusion constraints
+//
+// Constraint types:
+//   - 'p' = Primary key
+//   - 'f' = Foreign key
+//   - 'u' = Unique
+//   - 'c' = Check
+//   - 'x' = Exclusion
+//
+// Example:
+//
+//	constraints, err := dbc.GetTableConstraints("orders")
+//	if err != nil {
+//	    log.WithError(err).Error("failed to get constraints")
+//	}
+//	for _, c := range constraints {
+//	    log.WithFields(log.Fields{
+//	        "constraint": c.ConstraintName,
+//	        "type":       c.ConstraintType,
+//	    }).Info("found constraint")
+//	}
+func (dbc *DB) GetTableConstraints(tableName string) ([]ConstraintInfo, error) {
+	var constraints []ConstraintInfo
+
+	query := `
+		SELECT
+			con.conname AS constraint_name,
+			t.relname AS table_name,
+			con.contype AS constraint_type,
+			pg_get_constraintdef(con.oid) AS definition
+		FROM pg_constraint con
+		JOIN pg_class t ON con.conrelid = t.oid
+		JOIN pg_namespace n ON n.oid = t.relnamespace
+		WHERE t.relname = @table_name
+			AND n.nspname = 'public'
+		ORDER BY con.contype, con.conname
+	`
+
+	result := dbc.DB.Raw(query, sql.Named("table_name", tableName)).Scan(&constraints)
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to get constraints for table %s: %w", tableName, result.Error)
+	}
+
+	return constraints, nil
+}
+
+// IndexInfo represents metadata about a table index
+type IndexInfo struct {
+	IndexName  string
+	TableName  string
+	Definition string // Index definition (CREATE INDEX statement)
+	IsPrimary  bool   // true if this is a primary key index
+	IsUnique   bool   // true if this is a unique index
+}
+
+// GetTableIndexes returns all indexes for a table
+// This includes indexes created explicitly and indexes backing constraints (primary keys, unique constraints)
+//
+// Note: Indexes backing constraints may have the same name as the constraint,
+// but they are separate objects. Renaming a constraint does NOT rename the index.
+//
+// Example:
+//
+//	indexes, err := dbc.GetTableIndexes("orders")
+//	if err != nil {
+//	    log.WithError(err).Error("failed to get indexes")
+//	}
+//	for _, idx := range indexes {
+//	    log.WithFields(log.Fields{
+//	        "index":      idx.IndexName,
+//	        "is_primary": idx.IsPrimary,
+//	        "is_unique":  idx.IsUnique,
+//	    }).Info("found index")
+//	}
+func (dbc *DB) GetTableIndexes(tableName string) ([]IndexInfo, error) {
+	var indexes []IndexInfo
+
+	query := `
+		SELECT
+			i.indexname AS index_name,
+			i.tablename AS table_name,
+			i.indexdef AS definition,
+			ix.indisprimary AS is_primary,
+			ix.indisunique AS is_unique
+		FROM pg_indexes i
+		JOIN pg_class c ON c.relname = i.indexname
+		JOIN pg_index ix ON ix.indexrelid = c.oid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE i.tablename = @table_name
+			AND i.schemaname = 'public'
+			AND n.nspname = 'public'
+		ORDER BY i.indexname
+	`
+
+	result := dbc.DB.Raw(query, sql.Named("table_name", tableName)).Scan(&indexes)
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to get indexes for table %s: %w", tableName, result.Error)
+	}
+
+	return indexes, nil
+}
+
+// FKRelationship represents a foreign key relationship between two tables
+type FKRelationship struct {
+	ConstraintName    string // Name of the FK constraint
+	SourceTable       string // Table that has the FK column(s)
+	SourceColumns     string // FK column(s) on the source table
+	ReferencedTable   string // Table being referenced
+	ReferencedColumns string // Referenced column(s) on the target table
+	Definition        string // Full constraint definition
+}
+
+// GetFKRelationships returns all foreign key relationships to or from the given table.
+// "From" means the table has FK columns pointing to other tables.
+// "To" means other tables have FK columns pointing to this table.
+func (dbc *DB) GetFKRelationships(tableName string) ([]FKRelationship, error) {
+	var relationships []FKRelationship
+
+	query := `
+		SELECT
+			con.conname AS constraint_name,
+			src.relname AS source_table,
+			(
+				SELECT string_agg(a.attname, ', ' ORDER BY ap.ord)
+				FROM unnest(con.conkey) WITH ORDINALITY AS ap(attnum, ord)
+				JOIN pg_attribute a ON a.attrelid = con.conrelid AND a.attnum = ap.attnum
+			) AS source_columns,
+			ref.relname AS referenced_table,
+			(
+				SELECT string_agg(a.attname, ', ' ORDER BY ap.ord)
+				FROM unnest(con.confkey) WITH ORDINALITY AS ap(attnum, ord)
+				JOIN pg_attribute a ON a.attrelid = con.confrelid AND a.attnum = ap.attnum
+			) AS referenced_columns,
+			pg_get_constraintdef(con.oid) AS definition
+		FROM pg_constraint con
+		JOIN pg_class src ON con.conrelid = src.oid
+		JOIN pg_class ref ON con.confrelid = ref.oid
+		JOIN pg_namespace ns ON ns.oid = src.relnamespace
+		JOIN pg_namespace nr ON nr.oid = ref.relnamespace
+		WHERE con.contype = 'f'
+			AND ns.nspname = 'public'
+			AND nr.nspname = 'public'
+			AND (src.relname = @table_name OR ref.relname = @table_name)
+		ORDER BY con.conname
+	`
+
+	result := dbc.DB.Raw(query, sql.Named("table_name", tableName)).Scan(&relationships)
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to get FK relationships for table %s: %w", tableName, result.Error)
+	}
+
+	return relationships, nil
+}
+
+// fkDetail holds foreign key metadata needed to drop and recreate constraints.
+type fkDetail struct {
+	ConstraintName    string
+	SourceTable       string
+	SourceColumns     string
+	ReferencedTable   string
+	ReferencedColumns string
+	OnUpdate          string
+	OnDelete          string
+}
+
+// MoveForeignKeys moves all foreign key constraints associated with fromTable
+// so they reference or belong to toTable instead. This is useful during partition
+// migrations when swapping an old table for a new one.
+//
+// If toTable is empty, all FK constraints associated with fromTable are dropped
+// without being recreated.
+//
+// For FKs FROM fromTable (fromTable has the FK column):
+//   - Drops the constraint on fromTable and recreates it on toTable
+//
+// For FKs TO fromTable (other tables reference fromTable):
+//   - Drops the constraint and recreates it pointing to toTable
+//   - If toTable is partitioned, the FK is expanded to include the partition key
+//     columns on both sides. A UNIQUE constraint is created on toTable for the
+//     expanded column set. The source table must have columns matching the
+//     partition key names; if not, the FK is dropped without being recreated.
+//
+// All operations run in a single transaction. Returns the number of FKs processed.
+func (dbc *DB) MoveForeignKeys(fromTable, toTable string, dryRun bool) (int, error) {
+	start := time.Now()
+	dropOnly := toTable == ""
+	operation := "moving"
+	if dropOnly {
+		operation = "dropping"
+	}
+	log.WithFields(log.Fields{
+		"from_table": fromTable,
+		"to_table":   toTable,
+		"drop_only":  dropOnly,
+		"dry_run":    dryRun,
+	}).Info(operation + " foreign keys")
+
+	// Query all FK details including ON UPDATE/DELETE actions
+	var fks []fkDetail
+	query := `
+		SELECT
+			con.conname AS constraint_name,
+			src.relname AS source_table,
+			(
+				SELECT string_agg(a.attname, ', ' ORDER BY ap.ord)
+				FROM unnest(con.conkey) WITH ORDINALITY AS ap(attnum, ord)
+				JOIN pg_attribute a ON a.attrelid = con.conrelid AND a.attnum = ap.attnum
+			) AS source_columns,
+			ref.relname AS referenced_table,
+			(
+				SELECT string_agg(a.attname, ', ' ORDER BY ap.ord)
+				FROM unnest(con.confkey) WITH ORDINALITY AS ap(attnum, ord)
+				JOIN pg_attribute a ON a.attrelid = con.confrelid AND a.attnum = ap.attnum
+			) AS referenced_columns,
+			CASE con.confupdtype
+				WHEN 'a' THEN 'NO ACTION'
+				WHEN 'r' THEN 'RESTRICT'
+				WHEN 'c' THEN 'CASCADE'
+				WHEN 'n' THEN 'SET NULL'
+				WHEN 'd' THEN 'SET DEFAULT'
+			END AS on_update,
+			CASE con.confdeltype
+				WHEN 'a' THEN 'NO ACTION'
+				WHEN 'r' THEN 'RESTRICT'
+				WHEN 'c' THEN 'CASCADE'
+				WHEN 'n' THEN 'SET NULL'
+				WHEN 'd' THEN 'SET DEFAULT'
+			END AS on_delete
+		FROM pg_constraint con
+		JOIN pg_class src ON con.conrelid = src.oid
+		JOIN pg_class ref ON con.confrelid = ref.oid
+		JOIN pg_namespace ns ON ns.oid = src.relnamespace
+		JOIN pg_namespace nr ON nr.oid = ref.relnamespace
+		WHERE con.contype = 'f'
+			AND ns.nspname = 'public'
+			AND nr.nspname = 'public'
+			AND (src.relname = @table_name OR ref.relname = @table_name)
+		ORDER BY con.conname
+	`
+
+	result := dbc.DB.Raw(query, sql.Named("table_name", fromTable)).Scan(&fks)
+	if result.Error != nil {
+		return 0, fmt.Errorf("failed to query FK relationships for table %s: %w", fromTable, result.Error)
+	}
+
+	if len(fks) == 0 {
+		log.WithField("table", fromTable).Info("no foreign keys found")
+		return 0, nil
+	}
+
+	log.WithFields(log.Fields{
+		"table": fromTable,
+		"count": len(fks),
+	}).Info("found foreign keys to process")
+
+	// Check if toTable is partitioned and get its partition columns
+	var toTablePartitionCols []string
+	if !dropOnly {
+		toTablePartitionCols, _ = dbc.getPartitionColumns(toTable)
+		if len(toTablePartitionCols) > 0 {
+			log.WithFields(log.Fields{
+				"table":             toTable,
+				"partition_columns": toTablePartitionCols,
+			}).Info("target table is partitioned, FKs pointing to it will include partition columns")
+		}
+	}
+
+	if dryRun {
+		for _, fk := range fks {
+			fields := log.Fields{
+				"constraint": fk.ConstraintName,
+			}
+			if dropOnly {
+				if fk.SourceTable == fromTable {
+					fields["drop_on"] = fromTable
+				} else {
+					fields["drop_on"] = fk.SourceTable
+				}
+				log.WithFields(fields).Info("[DRY RUN] would drop foreign key")
+			} else if fk.SourceTable == fromTable {
+				fields["direction"] = "from"
+				fields["drop_on"] = fromTable
+				fields["add_on"] = toTable
+				fields["references"] = fk.ReferencedTable
+				log.WithFields(fields).Info("[DRY RUN] would move foreign key")
+			} else {
+				// FK TO the table — check if partition columns need to be added
+				fields["direction"] = "to"
+				fields["source"] = fk.SourceTable
+				fields["old_references"] = fromTable
+				fields["new_references"] = toTable
+				if len(toTablePartitionCols) > 0 {
+					expandedSrc, expandedRef := expandFKColumnsForPartitioning(
+						splitColumns(fk.SourceColumns),
+						splitColumns(fk.ReferencedColumns),
+						toTablePartitionCols,
+					)
+					fields["expanded_source_columns"] = strings.Join(expandedSrc, ", ")
+					fields["expanded_ref_columns"] = strings.Join(expandedRef, ", ")
+				}
+				log.WithFields(fields).Info("[DRY RUN] would move foreign key")
+			}
+		}
+		return len(fks), nil
+	}
+
+	tx := dbc.DB.Begin()
+	if tx.Error != nil {
+		return 0, fmt.Errorf("failed to begin transaction: %w", tx.Error)
+	}
+
+	committed := false
+	defer func() {
+		if !committed {
+			tx.Rollback()
+		}
+	}()
+
+	// Track UNIQUE constraints we've already created on toTable to avoid duplicates
+	createdUniqueConstraints := make(map[string]bool)
+
+	processedCount := 0
+	for _, fk := range fks {
+		// Determine which table the constraint lives on
+		var dropTable string
+		if fk.SourceTable == fromTable {
+			dropTable = fromTable
+		} else {
+			dropTable = fk.SourceTable
+		}
+
+		// Drop the existing constraint
+		dropSQL := fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s",
+			pq.QuoteIdentifier(dropTable),
+			pq.QuoteIdentifier(fk.ConstraintName))
+
+		log.WithFields(log.Fields{
+			"constraint": fk.ConstraintName,
+			"table":      dropTable,
+		}).Info("dropping foreign key")
+
+		if r := tx.Exec(dropSQL); r.Error != nil {
+			return 0, fmt.Errorf("failed to drop constraint %s on %s: %w",
+				fk.ConstraintName, dropTable, r.Error)
+		}
+
+		// Recreate the constraint on the target table (skip if drop-only)
+		if !dropOnly {
+			var addTable, refTable string
+			srcColList := splitColumns(fk.SourceColumns)
+			refColList := splitColumns(fk.ReferencedColumns)
+
+			if fk.SourceTable == fromTable {
+				// FK FROM fromTable: move to toTable, same referenced table
+				addTable = toTable
+				refTable = fk.ReferencedTable
+			} else {
+				// FK TO fromTable: recreate on same source table, pointing to toTable
+				addTable = fk.SourceTable
+				refTable = toTable
+
+				// If toTable is partitioned, expand the FK to include partition columns
+				if len(toTablePartitionCols) > 0 {
+					// Verify the source table has the partition columns
+					sourceColumns, err := dbc.GetTableColumns(addTable)
+					if err != nil {
+						return 0, fmt.Errorf("failed to get columns for table %s: %w", addTable, err)
+					}
+					sourceColSet := make(map[string]bool)
+					for _, col := range sourceColumns {
+						sourceColSet[col.ColumnName] = true
+					}
+
+					missingCols := []string{}
+					for _, partCol := range toTablePartitionCols {
+						if !sourceColSet[partCol] {
+							missingCols = append(missingCols, partCol)
+						}
+					}
+
+					if len(missingCols) > 0 {
+						log.WithFields(log.Fields{
+							"constraint":      fk.ConstraintName,
+							"source_table":    addTable,
+							"target_table":    refTable,
+							"missing_columns": missingCols,
+						}).Warn("source table missing partition columns, skipping FK (drop only)")
+						processedCount++
+						continue
+					}
+
+					// Expand FK columns to include partition columns
+					srcColList, refColList = expandFKColumnsForPartitioning(srcColList, refColList, toTablePartitionCols)
+
+					// Create UNIQUE constraint on toTable if not already created
+					uniqueKey := strings.Join(refColList, ",")
+					if !createdUniqueConstraints[uniqueKey] {
+						uniqueConsName := fmt.Sprintf("%s_%s_key", refTable, strings.Join(refColList, "_"))
+						uniqueSQL := fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s UNIQUE (%s)",
+							pq.QuoteIdentifier(refTable),
+							pq.QuoteIdentifier(uniqueConsName),
+							quoteIdentifierList(refColList))
+
+						log.WithFields(log.Fields{
+							"table":      refTable,
+							"constraint": uniqueConsName,
+							"columns":    refColList,
+						}).Info("creating unique constraint for partitioned FK")
+
+						if r := tx.Exec(uniqueSQL); r.Error != nil {
+							return 0, fmt.Errorf("failed to create unique constraint %s on %s: %w",
+								uniqueConsName, refTable, r.Error)
+						}
+						createdUniqueConstraints[uniqueKey] = true
+					}
+				}
+			}
+
+			srcCols := quoteIdentifierList(srcColList)
+			refCols := quoteIdentifierList(refColList)
+
+			addSQL := fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s(%s) ON UPDATE %s ON DELETE %s",
+				pq.QuoteIdentifier(addTable),
+				pq.QuoteIdentifier(fk.ConstraintName),
+				srcCols,
+				pq.QuoteIdentifier(refTable),
+				refCols,
+				fk.OnUpdate,
+				fk.OnDelete)
+
+			log.WithFields(log.Fields{
+				"constraint": fk.ConstraintName,
+				"table":      addTable,
+				"references": refTable,
+			}).Info("adding foreign key")
+
+			if r := tx.Exec(addSQL); r.Error != nil {
+				return 0, fmt.Errorf("failed to add constraint %s on %s: %w",
+					fk.ConstraintName, addTable, r.Error)
+			}
+		}
+
+		processedCount++
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		return 0, fmt.Errorf("failed to commit FK transaction: %w", err)
+	}
+	committed = true
+
+	log.WithFields(log.Fields{
+		"from_table": fromTable,
+		"to_table":   toTable,
+		"drop_only":  dropOnly,
+		"count":      processedCount,
+		"elapsed":    time.Since(start),
+	}).Info("foreign keys processed successfully")
+
+	return processedCount, nil
+}
+
+// splitColumns splits a comma-separated column list and trims whitespace.
+func splitColumns(cols string) []string {
+	parts := strings.Split(cols, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+// expandFKColumnsForPartitioning appends partition columns to both the source
+// and referenced column lists of an FK, skipping any that are already present.
+// This is needed because PostgreSQL requires UNIQUE constraints on partitioned
+// tables to include all partition key columns, and FKs must reference a matching
+// UNIQUE constraint.
+func expandFKColumnsForPartitioning(srcCols, refCols, partitionCols []string) ([]string, []string) {
+	existing := make(map[string]bool)
+	for _, col := range refCols {
+		existing[col] = true
+	}
+	for _, partCol := range partitionCols {
+		if !existing[partCol] {
+			srcCols = append(srcCols, partCol)
+			refCols = append(refCols, partCol)
+		}
+	}
+	return srcCols, refCols
+}
+
+// GetTablePartitions returns all partitions of a partitioned table
+// Uses PostgreSQL's partition inheritance system to find child partitions
+func (dbc *DB) GetTablePartitions(tableName string) ([]PartitionTableInfo, error) {
+	var partitions []PartitionTableInfo
+
+	query := `
+		SELECT
+			child.relname AS partition_name,
+			parent.relname AS parent_table
+		FROM pg_inherits
+		JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
+		JOIN pg_class child ON pg_inherits.inhrelid = child.oid
+		JOIN pg_namespace nmsp_parent ON nmsp_parent.oid = parent.relnamespace
+		JOIN pg_namespace nmsp_child ON nmsp_child.oid = child.relnamespace
+		WHERE parent.relname = @table_name
+			AND nmsp_parent.nspname = 'public'
+			AND nmsp_child.nspname = 'public'
+		ORDER BY child.relname
+	`
+
+	result := dbc.DB.Raw(query, sql.Named("table_name", tableName)).Scan(&partitions)
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to get partitions for table %s: %w", tableName, result.Error)
+	}
+
+	return partitions, nil
+}
+
+// SequenceMetadata represents detailed metadata about how a sequence is linked to a column
+type SequenceMetadata struct {
+	SequenceName     string
+	TableName        string
+	ColumnName       string
+	DependencyType   string // 'a' = auto (SERIAL), 'i' = internal (IDENTITY)
+	IsIdentityColumn bool   // true if column uses GENERATED AS IDENTITY
+	SequenceOwner    string // Table.Column that owns this sequence
+}
+
+// GetSequenceMetadata returns detailed metadata about how a sequence is linked to a column
+// This shows the internal PostgreSQL mechanisms that link IDENTITY/SERIAL columns to sequences:
+//
+// For IDENTITY columns, PostgreSQL uses:
+//  1. pg_depend: Creates an internal dependency (deptype='i') linking sequence to column
+//  2. pg_attribute.attidentity: Marks column as identity ('d' or 'a')
+//  3. pg_sequence: Stores sequence ownership information
+//
+// For SERIAL columns, PostgreSQL uses:
+//  1. pg_depend: Creates an auto dependency (deptype='a') linking sequence to column
+//  2. Column default: Uses nextval('sequence_name')
+//
+// When you rename a sequence using ALTER SEQUENCE...RENAME:
+//   - PostgreSQL automatically updates pg_depend (OID-based, not name-based)
+//   - For SERIAL: You must also update the column default expression (name-based!)
+//   - For IDENTITY: No additional updates needed (uses OID internally)
+//
+// This is why our RenameTables function just renames sequences - PostgreSQL handles the rest
+// for IDENTITY columns, but SERIAL columns may have stale defaults if renamed outside ALTER TABLE.
+//
+// Example:
+//
+//	metadata, err := dbc.GetSequenceMetadata("orders")
+//	for _, m := range metadata {
+//	    log.WithFields(log.Fields{
+//	        "sequence":     m.SequenceName,
+//	        "column":       m.ColumnName,
+//	        "dep_type":     m.DependencyType,
+//	        "is_identity":  m.IsIdentityColumn,
+//	    }).Info("sequence linkage")
+//	}
+func (dbc *DB) GetSequenceMetadata(tableName string) ([]SequenceMetadata, error) {
+	var metadata []SequenceMetadata
+
+	query := `
+		SELECT
+			s.relname AS sequence_name,
+			t.relname AS table_name,
+			a.attname AS column_name,
+			d.deptype AS dependency_type,
+			CASE WHEN a.attidentity IN ('a', 'd') THEN true ELSE false END AS is_identity_column,
+			t.relname || '.' || a.attname AS sequence_owner
+		FROM pg_class s
+		JOIN pg_depend d ON d.objid = s.oid
+		JOIN pg_class t ON d.refobjid = t.oid
+		JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = d.refobjsubid
+		JOIN pg_namespace n ON n.oid = s.relnamespace
+		WHERE s.relkind = 'S'
+			AND t.relname = @table_name
+			AND n.nspname = 'public'
+			AND d.deptype IN ('a', 'i')
+		ORDER BY a.attnum
+	`
+
+	result := dbc.DB.Raw(query, sql.Named("table_name", tableName)).Scan(&metadata)
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to get sequence metadata for table %s: %w", tableName, result.Error)
+	}
+
+	return metadata, nil
+}
+
+// GetTableSequences returns all sequences owned by columns in the specified table
+// This includes sequences from:
+//   - SERIAL/BIGSERIAL columns (dependency type 'a' - auto)
+//   - IDENTITY columns (dependency type 'i' - internal, e.g., GENERATED BY DEFAULT AS IDENTITY)
+//
+// Example:
+//
+//	sequences, err := dbc.GetTableSequences("orders")
+//	if err != nil {
+//	    log.WithError(err).Error("failed to get sequences")
+//	}
+//	for _, seq := range sequences {
+//	    log.WithFields(log.Fields{
+//	        "sequence": seq.SequenceName,
+//	        "table":    seq.TableName,
+//	        "column":   seq.ColumnName,
+//	    }).Info("found sequence")
+//	}
+func (dbc *DB) GetTableSequences(tableName string) ([]SequenceInfo, error) {
+	var sequences []SequenceInfo
+
+	query := `
+		SELECT
+			s.relname AS sequence_name,
+			t.relname AS table_name,
+			a.attname AS column_name
+		FROM pg_class s
+		JOIN pg_depend d ON d.objid = s.oid
+		JOIN pg_class t ON d.refobjid = t.oid
+		JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = d.refobjsubid
+		JOIN pg_namespace n ON n.oid = s.relnamespace
+		WHERE s.relkind = 'S'
+			AND t.relname = @table_name
+			AND n.nspname = 'public'
+			AND d.deptype IN ('a', 'i')
+		ORDER BY a.attnum
+	`
+
+	result := dbc.DB.Raw(query, sql.Named("table_name", tableName)).Scan(&sequences)
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to get sequences for table %s: %w", tableName, result.Error)
+	}
+
+	return sequences, nil
+}
+
+// ListAllTableSequences returns all sequences owned by table columns in the public schema
+// This includes sequences from:
+//   - SERIAL/BIGSERIAL columns (dependency type 'a' - auto)
+//   - IDENTITY columns (dependency type 'i' - internal, e.g., GENERATED BY DEFAULT AS IDENTITY)
+//
+// This is useful for:
+// - Auditing sequence ownership across the entire database
+// - Understanding which tables use auto-increment columns
+// - Finding sequences that may need to be renamed or synced
+// - Database documentation and inventory
+//
+// # Returns a map where keys are table names and values are lists of sequences
+//
+// Example:
+//
+//	allSequences, err := dbc.ListAllTableSequences()
+//	if err != nil {
+//	    log.WithError(err).Error("failed to list sequences")
+//	}
+//	for tableName, sequences := range allSequences {
+//	    log.WithFields(log.Fields{
+//	        "table": tableName,
+//	        "count": len(sequences),
+//	    }).Info("table sequences")
+//	    for _, seq := range sequences {
+//	        log.WithFields(log.Fields{
+//	            "sequence": seq.SequenceName,
+//	            "column":   seq.ColumnName,
+//	        }).Debug("sequence detail")
+//	    }
+//	}
+func (dbc *DB) ListAllTableSequences() (map[string][]SequenceInfo, error) {
+	var allSequences []SequenceInfo
+
+	query := `
+		SELECT
+			s.relname AS sequence_name,
+			t.relname AS table_name,
+			a.attname AS column_name
+		FROM pg_class s
+		JOIN pg_depend d ON d.objid = s.oid
+		JOIN pg_class t ON d.refobjid = t.oid
+		JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = d.refobjsubid
+		JOIN pg_namespace n ON n.oid = s.relnamespace
+		WHERE s.relkind = 'S'
+			AND n.nspname = 'public'
+			AND d.deptype IN ('a', 'i')
+		ORDER BY t.relname, a.attnum
+	`
+
+	result := dbc.DB.Raw(query).Scan(&allSequences)
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to list all table sequences: %w", result.Error)
+	}
+
+	// Group sequences by table name
+	sequencesByTable := make(map[string][]SequenceInfo)
+	for _, seq := range allSequences {
+		sequencesByTable[seq.TableName] = append(sequencesByTable[seq.TableName], seq)
+	}
+
+	log.WithFields(log.Fields{
+		"tables":    len(sequencesByTable),
+		"sequences": len(allSequences),
+	}).Info("listed all table sequences")
+
+	return sequencesByTable, nil
+}
+
+// TableRename represents a single table rename operation
+type TableRename struct {
+	From string // Source table name
+	To   string // Target table name
+}
+
+// constraintRenameEntry holds a constraint rename tied to a specific table
+type constraintRenameEntry struct {
+	TableName     string // Original table (or partition) name
+	OldConstraint string
+	NewConstraint string
+}
+
+// indexRenameEntry holds an index rename tied to a specific table
+type indexRenameEntry struct {
+	TableName string // Original table (or partition) name
+	OldIndex  string
+	NewIndex  string
+}
+
+// RenameTables renames multiple tables atomically in a single transaction
+// This function is useful for:
+// - Swapping partitioned tables with non-partitioned tables
+// - Renaming related tables together to maintain consistency
+// - Performing atomic schema migrations
+//
+// Parameters:
+//   - tableRenames: Ordered list of table renames to execute (executed in the order provided)
+//   - renameSequences: If true, also renames sequences owned by table columns (e.g., SERIAL, IDENTITY)
+//   - renamePartitions: If true, also renames child partitions of partitioned tables
+//   - renameConstraints: If true, also renames table constraints (primary keys, foreign keys, unique, check)
+//   - renameIndexes: If true, also renames table indexes (including those backing constraints)
+//   - dryRun: If true, only validates the operation without executing it
+//
+// Returns:
+//   - renamedCount: Number of tables successfully renamed (0 if dryRun is true)
+//   - error: Any error encountered during the operation
+//
+// Example:
+//
+//	renames := []db.TableRename{
+//	    {From: "orders_old", To: "orders_backup"},      // Execute first
+//	    {From: "orders_new", To: "orders"},             // Execute second
+//	    {From: "orders_archive", To: "orders_old"},     // Execute third
+//	}
+//	count, err := dbc.RenameTables(renames, true, true, true, true, false)
+//	if err != nil {
+//	    log.WithError(err).Error("table rename failed")
+//	}
+//
+// Important Notes:
+//   - All renames are executed in a single transaction - either all succeed or all fail
+//   - The function validates that all source tables exist before attempting renames
+//   - The function checks for conflicts (target table already exists)
+//   - Views, indexes, and foreign keys are automatically updated by PostgreSQL
+//   - Renaming is extremely fast - PostgreSQL only updates metadata, not data
+//   - When renameSequences=true, sequences follow naming pattern: newtablename_columnname_seq
+//   - Sequences owned by SERIAL, BIGSERIAL, and IDENTITY columns will be renamed
+//   - When renamePartitions=true, child partitions follow naming pattern: newtablename_suffix
+//   - Partition renaming extracts suffix from old name and applies to new table name
+//   - When renamePartitions=true AND renameSequences/Constraints/Indexes=true, partition sequences/constraints/indexes are also renamed
+//   - When renameConstraints=true, constraints follow naming pattern: newtablename_suffix
+//   - Constraint renaming applies to primary keys, foreign keys, unique, check, and exclusion constraints
+//   - When renameIndexes=true, indexes follow naming pattern: newtablename_suffix
+//   - Index renaming applies to all indexes including those backing constraints
+//   - Indexes with the same name as constraints are skipped (they're renamed automatically with the constraint)
+//   - Renames are executed in the order provided - caller is responsible for dependency ordering
+//   - For table swaps (A->B, B->C), ensure B->C comes before A->B in the array
+func (dbc *DB) RenameTables(tableRenames []TableRename, renameSequences bool, renamePartitions bool, renameConstraints bool, renameIndexes bool, dryRun bool) (int, error) {
+	if len(tableRenames) == 0 {
+		return 0, fmt.Errorf("no tables to rename")
+	}
+
+	log.WithFields(log.Fields{
+		"count":   len(tableRenames),
+		"dry_run": dryRun,
+	}).Info("starting table rename operation")
+
+	// Convert to map for easier lookups during validation and discovery
+	tableRenameMap := make(map[string]string)
+	var sourceNames []string
+	var targetNames []string
+	for _, rename := range tableRenames {
+		if rename.From == "" || rename.To == "" {
+			return 0, fmt.Errorf("invalid rename: both From and To must be specified")
+		}
+		if _, exists := tableRenameMap[rename.From]; exists {
+			return 0, fmt.Errorf("duplicate source table: %s", rename.From)
+		}
+		tableRenameMap[rename.From] = rename.To
+		sourceNames = append(sourceNames, rename.From)
+		targetNames = append(targetNames, rename.To)
+	}
+
+	// Step 1: Validate all source tables exist and check for conflicts
+
+	// Check that all source tables exist
+	for _, rename := range tableRenames {
+		var exists bool
+		query := `
+			SELECT EXISTS (
+				SELECT 1 FROM pg_tables
+				WHERE schemaname = 'public' AND tablename = @table_name
+			)
+		`
+		result := dbc.DB.Raw(query, sql.Named("table_name", rename.From)).Scan(&exists)
+		if result.Error != nil {
+			return 0, fmt.Errorf("failed to check if table %s exists: %w", rename.From, result.Error)
+		}
+		if !exists {
+			return 0, fmt.Errorf("source table %s does not exist", rename.From)
+		}
+	}
+
+	// Check for conflicts - ensure no target tables already exist
+	// (unless they're also being renamed as part of this operation)
+	for _, rename := range tableRenames {
+		source := rename.From
+		target := rename.To
+		// Skip check if this target is also a source (table swap scenario)
+		if _, isAlsoSource := tableRenameMap[target]; isAlsoSource {
+			log.WithFields(log.Fields{
+				"source": source,
+				"target": target,
+			}).Debug("target is also a source - table swap detected")
+			continue
+		}
+
+		var exists bool
+		query := `
+			SELECT EXISTS (
+				SELECT 1 FROM pg_tables
+				WHERE schemaname = 'public' AND tablename = @table_name
+			)
+		`
+		result := dbc.DB.Raw(query, sql.Named("table_name", target)).Scan(&exists)
+		if result.Error != nil {
+			return 0, fmt.Errorf("failed to check if target table %s exists: %w", target, result.Error)
+		}
+		if exists {
+			return 0, fmt.Errorf("target table %s already exists (conflict with rename from %s)", target, source)
+		}
+	}
+
+	log.WithFields(log.Fields{
+		"sources": sourceNames,
+		"targets": targetNames,
+	}).Info("validation passed - all source tables exist and no conflicts detected")
+
+	// Step 2: Find sequences that need to be renamed (if requested)
+	var sequenceRenames []TableRename
+	if renameSequences {
+		for _, rename := range tableRenames {
+			sequences, err := dbc.GetTableSequences(rename.From)
+			if err != nil {
+				return 0, fmt.Errorf("failed to get sequences for table %s: %w", rename.From, err)
+			}
+
+			for _, seq := range sequences {
+				// Generate new sequence name following PostgreSQL convention
+				// old: oldtable_columnname_seq -> new: newtable_columnname_seq
+				newSeqName := fmt.Sprintf("%s_%s_seq", rename.To, seq.ColumnName)
+				sequenceRenames = append(sequenceRenames, TableRename{From: seq.SequenceName, To: newSeqName})
+
+				log.WithFields(log.Fields{
+					"table":        rename.From,
+					"column":       seq.ColumnName,
+					"old_sequence": seq.SequenceName,
+					"new_sequence": newSeqName,
+				}).Debug("will rename sequence")
+			}
+		}
+
+		if len(sequenceRenames) > 0 {
+			log.WithField("count", len(sequenceRenames)).Info("found sequences to rename")
+		}
+	}
+
+	// Step 2b: Find partitions that need to be renamed (if requested)
+	var partitionRenames []TableRename
+	// partitionRenameMap is used for lookups when resolving new table names for constraints/indexes
+	partitionRenameMap := make(map[string]string)
+	if renamePartitions {
+		for _, rename := range tableRenames {
+			partitions, err := dbc.GetTablePartitions(rename.From)
+			if err != nil {
+				return 0, fmt.Errorf("failed to get partitions for table %s: %w", rename.From, err)
+			}
+
+			for _, part := range partitions {
+				// Extract suffix from old partition name
+				// old: oldtable_2024_01_01 -> suffix: _2024_01_01
+				// new: newtable_2024_01_01
+				suffix := strings.TrimPrefix(part.PartitionName, rename.From)
+				if suffix == part.PartitionName {
+					// Partition name doesn't start with parent table name - skip
+					log.WithFields(log.Fields{
+						"partition": part.PartitionName,
+						"parent":    rename.From,
+					}).Warn("partition name doesn't start with parent table name - skipping")
+					continue
+				}
+
+				newPartName := rename.To + suffix
+				partitionRenames = append(partitionRenames, TableRename{From: part.PartitionName, To: newPartName})
+				partitionRenameMap[part.PartitionName] = newPartName
+
+				log.WithFields(log.Fields{
+					"parent":        rename.From,
+					"old_partition": part.PartitionName,
+					"new_partition": newPartName,
+					"suffix":        suffix,
+				}).Debug("will rename partition")
+			}
+		}
+
+		if len(partitionRenames) > 0 {
+			log.WithField("count", len(partitionRenames)).Info("found partitions to rename")
+
+			// Also find sequences for partition tables
+			if renameSequences {
+				for _, partRename := range partitionRenames {
+					partSeqs, err := dbc.GetTableSequences(partRename.From)
+					if err != nil {
+						return 0, fmt.Errorf("failed to get sequences for partition %s: %w", partRename.From, err)
+					}
+
+					for _, seq := range partSeqs {
+						newSeqName := fmt.Sprintf("%s_%s_seq", partRename.To, seq.ColumnName)
+						sequenceRenames = append(sequenceRenames, TableRename{From: seq.SequenceName, To: newSeqName})
+
+						log.WithFields(log.Fields{
+							"partition":    partRename.From,
+							"column":       seq.ColumnName,
+							"old_sequence": seq.SequenceName,
+							"new_sequence": newSeqName,
+						}).Debug("will rename partition sequence")
+					}
+				}
+			}
+		}
+	}
+
+	// Step 2c: Find constraints that need to be renamed (if requested)
+	var constraintRenames []constraintRenameEntry
+	if renameConstraints {
+		for _, rename := range tableRenames {
+			constraints, err := dbc.GetTableConstraints(rename.From)
+			if err != nil {
+				return 0, fmt.Errorf("failed to get constraints for table %s: %w", rename.From, err)
+			}
+
+			for _, cons := range constraints {
+				suffix := strings.TrimPrefix(cons.ConstraintName, rename.From)
+				if suffix == cons.ConstraintName {
+					log.WithFields(log.Fields{
+						"constraint": cons.ConstraintName,
+						"table":      rename.From,
+					}).Debug("constraint name doesn't start with table name - skipping")
+					continue
+				}
+
+				newConsName := rename.To + suffix
+				constraintRenames = append(constraintRenames, constraintRenameEntry{
+					TableName:     rename.From,
+					OldConstraint: cons.ConstraintName,
+					NewConstraint: newConsName,
+				})
+
+				log.WithFields(log.Fields{
+					"table":          rename.From,
+					"old_constraint": cons.ConstraintName,
+					"new_constraint": newConsName,
+					"type":           cons.ConstraintType,
+					"suffix":         suffix,
+				}).Debug("will rename constraint")
+			}
+		}
+
+		if len(constraintRenames) > 0 {
+			log.WithField("count", len(constraintRenames)).Info("found constraints to rename")
+		}
+
+		// Also find constraints for partition tables
+		if renamePartitions && len(partitionRenames) > 0 {
+			for _, partRename := range partitionRenames {
+				partCons, err := dbc.GetTableConstraints(partRename.From)
+				if err != nil {
+					return 0, fmt.Errorf("failed to get constraints for partition %s: %w", partRename.From, err)
+				}
+
+				for _, cons := range partCons {
+					suffix := strings.TrimPrefix(cons.ConstraintName, partRename.From)
+					if suffix == cons.ConstraintName {
+						log.WithFields(log.Fields{
+							"constraint": cons.ConstraintName,
+							"partition":  partRename.From,
+						}).Debug("constraint name doesn't start with partition name - skipping")
+						continue
+					}
+
+					newConsName := partRename.To + suffix
+					constraintRenames = append(constraintRenames, constraintRenameEntry{
+						TableName:     partRename.From,
+						OldConstraint: cons.ConstraintName,
+						NewConstraint: newConsName,
+					})
+
+					log.WithFields(log.Fields{
+						"partition":      partRename.From,
+						"old_constraint": cons.ConstraintName,
+						"new_constraint": newConsName,
+						"type":           cons.ConstraintType,
+						"suffix":         suffix,
+					}).Debug("will rename partition constraint")
+				}
+			}
+		}
+	}
+
+	// Step 2d: Find indexes that need to be renamed (if requested)
+	var indexRenames []indexRenameEntry
+	if renameIndexes {
+		for _, rename := range tableRenames {
+			indexes, err := dbc.GetTableIndexes(rename.From)
+			if err != nil {
+				return 0, fmt.Errorf("failed to get indexes for table %s: %w", rename.From, err)
+			}
+
+			for _, idx := range indexes {
+				suffix := strings.TrimPrefix(idx.IndexName, rename.From)
+				if suffix == idx.IndexName {
+					log.WithFields(log.Fields{
+						"index": idx.IndexName,
+						"table": rename.From,
+					}).Debug("index name doesn't start with table name - skipping")
+					continue
+				}
+
+				newIdxName := rename.To + suffix
+				indexRenames = append(indexRenames, indexRenameEntry{
+					TableName: rename.From,
+					OldIndex:  idx.IndexName,
+					NewIndex:  newIdxName,
+				})
+
+				log.WithFields(log.Fields{
+					"table":      rename.From,
+					"old_index":  idx.IndexName,
+					"new_index":  newIdxName,
+					"is_unique":  idx.IsUnique,
+					"is_primary": idx.IsPrimary,
+					"suffix":     suffix,
+				}).Debug("will rename index")
+			}
+		}
+
+		if len(indexRenames) > 0 {
+			log.WithField("count", len(indexRenames)).Info("found indexes to rename")
+		}
+
+		// Also find indexes for partition tables
+		if renamePartitions && len(partitionRenames) > 0 {
+			for _, partRename := range partitionRenames {
+				partIdxs, err := dbc.GetTableIndexes(partRename.From)
+				if err != nil {
+					return 0, fmt.Errorf("failed to get indexes for partition %s: %w", partRename.From, err)
+				}
+
+				for _, idx := range partIdxs {
+					suffix := strings.TrimPrefix(idx.IndexName, partRename.From)
+					if suffix == idx.IndexName {
+						log.WithFields(log.Fields{
+							"index":     idx.IndexName,
+							"partition": partRename.From,
+						}).Debug("index name doesn't start with partition name - skipping")
+						continue
+					}
+
+					newIdxName := partRename.To + suffix
+					indexRenames = append(indexRenames, indexRenameEntry{
+						TableName: partRename.From,
+						OldIndex:  idx.IndexName,
+						NewIndex:  newIdxName,
+					})
+
+					log.WithFields(log.Fields{
+						"partition":  partRename.From,
+						"old_index":  idx.IndexName,
+						"new_index":  newIdxName,
+						"is_unique":  idx.IsUnique,
+						"is_primary": idx.IsPrimary,
+						"suffix":     suffix,
+					}).Debug("will rename partition index")
+				}
+			}
+		}
+	}
+
+	// Step 3: Dry run - report what would be renamed
+	if dryRun {
+		log.Info("[DRY RUN] would rename the following tables:")
+		for _, rename := range tableRenames {
+			log.WithFields(log.Fields{
+				"from": rename.From,
+				"to":   rename.To,
+			}).Info("[DRY RUN] table rename")
+		}
+
+		if len(partitionRenames) > 0 {
+			log.Info("[DRY RUN] would rename the following partitions:")
+			for _, r := range partitionRenames {
+				log.WithFields(log.Fields{
+					"from": r.From,
+					"to":   r.To,
+				}).Info("[DRY RUN] partition rename")
+			}
+		}
+
+		if len(sequenceRenames) > 0 {
+			log.Info("[DRY RUN] would rename the following sequences:")
+			for _, r := range sequenceRenames {
+				log.WithFields(log.Fields{
+					"from": r.From,
+					"to":   r.To,
+				}).Info("[DRY RUN] sequence rename")
+			}
+		}
+
+		if len(constraintRenames) > 0 {
+			log.Info("[DRY RUN] would rename the following constraints:")
+			for _, r := range constraintRenames {
+				log.WithFields(log.Fields{
+					"table": r.TableName,
+					"from":  r.OldConstraint,
+					"to":    r.NewConstraint,
+				}).Info("[DRY RUN] constraint rename")
+			}
+		}
+
+		if len(indexRenames) > 0 {
+			log.Info("[DRY RUN] would rename the following indexes:")
+			for _, r := range indexRenames {
+				log.WithFields(log.Fields{
+					"table": r.TableName,
+					"from":  r.OldIndex,
+					"to":    r.NewIndex,
+				}).Info("[DRY RUN] index rename")
+			}
+		}
+
+		return 0, nil
+	}
+
+	// Step 4: Execute all renames in a single transaction
+	tx := dbc.DB.Begin()
+	if tx.Error != nil {
+		return 0, fmt.Errorf("failed to begin transaction: %w", tx.Error)
+	}
+
+	// Use defer to handle rollback on error
+	committed := false
+	defer func() {
+		if !committed {
+			tx.Rollback()
+		}
+	}()
+
+	// Execute each table rename in the order provided
+	renamedCount := 0
+	for _, rename := range tableRenames {
+		renameSQL := fmt.Sprintf("ALTER TABLE %s RENAME TO %s", pq.QuoteIdentifier(rename.From), pq.QuoteIdentifier(rename.To))
+
+		log.WithFields(log.Fields{
+			"from": rename.From,
+			"to":   rename.To,
+		}).Info("renaming table")
+
+		result := tx.Exec(renameSQL)
+		if result.Error != nil {
+			return 0, fmt.Errorf("failed to rename table %s to %s: %w", rename.From, rename.To, result.Error)
+		}
+
+		renamedCount++
+	}
+
+	// Execute each partition rename
+	partitionsRenamed := 0
+	for _, r := range partitionRenames {
+		renameSQL := fmt.Sprintf("ALTER TABLE %s RENAME TO %s", pq.QuoteIdentifier(r.From), pq.QuoteIdentifier(r.To))
+
+		log.WithFields(log.Fields{
+			"from": r.From,
+			"to":   r.To,
+		}).Info("renaming partition")
+
+		result := tx.Exec(renameSQL)
+		if result.Error != nil {
+			return 0, fmt.Errorf("failed to rename partition %s to %s: %w", r.From, r.To, result.Error)
+		}
+
+		partitionsRenamed++
+	}
+
+	// Execute each sequence rename
+	sequencesRenamed := 0
+	for _, r := range sequenceRenames {
+		renameSQL := fmt.Sprintf("ALTER SEQUENCE %s RENAME TO %s", pq.QuoteIdentifier(r.From), pq.QuoteIdentifier(r.To))
+
+		log.WithFields(log.Fields{
+			"from": r.From,
+			"to":   r.To,
+		}).Info("renaming sequence")
+
+		result := tx.Exec(renameSQL)
+		if result.Error != nil {
+			return 0, fmt.Errorf("failed to rename sequence %s to %s: %w", r.From, r.To, result.Error)
+		}
+
+		sequencesRenamed++
+	}
+
+	// Execute each constraint rename
+	constraintsRenamed := 0
+	for _, r := range constraintRenames {
+		// Get the new table name (in case table or partition was renamed)
+		newTableName := r.TableName
+		if renamed, exists := tableRenameMap[r.TableName]; exists {
+			newTableName = renamed
+		} else if renamed, exists := partitionRenameMap[r.TableName]; exists {
+			newTableName = renamed
+		}
+
+		renameSQL := fmt.Sprintf("ALTER TABLE %s RENAME CONSTRAINT %s TO %s", pq.QuoteIdentifier(newTableName), pq.QuoteIdentifier(r.OldConstraint), pq.QuoteIdentifier(r.NewConstraint))
+
+		log.WithFields(log.Fields{
+			"table": newTableName,
+			"from":  r.OldConstraint,
+			"to":    r.NewConstraint,
+		}).Info("renaming constraint")
+
+		result := tx.Exec(renameSQL)
+		if result.Error != nil {
+			return 0, fmt.Errorf("failed to rename constraint %s to %s on table %s: %w", r.OldConstraint, r.NewConstraint, newTableName, result.Error)
+		}
+
+		constraintsRenamed++
+	}
+
+	// Build a set of constraint names that were renamed
+	// (to skip indexes with the same name, as they're renamed automatically with the constraint)
+	renamedConstraintNames := make(map[string]bool)
+	for _, r := range constraintRenames {
+		renamedConstraintNames[r.OldConstraint] = true
+	}
+
+	// Execute each index rename
+	indexesRenamed := 0
+	for _, r := range indexRenames {
+		// Skip if this index has the same name as a constraint we renamed
+		// PostgreSQL automatically renames the backing index when renaming PRIMARY KEY or UNIQUE constraints
+		if renamedConstraintNames[r.OldIndex] {
+			log.WithFields(log.Fields{
+				"table": r.TableName,
+				"index": r.OldIndex,
+			}).Debug("skipping index - already renamed as part of constraint rename")
+			continue
+		}
+
+		renameSQL := fmt.Sprintf("ALTER INDEX %s RENAME TO %s", pq.QuoteIdentifier(r.OldIndex), pq.QuoteIdentifier(r.NewIndex))
+
+		log.WithFields(log.Fields{
+			"table": r.TableName,
+			"from":  r.OldIndex,
+			"to":    r.NewIndex,
+		}).Info("renaming index")
+
+		result := tx.Exec(renameSQL)
+		if result.Error != nil {
+			return 0, fmt.Errorf("failed to rename index %s to %s: %w", r.OldIndex, r.NewIndex, result.Error)
+		}
+
+		indexesRenamed++
+	}
+
+	// Commit the transaction
+	if err := tx.Commit().Error; err != nil {
+		return 0, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	committed = true
+
+	log.WithFields(log.Fields{
+		"renamed_tables":      renamedCount,
+		"renamed_partitions":  partitionsRenamed,
+		"renamed_sequences":   sequencesRenamed,
+		"renamed_constraints": constraintsRenamed,
+		"renamed_indexes":     indexesRenamed,
+	}).Info("rename operation completed successfully")
+
+	return renamedCount, nil
+}
+
+// SyncIdentityColumn synchronizes the IDENTITY sequence for a column to match the current maximum value
+// This is useful after migrating data to a partitioned table that uses IDENTITY columns
+//
+// NOTE: PostgreSQL does not have a SYNC IDENTITY command. Instead, this function uses
+// ALTER TABLE ... ALTER COLUMN ... RESTART WITH, which is the standard PostgreSQL syntax
+// for resetting an IDENTITY column's sequence to a specific value.
+//
+// Parameters:
+//   - tableName: Name of the table containing the IDENTITY column
+//   - columnName: Name of the IDENTITY column to sync (typically "id")
+//
+// The function executes: ALTER TABLE table_name ALTER COLUMN column_name RESTART WITH (max_value + 1)
+// where max_value is the current maximum value in the column.
+//
+// Use cases:
+//   - After migrating data from a non-partitioned table to a partitioned table
+//   - After bulk inserting data with explicit IDs
+//   - When IDENTITY sequence is out of sync with actual data
+//
+// Example:
+//
+//	err := dbc.SyncIdentityColumn("my_table", "id")
+//	if err != nil {
+//	    log.WithError(err).Error("failed to sync identity column")
+//	}
+func (dbc *DB) SyncIdentityColumn(tableName, columnName string) error {
+	log.WithFields(log.Fields{
+		"table":  tableName,
+		"column": columnName,
+	}).Info("synchronizing identity column")
+
+	// Get the current maximum value
+	var maxValue sql.NullInt64
+	query := fmt.Sprintf("SELECT MAX(%s) FROM %s", pq.QuoteIdentifier(columnName), pq.QuoteIdentifier(tableName))
+	result := dbc.DB.Raw(query).Scan(&maxValue)
+	if result.Error != nil {
+		return fmt.Errorf("failed to get max value for %s.%s: %w", tableName, columnName, result.Error)
+	}
+
+	// If table is empty or column has all NULL values, start at 1
+	nextValue := int64(1)
+	if maxValue.Valid {
+		nextValue = maxValue.Int64 + 1
+	}
+
+	log.WithFields(log.Fields{
+		"table":      tableName,
+		"column":     columnName,
+		"max_value":  maxValue.Int64,
+		"next_value": nextValue,
+	}).Debug("restarting identity sequence")
+
+	// Restart the identity sequence
+	// NOTE: PostgreSQL requires "RESTART WITH" for IDENTITY columns, not "SYNC IDENTITY"
+	// This is the standard way to synchronize an IDENTITY sequence in PostgreSQL
+	alterSQL := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s RESTART WITH %d", pq.QuoteIdentifier(tableName), pq.QuoteIdentifier(columnName), nextValue)
+	result = dbc.DB.Exec(alterSQL)
+	if result.Error != nil {
+		return fmt.Errorf("failed to sync identity for %s.%s: %w", tableName, columnName, result.Error)
+	}
+
+	log.WithFields(log.Fields{
+		"table":      tableName,
+		"column":     columnName,
+		"next_value": nextValue,
+	}).Info("identity column synchronized successfully")
+
+	return nil
+}

--- a/pkg/db/utils.go
+++ b/pkg/db/utils.go
@@ -1554,7 +1554,7 @@ type indexRenameEntry struct {
 //   - For table swaps (A->B, B->C), ensure B->C comes before A->B in the array
 //
 //nolint:gocyclo
-func (dbc *DB) RenameTables(tableRenames []TableRename, renameSequences bool, renamePartitions bool, renameConstraints bool, renameIndexes bool, dryRun bool) (int, error) {
+func (dbc *DB) RenameTables(tableRenames []TableRename, renameSequences, renamePartitions, renameConstraints, renameIndexes, dryRun bool) (int, error) {
 	if len(tableRenames) == 0 {
 		return 0, fmt.Errorf("no tables to rename")
 	}

--- a/pkg/db/utils.go
+++ b/pkg/db/utils.go
@@ -1552,6 +1552,8 @@ type indexRenameEntry struct {
 //   - Indexes with the same name as constraints are skipped (they're renamed automatically with the constraint)
 //   - Renames are executed in the order provided - caller is responsible for dependency ordering
 //   - For table swaps (A->B, B->C), ensure B->C comes before A->B in the array
+//
+//nolint:gocyclo
 func (dbc *DB) RenameTables(tableRenames []TableRename, renameSequences bool, renamePartitions bool, renameConstraints bool, renameIndexes bool, dryRun bool) (int, error) {
 	if len(tableRenames) == 0 {
 		return 0, fmt.Errorf("no tables to rename")

--- a/pkg/db/utils_test.go
+++ b/pkg/db/utils_test.go
@@ -1,0 +1,480 @@
+package db
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestNormalizeDataType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "character varying to varchar",
+			input:    "character varying",
+			expected: "varchar",
+		},
+		{
+			name:     "integer to int",
+			input:    "integer",
+			expected: "int",
+		},
+		{
+			name:     "int4 to int",
+			input:    "int4",
+			expected: "int",
+		},
+		{
+			name:     "int8 to bigint",
+			input:    "int8",
+			expected: "bigint",
+		},
+		{
+			name:     "bigserial to bigint",
+			input:    "bigserial",
+			expected: "bigint",
+		},
+		{
+			name:     "timestamp without time zone",
+			input:    "timestamp without time zone",
+			expected: "timestamp",
+		},
+		{
+			name:     "timestamp with time zone to timestamptz",
+			input:    "timestamp with time zone",
+			expected: "timestamptz",
+		},
+		{
+			name:     "double precision to float8",
+			input:    "double precision",
+			expected: "float8",
+		},
+		{
+			name:     "boolean to bool",
+			input:    "boolean",
+			expected: "bool",
+		},
+		{
+			name:     "text remains text",
+			input:    "text",
+			expected: "text",
+		},
+		{
+			name:     "uppercase INTEGER to int",
+			input:    "INTEGER",
+			expected: "int",
+		},
+		{
+			name:     "mixed case Boolean to bool",
+			input:    "Boolean",
+			expected: "bool",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeDataType(tt.input)
+			if got != tt.expected {
+				t.Errorf("normalizeDataType(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestColumnInfo(t *testing.T) {
+	// Test that ColumnInfo struct can be instantiated
+	col := ColumnInfo{
+		ColumnName:    "test_column",
+		DataType:      "varchar",
+		IsNullable:    "NO",
+		ColumnDefault: sql.NullString{String: "default_value", Valid: true},
+		OrdinalPos:    1,
+	}
+
+	if col.ColumnName != "test_column" {
+		t.Errorf("unexpected column name: %s", col.ColumnName)
+	}
+
+	if col.DataType != "varchar" {
+		t.Errorf("unexpected data type: %s", col.DataType)
+	}
+
+	if col.IsNullable != "NO" {
+		t.Errorf("unexpected nullable: %s", col.IsNullable)
+	}
+
+	if !col.ColumnDefault.Valid || col.ColumnDefault.String != "default_value" {
+		t.Errorf("unexpected default: %v", col.ColumnDefault)
+	}
+
+	if col.OrdinalPos != 1 {
+		t.Errorf("unexpected ordinal position: %d", col.OrdinalPos)
+	}
+}
+
+// Note: Integration tests for MigrateTableData require a live database connection
+// and would be in a separate integration test suite. Unit tests verify the
+// basic structure and flow of the function.
+
+func TestMigrateTableDataValidation(t *testing.T) {
+	// This test documents the expected behavior and parameters
+	// Actual migration testing requires database fixtures
+
+	type testCase struct {
+		name          string
+		sourceTable   string
+		targetTable   string
+		omitColumns   []string
+		dryRun        bool
+		expectError   bool
+		errorContains string
+	}
+
+	tests := []testCase{
+		{
+			name:        "dry run mode",
+			sourceTable: "source_table",
+			targetTable: "target_table",
+			omitColumns: nil,
+			dryRun:      true,
+			expectError: false,
+		},
+		{
+			name:        "actual migration",
+			sourceTable: "source_table",
+			targetTable: "target_table",
+			omitColumns: nil,
+			dryRun:      false,
+			expectError: false,
+		},
+		{
+			name:        "migration with omitted id column",
+			sourceTable: "source_table",
+			targetTable: "target_table",
+			omitColumns: []string{"id"},
+			dryRun:      false,
+			expectError: false,
+		},
+		{
+			name:        "migration with multiple omitted columns",
+			sourceTable: "source_table",
+			targetTable: "target_table",
+			omitColumns: []string{"id", "updated_at", "version"},
+			dryRun:      false,
+			expectError: false,
+		},
+	}
+
+	// Document expected behavior for each test case
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test validates structure and parameters are correct
+			// Actual database testing would be done in integration tests
+			if tt.sourceTable == "" {
+				t.Error("source table should not be empty")
+			}
+			if tt.targetTable == "" {
+				t.Error("target table should not be empty")
+			}
+		})
+	}
+}
+
+func TestOmitColumnsLogic(t *testing.T) {
+	// Test the omit columns filtering logic
+	columns := []ColumnInfo{
+		{ColumnName: "id", DataType: "bigint"},
+		{ColumnName: "name", DataType: "varchar"},
+		{ColumnName: "created_at", DataType: "timestamp"},
+		{ColumnName: "updated_at", DataType: "timestamp"},
+	}
+
+	tests := []struct {
+		name         string
+		omitColumns  []string
+		expectedCols []string
+	}{
+		{
+			name:         "no columns omitted",
+			omitColumns:  nil,
+			expectedCols: []string{"id", "name", "created_at", "updated_at"},
+		},
+		{
+			name:         "omit id column",
+			omitColumns:  []string{"id"},
+			expectedCols: []string{"name", "created_at", "updated_at"},
+		},
+		{
+			name:         "omit multiple columns",
+			omitColumns:  []string{"id", "updated_at"},
+			expectedCols: []string{"name", "created_at"},
+		},
+		{
+			name:         "omit all columns results in error case",
+			omitColumns:  []string{"id", "name", "created_at", "updated_at"},
+			expectedCols: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a map of columns to omit for quick lookup
+			omitMap := make(map[string]bool)
+			for _, col := range tt.omitColumns {
+				omitMap[col] = true
+			}
+
+			// Build column list, excluding omitted columns
+			var columnNames []string
+			for _, col := range columns {
+				if !omitMap[col.ColumnName] {
+					columnNames = append(columnNames, col.ColumnName)
+				}
+			}
+
+			// Verify result matches expected
+			if len(columnNames) != len(tt.expectedCols) {
+				t.Errorf("expected %d columns, got %d", len(tt.expectedCols), len(columnNames))
+			}
+
+			for i, colName := range columnNames {
+				if i >= len(tt.expectedCols) || colName != tt.expectedCols[i] {
+					t.Errorf("column mismatch at position %d: expected %s, got %s", i, tt.expectedCols[i], colName)
+				}
+			}
+		})
+	}
+}
+
+func TestSyncIdentityColumn(t *testing.T) {
+	// This test documents the expected behavior of SyncIdentityColumn
+	// which synchronizes the IDENTITY sequence for a column to match the current maximum value
+
+	// The function should:
+	// 1. Get the current maximum value from the column
+	// 2. Calculate the next value (max + 1, or 1 if table is empty)
+	// 3. Execute ALTER TABLE ... ALTER COLUMN ... RESTART WITH next_value
+	// 4. Log the operation with appropriate fields
+
+	// Use cases:
+	// - After migrating data from non-partitioned to partitioned table
+	// - After bulk inserting data with explicit IDs
+	// - When IDENTITY sequence is out of sync
+
+	// Example usage:
+	// err := dbc.SyncIdentityColumn("my_table", "id")
+	// if err != nil {
+	//     log.WithError(err).Error("failed to sync identity column")
+	// }
+
+	// Expected SQL for a table with max(id) = 100:
+	// ALTER TABLE my_table ALTER COLUMN id RESTART WITH 101
+
+	// Expected SQL for an empty table:
+	// ALTER TABLE my_table ALTER COLUMN id RESTART WITH 1
+
+	// This is a documentation test - actual functionality requires a live database
+	// and is tested in integration tests
+	t.Log("SyncIdentityColumn documented - integration tests required for full validation")
+}
+
+func TestMigrateTableDataRange(t *testing.T) {
+	// This test documents the expected behavior of MigrateTableDataRange
+	// which migrates data within a specific date range from one table to another
+
+	// The function should:
+	// 1. Verify schemas match between source and target tables
+	// 2. Check if target table is RANGE partitioned and verify partition coverage for the date range
+	// 3. Count rows in the source table within the date range
+	// 4. Execute INSERT INTO target SELECT * FROM source WHERE date_column >= start AND date_column < end
+	// 5. Verify row counts after migration
+	// 6. Support dry-run mode for testing
+
+	// Use cases:
+	// - Migrating data incrementally in smaller batches
+	// - Testing migrations with a subset of data
+	// - Moving specific time periods to archive tables
+	// - Migrating data to date-partitioned tables partition by partition
+
+	// Example usage:
+	// startDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	// endDate := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+	// rows, err := dbc.MigrateTableDataRange("orders", "orders_archive", "created_at", startDate, endDate, false)
+	// if err != nil {
+	//     log.WithError(err).Error("migration failed")
+	// }
+
+	// Expected behavior:
+	// - startDate is inclusive (>=)
+	// - endDate is exclusive (<)
+	// - Returns error if endDate is before startDate
+	// - Returns 0 rows if no data in range
+	// - Dry run mode returns 0 rows but validates everything else
+	// - If target is RANGE partitioned, verifies all partitions exist for the date range
+	// - Returns error if target is partitioned and partitions are missing for the date range
+	// - Skips partition check for non-RANGE partitioned tables (LIST, HASH)
+
+	// This is a documentation test - actual functionality requires a live database
+	// and is tested in integration tests
+	t.Log("MigrateTableDataRange documented - integration tests required for full validation")
+}
+
+func TestGetPartitionStrategy(t *testing.T) {
+	// This test documents the expected behavior of GetPartitionStrategy
+	// which checks if a table is partitioned and returns its partition strategy
+
+	// The function should:
+	// 1. Query PostgreSQL system catalogs (pg_partitioned_table)
+	// 2. Return empty string ("") if table is not partitioned
+	// 3. Return PartitionStrategyRange, PartitionStrategyList, PartitionStrategyHash, or "UNKNOWN"
+	// 4. Handle non-existent tables gracefully
+
+	// Example usage:
+	// strategy, err := dbc.GetPartitionStrategy("orders")
+	// if err != nil {
+	//     log.WithError(err).Error("failed to check partition strategy")
+	// }
+	// if strategy == PartitionStrategyRange {
+	//     // Table uses RANGE partitioning
+	// }
+
+	// Expected behavior:
+	// - Returns "" for non-partitioned tables
+	// - Returns PartitionStrategyRange for RANGE partitioned tables (partstrat = 'r')
+	// - Returns PartitionStrategyList for LIST partitioned tables (partstrat = 'l')
+	// - Returns PartitionStrategyHash for HASH partitioned tables (partstrat = 'h')
+	// - Returns "UNKNOWN" for other partition strategies
+	// - Constants defined in pkg/db: PartitionStrategyRange, PartitionStrategyList, PartitionStrategyHash
+
+	// This is a documentation test - actual functionality requires a live database
+	// and is tested in integration tests
+	t.Log("GetPartitionStrategy documented - integration tests required for full validation")
+}
+
+func TestVerifyPartitionCoverage(t *testing.T) {
+	// This test documents the expected behavior of VerifyPartitionCoverage
+	// which verifies that all necessary partitions exist for a date range
+
+	// The function should:
+	// 1. Query all partitions for the table
+	// 2. Check that a partition exists for each day in [startDate, endDate)
+	// 3. Return error listing missing partition dates if any are missing
+	// 4. Return nil if all partitions exist
+	// 5. Log successful verification with partition count
+
+	// Assumptions:
+	// - Daily partitions with naming: tablename_YYYY_MM_DD
+	// - Partitions cover single calendar days
+	// - startDate is inclusive, endDate is exclusive
+
+	// Example usage:
+	// err := dbc.VerifyPartitionCoverage("orders", startDate, endDate)
+	// if err != nil {
+	//     // Error message: "missing partitions for dates: [2024-01-15 2024-01-16]"
+	//     log.WithError(err).Error("partition coverage check failed")
+	// }
+
+	// Expected behavior:
+	// - Returns nil if all partitions exist for the date range
+	// - Returns error if any partitions are missing
+	// - Error message includes list of missing dates
+	// - Useful before data migrations to partitioned tables
+
+	// This is a documentation test - actual functionality requires a live database
+	// and is tested in integration tests
+	t.Log("VerifyPartitionCoverage documented - integration tests required for full validation")
+}
+
+func TestRenameTables(t *testing.T) {
+	// This test documents the expected behavior of RenameTables
+	// which renames multiple tables atomically in a single transaction
+
+	// The function should:
+	// 1. Validate that all source tables exist
+	// 2. Check for conflicts (target table already exists)
+	// 3. Allow table swaps (where target is also a source)
+	// 4. Execute all renames in a single transaction
+	// 5. Rollback all renames if any fail
+	// 6. Support dry-run mode
+
+	// Example usage:
+	// renames := map[string]string{
+	//     "orders_old": "orders_backup",
+	//     "orders_new": "orders",
+	// }
+	// count, err := dbc.RenameTables(renames, false)
+	// if err != nil {
+	//     log.WithError(err).Error("rename failed")
+	// }
+
+	// Expected behavior:
+	// - Returns error if any source table doesn't exist
+	// - Returns error if target table exists (unless it's also a source - table swap)
+	// - All renames happen atomically (all succeed or all fail)
+	// - PostgreSQL automatically updates views, indexes, and foreign keys
+	// - Very fast operation (only metadata update)
+	// - Dry run returns 0 count but validates everything
+
+	// Test cases for validation logic
+	tests := []struct {
+		name          string
+		renames       map[string]string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "simple rename",
+			renames: map[string]string{
+				"table_old": "table_new",
+			},
+			expectError: false,
+		},
+		{
+			name: "table swap",
+			renames: map[string]string{
+				"table_a": "table_b",
+				"table_b": "table_a",
+			},
+			expectError: false, // Allowed - swap scenario
+		},
+		{
+			name: "multiple renames",
+			renames: map[string]string{
+				"orders_old": "orders_backup",
+				"orders_new": "orders",
+				"items_old":  "items_backup",
+			},
+			expectError: false,
+		},
+		{
+			name:        "empty map",
+			renames:     map[string]string{},
+			expectError: true,
+		},
+		{
+			name: "three-way swap",
+			renames: map[string]string{
+				"orders":        "orders_backup",
+				"orders_new":    "orders",
+				"orders_backup": "orders_archive",
+			},
+			expectError: false, // Complex swap allowed
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Validate structure
+			if tt.expectError && len(tt.renames) > 0 {
+				// Should expect error for valid reason
+				t.Logf("Expected error case: %s", tt.name)
+			}
+		})
+	}
+
+	// This is a documentation test - actual functionality requires a live database
+	// and is tested in integration tests
+	t.Log("RenameTables documented - integration tests required for full validation")
+}


### PR DESCRIPTION
- Adds migration helpers for one off partition migration steps
- Adds FK analysis for pre-migration review
- Adds example delete helper to handle deletes without relying on cascading deletes / FK constraints
- Adds partition mananagement for 
  - Updating partitioned tables
  - Detaching old partitions
  - Dropping older detached partitions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added automated PostgreSQL partition lifecycle management for improved database performance and storage efficiency.
  * Introduced comprehensive database migration utilities for seamless table partitioning and data reorganization.
  * Enhanced database schema utilities for foreign-key management, table operations, and retention policies.

* **Tests**
  * Added extensive test coverage for partition management functionality and database schema operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->