### PR TITLE
config: add stolostron/capi-tests CAPZ e2e jobs

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -35,10 +35,9 @@ releases:
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-uksouth-e2e-parallel: true
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-e2e-parallel-ocp-nightly: true
       branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel: true
-  capz-qe:
+  capi-qe:
     jobs:
       periodic-ci-stolostron-capi-tests-configure-prow-mgmt-periodics-capz-e2e: true
-      pull-ci-stolostron-capi-tests-configure-prow-mgmt-capz-e2e: true
   aro-classic-integration:
     synthetic: true
     jobs:

--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -36,6 +36,7 @@ releases:
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-e2e-parallel-ocp-nightly: true
       branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel: true
   capi-qe:
+    synthetic: true
     jobs:
       periodic-ci-stolostron-capi-tests-configure-prow-mgmt-periodics-capz-e2e: true
   aro-classic-integration:

--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -35,6 +35,11 @@ releases:
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-uksouth-e2e-parallel: true
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-e2e-parallel-ocp-nightly: true
       branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel: true
+  capz-qe:
+    jobs:
+      periodic-ci-stolostron-capi-tests-configure-prow-mgmt-periodics-capz-e2e: true
+    regexp:
+      - "^pull-ci-stolostron-capi-tests-.*-capz-e2e$"
   aro-classic-integration:
     synthetic: true
     jobs:

--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -38,8 +38,7 @@ releases:
   capz-qe:
     jobs:
       periodic-ci-stolostron-capi-tests-configure-prow-mgmt-periodics-capz-e2e: true
-    regexp:
-      - "^pull-ci-stolostron-capi-tests-.*-capz-e2e$"
+      pull-ci-stolostron-capi-tests-configure-prow-mgmt-capz-e2e: true
   aro-classic-integration:
     synthetic: true
     jobs:


### PR DESCRIPTION
## Summary
- Add `capi-qe` section to `openshift-customizations.yaml` to register stolostron/capi-tests CAPZ e2e jobs in Sippy
- Registers the periodic job (`periodic-ci-stolostron-capi-tests-configure-prow-mgmt-periodics-capz-e2e` and `pull-ci-stolostron-capi-tests-configure-prow-mgmt-capz-e2e`) by exact name

🤖 Generated with [Claude Code](https://claude.com/claude-code)