### PR TITLE
TRT-2600: Determine OS variant from cluster data

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -2,6 +2,7 @@ package variantregistry
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
@@ -198,6 +199,7 @@ ORDER BY j.prowjob_job_name;
 						return // Channel was closed
 					}
 					clusterData := map[string]string{}
+					var osData clusterDataOS
 					jLog := log.WithField("job", jlr.JobName)
 					if jlr.URL.Valid && jlr.GCSBucket.Valid {
 						path, err := prowloader.GetGCSPathForProwJobURL(jLog, jlr.URL.StringVal)
@@ -232,12 +234,13 @@ ORDER BY j.prowjob_job_name;
 							} else {
 								jLog.Infof("loaded cluster data: %+v", clusterData)
 							}
+							osData = parseClusterDataOS(clusterDataBytes)
 						}
 					} else {
 						jLog.WithField("gcs_bucket", jlr.GCSBucket).WithField("url", jlr.URL.StringVal).Error("job had no gcs bucket or prow job url, proceeding without")
 					}
 
-					variants := v.CalculateVariantsForJob(jLog, jlr.JobName, clusterData)
+					variants := v.calculateVariantsForJob(jLog, jlr.JobName, clusterData, osData)
 					variantsByJobMu.Lock()
 					variantsByJob[jlr.JobName] = variants
 					variantsByJobMu.Unlock()
@@ -263,9 +266,9 @@ var fileVariantsToIgnore = map[string]bool{
 	"MasterNodesUpdated": true,
 }
 
