### PR TITLE
SREP-3882: Add rosa-e2e and conformance jobs to rosa-stage view

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -62,6 +62,13 @@ releases:
       periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-y-plus-1-to-latest-y: true
       # OSD-AWS informing (stage)
       periodic-ci-openshift-osde2e-main-aws-stage-informing-default: true
+    regexp:
+      # rosa-e2e managed service validation + OCM FVT (current and future versioned jobs)
+      - "^periodic-ci-openshift-online-rosa-e2e-main-.*"
+      # ROSA HCP conformance (all versions)
+      - "^periodic-ci-openshift-release-main-nightly-.*-e2e-rosa-hcp-ovn$"
+      # ROSA Classic/STS conformance (all versions)
+      - "^periodic-ci-openshift-release-main-nightly-.*-e2e-rosa-sts-ovn$"
   rosa-integration:
     jobs: {}
   rosa-production:


### PR DESCRIPTION
## Summary

Add ROSA CI jobs to the rosa-stage Sippy release view so we can track pass rates and trends in a unified dashboard.

Jobs added:
- `periodic-ci-openshift-online-rosa-e2e-main-rosa-hcp-e2e-nightly` -- rosa-e2e managed service validation
- `periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-periodic-cs-rosa-hcp-ad-staging-main` -- OCM FVT (clusters-service tests)
- `periodic-ci-openshift-release-main-nightly-4.{19-23}-e2e-rosa-hcp-ovn` -- ROSA HCP conformance
- `periodic-ci-openshift-release-main-nightly-4.{18-23}-e2e-rosa-sts-ovn` -- ROSA Classic STS conformance

These jobs are now all running and passing after recent CI stability fixes ([SREP-4345](https://redhat.atlassian.net/browse/SREP-4345)).

Jira: https://redhat.atlassian.net/browse/SREP-3882

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enabled extended conformance and validation testing for ROSA managed service deployments across OpenShift versions 4.18–4.23, including hosted control plane and STS configurations for enhanced test coverage.
  * Added regex-based job selection to activate additional automated E2E and nightly test jobs for ROSA, increasing test coverage without removing existing explicit job listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->