### PR TITLE
TRT-2634: add a redirect for regression urls

### DIFF
--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -37,6 +37,7 @@ import CompReadyRow from './CompReadyRow'
 import CopyPageURL from './CopyPageURL'
 import GeneratedAt from './GeneratedAt'
 import React, { Fragment, useContext, useEffect, useState } from 'react'
+import RegressionRedirect from './RegressionRedirect'
 import Sidebar from './Sidebar'
 import Table from '@mui/material/Table'
 import TableBody from '@mui/material/TableBody'
@@ -592,6 +593,10 @@ export default function ComponentReadiness(props) {
               />
               <Route path="/triages/:triageId" element={<TriageWrapper />} />
               <Route path="/triages" element={<TriageList />} />
+              <Route
+                path="regressions/:regressionId"
+                element={<RegressionRedirect />}
+              />
               <Route
                 path="main"
                 element={

--- a/sippy-ng/src/component_readiness/RegressionRedirect.js
+++ b/sippy-ng/src/component_readiness/RegressionRedirect.js
@@ -10,6 +10,7 @@ export default function RegressionRedirect() {
   const [error, setError] = React.useState(null)
 
   React.useEffect(() => {
+    setError(null)
     const abortController = new AbortController()
 
     fetch(getRegressionAPIUrl(regressionId), {
@@ -34,11 +35,18 @@ export default function RegressionRedirect() {
         const pathAfterApi = regression.links.test_details.substring(
           apiIndex + 5
         )
-        if (!pathAfterApi.startsWith('component_readiness/')) {
+        let parsed
+        try {
+          parsed = new URL(pathAfterApi, window.location.origin)
+        } catch {
+          setError('Could not parse test details link.')
+          return
+        }
+        if (!parsed.pathname.startsWith('/component_readiness/')) {
           setError('Unexpected redirect path.')
           return
         }
-        navigate('/' + pathAfterApi, { replace: true })
+        navigate(parsed.pathname + parsed.search, { replace: true })
       })
       .catch((err) => {
         if (err.name === 'AbortError') {

--- a/sippy-ng/src/component_readiness/RegressionRedirect.js
+++ b/sippy-ng/src/component_readiness/RegressionRedirect.js
@@ -1,0 +1,45 @@
+import { getRegressionAPIUrl } from './CompReadyUtils'
+import { useNavigate, useParams } from 'react-router-dom'
+import Alert from '@mui/material/Alert'
+import React from 'react'
+import Typography from '@mui/material/Typography'
+
+export default function RegressionRedirect() {
+  const { regressionId } = useParams()
+  const navigate = useNavigate()
+  const [error, setError] = React.useState(null)
+
+  React.useEffect(() => {
+    fetch(getRegressionAPIUrl(regressionId))
+      .then((response) => {
+        if (response.status !== 200) {
+          throw new Error('API server returned ' + response.status)
+        }
+        return response.json()
+      })
+      .then((regression) => {
+        if (!regression.links?.test_details) {
+          setError('No test details link available for this regression.')
+          return
+        }
+        const apiIndex = regression.links.test_details.indexOf('/api/')
+        if (apiIndex === -1) {
+          setError('Could not parse test details link.')
+          return
+        }
+        const pathAfterApi = regression.links.test_details.substring(
+          apiIndex + 5
+        )
+        navigate('/' + pathAfterApi, { replace: true })
+      })
+      .catch((err) => {
+        setError('Failed to load regression: ' + err.message)
+      })
+  }, [regressionId, navigate])
+
+  if (error) {
+    return <Alert severity="error">{error}</Alert>
+  }
+
+  return <Typography>Loading regression details...</Typography>
+}

--- a/sippy-ng/src/component_readiness/RegressionRedirect.js
+++ b/sippy-ng/src/component_readiness/RegressionRedirect.js
@@ -34,6 +34,10 @@ export default function RegressionRedirect() {
         const pathAfterApi = regression.links.test_details.substring(
           apiIndex + 5
         )
+        if (!pathAfterApi.startsWith('component_readiness/')) {
+          setError('Unexpected redirect path.')
+          return
+        }
         navigate('/' + pathAfterApi, { replace: true })
       })
       .catch((err) => {

--- a/sippy-ng/src/component_readiness/RegressionRedirect.js
+++ b/sippy-ng/src/component_readiness/RegressionRedirect.js
@@ -10,7 +10,11 @@ export default function RegressionRedirect() {
   const [error, setError] = React.useState(null)
 
   React.useEffect(() => {
-    fetch(getRegressionAPIUrl(regressionId))
+    const abortController = new AbortController()
+
+    fetch(getRegressionAPIUrl(regressionId), {
+      signal: abortController.signal,
+    })
       .then((response) => {
         if (response.status !== 200) {
           throw new Error('API server returned ' + response.status)
@@ -18,7 +22,7 @@ export default function RegressionRedirect() {
         return response.json()
       })
       .then((regression) => {
-        if (!regression.links?.test_details) {
+        if (!regression?.links?.test_details) {
           setError('No test details link available for this regression.')
           return
         }
@@ -33,8 +37,14 @@ export default function RegressionRedirect() {
         navigate('/' + pathAfterApi, { replace: true })
       })
       .catch((err) => {
+        if (err.name === 'AbortError') {
+          return
+        }
         setError('Failed to load regression: ' + err.message)
       })
+    return () => {
+      abortController.abort()
+    }
   }, [regressionId, navigate])
 
   if (error) {


### PR DESCRIPTION
Analyzed and assisted by Claude.  Many of our bugs have links that do not render like:https://sippy-auth.dptools.openshift.org/sippy-ng/component_readiness/regressions/37839?view=4.22-main 

```
The URL /sippy-ng/component_readiness/regressions/37839?view=4.22-main matches the wildcard route 
component_readiness/* in App.js:740, which renders the ComponentReadiness component. 
Inside ComponentReadiness, the <Routes> block (lines 500-758) defines sub-routes for main, help, test_details, test,        
env_test, capability, env_capability, capabilities, env_capabilities, triages/:triageId, and triages 

— but there is no route for regressions/:id. 
```
  
  Fix is to add a redirect to the test details page                                        

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a regressions URL (regressions/:regressionId) for direct navigation to regression pages.
  * Automatically fetches regression data and redirects users to the related test-details page when available.
  * Shows a loading message during fetch and displays clear error alerts if data is missing, invalid, or cannot be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->