### PR TITLE
Add new prow jobs that test ARO-HCP with OCP nightly builds

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -22,9 +22,11 @@ releases:
   aro-integration:
     jobs:
       periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel: true
+      periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel-ocp-nightly: true
   aro-stage:
     jobs:
       periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel: true
+      periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel-ocp-nightly: true
   aro-production:
     jobs:
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-e2e-parallel: true
@@ -32,6 +34,7 @@ releases:
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-brazilsouth-e2e-parallel: true
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-centralindia-e2e-parallel: true
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-uksouth-e2e-parallel: true
+      periodic-ci-Azure-ARO-HCP-main-periodic-prod-e2e-parallel-ocp-nightly: true
   rosa-stage:
     jobs:
       # ROSA Classic/STS nightly (stage)

--- a/config/openshift.yaml
+++ b/config/openshift.yaml
@@ -17009,6 +17009,7 @@ releases:
     aro-integration:
         jobs:
             periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel: true
+            periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel-ocp-nightly: true
     aro-production:
         jobs:
             periodic-ci-Azure-ARO-HCP-main-periodic-create-aro-hcp-in-prod-uksouth: true
@@ -17016,9 +17017,11 @@ releases:
             periodic-ci-Azure-ARO-HCP-main-periodic-prod-centralindia-e2e-parallel: true
             periodic-ci-Azure-ARO-HCP-main-periodic-prod-e2e-parallel: true
             periodic-ci-Azure-ARO-HCP-main-periodic-prod-uksouth-e2e-parallel: true
+            periodic-ci-Azure-ARO-HCP-main-periodic-prod-e2e-parallel-ocp-nightly: true
     aro-stage:
         jobs:
             periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel: true
+            periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel-ocp-nightly: true
     automation:
         jobs:
             periodic-ci-openshift-hypershift-main-periodic-jira-agent: true


### PR DESCRIPTION
Add new prow jobs that test ARO-HCP with OCP nightly builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enabled new nightly OpenShift testing jobs for Azure ARO HCP deployments across integration, staging, and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->