### PR TITLE
Add support for using regex patterns in findSuite

### DIFF
--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -1167,12 +1167,23 @@ func (pl *ProwLoader) findSuite(name string) *uint {
 	suite := &models.Suite{}
 	pl.dbc.DB.Where("name = ?", name).Find(&suite)
 	if suite.ID == 0 {
-		pl.suiteCache[name] = nil
-	} else {
-		id := suite.ID
-		pl.suiteCache[name] = &id
+		// No row - the exact suite name is not in the database (for example, by populateTestSuitesInDB)
+		if !db.IsTestSuiteImportable(name) {
+			pl.suiteCache[name] = nil
+			return nil
+		}
+		// If IsTestSuiteImportable() returns true (for example, pattern match), add the Suite row.
+		suite.Name = name
+		tx := pl.dbc.DB.Save(suite)
+		if tx.Error != nil {
+			log.WithError(tx.Error).Warningf("failed to create suite %q", name)
+			return nil
+		}
+		log.WithField("suite", name).Info("created new test suite")
 	}
-	return pl.suiteCache[name]
+	id := suite.ID
+	pl.suiteCache[name] = &id
+	return &id
 }
 
 func (pl *ProwLoader) prowJobRunTestsFromGCS(ctx context.Context, pj *prow.ProwJob, id uint, path string, junitPaths []string) ([]*models.ProwJobRunTest, int, sippyprocessingv1.JobOverallResult, error) {

--- a/pkg/db/suites.go
+++ b/pkg/db/suites.go
@@ -81,7 +81,7 @@ var testSuites = []string{
 var testSuitePatterns = []string{
 	// LP interop naming: `lp-interop-<product>--<suffix>`.
 	`^lp-interop-`,
-
+}
 
 var compiledTestSuitePatterns []*regexp.Regexp
 

--- a/pkg/db/suites.go
+++ b/pkg/db/suites.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"regexp"
+
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
@@ -74,6 +76,44 @@ var testSuites = []string{
 	"tracing-uiplugin",
 }
 
+// testSuitePatterns are regular expressions (MatchString) for suite names that should be imported
+// without listing every literal name. Patterns are compiled in init().
+var testSuitePatterns = []string{
+	// LP interop naming: `lp-interop-<product>--<suffix>`.
+	`^lp-interop-`,
+
+
+var compiledTestSuitePatterns []*regexp.Regexp
+
+// Invalid regexes panic at process start.
+func init() {
+	compiledTestSuitePatterns = make([]*regexp.Regexp, len(testSuitePatterns))
+	for i, p := range testSuitePatterns {
+		compiledTestSuitePatterns[i] = regexp.MustCompile(p)
+	}
+}
+
+// Runs inside the prow loader on every unknown suite name
+// Reports whether junit from this testsuite name should be imported: either an
+// exact entry in testSuites or a match against testSuitePatterns.
+func IsTestSuiteImportable(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, s := range testSuites {
+		if s == name {
+			return true
+		}
+	}
+	for _, re := range compiledTestSuitePatterns {
+		if re.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// Runs when the DB is set up / migrated.
 func populateTestSuitesInDB(db *gorm.DB) error {
 	for _, suiteName := range testSuites {
 		s := models.Suite{}

--- a/pkg/db/suites_test.go
+++ b/pkg/db/suites_test.go
@@ -1,0 +1,28 @@
+package db
+
+import "testing"
+
+func TestIsTestSuiteImportable(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"", false},
+		{"openshift-tests", true},
+		{"CNV-lp-interop", true},
+		{"ACS-lp-interop", true},
+		{"lp-interop-ACS--my-tests", true},
+		{"lp-interop-Foo", true},
+		{"CNV-lp-interop-extra-suffix", false},
+		{"random-suite", false},
+		{"-lp-interop", false},
+		{"lp-interop", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTestSuiteImportable(tt.name); got != tt.want {
+				t.Errorf("IsTestSuiteImportable(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Building on [ci-test-mapping #616](https://github.com/openshift-eng/ci-test-mapping/pull/616); this PR provides complmentry support for loading desired test suites based on a matching regex pattern, 
instead of holding list of static suite names, [ref](https://github.com/openshift/sippy/blob/main/pkg/db/suites.go#L19), and reducing the need to add every suite name explicitly.

Main changes:
- In addition to the `testSuite` list, add `testSuitePatterns` and compile them on init
- Add helper function `TestIsTestSuiteImportable` for find matches, and use it in `findSuite`
- Add unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Importable test suites that match configured literal names or patterns are now auto-created instead of ignored.

* **Bug Fixes**
  * Missing suite lookups now consult importable-pattern rules and create the suite when permitted, improving reliability.

* **Tests**
  * Added coverage validating suite importability across multiple naming patterns and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->