### PR TITLE
Mass Failure and Job Label Display in Test Details Reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ The system consists of:
 * Written in **Golang**.
 * When adding or updating APIs, **use HATEOAS** in responses to support discoverability and consistent client interaction.
 * Follow idiomatic Go practices.
+* After making changes, always run `gofmt -w` on modified files to ensure proper formatting.
 
 ## Frontend Guidelines
 

--- a/pkg/api/componentreadiness/query/querygenerators.go
+++ b/pkg/api/componentreadiness/query/querygenerators.go
@@ -562,6 +562,15 @@ func buildTestDetailsQuery(
 	// Build WITH clause with key test filtering if configured
 	withClause, commonParams := buildCRQueryCTEs(client.Dataset, junitTable, jobNameQueryPortion, jobRunAnnotationToIgnore, c.AdvancedOption.KeyTestNames)
 
+	jobLabelsJoin := fmt.Sprintf(`LEFT JOIN (
+						SELECT prowjob_build_id, STRING_AGG(DISTINCT label, ',' ORDER BY label) AS job_labels
+						FROM %s.job_labels
+						WHERE prowjob_start >= DATETIME(@From)
+						AND prowjob_start < DATETIME(@To)
+						GROUP BY prowjob_build_id
+					) agg_labels ON junit.prowjob_build_id = agg_labels.prowjob_build_id
+`, client.Dataset)
+
 	queryString := fmt.Sprintf(`%s
 					SELECT
 						cm.id AS test_id,
@@ -579,9 +588,12 @@ func buildTestDetailsQuery(
 						ANY_VALUE(cm.capabilities) as capabilities,
 						SUM(adjusted_success_val) AS success_count,
 						SUM(adjusted_flake_count) AS flake_count,
+						ANY_VALUE(agg_labels.job_labels) AS job_labels,
 					FROM deduped_testcases junit
 					INNER JOIN latest_component_mapping cm ON testsuite = cm.suite AND test_name = cm.name
 `, withClause, selectVariants)
+
+	queryString += jobLabelsJoin
 
 	queryString += joinVariants
 
@@ -1064,6 +1076,10 @@ func deserializeRowToJobRunTestReportStatus(row []bigquery.Value, schema bigquer
 			cts.JiraComponent = row[i].(string)
 		case col == "jira_component_id":
 			cts.JiraComponentID = row[i].(*big.Rat)
+		case col == "job_labels":
+			if row[i] != nil {
+				cts.JobLabels = strings.Split(row[i].(string), ",")
+			}
 		case strings.HasPrefix(col, "variant_"):
 			variantName := col[len("variant_"):]
 			if row[i] != nil {

--- a/pkg/api/componentreadiness/query/querygenerators.go
+++ b/pkg/api/componentreadiness/query/querygenerators.go
@@ -571,6 +571,14 @@ func buildTestDetailsQuery(
 					) agg_labels ON junit.prowjob_build_id = agg_labels.prowjob_build_id
 `, client.Dataset)
 
+	jobRunFailuresJoin := `LEFT JOIN (
+						SELECT prowjob_build_id, COUNT(DISTINCT test_name) AS job_run_test_failure_count
+						FROM deduped_testcases
+						WHERE adjusted_success_val = 0 AND adjusted_flake_count = 0
+						GROUP BY prowjob_build_id
+					) agg_failures ON junit.prowjob_build_id = agg_failures.prowjob_build_id
+`
+
 	queryString := fmt.Sprintf(`%s
 					SELECT
 						cm.id AS test_id,
@@ -589,11 +597,13 @@ func buildTestDetailsQuery(
 						SUM(adjusted_success_val) AS success_count,
 						SUM(adjusted_flake_count) AS flake_count,
 						ANY_VALUE(agg_labels.job_labels) AS job_labels,
+						ANY_VALUE(agg_failures.job_run_test_failure_count) AS job_run_test_failure_count,
 					FROM deduped_testcases junit
 					INNER JOIN latest_component_mapping cm ON testsuite = cm.suite AND test_name = cm.name
 `, withClause, selectVariants)
 
 	queryString += jobLabelsJoin
+	queryString += jobRunFailuresJoin
 
 	queryString += joinVariants
 
@@ -1079,6 +1089,10 @@ func deserializeRowToJobRunTestReportStatus(row []bigquery.Value, schema bigquer
 		case col == "job_labels":
 			if row[i] != nil {
 				cts.JobLabels = strings.Split(row[i].(string), ",")
+			}
+		case col == "job_run_test_failure_count":
+			if row[i] != nil {
+				cts.TestFailures = int(row[i].(int64))
 			}
 		case strings.HasPrefix(col, "variant_"):
 			variantName := col[len("variant_"):]

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -670,6 +670,7 @@ func (c *ComponentReportGenerator) getJobRunStats(stats bq.TestJobRunRows) testd
 		JobURL:    stats.ProwJobURL,
 		JobRunID:  stats.ProwJobRunID,
 		StartTime: stats.StartTime,
+		JobLabels: stats.JobLabels,
 	}
 	return jobRunStats
 }

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -667,10 +667,11 @@ func (c *ComponentReportGenerator) getJobRunStats(stats bq.TestJobRunRows) testd
 			stats.FlakeCount,
 			c.ReqOptions.AdvancedOption.FlakeAsFailure,
 		),
-		JobURL:    stats.ProwJobURL,
-		JobRunID:  stats.ProwJobRunID,
-		StartTime: stats.StartTime,
-		JobLabels: stats.JobLabels,
+		JobURL:                 stats.ProwJobURL,
+		JobRunID:               stats.ProwJobRunID,
+		StartTime:              stats.StartTime,
+		JobLabels:              stats.JobLabels,
+		TestFailures:           stats.TestFailures,
 	}
 	return jobRunStats
 }

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -667,11 +667,11 @@ func (c *ComponentReportGenerator) getJobRunStats(stats bq.TestJobRunRows) testd
 			stats.FlakeCount,
 			c.ReqOptions.AdvancedOption.FlakeAsFailure,
 		),
-		JobURL:                 stats.ProwJobURL,
-		JobRunID:               stats.ProwJobRunID,
-		StartTime:              stats.StartTime,
-		JobLabels:              stats.JobLabels,
-		TestFailures:           stats.TestFailures,
+		JobURL:       stats.ProwJobURL,
+		JobRunID:     stats.ProwJobRunID,
+		StartTime:    stats.StartTime,
+		JobLabels:    stats.JobLabels,
+		TestFailures: stats.TestFailures,
 	}
 	return jobRunStats
 }

--- a/pkg/apis/api/componentreport/bq/types.go
+++ b/pkg/apis/api/componentreport/bq/types.go
@@ -62,6 +62,7 @@ type TestJobRunRows struct {
 	crtest.Count
 	JiraComponent   string   `bigquery:"jira_component"`
 	JiraComponentID *big.Rat `bigquery:"jira_component_id"`
+	JobLabels       []string `json:"job_labels,omitempty"`
 }
 
 // JobVariant defines a variant and the possible values

--- a/pkg/apis/api/componentreport/bq/types.go
+++ b/pkg/apis/api/componentreport/bq/types.go
@@ -60,9 +60,10 @@ type TestJobRunRows struct {
 	ProwJobURL   string                 `bigquery:"prowjob_url"`
 	StartTime    civil.DateTime         `bigquery:"prowjob_start"`
 	crtest.Count
-	JiraComponent   string   `bigquery:"jira_component"`
-	JiraComponentID *big.Rat `bigquery:"jira_component_id"`
-	JobLabels       []string `json:"job_labels,omitempty"`
+	JiraComponent          string   `bigquery:"jira_component"`
+	JiraComponentID        *big.Rat `bigquery:"jira_component_id"`
+	JobLabels              []string `json:"job_labels,omitempty"`
+	TestFailures           int      `json:"test_failures"`
 }
 
 // JobVariant defines a variant and the possible values

--- a/pkg/apis/api/componentreport/bq/types.go
+++ b/pkg/apis/api/componentreport/bq/types.go
@@ -62,8 +62,8 @@ type TestJobRunRows struct {
 	crtest.Count
 	JiraComponent   string   `bigquery:"jira_component"`
 	JiraComponentID *big.Rat `bigquery:"jira_component_id"`
-	JobLabels       []string `json:"job_labels,omitempty"`
-	TestFailures    int      `json:"test_failures"`
+	JobLabels       []string `bigquery:"-" json:"job_labels,omitempty"`
+	TestFailures    int      `bigquery:"-" json:"test_failures"`
 }
 
 // JobVariant defines a variant and the possible values

--- a/pkg/apis/api/componentreport/bq/types.go
+++ b/pkg/apis/api/componentreport/bq/types.go
@@ -60,10 +60,10 @@ type TestJobRunRows struct {
 	ProwJobURL   string                 `bigquery:"prowjob_url"`
 	StartTime    civil.DateTime         `bigquery:"prowjob_start"`
 	crtest.Count
-	JiraComponent          string   `bigquery:"jira_component"`
-	JiraComponentID        *big.Rat `bigquery:"jira_component_id"`
-	JobLabels              []string `json:"job_labels,omitempty"`
-	TestFailures           int      `json:"test_failures"`
+	JiraComponent   string   `bigquery:"jira_component"`
+	JiraComponentID *big.Rat `bigquery:"jira_component_id"`
+	JobLabels       []string `json:"job_labels,omitempty"`
+	TestFailures    int      `json:"test_failures"`
 }
 
 // JobVariant defines a variant and the possible values

--- a/pkg/apis/api/componentreport/testdetails/types.go
+++ b/pkg/apis/api/componentreport/testdetails/types.go
@@ -111,4 +111,5 @@ type JobRunStats struct {
 	// For the majority of the tests, there is only one junit. But
 	// there are cases multiple junits are generated for the same test.
 	TestStats crtest.Stats `json:"test_stats"`
+	JobLabels []string     `json:"job_labels,omitempty"`
 }

--- a/pkg/apis/api/componentreport/testdetails/types.go
+++ b/pkg/apis/api/componentreport/testdetails/types.go
@@ -110,6 +110,7 @@ type JobRunStats struct {
 	// TestStats is the test stats from one particular job run.
 	// For the majority of the tests, there is only one junit. But
 	// there are cases multiple junits are generated for the same test.
-	TestStats crtest.Stats `json:"test_stats"`
-	JobLabels []string     `json:"job_labels,omitempty"`
+	TestStats              crtest.Stats `json:"test_stats"`
+	JobLabels              []string     `json:"job_labels,omitempty"`
+	TestFailures           int          `json:"test_failures"`
 }

--- a/pkg/apis/api/componentreport/testdetails/types.go
+++ b/pkg/apis/api/componentreport/testdetails/types.go
@@ -110,7 +110,7 @@ type JobRunStats struct {
 	// TestStats is the test stats from one particular job run.
 	// For the majority of the tests, there is only one junit. But
 	// there are cases multiple junits are generated for the same test.
-	TestStats              crtest.Stats `json:"test_stats"`
-	JobLabels              []string     `json:"job_labels,omitempty"`
-	TestFailures           int          `json:"test_failures"`
+	TestStats    crtest.Stats `json:"test_stats"`
+	JobLabels    []string     `json:"job_labels,omitempty"`
+	TestFailures int          `json:"test_failures"`
 }

--- a/sippy-ng/src/component_readiness/CompReadyTestDetailRow.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestDetailRow.js
@@ -9,8 +9,13 @@ import TableRow from '@mui/material/TableRow'
 
 import { getTestStatus } from '../helpers'
 
+const MASS_FAILURE_THRESHOLD = 10
+
 const isMassFailure = (jobRun) => {
-  return jobRun.test_stats.failure_count > 0 && jobRun.test_failures > 10
+  return (
+    jobRun.test_stats.failure_count > 0 &&
+    (jobRun.test_failures || 0) > MASS_FAILURE_THRESHOLD
+  )
 }
 
 const getJobRunColor = (jobRun) => {
@@ -100,7 +105,7 @@ export default function CompReadyTestDetailRow(props) {
                   ' (#' +
                   jobRun.job_run_id +
                   ') | ' +
-                  jobRun.test_failures +
+                  (jobRun.test_failures ?? 0) +
                   ' test failures in job run'
                 if (jobRun.job_labels && jobRun.job_labels.length > 0) {
                   tooltipText += ' | Labels: ' + jobRun.job_labels.join(', ')

--- a/sippy-ng/src/component_readiness/CompReadyTestDetailRow.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestDetailRow.js
@@ -9,7 +9,14 @@ import TableRow from '@mui/material/TableRow'
 
 import { getTestStatus } from '../helpers'
 
+const isMassFailure = (jobRun) => {
+  return jobRun.test_stats.failure_count > 0 && jobRun.test_failures > 10
+}
+
 const getJobRunColor = (jobRun) => {
+  if (isMassFailure(jobRun)) {
+    return 'orange'
+  }
   return getTestStatus(jobRun.test_stats, 'purple', 'red', 'green')
 }
 
@@ -86,17 +93,23 @@ export default function CompReadyTestDetailRow(props) {
               .slice()
               .reverse()
               .map((jobRun, jobRunIndex) => {
+                let letter = jobRun.test_stats.failure_count > 0 ? 'F' : 'S'
+
+                let tooltipText =
+                  new Date(jobRun.start_time).toUTCString() +
+                  ' (#' +
+                  jobRun.job_run_id +
+                  ') | ' +
+                  jobRun.test_failures +
+                  ' test failures in job run'
+                if (jobRun.job_labels && jobRun.job_labels.length > 0) {
+                  tooltipText += ' | Labels: ' + jobRun.job_labels.join(', ')
+                }
+
                 var content = (
-                  <Tooltip
-                    title={
-                      new Date(jobRun.start_time).toUTCString() +
-                      ' (#' +
-                      jobRun.job_run_id +
-                      ')'
-                    }
-                  >
+                  <Tooltip title={tooltipText}>
                     <Typography className={classes.crCellName}>
-                      {jobRun.test_stats.failure_count > 0 ? 'F' : 'S'}
+                      {letter}
                     </Typography>
                   </Tooltip>
                 )


### PR DESCRIPTION
- **Expose job labels in test details API response**
- **Include test failure count with test details report job run data**
- **Show mass failures in orange and test failure count in tooltip on test details reports**

This provides insight for humans viewing the test details report we've wanted for some time ,but the data in the API response will also make it available for AI analysis to detect that the bulk of the jobs are mass failing, or were impacted by a particular symptom and job label.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced job-run tooltips to show job labels, test failure counts, UTC timestamp and run ID for easier diagnostics.
  * Added visual highlighting for mass-failure job runs (high test-failure counts shown in orange).

* **Documentation**
  * Added contributor guideline to enforce Go code formatting with gofmt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->