-func (v *OCPVariantLoader) CalculateVariantsForJob(jLog logrus.FieldLogger, jobName string, variantFile map[string]string) map[string]string {
+func (v *OCPVariantLoader) calculateVariantsForJob(jLog logrus.FieldLogger, jobName string, variantFile map[string]string, osData clusterDataOS) map[string]string {
 	// Calculate variants based on job name:
-	variants := v.IdentifyVariants(jLog, jobName)
+	variants := v.identifyVariants(jLog, jobName, osData)
 
 	// Carefully merge in the values read from cluster-data.json or any arbitrary variants data file
 	// containing a map. Some properties will be ignored as they are job RUN specific, not job specific.
@@ -439,9 +442,26 @@ const (
 	VariantNoValue          = "none"
 )
 
-func (v *OCPVariantLoader) IdentifyVariants(jLog logrus.FieldLogger, jobName string) map[string]string {
-	variants := map[string]string{}
+// clusterDataOS holds OS image stream information from cluster data.
+type clusterDataOS struct {
+	Default      string   `json:"Default"`
+	ControlPlane string   `json:"ControlPlaneMachineConfigPool"`
+	Workers      string   `json:"WorkerMachineConfigPool"`
+	Additional   []string `json:"Additional,omitempty"`
+}
 
+func parseClusterDataOS(data []byte) clusterDataOS {
+	var raw struct {
+		OS clusterDataOS `json:"os"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return clusterDataOS{}
+	}
+	return raw.OS
+}
+
+func (v *OCPVariantLoader) identifyVariants(jLog logrus.FieldLogger, jobName string, osData clusterDataOS) map[string]string {
+	variants := map[string]string{}
 	for _, setter := range []func(jLog logrus.FieldLogger, variants map[string]string, jobName string){
 		v.setRelease, // Keep release first, other setters may look up release info in variants map
 		setAggregation,
@@ -461,7 +481,7 @@ func (v *OCPVariantLoader) IdentifyVariants(jLog logrus.FieldLogger, jobName str
 		setLayeredProduct,
 		setContainerRuntime,
 		setProcedure,
-		setOS,
+		osData.setOS,
 		v.setJobTier, // Keep this near last, it relies on other variants like owner
 	} {
 		setter(jLog, variants, jobName)
@@ -1258,22 +1278,69 @@ func setLayeredProduct(_ logrus.FieldLogger, variants map[string]string, jobName
 	}
 }
 
-func setOS(_ logrus.FieldLogger, variants map[string]string, jobName string) {
-	jobNameLower := strings.ToLower(jobName)
+func (os clusterDataOS) setOS(_ logrus.FieldLogger, variants map[string]string, _ string) {
+	resolved := os
+	if resolved.Default == "" {
+		resolved.Default = defaultOSForReleaseMajor(variants[VariantReleaseMajor])
+	}
+	variants[VariantOS] = resolved.resolve()
+}
 
-	osPatterns := []struct {
-		substring string
-		os        string
-	}{
-		{"rhcos9-10", "rhcos9-10"},
-		{"rhcos10", "rhcos10"},
+func defaultOSForReleaseMajor(major string) string { //nolint:unparam
+	switch major {
+	case "5":
+		return "rhcos9"
+	default:
+		return "rhcos9"
+	}
+}
+
+var rhelStreamRegexp = regexp.MustCompile(`^rhel-(\d+)`)
+
+// mapOSStreamToVariant maps OS image stream names to variant values.
+// rhel-9, rhel-9.6, rhel-9-nvidia all map to rhcos9. Unrecognized names pass through.
+func mapOSStreamToVariant(stream string) string {
+	if m := rhelStreamRegexp.FindStringSubmatch(stream); m != nil {
+		return "rhcos" + m[1]
+	}
+	return stream
+}
+
+func (os clusterDataOS) resolve() string {
+	cp := os.ControlPlane
+	if cp == "" {
+		cp = os.Default
+	}
+	w := os.Workers
+	if w == "" {
+		w = os.Default
 	}
 
-	variants[VariantOS] = "rhcos9"
-	for _, entry := range osPatterns {
-		if strings.Contains(jobNameLower, entry.substring) {
-			variants[VariantOS] = entry.os
-			return
+	cp = mapOSStreamToVariant(cp)
+	w = mapOSStreamToVariant(w)
+
+	if cp == "" {
+		return ""
+	}
+
+	seen := map[string]bool{cp: true}
+	if w != "" {
+		seen[w] = true
+	}
+	for _, a := range os.Additional {
+		if a == "" {
+			a = os.Default
+		}
+		if mapped := mapOSStreamToVariant(a); mapped != "" {
+			seen[mapped] = true
 		}
 	}
+
+	if len(seen) == 1 {
+		return cp
+	}
+	if len(seen) == 2 && seen["rhcos9"] && seen["rhcos10"] {
+		return "rhcos9-10"
+	}
+	return "mixed"
 }

--- a/pkg/variantregistry/ocp_test.go
+++ b/pkg/variantregistry/ocp_test.go
@@ -24,6 +24,7 @@ func TestVariantSyncer(t *testing.T) {
 	tests := []struct {
 		job          string
 		variantsFile map[string]string
+		osData       clusterDataOS
 		expected     map[string]string
 	}{
 		{
@@ -1719,6 +1720,10 @@ func TestVariantSyncer(t *testing.T) {
 		{
 			job:          "periodic-ci-openshift-release-master-nightly-4.20-e2e-aws-rhcos9-10-ovn",
 			variantsFile: map[string]string{},
+			osData: clusterDataOS{
+				ControlPlane: "rhel-9",
+				Workers:      "rhel-10",
+			},
 			expected: map[string]string{
 				VariantRelease:          "4.20",
 				VariantReleaseMajor:     "4",
@@ -1748,6 +1753,10 @@ func TestVariantSyncer(t *testing.T) {
 		{
 			job:          "periodic-ci-openshift-release-master-nightly-4.20-e2e-aws-rhcos10-ovn",
 			variantsFile: map[string]string{},
+			osData: clusterDataOS{
+				ControlPlane: "rhcos10",
+				Workers:      "rhcos10",
+			},
 			expected: map[string]string{
 				VariantRelease:          "4.20",
 				VariantReleaseMajor:     "4",
@@ -1810,10 +1819,11 @@ func TestVariantSyncer(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.job, func(t *testing.T) {
 			assert.Equal(t, test.expected,
-				variantSyncer.CalculateVariantsForJob(
+				variantSyncer.calculateVariantsForJob(
 					logrus.WithField("source", "TestVariantSyncer"),
 					test.job,
-					test.variantsFile))
+					test.variantsFile,
+					test.osData))
 		})
 	}
 }
@@ -1903,6 +1913,251 @@ func testView(name string, includeVariants map[string][]string) crview.View {
 			DBGroupBy:       sets.String{},
 			IncludeVariants: includeVariants,
 		},
+	}
+}
+
+func TestSetOS(t *testing.T) {
+	tests := []struct {
+		name          string
+		releaseMajor  string
+		clusterDataOS clusterDataOS
+		expectedOS    string
+	}{
+		{
+			name:         "no cluster data with release major 4 defaults to rhcos9",
+			releaseMajor: "4",
+			expectedOS:   "rhcos9",
+		},
+		{
+			name:         "no cluster data with release major 5 defaults to rhcos9",
+			releaseMajor: "5",
+			expectedOS:   "rhcos9",
+		},
+		{
+			name: "mix of rhcos9 and rhcos10 in cp and workers produces rhcos9-10",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "rhel-9",
+				Workers:      "rhel-10",
+			},
+			expectedOS: "rhcos9-10",
+		},
+		{
+			name: "cluster data with matching control plane and workers",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "rhcos10",
+				Workers:      "rhcos10",
+			},
+			expectedOS: "rhcos10",
+		},
+		{
+			name: "cluster data with additional matching control plane and workers",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "rhcos9",
+				Workers:      "rhcos9",
+				Additional:   []string{"rhcos9"},
+			},
+			expectedOS: "rhcos9",
+		},
+		{
+			name: "cluster data with rhcos10 additional and rhcos9 pools is rhcos9-10",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "rhcos9",
+				Workers:      "rhcos9",
+				Additional:   []string{"rhcos10"},
+			},
+			expectedOS: "rhcos9-10",
+		},
+		{
+			name: "cluster data with rhcos9 cp and rhcos10 workers is rhcos9-10",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "rhcos9",
+				Workers:      "rhcos10",
+			},
+			expectedOS: "rhcos9-10",
+		},
+		{
+			name: "cluster data with three different OS values is mixed",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "rhcos9",
+				Workers:      "rhcos10",
+				Additional:   []string{"fcos"},
+			},
+			expectedOS: "mixed",
+		},
+		{
+			name: "default backfills both empty cp and workers",
+			clusterDataOS: clusterDataOS{
+				Default: "rhcos10",
+			},
+			expectedOS: "rhcos10",
+		},
+		{
+			name: "default backfills both empty cp and workers but additional is rhcos9-10 mix",
+			clusterDataOS: clusterDataOS{
+				Default:    "rhcos10",
+				Additional: []string{"rhcos9"},
+			},
+			expectedOS: "rhcos9-10",
+		},
+		{
+			name: "default backfills empty cp to match workers",
+			clusterDataOS: clusterDataOS{
+				Default: "rhcos9",
+				Workers: "rhcos9",
+			},
+			expectedOS: "rhcos9",
+		},
+		{
+			name: "default backfills empty cp producing rhcos9-10 mix with workers",
+			clusterDataOS: clusterDataOS{
+				Default: "rhcos9",
+				Workers: "rhcos10",
+			},
+			expectedOS: "rhcos9-10",
+		},
+		{
+			name: "default backfills empty workers to match cp",
+			clusterDataOS: clusterDataOS{
+				Default:      "rhcos10",
+				ControlPlane: "rhcos10",
+			},
+			expectedOS: "rhcos10",
+		},
+		{
+			name: "default backfills empty workers producing rhcos9-10 mix with cp",
+			clusterDataOS: clusterDataOS{
+				Default:      "rhcos9",
+				ControlPlane: "rhcos10",
+			},
+			expectedOS: "rhcos9-10",
+		},
+		{
+			name:         "release major 4 backfills default which backfills empty cp and workers",
+			releaseMajor: "4",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "rhcos9",
+			},
+			expectedOS: "rhcos9",
+		},
+		{
+			name:         "release major backfilled default does not override explicit default",
+			releaseMajor: "4",
+			clusterDataOS: clusterDataOS{
+				Default: "rhcos10",
+			},
+			expectedOS: "rhcos10",
+		},
+		{
+			name:         "release major backfilled default produces rhcos9-10 mix with cp",
+			releaseMajor: "4",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "rhcos10",
+			},
+			expectedOS: "rhcos9-10",
+		},
+		{
+			name: "empty string in additional is backfilled from default",
+			clusterDataOS: clusterDataOS{
+				Default:      "rhcos9",
+				ControlPlane: "rhcos9",
+				Workers:      "rhcos9",
+				Additional:   []string{""},
+			},
+			expectedOS: "rhcos9",
+		},
+		{
+			name: "empty string in additional backfilled from default produces rhcos9-10 mix",
+			clusterDataOS: clusterDataOS{
+				Default:      "rhcos10",
+				ControlPlane: "rhcos9",
+				Workers:      "rhcos9",
+				Additional:   []string{""},
+			},
+			expectedOS: "rhcos9-10",
+		},
+		{
+			name: "rhel-9 stream maps to rhcos9",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "rhel-9",
+				Workers:      "rhel-9",
+			},
+			expectedOS: "rhcos9",
+		},
+		{
+			name: "rhel-9.6 stream maps to rhcos9",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "rhel-9.6",
+				Workers:      "rhel-9.6",
+			},
+			expectedOS: "rhcos9",
+		},
+		{
+			name: "rhel-9.6.1 stream maps to rhcos9",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "rhel-9.6.1",
+				Workers:      "rhel-9.6.1",
+			},
+			expectedOS: "rhcos9",
+		},
+		{
+			name: "rhel-9-nvidia stream maps to rhcos9",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "rhel-9-nvidia",
+				Workers:      "rhel-9-nvidia",
+			},
+			expectedOS: "rhcos9",
+		},
+		{
+			name: "rhel-10 stream maps to rhcos10",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "rhel-10",
+				Workers:      "rhel-10",
+			},
+			expectedOS: "rhcos10",
+		},
+		{
+			name: "rhel-10.0 stream maps to rhcos10",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "rhel-10.0",
+				Workers:      "rhel-10.0",
+			},
+			expectedOS: "rhcos10",
+		},
+		{
+			name: "different rhel-9 minor versions map to same variant",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "rhel-9.4",
+				Workers:      "rhel-9.6",
+			},
+			expectedOS: "rhcos9",
+		},
+		{
+			name: "rhel-9 and rhel-10 streams produce rhcos9-10",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "rhel-9.6",
+				Workers:      "rhel-10.0",
+			},
+			expectedOS: "rhcos9-10",
+		},
+		{
+			name: "unrecognized stream name passes through",
+			clusterDataOS: clusterDataOS{
+				ControlPlane: "custom-os",
+				Workers:      "custom-os",
+			},
+			expectedOS: "custom-os",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			variants := map[string]string{}
+			if tt.releaseMajor != "" {
+				variants[VariantReleaseMajor] = tt.releaseMajor
+			}
+			tt.clusterDataOS.setOS(logrus.WithField("test", "TestSetOS"), variants, "")
+			assert.Equal(t, tt.expectedOS, variants[VariantOS])
+		})
 	}
 }
 

--- a/pkg/variantregistry/snapshot.go
+++ b/pkg/variantregistry/snapshot.go
@@ -37,11 +37,22 @@ func (s *VariantSnapshot) Identify() JobVariants {
 				continue
 			}
 
-			newVariants[job] = variantSyncer.CalculateVariantsForJob(s.log, job, nil)
+			newVariants[job] = variantSyncer.calculateVariantsForJob(s.log, job, nil, syntheticClusterDataOS(job))
 		}
 	}
 
 	return newVariants
+}
+
+func syntheticClusterDataOS(jobName string) clusterDataOS {
+	lower := strings.ToLower(jobName)
+	if strings.Contains(lower, "rhcos9-10") {
+		return clusterDataOS{ControlPlane: "rhel-9", Workers: "rhel-10"}
+	}
+	if strings.Contains(lower, "rhcos10") {
+		return clusterDataOS{Default: "rhel-10"}
+	}
+	return clusterDataOS{}
 }
 
 func (s *VariantSnapshot) Load(path string) (JobVariants, error) {


### PR DESCRIPTION
Reworks OS variant detection to derive the value from structured cluster data (the `os` object in cluster-data.json added in https://github.com/openshift/origin/pull/30827) instead of job name patterns. The cluster data contains OS image stream names for the default, control plane, and worker machine config pools. These stream names (e.g. `rhel-9.6`, `rhel-10.0`, `rhel-9-nvidia`) are mapped to variant values (`rhcos9`, `rhcos10`) using a regex that extracts the major version.

When all node pools agree on the OS, that value becomes the variant; when they disagree, the variant is `mixed`. Empty pool values are backfilled from the default, and if the default is also empty, it is inferred from the release major version. The only job-name pattern preserved is `rhcos9-10`, which takes precedence over cluster data.

For the variant snapshot (which has no access to real cluster data), jobs with `rhcos10` in their name get synthetic cluster data so the snapshot accurately reflects their expected OS variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * OS variant detection now reads cluster-data to determine ControlPlane/Workers/Optional OS, applies smarter defaults, maps rhel-* streams to rhcos variants, and correctly produces rhcos9, rhcos10, rhcos9-10, or mixed outcomes.

* **Tests**
  * Expanded unit and snapshot tests covering defaulting, backfilling, mixing behaviors, stream-name mappings, and multiple job scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->