### PR TITLE
ipv4 dualstack installer job should also be candidate

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -810,6 +810,7 @@ func (v *OCPVariantLoader) setJobTier(_ logrus.FieldLogger, variants map[string]
 		// AWS DualStack Techpreview jobs - candidate tier to collect data while stabilizing
 		{[]string{"-aws-ovn-dualstack"}, "candidate"},
 		{[]string{"-aws-ovn-installer-dualstack-ipv6-primary-techpreview"}, "candidate"},
+		{[]string{"-aws-ovn-installer-dualstack-ipv4-primary-techpreview"}, "candidate"},
 
 		{[]string{"periodic-ci-openshift-hypershift-", "-mce-e2e-agent-", "-metal-conformance"}, "candidate"},
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated AWS OVN installer variant classifications for dualstack configurations
    - AWS OVN dualstack IPv4 primary installer now classified as candidate tier
    - AWS OVN dualstack IPv6 primary installers updated to candidate tier

<!-- end of auto-generated comment: release notes by coderabbit.ai -->