### PR TITLE
SREP-4403: Add rosa-e2e nightly jobs explicitly to rosa-stage config

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -65,6 +65,12 @@ releases:
       periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-y-plus-1-to-latest-y: true
       # OSD-AWS informing (stage)
       periodic-ci-openshift-osde2e-main-aws-stage-informing-default: true
+      # rosa-e2e nightly (managed service validation)
+      periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-20: true
+      periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-21: true
+      periodic-ci-openshift-online-rosa-e2e-main-periodics-rosa-hcp-e2e-nightly-4-22: true
+      # OCM FVT (clusters-service API contract tests)
+      periodic-ci-openshift-online-rosa-e2e-main-periodics-ocm-fvt-periodic-cs-rosa-hcp-ad-staging-main: true
     regexp:
       # rosa-e2e managed service validation + OCM FVT (current and future versioned jobs)
       - "^periodic-ci-openshift-online-rosa-e2e-main-.*"


### PR DESCRIPTION
## Summary

- Add rosa-e2e nightly jobs (4.20, 4.21, 4.22) and OCM FVT as explicit entries in the rosa-stage release config
- The existing regexp should match these jobs, but explicit entries guarantee ingestion regardless of prowjobs.js discovery timing
- The regexp is kept for future versioned jobs

## Context

The rosa-e2e nightly jobs are running and producing JUnit results in GCS, but they do not appear in the Sippy rosa-stage dashboard. The daily-status job (matching the same regexp) does appear, suggesting a discovery timing issue with regexp-only matching.

Companion PR in openshift/release adds these jobs to the testgrid allow-list for BigQuery indexing.

## Jira

- https://redhat.atlassian.net/browse/SREP-4403
- https://redhat.atlassian.net/browse/TRT-2588

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled additional ROSA HCP E2E nightly test jobs for versions 4-20, 4-21, and 4-22
  * Enabled new OCM FVT periodic test job for ROSA HCP AD staging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->