### PR TITLE
Fix missing test_details link on regressions with fallback base release

### DIFF
--- a/pkg/api/componentreadiness/triage.go
+++ b/pkg/api/componentreadiness/triage.go
@@ -756,8 +756,13 @@ func InjectRegressionHATEOASLinks(regression *models.TestRegression, views []crv
 		"self": fmt.Sprintf(regressionLink, baseAPIURL, regression.ID),
 	}
 
-	// The test_details link will be that of the main view for the given release pair
+	// The test_details link will be that of the main view for the given release pair.
+	// When release fallback is used, the regression's BaseRelease may differ from the view's base release
+	// (e.g., "4.20" instead of "4.21"), so fall back to matching by sample release only.
 	view, ok := GetMainViewForRelease(regression.BaseRelease, regression.Release, views)
+	if !ok {
+		view, ok = GetMainViewForSampleRelease(regression.Release, views)
+	}
 	if !ok {
 		log.Errorf("no main view found for base: %s, and sample: %s", regression.BaseRelease, regression.Release)
 		return
@@ -824,6 +829,17 @@ func GetMainViewForRelease(baseRelease, sampleRelease string, views []crview.Vie
 	matching := ViewsMatchingReleases(baseRelease, sampleRelease, views)
 	for _, v := range matching {
 		if strings.HasSuffix(v.Name, "-main") {
+			return v, true
+		}
+	}
+	return crview.View{}, false
+}
+
+// GetMainViewForSampleRelease returns the main view matching only the sample release.
+// Used as a fallback when a regression's base release differs from the view's due to release fallback.
+func GetMainViewForSampleRelease(sampleRelease string, views []crview.View) (view crview.View, ok bool) {
+	for _, v := range views {
+		if v.RegressionTracking.Enabled && v.SampleRelease.Name == sampleRelease && strings.HasSuffix(v.Name, "-main") {
 			return v, true
 		}
 	}

--- a/pkg/api/componentreadiness/triage.go
+++ b/pkg/api/componentreadiness/triage.go
@@ -756,13 +756,7 @@ func InjectRegressionHATEOASLinks(regression *models.TestRegression, views []crv
 		"self": fmt.Sprintf(regressionLink, baseAPIURL, regression.ID),
 	}
 
-	// The test_details link will be that of the main view for the given release pair.
-	// When release fallback is used, the regression's BaseRelease may differ from the view's base release
-	// (e.g., "4.20" instead of "4.21"), so fall back to matching by sample release only.
-	view, ok := GetMainViewForRelease(regression.BaseRelease, regression.Release, views)
-	if !ok {
-		view, ok = GetMainViewForSampleRelease(regression.Release, views)
-	}
+	view, ok := GetMainViewForSampleRelease(regression.Release, views)
 	if !ok {
 		log.Errorf("no main view found for base: %s, and sample: %s", regression.BaseRelease, regression.Release)
 		return
@@ -823,20 +817,7 @@ func GetViewsForTriage(triage *models.Triage, views []crview.View) []string {
 	return matchingViews.UnsortedList()
 }
 
-// GetMainViewForRelease returns the main view for the given base and sample release.
-// ok is false if none match.
-func GetMainViewForRelease(baseRelease, sampleRelease string, views []crview.View) (view crview.View, ok bool) {
-	matching := ViewsMatchingReleases(baseRelease, sampleRelease, views)
-	for _, v := range matching {
-		if strings.HasSuffix(v.Name, "-main") {
-			return v, true
-		}
-	}
-	return crview.View{}, false
-}
-
-// GetMainViewForSampleRelease returns the main view matching only the sample release.
-// Used as a fallback when a regression's base release differs from the view's due to release fallback.
+// GetMainViewForSampleRelease returns the main view for the given sample release.
 func GetMainViewForSampleRelease(sampleRelease string, views []crview.View) (view crview.View, ok bool) {
 	for _, v := range views {
 		if v.RegressionTracking.Enabled && v.SampleRelease.Name == sampleRelease && strings.HasSuffix(v.Name, "-main") {

--- a/pkg/api/componentreadiness/triage_test.go
+++ b/pkg/api/componentreadiness/triage_test.go
@@ -429,7 +429,7 @@ func TestInjectRegressionHATEOASLinks(t *testing.T) {
 		expectLink bool
 	}{
 		{
-			name: "base release matches view",
+			name: "sample release matches view",
 			regression: &models.TestRegression{
 				ID:          1,
 				Release:     "4.22",
@@ -442,7 +442,7 @@ func TestInjectRegressionHATEOASLinks(t *testing.T) {
 			expectLink: true,
 		},
 		{
-			name: "fallback base release does not match view but sample does",
+			name: "fallback base release differs from view",
 			regression: &models.TestRegression{
 				ID:          2,
 				Release:     "4.22",

--- a/pkg/api/componentreadiness/triage_test.go
+++ b/pkg/api/componentreadiness/triage_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lib/pq"
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/crview"
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
+	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/stretchr/testify/assert"
 )
@@ -391,6 +395,92 @@ func TestCompareTriageObjects(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := compareTriageObjects(tc.oldTriage, tc.newTriage)
 			assert.Equal(t, tc.expectedChanges, result, "Expected changes should match actual changes")
+		})
+	}
+}
+
+func TestInjectRegressionHATEOASLinks(t *testing.T) {
+	ga421 := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	releases := []v1.Release{
+		{Release: "4.20", GADate: &ga421},
+		{Release: "4.21", GADate: &ga421},
+	}
+
+	views := []crview.View{
+		{
+			Name: "4.22-main",
+			BaseRelease: reqopts.RelativeRelease{
+				Release:       reqopts.Release{Name: "4.21"},
+				RelativeStart: "ga-30d",
+				RelativeEnd:   "ga",
+			},
+			SampleRelease: reqopts.RelativeRelease{
+				Release:       reqopts.Release{Name: "4.22"},
+				RelativeStart: "now-7d",
+				RelativeEnd:   "now",
+			},
+			RegressionTracking: crview.RegressionTracking{Enabled: true},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		regression *models.TestRegression
+		expectLink bool
+	}{
+		{
+			name: "base release matches view",
+			regression: &models.TestRegression{
+				ID:          1,
+				Release:     "4.22",
+				BaseRelease: "4.21",
+				TestID:      "test-123",
+				Component:   "component",
+				Capability:  "capability",
+				Variants:    pq.StringArray{"Platform:aws"},
+			},
+			expectLink: true,
+		},
+		{
+			name: "fallback base release does not match view but sample does",
+			regression: &models.TestRegression{
+				ID:          2,
+				Release:     "4.22",
+				BaseRelease: "4.20",
+				TestID:      "test-456",
+				Component:   "component",
+				Capability:  "capability",
+				Variants:    pq.StringArray{"Platform:aws"},
+			},
+			expectLink: true,
+		},
+		{
+			name: "sample release matches no view",
+			regression: &models.TestRegression{
+				ID:          3,
+				Release:     "4.99",
+				BaseRelease: "4.98",
+				TestID:      "test-789",
+				Component:   "component",
+				Capability:  "capability",
+				Variants:    pq.StringArray{"Platform:aws"},
+			},
+			expectLink: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			InjectRegressionHATEOASLinks(tt.regression, views, releases, 0, "http://api", "http://frontend")
+
+			assert.Contains(t, tt.regression.Links, "self")
+
+			if tt.expectLink {
+				assert.Contains(t, tt.regression.Links, "test_details", "expected test_details link to be present")
+				assert.Contains(t, tt.regression.Links["test_details"], "test_details")
+			} else {
+				assert.NotContains(t, tt.regression.Links, "test_details", "expected test_details link to be absent")
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- When release fallback is used, a regression's `BaseRelease` can differ from the view's base release (e.g., `4.20` instead of `4.21`), causing `GetMainViewForRelease` to fail and the `test_details` link to be silently omitted from the regression API response.
- Each sample release has exactly one `-main` view, so matching on the base release was unnecessary. Replaced `GetMainViewForRelease` with `GetMainViewForSampleRelease` which matches by sample release only.
- The generated URL still correctly includes the regression's actual `BaseRelease` as the override parameter.

## Test plan
- [x] Unit test `TestInjectRegressionHATEOASLinks` covers:
  - Sample release matches a view (link generated)
  - Fallback base release differs from view (link still generated)
  - No matching view at all (no link, negative case)
- [x] All existing `componentreadiness` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regression link matching so the "test_details" link targets views based on the sample release, improving accuracy of detail links for regressions and reducing incorrect view matches.

* **Tests**
  * Added comprehensive tests for regression link injection, validating link presence and absence across sample-release and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->