### PR TITLE
OCPBUGS-83289 : removing job until stable

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -773,6 +773,9 @@ func (v *OCPVariantLoader) setJobTier(_ logrus.FieldLogger, variants map[string]
 		{[]string{"periodic-ci-openshift-operator-framework-operator-controller-", "-extended-"}, "candidate"},
 		{[]string{"periodic-ci-openshift-operator-framework-olm-", "-extended-"}, "candidate"},
 
+		// GCP multi-operator periodic jobs are not yet stable enough for component readiness
+		{[]string{"e2e-gcp-multi-operator-periodic"}, "candidate"},
+
 		// Hidden jobs
 		{[]string{"-cilium"}, "hidden"},
 		{[]string{"-disruptive"}, "hidden"},


### PR DESCRIPTION
PTAL when time permits , 

This was raised by Zhaohua [earlier](https://github.com/openshift/release/pull/75883/changes#diff-b8ae75a7eb00a77c010b0e9f0e428eaa40bb965c95c5a9cbb5e76d1438a5333b) 

@damdo we can move the tier to standard until stable , rest jobs looks good only the gcp-multi is flaking , causing some signal noise 

cc @dgoodwin 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated job tier classification for GCP multi-operator periodic e2e tests to `candidate` tier, including a new matching rule for related test jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->