### PR TITLE
Fix npm audit CVE in protocol-buffers-schema

### DIFF
--- a/sippy-ng/package-lock.json
+++ b/sippy-ng/package-lock.json
@@ -23307,9 +23307,9 @@
       }
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
       "license": "MIT"
     },
     "node_modules/proxy-addr": {


### PR DESCRIPTION
## Summary
- Bumps `protocol-buffers-schema` from 3.6.0 to 3.6.1 in `sippy-ng/package-lock.json`
- Fixes GHSA-j452-xhg8-qg39 (prototype pollution), which was causing `npm audit --omit=dev` to fail in the lint CI job

## Test plan
- [x] `npm audit --omit=dev` passes with 0 vulnerabilities
- [ ] Lint CI job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)