### PR TITLE
TRT-2588: add the correct default BigQuery project for the `update-variants` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,5 +69,6 @@ images:
 # the Synthetic column on the Releases table). Set GOOGLE_APPLICATION_CREDENTIALS
 # to a service account key file, e.g.:
 #   GOOGLE_APPLICATION_CREDENTIALS=path/to/key.json make update-variants
+BIGQUERY_PROJECT ?= openshift-ci-data-analysis
 update-variants: sippy
-	./sippy variants snapshot --config ./config/openshift.yaml --views ./config/views.yaml
+	./sippy variants snapshot --config ./config/openshift.yaml --views ./config/views.yaml --bigquery-project $(BIGQUERY_PROJECT)


### PR DESCRIPTION
This should allow the `periodic-prow-auto-sippy-config-generator` job to run without any additional changes, but it can be overridden later if we move the table or something.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to support configurable BigQuery project selection for variant snapshot operations with a sensible default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->