### PR TITLE
NO-JIRA: MCO jobs: re-add cloud jobs to standard, default to candidate

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -745,22 +745,18 @@ func (v *OCPVariantLoader) setJobTier(_ logrus.FieldLogger, variants map[string]
 		// not ready to make release blocking yet.
 		{[]string{"-vsphere-host-groups"}, "candidate"},
 
-		// Periodic MCO metal jobs and vsphere jobs are not ready for component readiness yet, marking them as candidate
-		{[]string{"metal-ipi-ovn-dualstack-mco-disruptive"}, "candidate"},
-		{[]string{"metal-ipi-ovn-ipv4-mco-disruptive"}, "candidate"},
-		{[]string{"metal-ipi-ovn-ipv6-mco-disruptive"}, "candidate"},
-		{[]string{"vsphere-mco-disruptive"}, "candidate"},
-
-		// Set MCO OCL jobs to candidate
-		{[]string{"e2e-aws-ovn-ocl"}, "candidate"},
-		{[]string{"e2e-aws-ovn-upgrade-ocl"}, "candidate"},
-
-		// All remaining 4.19/4.20 MCO disruptive jobs are not ready for component readiness yet, marking them as candidate
+		// All 4.19/4.20 MCO jobs default to candidate
 		{[]string{"machine-config-operator-release-4.19"}, "candidate"},
 		{[]string{"machine-config-operator-release-4.20"}, "candidate"},
 
-		// Set remaining periodic MCO jobs to standard for component readiness
-		{[]string{"-mco-disruptive"}, "candidate"},
+		// Cloud MCO disruptive jobs set to standard for component readiness
+		// This also includes techpreview variants
+		{[]string{"e2e-aws-mco-disruptive"}, "standard"},
+		{[]string{"e2e-azure-mco-disruptive"}, "standard"},
+		{[]string{"e2e-gcp-mco-disruptive"}, "standard"},
+
+		// All remaining MCO periodic jobs default to candidate
+		{[]string{"machine-config-operator"}, "candidate"},
 
 		// Konflux jobs aren't ready yet
 		{[]string{"-konflux"}, "candidate"},


### PR DESCRIPTION
This changes the MCO logic a bit to always start in candidate, and explicitly set AWS/GCP/Azure disruptive and disruptive-techpreview jobs to standard. With this,

  - e2e-aws-mco-fips-proxy-longduration
  - e2e-aws-ovn-day1-ocl
  - e2e-vsphere-mco-tp-longduration
  - update-amis

Has been moved to candidate instead since I'm not sure they should have been standard by default. The cloud jobs should be stable enough, and is intended to serve as our component readiness for MCO specific tests.

For older context see https://github.com/openshift/sippy/pull/3393 and https://github.com/openshift/sippy/pull/3094

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated job-tier classifications for Machine Config Operator test jobs—refined defaults, promoted several cloud disruptive tests to the standard tier, and preserved candidate status for select release branches.
  * Synchronized periodic test snapshot tier values across multiple releases and infrastructure variants to reflect the revised tier mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->