### PR TITLE
Add failure diagnostics to e2e setup and test scripts

### DIFF
--- a/e2e-scripts/sippy-e2e-sippy-e2e-setup-commands.sh
+++ b/e2e-scripts/sippy-e2e-sippy-e2e-setup-commands.sh
@@ -194,22 +194,68 @@ ${KUBECTL_CMD} -n sippy-e2e wait --for=condition=Ready pod/postg1 --timeout=${TI
 postgres_retVal=$?
 ${KUBECTL_CMD} -n sippy-e2e wait --for=condition=Ready pod/redis1 --timeout=${TIMEOUT}
 redis_retVal=$?
-set -e
+
 echo
+echo "=== Pod status ==="
+${KUBECTL_CMD} -n sippy-e2e get po -o wide
+echo
+
 echo "Saving postgres logs ..."
-${KUBECTL_CMD} -n sippy-e2e logs postg1 > ${ARTIFACT_DIR}/postgres.log
+${KUBECTL_CMD} -n sippy-e2e logs postg1 > ${ARTIFACT_DIR}/postgres.log 2>&1
 echo "Saving redis logs ..."
-${KUBECTL_CMD} -n sippy-e2e logs redis1 > ${ARTIFACT_DIR}/redis.log
+${KUBECTL_CMD} -n sippy-e2e logs redis1 > ${ARTIFACT_DIR}/redis.log 2>&1
+
+if [ ${postgres_retVal} -ne 0 ] || [ ${redis_retVal} -ne 0 ]; then
+  echo
+  echo "=== FAILURE DIAGNOSTICS ==="
+  echo
+
+  echo "=== Pod descriptions ==="
+  ${KUBECTL_CMD} -n sippy-e2e describe pod/postg1
+  echo "---"
+  ${KUBECTL_CMD} -n sippy-e2e describe pod/redis1
+  echo
+
+  echo "=== Namespace events (sorted by time) ==="
+  ${KUBECTL_CMD} -n sippy-e2e get events --sort-by='.lastTimestamp'
+  echo
+
+  echo "=== Pod conditions ==="
+  ${KUBECTL_CMD} -n sippy-e2e get pod postg1 -o jsonpath='{range .status.conditions[*]}{.type}={.status} reason={.reason} message={.message}{"\n"}{end}' 2>/dev/null
+  echo "---"
+  ${KUBECTL_CMD} -n sippy-e2e get pod redis1 -o jsonpath='{range .status.conditions[*]}{.type}={.status} reason={.reason} message={.message}{"\n"}{end}' 2>/dev/null
+  echo
+
+  echo "=== Container statuses ==="
+  ${KUBECTL_CMD} -n sippy-e2e get pod postg1 -o jsonpath='{range .status.containerStatuses[*]}name={.name} ready={.ready} state={.state}{"\n"}{end}' 2>/dev/null
+  echo "---"
+  ${KUBECTL_CMD} -n sippy-e2e get pod redis1 -o jsonpath='{range .status.containerStatuses[*]}name={.name} ready={.ready} state={.state}{"\n"}{end}' 2>/dev/null
+  echo
+
+  echo "=== Node status for scheduled nodes ==="
+  postg1_node=$(${KUBECTL_CMD} -n sippy-e2e get pod postg1 -o jsonpath='{.spec.nodeName}' 2>/dev/null)
+  redis1_node=$(${KUBECTL_CMD} -n sippy-e2e get pod redis1 -o jsonpath='{.spec.nodeName}' 2>/dev/null)
+  for node in ${postg1_node} ${redis1_node}; do
+    if [ -n "${node}" ]; then
+      echo "Node ${node} conditions:"
+      ${KUBECTL_CMD} get node ${node} -o jsonpath='{range .status.conditions[*]}  {.type}={.status} message={.message}{"\n"}{end}' 2>/dev/null
+    fi
+  done
+  echo
+
+  echo "=== END FAILURE DIAGNOSTICS ==="
+fi
+set -e
+
 if [ ${postgres_retVal} -ne 0 ]; then
-  echo "Postgres pod never came up"
+  echo "ERROR: Postgres pod never became Ready (timed out after ${TIMEOUT})"
   exit 1
 fi
 if [ ${redis_retVal} -ne 0 ]; then
-  echo "Redis pod never came up"
+  echo "ERROR: Redis pod never became Ready (timed out after ${TIMEOUT})"
   exit 1
 fi
 
-${KUBECTL_CMD} -n sippy-e2e get po -o wide
 ${KUBECTL_CMD} -n sippy-e2e get svc,ep
 
 # Get the gcs credentials out to the cluster-pool cluster.
@@ -294,10 +340,20 @@ retVal=$?
 set -e
 
 job_pod=$(${KUBECTL_CMD} -n sippy-e2e get pod --selector=job-name=sippy-load-job --output=jsonpath='{.items[0].metadata.name}')
-${KUBECTL_CMD} -n sippy-e2e logs ${job_pod} > ${ARTIFACT_DIR}/sippy-load.log
+${KUBECTL_CMD} -n sippy-e2e logs ${job_pod} > ${ARTIFACT_DIR}/sippy-load.log 2>&1
 
 if [ ${retVal} -ne 0 ]; then
-  echo "sippy loading never finished on time."
+  echo
+  echo "=== SIPPY LOAD JOB FAILURE DIAGNOSTICS ==="
+  echo "=== Job status ==="
+  ${KUBECTL_CMD} -n sippy-e2e describe job sippy-load-job
+  echo "=== Job pod status ==="
+  ${KUBECTL_CMD} -n sippy-e2e describe pod ${job_pod}
+  echo "=== Recent namespace events ==="
+  ${KUBECTL_CMD} -n sippy-e2e get events --sort-by='.lastTimestamp'
+  echo "=== END SIPPY LOAD JOB FAILURE DIAGNOSTICS ==="
+  echo
+  echo "ERROR: sippy-load-job did not complete within ${SIPPY_LOAD_TIMEOUT}"
   exit 1
 fi
 

--- a/e2e-scripts/sippy-e2e-sippy-e2e-test-commands.sh
+++ b/e2e-scripts/sippy-e2e-sippy-e2e-test-commands.sh
@@ -112,10 +112,25 @@ END
 
 # The basic readiness probe will give us at least 10 seconds before declaring the pod as ready.
 echo "Waiting for sippy api server pod to be Ready ..."
+set +e
 ${KUBECTL_CMD} -n sippy-e2e wait --for=condition=Ready pod/sippy-server --timeout=600s
+server_retVal=$?
+set -e
 
 ${KUBECTL_CMD} -n sippy-e2e get pod -o wide
-${KUBECTL_CMD} -n sippy-e2e logs sippy-server > ${ARTIFACT_DIR}/sippy-server.log
+${KUBECTL_CMD} -n sippy-e2e logs sippy-server > ${ARTIFACT_DIR}/sippy-server.log 2>&1
+
+if [ ${server_retVal} -ne 0 ]; then
+  echo
+  echo "=== SIPPY SERVER FAILURE DIAGNOSTICS ==="
+  ${KUBECTL_CMD} -n sippy-e2e describe pod/sippy-server
+  echo "=== Namespace events ==="
+  ${KUBECTL_CMD} -n sippy-e2e get events --sort-by='.lastTimestamp'
+  echo "=== END SIPPY SERVER FAILURE DIAGNOSTICS ==="
+  echo
+  echo "ERROR: sippy-server pod never became Ready (timed out after 600s)"
+  exit 1
+fi
 
 echo "Setup services and port forwarding for the sippy api server ..."
 


### PR DESCRIPTION
## Summary
- When e2e pods (postgres, redis, sippy-load-job, sippy-server) fail to become Ready, the scripts now capture detailed diagnostics before exiting: pod descriptions, namespace events, pod conditions, container statuses, and node conditions
- Previously, failures produced only a one-line error and often 0-byte log files (e.g. when kubelet TLS errors prevented log retrieval), making root cause analysis impossible
- Motivated by [4 consecutive e2e failures on April 13](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_sippy/3426/pull-ci-openshift-sippy-main-e2e/2043683614276718592) where postgres/redis pods timed out but no diagnostic info was available to determine the cause


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test setup and execution reliability with enhanced error handling and diagnostics
  * Added comprehensive failure diagnostics including pod status, events, and detailed logs when issues occur
  * Enhanced timeout error messages with specific duration information for better troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->