### PR TITLE
TRT-2574: Formalize regression-view associations and cross-compare isolation

### DIFF
--- a/docs/plans/regression-view-association-plan.md
+++ b/docs/plans/regression-view-association-plan.md
@@ -1,0 +1,182 @@
+# Implementation Plan: Regression-View Junction Table
+
+This plan covers the implementation of a `regression_views` junction table that formally associates regressions with the views that detected them.
+
+**Updated 2026-04-24** to reflect completed implementation and remaining work for cross-compare view regression tracking.
+
+## Status Summary
+
+| Section | Status |
+|---------|--------|
+| 1. New Model and Schema | Done |
+| 2. RegressionStore Interface | Done |
+| 3. Unified Loader Changes | Done |
+| 4. HATEOAS Link Generation | Done |
+| 5. Preload Views on Queries | Done |
+| 6. Triage Expansion Updates | Done |
+| 7. Cleanup of Deprecated Functions | Done |
+| 8. Migration and Backfill | Done |
+| 9. Frontend Updates | Done |
+| 10. Potential Matches API | Done |
+| 11. Cross-Compare View Regression Tracking | Done |
+
+## 1–8: Backend Implementation (Complete)
+
+All backend changes from the original plan have been implemented:
+
+- **`regression_views` table** with composite PK `(test_regression_id, view_name)` and `active` boolean, with `ON DELETE CASCADE` from `test_regressions`
+- **`RegressionStore` interface** extended with `UpsertRegressionView` and `DeactivateRolledOffViews` (originally named `DeactivateStaleViews`, renamed for clarity)
+- **`RegressionCacheLoader`** tracks `activeViewMap` per release, calls `UpsertRegressionView` after sync, calls `DeactivateRolledOffViews` after closing
+- **HATEOAS links** on regression objects use composite keys `test_details:<viewName>` generated per active view from `InjectRegressionHATEOASLinks`
+- **Preloads** added for `Views` / `Regressions.Views` on all relevant queries
+- **`GetViewsForTriage`** reads from preloaded `regression.Views` instead of runtime release matching
+- **`getRegressedTestsForRegressions`** collects view names from preloaded `reg.Views`
+- **`FindViewByName`** exported for use by server.go
+- **Schema migration** handled by GORM `AutoMigrate`; backfill happens naturally on first loader run
+
+### Files changed (backend)
+
+| File | Changes |
+|------|---------|
+| `pkg/db/models/triage.go` | Added `RegressionView` model, added `Views` field with `ON DELETE CASCADE` to `TestRegression` |
+| `pkg/db/db.go` | Added `RegressionView` to auto-migrate list |
+| `pkg/api/componentreadiness/regressiontracker.go` | Extended `RegressionStore` interface, implemented `UpsertRegressionView` and `DeactivateRolledOffViews` |
+| `pkg/dataloader/regressioncacheloader/regressioncacheloader.go` | Track `activeViewMap`, call `UpsertRegressionView` after sync, call `DeactivateRolledOffViews` after closing |
+| `pkg/api/componentreadiness/triage.go` | Rewrote `InjectRegressionHATEOASLinks` with per-view composite keys, updated `GetViewsForTriage`, exported `FindViewByName` |
+| `pkg/db/query/triage_queries.go` | Added `.Preload("Views")` / `.Preload("Regressions.Views")` |
+| `pkg/sippyserver/server.go` | Updated expanded triage handler and `getRegressedTestsForRegressions` to use preloaded views |
+| `pkg/api/componentreadiness/middleware/linkinjector/linkinjector.go` | Kept plain `test_details` key (regressed tests in component reports are already scoped to a view) |
+
+## 9. Frontend Updates (Complete)
+
+### 9.1 `getTestDetailsLink` utility
+
+**File:** `sippy-ng/src/component_readiness/CompReadyUtils.js`
+
+Added a utility function that handles both link formats:
+
+```js
+export function getTestDetailsLink(links, viewName) {
+  if (!links) return null
+  if (links['test_details']) return links['test_details']
+  if (viewName && links[`test_details:${viewName}`]) {
+    return links[`test_details:${viewName}`]
+  }
+  const key = Object.keys(links).find((k) => k.startsWith('test_details:'))
+  return key ? links[key] : null
+}
+```
+
+Lookup order:
+1. Plain `test_details` — preferred (used by regressed tests in component reports)
+2. `test_details:<viewName>` — view-specific composite key (used by regression objects)
+3. First `test_details:*` — fallback to any composite key
+
+`generateTestDetailsReportLink` updated to accept an optional `viewName` parameter.
+
+### 9.2 Per-file changes
+
+| File | Object type | Strategy |
+|------|------------|----------|
+| `RegressionRedirect.js` | Regression | Prefers `-main` view key, falls back to `getTestDetailsLink` |
+| `ComponentReadinessIndicator.js` | Regression | Uses `getTestDetailsLink(links, `${release}-main`)` |
+| `Triage.js` | Regressed test (chat context) | Uses `getTestDetailsLink(rt.links, view)` |
+| `TriagedRegressionTestList.js` | Regressed test (per-view columns) | Passes `viewName` from column loop to `generateTestDetailsReportLink` |
+
+### 9.3 Two link formats
+
+The backend produces two distinct link formats:
+
+- **Regression objects** (`TestRegression`): Composite keys `test_details:<viewName>` — set by `InjectRegressionHATEOASLinks`, because a single regression can appear in multiple views.
+- **Regressed tests** (`ReportTestSummary` from component reports): Plain `test_details` key — set by `LinkInjector` middleware, because these are already in the context of a single view.
+
+The frontend `getTestDetailsLink` handles both formats transparently.
+
+## 10. Potential Matches API (Complete)
+
+### 10.1 Backend
+
+**File:** `pkg/sippyserver/server.go`
+
+`jsonTriagePotentialMatchingRegressions` now accepts `?view=<name>` instead of `?baseRelease=...&sampleRelease=...`. The view is resolved via `FindViewByName` to obtain the sample release for the regression query.
+
+### 10.2 Frontend
+
+**File:** `sippy-ng/src/component_readiness/TriagePotentialMatches.js`
+
+- Replaced base/sample release dropdowns with a single **View** dropdown
+- Available views extracted from `triage.regressions[].views[]` (active only), sorted with `-main` views first
+- Fetch URL sends `?view=...`
+
+## 11. Cross-Compare View Regression Tracking (Done)
+
+Cross-compare views (e.g., `5.0-ha-vs-two-node-fencing`, `5.0-techpreview-rhcos9-vs-rhcos10`) are currently configured with `RegressionTracking.Enabled = false`. Enabling regression tracking on these views would encounter a regression identity collision problem.
+
+### 11.1 The problem
+
+`FindOpenRegression` matches regressions by `(release, testID, variants)`. Cross-compare views share the same sample release as the main view (e.g., both use `5.0`), so the same test with the same variants could be independently regressed in both:
+
+- `5.0-main` (base=4.22): test X regressed because it was passing in 4.22 and failing in 5.0
+- `5.0-ha-vs-two-node-fencing` (base=5.0/HA): test X regressed because it passes on HA but fails on two-node-fencing
+
+These are different regressions with different root causes, but `FindOpenRegression` would match them as the same regression because `(release=5.0, testID, variants)` are identical. This causes:
+
+1. **Regression collision**: Two conceptually distinct regressions get merged into one record
+2. **`BaseRelease` overwrite**: Whichever view processes last overwrites the `BaseRelease` field, corrupting it for the other view
+
+### 11.2 Rejected approach: match on base release
+
+Adding `baseRelease` to the `FindOpenRegression` matching identity was considered but rejected because `BaseRelease` serves two conflicting purposes:
+
+1. **Matching identity** — needs to be stable across runs
+2. **Link generation** — `generateTestDetailsURLFromRegression` reads `regression.BaseRelease` to produce `testBasisRelease` URL params for release fallback
+
+Release fallback makes `BaseRelease` unstable: when a test lacks sufficient data in the configured base release (e.g., 4.22), it falls back to a prior release (e.g., 4.21). This fallback can change between runs. If `BaseRelease` is part of the matching identity, a fallback shift creates duplicate regressions. Additionally, the `RegressionTracker` middleware only has access to the view's configured base release, not the actual fallback release, creating an inconsistency with `SyncRegressionsForReport`.
+
+### 11.3 Solution: `CrossCompare` flag on `TestRegression`
+
+Cross-compare regressions are fundamentally different from standard regressions — a cross-compare regression will never be shared with a standard view, and vice versa. A `CrossCompare bool` field on `TestRegression` partitions regressions into two non-overlapping pools. Cross-compare views can share regressions with each other. A view is cross-compare if `len(view.VariantOptions.VariantCrossCompare) > 0`.
+
+GORM `AutoMigrate` adds the column with `DEFAULT false`, so existing regressions are automatically standard.
+
+### 11.4 Changes
+
+| File | Changes |
+|------|---------|
+| `pkg/db/models/triage.go` | Added `CrossCompare bool` field with `gorm:"not null;default:false"` to `TestRegression` |
+| `pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go` | Added `crossCompare bool` param to `FindOpenRegression` with `tr.CrossCompare != crossCompare` check. `PreAnalysis`/`PostAnalysis` pass `len(r.reqOptions.VariantOption.VariantCrossCompare) > 0`. |
+| `pkg/api/componentreadiness/regressiontracker.go` | `SyncRegressionsForReport` passes `crossCompare` from view config. `OpenRegression` sets `CrossCompare` on new regressions. |
+| `pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker_test.go` | Updated all `FindOpenRegression` calls with `crossCompare` param. Added `TestFindOpenRegression_CrossCompareIsolation` (2 subtests) and "no match when cross-compare flag differs" case. |
+
+### 11.5 Enable regression tracking on cross-compare views
+
+All 6 cross-compare views already have `regression_tracking.enabled: true` in `config/views.yaml`. No config changes needed.
+
+## 12. Files Changed Summary (All Sections)
+
+| File | Changes |
+|------|---------|
+| `pkg/db/models/triage.go` | `RegressionView` model, `Views` field with CASCADE on `TestRegression`, `CrossCompare` field |
+| `pkg/db/db.go` | `RegressionView` in auto-migrate list |
+| `pkg/api/componentreadiness/regressiontracker.go` | `RegressionStore` interface: `UpsertRegressionView`, `DeactivateRolledOffViews`. `OpenRegression` sets `CrossCompare`. `SyncRegressionsForReport` passes `crossCompare` to `FindOpenRegression`. |
+| `pkg/dataloader/regressioncacheloader/regressioncacheloader.go` | `activeViewMap` tracking, view upsert after sync, deactivation after closing |
+| `pkg/api/componentreadiness/triage.go` | Per-view HATEOAS links, `GetViewsForTriage` from preloaded views, `FindViewByName` exported |
+| `pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go` | `crossCompare` param on `FindOpenRegression`, `PreAnalysis`/`PostAnalysis` pass cross-compare flag from request options |
+| `pkg/api/componentreadiness/middleware/linkinjector/linkinjector.go` | Plain `test_details` key preserved for component report context |
+| `pkg/db/query/triage_queries.go` | `.Preload("Views")` / `.Preload("Regressions.Views")` |
+| `pkg/sippyserver/server.go` | Expanded triage uses preloaded views, potential matches uses `?view=` param |
+| `sippy-ng/src/component_readiness/CompReadyUtils.js` | `getTestDetailsLink` utility, `viewName` param on `generateTestDetailsReportLink` |
+| `sippy-ng/src/component_readiness/RegressionRedirect.js` | Uses `getTestDetailsLink`, prefers `-main` view |
+| `sippy-ng/src/component_readiness/ComponentReadinessIndicator.js` | Uses `getTestDetailsLink` with `${release}-main` |
+| `sippy-ng/src/component_readiness/Triage.js` | Uses `getTestDetailsLink` for chat context |
+| `sippy-ng/src/component_readiness/TriagedRegressionTestList.js` | Passes `viewName` to `generateTestDetailsReportLink` |
+| `sippy-ng/src/component_readiness/TriagePotentialMatches.js` | View dropdown replaces base/sample release dropdowns |
+
+### Tests
+
+| File | Changes |
+|------|---------|
+| `pkg/api/componentreadiness/triage_test.go` | `TestInjectRegressionHATEOASLinks` (7 cases), `TestFindViewByName` (3 cases), `TestGetViewsForTriage` (6 cases) |
+| `.../regressiontracker/regressiontracker_test.go` | `TestFindOpenRegression_CrossCompareIsolation` (2 subtests), cross-compare flag mismatch case, all calls updated with `crossCompare` param |
+| `test/e2e/.../regressiontracker_test.go` | `Test_RegressionViews` (10 subtests), CASCADE cleanup, `Test_CrossCompareIsolation` (5 subtests: OpenRegression sets CrossCompare, SyncRegressionsForReport creates isolated regressions, standard/cross-compare sync don't cross-match, re-sync reuses within same pool) |
+| `test/e2e/.../triageapi_test.go` | Composite HATEOAS link assertions, `UpsertRegressionView` calls, `?view=` param for potential matches, updated "error when view does not exist" test to use `?view=` instead of old `baseRelease`/`sampleRelease` params |

--- a/docs/plans/regression-view-association-plan.md
+++ b/docs/plans/regression-view-association-plan.md
@@ -79,7 +79,7 @@ Lookup order:
 | File | Object type | Strategy |
 |------|------------|----------|
 | `RegressionRedirect.js` | Regression | Prefers `-main` view key, falls back to `getTestDetailsLink` |
-| `ComponentReadinessIndicator.js` | Regression | Uses `getTestDetailsLink(links, `${release}-main`)` |
+| `ComponentReadinessIndicator.js` | Regression | Uses <code>getTestDetailsLink(links, \`${release}-main\`)</code> |
 | `Triage.js` | Regressed test (chat context) | Uses `getTestDetailsLink(rt.links, view)` |
 | `TriagedRegressionTestList.js` | Regressed test (per-view columns) | Passes `viewName` from column loop to `generateTestDetailsReportLink` |
 

--- a/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
+++ b/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
@@ -86,7 +86,7 @@ func (r *RegressionTracker) ensureRegressionsLoaded() error {
 
 func (r *RegressionTracker) PreAnalysis(testKey crtest.Identification, testStats *testdetails.TestComparison) error {
 	if len(r.openRegressions) > 0 {
-		or := FindOpenRegression(r.reqOptions.SampleRelease.Name, testKey.TestID, testKey.Variants, r.openRegressions)
+		or := FindOpenRegression(r.reqOptions.SampleRelease.Name, testKey.TestID, len(r.reqOptions.VariantOption.VariantCrossCompare) > 0, testKey.Variants, r.openRegressions)
 		if or != nil {
 			testStats.Regression = or
 
@@ -119,7 +119,7 @@ func (r *RegressionTracker) PostAnalysis(testKey crtest.Identification, testStat
 		return err
 	}
 	if len(r.openRegressions) > 0 {
-		or := FindOpenRegression(r.reqOptions.SampleRelease.Name, testKey.TestID, testKey.Variants, r.openRegressions)
+		or := FindOpenRegression(r.reqOptions.SampleRelease.Name, testKey.TestID, len(r.reqOptions.VariantOption.VariantCrossCompare) > 0, testKey.Variants, r.openRegressions)
 		r.log.Debugf("checking regressions for %+v", testKey)
 		if or == nil {
 			return nil
@@ -176,12 +176,16 @@ func (r *RegressionTracker) PostAnalysis(testKey crtest.Identification, testStat
 // The regressions list is expected to be pre-filtered by sample release (e.g. from ListOpenRegressions);
 // the sampleRelease check is redundant but kept for safety.
 func FindOpenRegression(sampleRelease, testID string,
+	crossCompare bool,
 	variants map[string]string,
 	regressions []*models.TestRegression) *models.TestRegression {
 
 	var matches []*models.TestRegression
 	for _, tr := range regressions {
 		if sampleRelease != tr.Release {
+			continue
+		}
+		if tr.CrossCompare != crossCompare {
 			continue
 		}
 		// We compare test ID not name, as names can change.

--- a/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker_test.go
+++ b/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker_test.go
@@ -692,11 +692,25 @@ func TestFindOpenRegression(t *testing.T) {
 			wantRelease:     sampleRelease,
 			wantBaseRelease: baseRelease,
 		},
+		{
+			name: "no match when cross-compare flag differs",
+			regressions: []*models.TestRegression{
+				{
+					ID:           1,
+					Release:      sampleRelease,
+					BaseRelease:  baseRelease,
+					CrossCompare: true,
+					TestID:       testID,
+					Variants:     []string{"arch:amd64"},
+				},
+			},
+			wantMatch: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FindOpenRegression(sampleRelease, testID, variants, tt.regressions)
+			got := FindOpenRegression(sampleRelease, testID, false, variants, tt.regressions)
 			if !tt.wantMatch {
 				assert.Nil(t, got, "expected no match")
 				return
@@ -707,6 +721,46 @@ func TestFindOpenRegression(t *testing.T) {
 			assert.Equal(t, testID, got.TestID)
 		})
 	}
+}
+
+func TestFindOpenRegression_CrossCompareIsolation(t *testing.T) {
+	sampleRelease := "5.0"
+	testID := "test-id-1"
+	variants := map[string]string{"arch": "amd64"}
+
+	// Both a standard and cross-compare regression exist for the same (release, testID, variants)
+	regressions := []*models.TestRegression{
+		{
+			ID:           1,
+			Release:      sampleRelease,
+			BaseRelease:  "4.22",
+			CrossCompare: false,
+			TestID:       testID,
+			Variants:     []string{"arch:amd64"},
+		},
+		{
+			ID:           2,
+			Release:      sampleRelease,
+			BaseRelease:  sampleRelease,
+			CrossCompare: true,
+			TestID:       testID,
+			Variants:     []string{"arch:amd64"},
+		},
+	}
+
+	t.Run("standard view selects standard regression", func(t *testing.T) {
+		got := FindOpenRegression(sampleRelease, testID, false, variants, regressions)
+		require.NotNil(t, got)
+		assert.Equal(t, uint(1), got.ID)
+		assert.False(t, got.CrossCompare)
+	})
+
+	t.Run("cross-compare view selects cross-compare regression", func(t *testing.T) {
+		got := FindOpenRegression(sampleRelease, testID, true, variants, regressions)
+		require.NotNil(t, got)
+		assert.Equal(t, uint(2), got.ID)
+		assert.True(t, got.CrossCompare)
+	})
 }
 
 // TestFindOpenRegression_SubsetMatching tests the subset variant matching behavior
@@ -821,7 +875,7 @@ func TestFindOpenRegression_SubsetMatching(t *testing.T) {
 				},
 			}
 
-			got := FindOpenRegression(sampleRelease, testID, tt.inputVariants, regressions)
+			got := FindOpenRegression(sampleRelease, testID, false, tt.inputVariants, regressions)
 
 			if !tt.wantMatch {
 				assert.Nil(t, got, "expected no match but got regression ID %v", got)

--- a/pkg/api/componentreadiness/regressiontracker.go
+++ b/pkg/api/componentreadiness/regressiontracker.go
@@ -37,6 +37,10 @@ type RegressionStore interface {
 	ResolveTriages() error
 	// MergeJobRuns upserts job runs for a regression, adding new ones and skipping duplicates.
 	MergeJobRuns(regressionID uint, jobRuns []models.RegressionJobRun) error
+	// UpsertRegressionView records that a regression was observed in a view, setting active=true.
+	UpsertRegressionView(regressionID uint, viewName string) error
+	// DeactivateRolledOffViews sets active=false on regression_views rows for regressions that have rolled off a view.
+	DeactivateRolledOffViews(regressionIDs []uint, activeViewMap map[uint][]string) error
 }
 
 type PostgresRegressionStore struct {
@@ -79,6 +83,7 @@ func (prs *PostgresRegressionStore) OpenRegression(view crview.View, newRegresse
 		newRegression.BaseRelease = newRegressedTest.BaseStats.Release
 	}
 
+	newRegression.CrossCompare = len(view.VariantOptions.VariantCrossCompare) > 0
 	newRegression.Capability = newRegressedTest.Capability
 	newRegression.Component = newRegressedTest.Component
 
@@ -108,6 +113,36 @@ func (prs *PostgresRegressionStore) MergeJobRuns(regressionID uint, jobRuns []mo
 		if res.Error != nil {
 			return fmt.Errorf("error merging job run %s for regression %d: %w",
 				jobRuns[i].ProwJobRunID, regressionID, res.Error)
+		}
+	}
+	return nil
+}
+
+func (prs *PostgresRegressionStore) UpsertRegressionView(regressionID uint, viewName string) error {
+	rv := models.RegressionView{
+		TestRegressionID: regressionID,
+		ViewName:         viewName,
+		Active:           true,
+	}
+	res := prs.dbc.DB.Exec(
+		"INSERT INTO regression_views (test_regression_id, view_name, active) VALUES (?, ?, true) ON CONFLICT (test_regression_id, view_name) DO UPDATE SET active = true",
+		rv.TestRegressionID, rv.ViewName)
+	return res.Error
+}
+
+func (prs *PostgresRegressionStore) DeactivateRolledOffViews(regressionIDs []uint, activeViewMap map[uint][]string) error {
+	if len(regressionIDs) == 0 {
+		return nil
+	}
+
+	for _, regID := range regressionIDs {
+		q := prs.dbc.DB.Model(&models.RegressionView{}).
+			Where("test_regression_id = ? AND active = true", regID)
+		if activeViews := activeViewMap[regID]; len(activeViews) > 0 {
+			q = q.Where("view_name NOT IN ?", activeViews)
+		}
+		if res := q.Update("active", false); res.Error != nil {
+			return fmt.Errorf("error deactivating rolled-off views for regression %d: %w", regID, res.Error)
 		}
 	}
 	return nil
@@ -196,7 +231,8 @@ func SyncRegressionsForReport(
 	var activeRegressions []*models.TestRegression // all the matches we found, and new regressions opened, used to determine what had no match
 	rLog.Infof("syncing %d open regressions", len(allRegressedTests))
 	for _, regTest := range allRegressedTests {
-		if openReg := regressiontracker.FindOpenRegression(view.SampleRelease.Name, regTest.TestID, regTest.Variants, regressions); openReg != nil {
+		crossCompare := len(view.VariantOptions.VariantCrossCompare) > 0
+		if openReg := regressiontracker.FindOpenRegression(view.SampleRelease.Name, regTest.TestID, crossCompare, regTest.Variants, regressions); openReg != nil {
 
 			// Check if we need to add new variants to the regression found via subset matching.
 			// This allows regressions to be split by new variant dimensions when db_column_groupby is modified.

--- a/pkg/api/componentreadiness/regressiontracker.go
+++ b/pkg/api/componentreadiness/regressiontracker.go
@@ -119,14 +119,14 @@ func (prs *PostgresRegressionStore) MergeJobRuns(regressionID uint, jobRuns []mo
 }
 
 func (prs *PostgresRegressionStore) UpsertRegressionView(regressionID uint, viewName string) error {
-	rv := models.RegressionView{
-		TestRegressionID: regressionID,
-		ViewName:         viewName,
-		Active:           true,
-	}
 	res := prs.dbc.DB.Exec(
-		"INSERT INTO regression_views (test_regression_id, view_name, active) VALUES (?, ?, true) ON CONFLICT (test_regression_id, view_name) DO UPDATE SET active = true",
-		rv.TestRegressionID, rv.ViewName)
+		`INSERT INTO regression_views (test_regression_id, view_name, active, opened_at)
+		 VALUES (?, ?, true, NOW())
+		 ON CONFLICT (test_regression_id, view_name) DO UPDATE
+		 SET active = true,
+		     opened_at = CASE WHEN regression_views.active = false THEN NOW() ELSE regression_views.opened_at END,
+		     closed_at = NULL`,
+		regressionID, viewName)
 	return res.Error
 }
 
@@ -141,7 +141,7 @@ func (prs *PostgresRegressionStore) DeactivateRolledOffViews(regressionIDs []uin
 		if activeViews := activeViewMap[regID]; len(activeViews) > 0 {
 			q = q.Where("view_name NOT IN ?", activeViews)
 		}
-		if res := q.Update("active", false); res.Error != nil {
+		if res := q.Updates(map[string]interface{}{"active": false, "closed_at": time.Now()}); res.Error != nil {
 			return fmt.Errorf("error deactivating rolled-off views for regression %d: %w", regID, res.Error)
 		}
 	}

--- a/pkg/api/componentreadiness/triage.go
+++ b/pkg/api/componentreadiness/triage.go
@@ -29,7 +29,7 @@ import (
 
 func GetTriage(dbc *db.DB, id int, req *http.Request) (*models.Triage, error) {
 	existingTriage := &models.Triage{}
-	res := dbc.DB.Preload("Bug").Preload("Regressions.JobRuns").Preload("Regressions").First(existingTriage, id)
+	res := dbc.DB.Preload("Bug").Preload("Regressions.JobRuns").Preload("Regressions.Views").Preload("Regressions").First(existingTriage, id)
 	if res.Error != nil {
 		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -324,7 +324,7 @@ func ListRegressions(dbc *db.DB, release string, views []crview.View, releases [
 // GetRegression returns the regression with the matching ID
 func GetRegression(dbc *db.DB, id int, views []crview.View, releases []v1.Release, crTimeRoundingFactor time.Duration, req *http.Request) (*models.TestRegression, error) {
 	regression := &models.TestRegression{}
-	res := dbc.DB.Preload("Triages").Preload("JobRuns").First(regression, id)
+	res := dbc.DB.Preload("Triages").Preload("JobRuns").Preload("Views").First(regression, id)
 	if res.Error != nil {
 		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -796,23 +796,37 @@ func injectHATEOASLinks(triage *models.Triage, baseURL string) {
 }
 
 // InjectRegressionHATEOASLinks adds restful links clients can follow for this regression record.
+// Per-view test_details links use composite keys: test_details:<view_name>.
 func InjectRegressionHATEOASLinks(regression *models.TestRegression, views []crview.View, releases []v1.Release, crTimeRoundingFactor time.Duration, baseAPIURL, baseFrontendURL string) {
 	regression.Links = map[string]string{
 		"self": fmt.Sprintf(regressionLink, baseAPIURL, regression.ID),
 	}
 
-	view, ok := GetMainViewForSampleRelease(regression.Release, views)
-	if !ok {
-		log.Errorf("no main view found for base: %s, and sample: %s", regression.BaseRelease, regression.Release)
-		return
+	for _, rv := range regression.Views {
+		if !rv.Active {
+			continue
+		}
+		view, ok := FindViewByName(rv.ViewName, views)
+		if !ok {
+			log.Errorf("view %s not found in config for regression %d", rv.ViewName, regression.ID)
+			continue
+		}
+		testDetailsURL, err := generateTestDetailsURLFromRegression(regression, view, releases, crTimeRoundingFactor, baseFrontendURL)
+		if err != nil {
+			log.WithError(err).Errorf("failed to generate test details URL for regression %d and view: %s", regression.ID, view.Name)
+			continue
+		}
+		regression.Links[fmt.Sprintf("test_details:%s", rv.ViewName)] = testDetailsURL
 	}
+}
 
-	testDetailsURL, err := generateTestDetailsURLFromRegression(regression, view, releases, crTimeRoundingFactor, baseFrontendURL)
-	if err != nil {
-		log.WithError(err).Errorf("failed to generate test details URL for regression %d and view: %s", regression.ID, view.Name)
-		return
+func FindViewByName(name string, views []crview.View) (crview.View, bool) {
+	for _, v := range views {
+		if v.Name == name {
+			return v, true
+		}
 	}
-	regression.Links["test_details"] = testDetailsURL
+	return crview.View{}, false
 }
 
 // generateTestDetailsURLFromRegression extracts the required data from a regression and view
@@ -849,37 +863,16 @@ func generateTestDetailsURLFromRegression(regression *models.TestRegression, vie
 	)
 }
 
-// GetViewsForTriage returns all views with regression tracking enabled that have the same base and sample releases
-// as any regression associated with the given triage.
-func GetViewsForTriage(triage *models.Triage, views []crview.View) []string {
+// GetViewsForTriage returns the names of all active views associated with the triage's regressions.
+func GetViewsForTriage(triage *models.Triage) []string {
 	matchingViews := make(sets.Set[string])
 	for _, regression := range triage.Regressions {
-		for _, view := range ViewsMatchingReleases(regression.BaseRelease, regression.Release, views) {
-			matchingViews.Insert(view.Name)
+		for _, rv := range regression.Views {
+			if rv.Active {
+				matchingViews.Insert(rv.ViewName)
+			}
 		}
 	}
 
 	return matchingViews.UnsortedList()
-}
-
-// GetMainViewForSampleRelease returns the main view for the given sample release.
-func GetMainViewForSampleRelease(sampleRelease string, views []crview.View) (view crview.View, ok bool) {
-	for _, v := range views {
-		if v.RegressionTracking.Enabled && v.SampleRelease.Name == sampleRelease && strings.HasSuffix(v.Name, "-main") {
-			return v, true
-		}
-	}
-	return crview.View{}, false
-}
-
-// ViewsMatchingReleases returns all views with regression tracking enabled whose base and sample release names match the given params.
-// Order is preserved from the input views slice (same as config file order), so the first returned view is the main view for the release.
-func ViewsMatchingReleases(baseRelease, sampleRelease string, views []crview.View) []crview.View {
-	var matchingViews []crview.View
-	for _, view := range views {
-		if view.RegressionTracking.Enabled && view.BaseRelease.Name == baseRelease && view.SampleRelease.Name == sampleRelease {
-			matchingViews = append(matchingViews, view)
-		}
-	}
-	return matchingViews
 }

--- a/pkg/api/componentreadiness/triage.go
+++ b/pkg/api/componentreadiness/triage.go
@@ -427,10 +427,7 @@ func calculateJobRunOverlap(candidateRunIDs sets.Set[string], triageRegression m
 	}
 
 	// Use the smaller set as the denominator so overlap is relative to the regression with fewer runs
-	denominator := candidateRunIDs.Len()
-	if len(triageRegression.JobRuns) < denominator {
-		denominator = len(triageRegression.JobRuns)
-	}
+	denominator := min(candidateRunIDs.Len(), len(triageRegression.JobRuns))
 	overlapPercent := float64(len(sharedIDs)) / float64(denominator) * 100
 
 	return &JobRunOverlap{
@@ -865,6 +862,9 @@ func generateTestDetailsURLFromRegression(regression *models.TestRegression, vie
 
 // GetViewsForTriage returns the names of all active views associated with the triage's regressions.
 func GetViewsForTriage(triage *models.Triage) []string {
+	if triage == nil {
+		return nil
+	}
 	matchingViews := make(sets.Set[string])
 	for _, regression := range triage.Regressions {
 		for _, rv := range regression.Views {

--- a/pkg/api/componentreadiness/triage_test.go
+++ b/pkg/api/componentreadiness/triage_test.go
@@ -632,15 +632,30 @@ func TestInjectRegressionHATEOASLinks(t *testing.T) {
 			},
 			RegressionTracking: crview.RegressionTracking{Enabled: true},
 		},
+		{
+			Name: "4.22-arm64",
+			BaseRelease: reqopts.RelativeRelease{
+				Release:       reqopts.Release{Name: "4.21"},
+				RelativeStart: "ga-30d",
+				RelativeEnd:   "ga",
+			},
+			SampleRelease: reqopts.RelativeRelease{
+				Release:       reqopts.Release{Name: "4.22"},
+				RelativeStart: "now-7d",
+				RelativeEnd:   "now",
+			},
+			RegressionTracking: crview.RegressionTracking{Enabled: true},
+		},
 	}
 
 	tests := []struct {
-		name       string
-		regression *models.TestRegression
-		expectLink bool
+		name            string
+		regression      *models.TestRegression
+		expectLinkKeys  []string
+		expectNoDetails bool
 	}{
 		{
-			name: "sample release matches view",
+			name: "single active view",
 			regression: &models.TestRegression{
 				ID:          1,
 				Release:     "4.22",
@@ -649,34 +664,103 @@ func TestInjectRegressionHATEOASLinks(t *testing.T) {
 				Component:   "component",
 				Capability:  "capability",
 				Variants:    pq.StringArray{"Platform:aws"},
+				Views:       []models.RegressionView{{TestRegressionID: 1, ViewName: "4.22-main", Active: true}},
 			},
-			expectLink: true,
+			expectLinkKeys: []string{"test_details:4.22-main"},
 		},
 		{
-			name: "fallback base release differs from view",
+			name: "multiple active views produce multiple links",
 			regression: &models.TestRegression{
 				ID:          2,
 				Release:     "4.22",
-				BaseRelease: "4.20",
+				BaseRelease: "4.21",
 				TestID:      "test-456",
 				Component:   "component",
 				Capability:  "capability",
 				Variants:    pq.StringArray{"Platform:aws"},
+				Views: []models.RegressionView{
+					{TestRegressionID: 2, ViewName: "4.22-main", Active: true},
+					{TestRegressionID: 2, ViewName: "4.22-arm64", Active: true},
+				},
 			},
-			expectLink: true,
+			expectLinkKeys: []string{"test_details:4.22-main", "test_details:4.22-arm64"},
 		},
 		{
-			name: "sample release matches no view",
+			name: "inactive views are excluded from links",
 			regression: &models.TestRegression{
 				ID:          3,
-				Release:     "4.99",
-				BaseRelease: "4.98",
+				Release:     "4.22",
+				BaseRelease: "4.21",
 				TestID:      "test-789",
 				Component:   "component",
 				Capability:  "capability",
 				Variants:    pq.StringArray{"Platform:aws"},
+				Views: []models.RegressionView{
+					{TestRegressionID: 3, ViewName: "4.22-main", Active: true},
+					{TestRegressionID: 3, ViewName: "4.22-arm64", Active: false},
+				},
 			},
-			expectLink: false,
+			expectLinkKeys: []string{"test_details:4.22-main"},
+		},
+		{
+			name: "no active views produces no test_details links",
+			regression: &models.TestRegression{
+				ID:          4,
+				Release:     "4.22",
+				BaseRelease: "4.21",
+				TestID:      "test-000",
+				Component:   "component",
+				Capability:  "capability",
+				Variants:    pq.StringArray{"Platform:aws"},
+				Views: []models.RegressionView{
+					{TestRegressionID: 4, ViewName: "4.22-main", Active: false},
+				},
+			},
+			expectNoDetails: true,
+		},
+		{
+			name: "empty views slice produces no test_details links",
+			regression: &models.TestRegression{
+				ID:          5,
+				Release:     "4.99",
+				BaseRelease: "4.98",
+				TestID:      "test-empty",
+				Component:   "component",
+				Capability:  "capability",
+				Variants:    pq.StringArray{"Platform:aws"},
+			},
+			expectNoDetails: true,
+		},
+		{
+			name: "view not found in config is skipped",
+			regression: &models.TestRegression{
+				ID:          6,
+				Release:     "4.22",
+				BaseRelease: "4.21",
+				TestID:      "test-missing-view",
+				Component:   "component",
+				Capability:  "capability",
+				Variants:    pq.StringArray{"Platform:aws"},
+				Views: []models.RegressionView{
+					{TestRegressionID: 6, ViewName: "4.22-main", Active: true},
+					{TestRegressionID: 6, ViewName: "nonexistent-view", Active: true},
+				},
+			},
+			expectLinkKeys: []string{"test_details:4.22-main"},
+		},
+		{
+			name: "fallback base release differs from view",
+			regression: &models.TestRegression{
+				ID:          7,
+				Release:     "4.22",
+				BaseRelease: "4.20",
+				TestID:      "test-fallback",
+				Component:   "component",
+				Capability:  "capability",
+				Variants:    pq.StringArray{"Platform:aws"},
+				Views:       []models.RegressionView{{TestRegressionID: 7, ViewName: "4.22-main", Active: true}},
+			},
+			expectLinkKeys: []string{"test_details:4.22-main"},
 		},
 	}
 
@@ -686,12 +770,158 @@ func TestInjectRegressionHATEOASLinks(t *testing.T) {
 
 			assert.Contains(t, tt.regression.Links, "self")
 
-			if tt.expectLink {
-				assert.Contains(t, tt.regression.Links, "test_details", "expected test_details link to be present")
-				assert.Contains(t, tt.regression.Links["test_details"], "test_details")
+			if tt.expectNoDetails {
+				for key := range tt.regression.Links {
+					assert.NotContains(t, key, "test_details", "expected no test_details links")
+				}
 			} else {
-				assert.NotContains(t, tt.regression.Links, "test_details", "expected test_details link to be absent")
+				for _, expectedKey := range tt.expectLinkKeys {
+					assert.Contains(t, tt.regression.Links, expectedKey, "expected %s link to be present", expectedKey)
+					assert.Contains(t, tt.regression.Links[expectedKey], "test_details", "link should point to test_details endpoint")
+				}
+				// Count test_details links matches expected count
+				detailsCount := 0
+				for key := range tt.regression.Links {
+					if key != "self" {
+						detailsCount++
+					}
+				}
+				assert.Equal(t, len(tt.expectLinkKeys), detailsCount, "number of test_details links should match expected")
 			}
+		})
+	}
+}
+
+func TestFindViewByName(t *testing.T) {
+	views := []crview.View{
+		{Name: "4.22-main"},
+		{Name: "4.22-arm64"},
+		{Name: "4.21-main"},
+	}
+
+	tests := []struct {
+		name       string
+		viewName   string
+		expectOK   bool
+		expectName string
+	}{
+		{
+			name:       "found",
+			viewName:   "4.22-main",
+			expectOK:   true,
+			expectName: "4.22-main",
+		},
+		{
+			name:     "not found",
+			viewName: "nonexistent",
+			expectOK: false,
+		},
+		{
+			name:     "empty name",
+			viewName: "",
+			expectOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			view, ok := FindViewByName(tt.viewName, views)
+			assert.Equal(t, tt.expectOK, ok)
+			if tt.expectOK {
+				assert.Equal(t, tt.expectName, view.Name)
+			}
+		})
+	}
+}
+
+func TestGetViewsForTriage(t *testing.T) {
+	tests := []struct {
+		name          string
+		triage        *models.Triage
+		expectedViews []string
+	}{
+		{
+			name: "single regression with active views",
+			triage: &models.Triage{
+				Regressions: []models.TestRegression{
+					{
+						Views: []models.RegressionView{
+							{ViewName: "4.22-main", Active: true},
+							{ViewName: "4.22-arm64", Active: true},
+						},
+					},
+				},
+			},
+			expectedViews: []string{"4.22-main", "4.22-arm64"},
+		},
+		{
+			name: "inactive views are excluded",
+			triage: &models.Triage{
+				Regressions: []models.TestRegression{
+					{
+						Views: []models.RegressionView{
+							{ViewName: "4.22-main", Active: true},
+							{ViewName: "4.22-arm64", Active: false},
+						},
+					},
+				},
+			},
+			expectedViews: []string{"4.22-main"},
+		},
+		{
+			name: "multiple regressions deduplicate views",
+			triage: &models.Triage{
+				Regressions: []models.TestRegression{
+					{
+						Views: []models.RegressionView{
+							{ViewName: "4.22-main", Active: true},
+						},
+					},
+					{
+						Views: []models.RegressionView{
+							{ViewName: "4.22-main", Active: true},
+							{ViewName: "4.22-arm64", Active: true},
+						},
+					},
+				},
+			},
+			expectedViews: []string{"4.22-main", "4.22-arm64"},
+		},
+		{
+			name: "no active views returns empty",
+			triage: &models.Triage{
+				Regressions: []models.TestRegression{
+					{
+						Views: []models.RegressionView{
+							{ViewName: "4.22-main", Active: false},
+						},
+					},
+				},
+			},
+			expectedViews: []string{},
+		},
+		{
+			name: "no regressions returns empty",
+			triage: &models.Triage{
+				Regressions: []models.TestRegression{},
+			},
+			expectedViews: []string{},
+		},
+		{
+			name: "regression with no views returns empty",
+			triage: &models.Triage{
+				Regressions: []models.TestRegression{
+					{Views: []models.RegressionView{}},
+				},
+			},
+			expectedViews: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetViewsForTriage(tt.triage)
+			assert.ElementsMatch(t, tt.expectedViews, result)
 		})
 	}
 }

--- a/pkg/api/componentreadiness/triage_test.go
+++ b/pkg/api/componentreadiness/triage_test.go
@@ -916,6 +916,11 @@ func TestGetViewsForTriage(t *testing.T) {
 			},
 			expectedViews: []string{},
 		},
+		{
+			name:          "nil triage returns nil",
+			triage:        nil,
+			expectedViews: nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/dataloader/regressioncacheloader/regressioncacheloader.go
+++ b/pkg/dataloader/regressioncacheloader/regressioncacheloader.go
@@ -100,7 +100,9 @@ func (l *RegressionCacheLoader) Load() {
 		StableExpiry:         cache.StandardStableExpiryCR,
 	}
 
-	// Group views by sample release so we can handle regression closing per-release
+	// Group views by sample release so we can handle regression closing per-release.
+	// Only regression-tracking views contribute to the closing/deactivation logic;
+	// cache-only views are still processed but don't affect regression lifecycle.
 	releaseResults := map[string]*struct {
 		activeIDs     sets.Set[uint]
 		activeViewMap map[uint][]string
@@ -114,6 +116,28 @@ func (l *RegressionCacheLoader) Load() {
 		vLog := l.logger.WithField("view", view.Name)
 		release := view.SampleRelease.Name
 
+		activeRegs, err := l.processView(ctx, view, cacheOpts, vLog)
+		if err != nil {
+			vLog.WithError(err).Error("error processing view")
+			l.errs = append(l.errs, err)
+			if view.RegressionTracking.Enabled {
+				if _, ok := releaseResults[release]; !ok {
+					releaseResults[release] = &struct {
+						activeIDs     sets.Set[uint]
+						activeViewMap map[uint][]string
+						hadErrors     bool
+					}{
+						activeIDs:     make(sets.Set[uint]),
+						activeViewMap: make(map[uint][]string),
+					}
+				}
+				releaseResults[release].hadErrors = true
+			}
+			continue
+		}
+		if !view.RegressionTracking.Enabled {
+			continue
+		}
 		if _, ok := releaseResults[release]; !ok {
 			releaseResults[release] = &struct {
 				activeIDs     sets.Set[uint]
@@ -123,14 +147,6 @@ func (l *RegressionCacheLoader) Load() {
 				activeIDs:     make(sets.Set[uint]),
 				activeViewMap: make(map[uint][]string),
 			}
-		}
-
-		activeRegs, err := l.processView(ctx, view, cacheOpts, vLog)
-		if err != nil {
-			vLog.WithError(err).Error("error processing view")
-			l.errs = append(l.errs, err)
-			releaseResults[release].hadErrors = true
-			continue
 		}
 		for _, reg := range activeRegs {
 			releaseResults[release].activeIDs.Insert(reg.ID)

--- a/pkg/dataloader/regressioncacheloader/regressioncacheloader.go
+++ b/pkg/dataloader/regressioncacheloader/regressioncacheloader.go
@@ -2,6 +2,7 @@ package regressioncacheloader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -168,7 +169,6 @@ func (l *RegressionCacheLoader) Load() {
 		if err != nil {
 			l.errs = append(l.errs, err)
 			anyErrors = true
-			continue
 		}
 		allIDs := append(result.activeIDs.UnsortedList(), closedIDs...)
 		if err := l.regressionStore.DeactivateRolledOffViews(allIDs, result.activeViewMap); err != nil {
@@ -443,6 +443,7 @@ func (l *RegressionCacheLoader) closeRolledOffRegressions(release string, active
 	}
 
 	var closedIDs []uint
+	var errs []error
 	now := time.Now()
 	rLog.Infof("checking %d regressions against %d active IDs for closing", len(regressions), activeIDs.Len())
 	for _, reg := range regressions {
@@ -453,12 +454,13 @@ func (l *RegressionCacheLoader) closeRolledOffRegressions(release string, active
 		reg.Closed.Valid = true
 		reg.Closed.Time = now
 		if err := l.regressionStore.UpdateRegression(reg); err != nil {
-			return nil, fmt.Errorf("error closing regression %d: %w", reg.ID, err)
+			errs = append(errs, fmt.Errorf("error closing regression %d: %w", reg.ID, err))
+			continue
 		}
 		closedIDs = append(closedIDs, reg.ID)
 	}
 	rLog.Infof("closed %d regressions", len(closedIDs))
-	return closedIDs, nil
+	return closedIDs, errors.Join(errs...)
 }
 
 func (l *RegressionCacheLoader) buildGenerator(

--- a/pkg/dataloader/regressioncacheloader/regressioncacheloader.go
+++ b/pkg/dataloader/regressioncacheloader/regressioncacheloader.go
@@ -102,8 +102,9 @@ func (l *RegressionCacheLoader) Load() {
 
 	// Group views by sample release so we can handle regression closing per-release
 	releaseResults := map[string]*struct {
-		activeIDs sets.Set[uint]
-		hadErrors bool
+		activeIDs     sets.Set[uint]
+		activeViewMap map[uint][]string
+		hadErrors     bool
 	}{}
 
 	for _, view := range l.views {
@@ -115,10 +116,12 @@ func (l *RegressionCacheLoader) Load() {
 
 		if _, ok := releaseResults[release]; !ok {
 			releaseResults[release] = &struct {
-				activeIDs sets.Set[uint]
-				hadErrors bool
+				activeIDs     sets.Set[uint]
+				activeViewMap map[uint][]string
+				hadErrors     bool
 			}{
-				activeIDs: make(sets.Set[uint]),
+				activeIDs:     make(sets.Set[uint]),
+				activeViewMap: make(map[uint][]string),
 			}
 		}
 
@@ -131,6 +134,8 @@ func (l *RegressionCacheLoader) Load() {
 		}
 		for _, reg := range activeRegs {
 			releaseResults[release].activeIDs.Insert(reg.ID)
+			releaseResults[release].activeViewMap[reg.ID] = append(
+				releaseResults[release].activeViewMap[reg.ID], view.Name)
 		}
 	}
 
@@ -143,7 +148,13 @@ func (l *RegressionCacheLoader) Load() {
 			anyErrors = true
 			continue
 		}
-		if err := l.closeStaleRegressions(release, result.activeIDs); err != nil {
+		if err := l.closeRolledOffRegressions(release, result.activeIDs); err != nil {
+			l.errs = append(l.errs, err)
+			anyErrors = true
+			continue
+		}
+		if err := l.regressionStore.DeactivateRolledOffViews(result.activeIDs.UnsortedList(), result.activeViewMap); err != nil {
+			l.logger.WithError(err).Errorf("error deactivating rolled-off regression views for release %s", release)
 			l.errs = append(l.errs, err)
 			anyErrors = true
 		}
@@ -190,6 +201,12 @@ func (l *RegressionCacheLoader) processView(
 			l.regressionStore, view, rLog, report)
 		if err != nil {
 			return nil, fmt.Errorf("error syncing regressions for view %s: %w", view.Name, err)
+		}
+		for _, reg := range activeRegressions {
+			if err := l.regressionStore.UpsertRegressionView(reg.ID, view.Name); err != nil {
+				return nil, fmt.Errorf("error upserting view %s for regression %d: %w",
+					view.Name, reg.ID, err)
+			}
 		}
 	}
 
@@ -399,7 +416,7 @@ func (l *RegressionCacheLoader) syncJobRunsFromReports(
 	return nil
 }
 
-func (l *RegressionCacheLoader) closeStaleRegressions(release string, activeIDs sets.Set[uint]) error {
+func (l *RegressionCacheLoader) closeRolledOffRegressions(release string, activeIDs sets.Set[uint]) error {
 	rLog := l.logger.WithField("release", release)
 
 	regressions, err := l.regressionStore.ListCurrentRegressionsForRelease(release)

--- a/pkg/dataloader/regressioncacheloader/regressioncacheloader.go
+++ b/pkg/dataloader/regressioncacheloader/regressioncacheloader.go
@@ -148,12 +148,14 @@ func (l *RegressionCacheLoader) Load() {
 			anyErrors = true
 			continue
 		}
-		if err := l.closeRolledOffRegressions(release, result.activeIDs); err != nil {
+		closedIDs, err := l.closeRolledOffRegressions(release, result.activeIDs)
+		if err != nil {
 			l.errs = append(l.errs, err)
 			anyErrors = true
 			continue
 		}
-		if err := l.regressionStore.DeactivateRolledOffViews(result.activeIDs.UnsortedList(), result.activeViewMap); err != nil {
+		allIDs := append(result.activeIDs.UnsortedList(), closedIDs...)
+		if err := l.regressionStore.DeactivateRolledOffViews(allIDs, result.activeViewMap); err != nil {
 			l.logger.WithError(err).Errorf("error deactivating rolled-off regression views for release %s", release)
 			l.errs = append(l.errs, err)
 			anyErrors = true
@@ -416,15 +418,15 @@ func (l *RegressionCacheLoader) syncJobRunsFromReports(
 	return nil
 }
 
-func (l *RegressionCacheLoader) closeRolledOffRegressions(release string, activeIDs sets.Set[uint]) error {
+func (l *RegressionCacheLoader) closeRolledOffRegressions(release string, activeIDs sets.Set[uint]) ([]uint, error) {
 	rLog := l.logger.WithField("release", release)
 
 	regressions, err := l.regressionStore.ListCurrentRegressionsForRelease(release)
 	if err != nil {
-		return fmt.Errorf("error listing regressions for release %s: %w", release, err)
+		return nil, fmt.Errorf("error listing regressions for release %s: %w", release, err)
 	}
 
-	closedCount := 0
+	var closedIDs []uint
 	now := time.Now()
 	rLog.Infof("checking %d regressions against %d active IDs for closing", len(regressions), activeIDs.Len())
 	for _, reg := range regressions {
@@ -435,12 +437,12 @@ func (l *RegressionCacheLoader) closeRolledOffRegressions(release string, active
 		reg.Closed.Valid = true
 		reg.Closed.Time = now
 		if err := l.regressionStore.UpdateRegression(reg); err != nil {
-			return fmt.Errorf("error closing regression %d: %w", reg.ID, err)
+			return nil, fmt.Errorf("error closing regression %d: %w", reg.ID, err)
 		}
-		closedCount++
+		closedIDs = append(closedIDs, reg.ID)
 	}
-	rLog.Infof("closed %d regressions", closedCount)
-	return nil
+	rLog.Infof("closed %d regressions", len(closedIDs))
+	return closedIDs, nil
 }
 
 func (l *RegressionCacheLoader) buildGenerator(

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -90,6 +90,7 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 		&models.FeatureGate{},
 		&models.TestRegression{},
 		&models.RegressionJobRun{},
+		&models.RegressionView{},
 		&models.Triage{},
 		&models.AuditLog{},
 		&models.ChatRating{},

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -106,13 +106,8 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 		}
 	}
 
-	// TODO(sgoeddel): This migration logic can be removed once we have a migration that drops the view column from test_regressions
-	if d.DB.Migrator().HasColumn(&models.TestRegression{}, "view") {
-		if err := d.DB.Migrator().DropColumn(&models.TestRegression{}, "view"); err != nil {
-			return err
-		}
-	}
-
+	// TODO(sgoeddel): This is temporary migration logic to backfill closed regressions with their most likely view.
+	// It should be removed after running for the first time.
 	if err := backfillClosedRegressionViews(d.DB); err != nil {
 		return err
 	}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -231,7 +231,8 @@ func backfillClosedRegressionViews(db *gorm.DB) error {
 		WHERE tr.closed IS NOT NULL
 		AND NOT EXISTS (
 			SELECT 1 FROM regression_views rv WHERE rv.test_regression_id = tr.id
-		)`)
+		)
+		ON CONFLICT (test_regression_id, view_name) DO NOTHING`)
 	if res.Error != nil {
 		return fmt.Errorf("error backfilling closed regression views: %w", res.Error)
 	}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -38,7 +38,7 @@ type log2LogrusWriter struct {
 	entry *log.Entry
 }
 
-func (w log2LogrusWriter) Printf(msg string, args ...interface{}) {
+func (w log2LogrusWriter) Printf(msg string, args ...any) {
 	w.entry.Debugf(msg, args...)
 }
 
@@ -67,7 +67,7 @@ func New(dsn string, logLevel gormlogger.LogLevel) (*DB, error) {
 
 func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 	// List of all models to migrate
-	modelsToMigrate := []interface{}{
+	modelsToMigrate := []any{
 		&models.ReleaseTag{},
 		&models.ReleasePullRequest{},
 		&models.ReleaseRepository{},
@@ -111,6 +111,10 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 		if err := d.DB.Migrator().DropColumn(&models.TestRegression{}, "view"); err != nil {
 			return err
 		}
+	}
+
+	if err := backfillClosedRegressionViews(d.DB); err != nil {
+		return err
 	}
 
 	if err := createAuditLogIndexes(d.DB); err != nil {
@@ -213,6 +217,28 @@ func syncSchema(db *gorm.DB, hashType SchemaHashType, name, desiredSchema, dropS
 		vlog.Debug("no schema update required")
 	}
 	return updateRequired, nil
+}
+
+// backfillClosedRegressionViews associates closed regressions that predate the regression_views
+// table with their most likely view (<release>-main). Historically only -main views had regression
+// tracking enabled, so this is our best approximation. Only targets regressions with no existing
+// view associations; open regressions are handled naturally by the loader.
+func backfillClosedRegressionViews(db *gorm.DB) error {
+	res := db.Exec(`
+		INSERT INTO regression_views (test_regression_id, view_name, active, opened_at, closed_at)
+		SELECT tr.id, tr.release || '-main', false, tr.opened, tr.closed
+		FROM test_regressions tr
+		WHERE tr.closed IS NOT NULL
+		AND NOT EXISTS (
+			SELECT 1 FROM regression_views rv WHERE rv.test_regression_id = tr.id
+		)`)
+	if res.Error != nil {
+		return fmt.Errorf("error backfilling closed regression views: %w", res.Error)
+	}
+	if res.RowsAffected > 0 {
+		log.Infof("backfilled %d closed regressions with release-main view associations", res.RowsAffected)
+	}
+	return nil
 }
 
 // createAuditLogIndexes creates GIN indexes for JSONB columns in audit_logs table

--- a/pkg/db/models/triage.go
+++ b/pkg/db/models/triage.go
@@ -240,9 +240,11 @@ type TestRegression struct {
 // RegressionView associates a regression with a component readiness view.
 // The Active flag tracks whether the regression currently appears in the view's component report.
 type RegressionView struct {
-	TestRegressionID uint   `json:"test_regression_id" gorm:"primaryKey"`
-	ViewName         string `json:"view_name" gorm:"primaryKey"`
-	Active           bool   `json:"active" gorm:"not null;default:true"`
+	TestRegressionID uint         `json:"test_regression_id" gorm:"primaryKey"`
+	ViewName         string       `json:"view_name" gorm:"primaryKey"`
+	Active           bool         `json:"active" gorm:"not null;default:true"`
+	OpenedAt         time.Time    `json:"opened_at" gorm:"not null;default:now()"`
+	ClosedAt         sql.NullTime `json:"closed_at"`
 }
 
 // RegressionJobRun represents a single job run observed during the lifetime of a regression.

--- a/pkg/db/models/triage.go
+++ b/pkg/db/models/triage.go
@@ -209,15 +209,16 @@ type TestRegression struct {
 	Release string `json:"release" gorm:"not null;index:idx_test_regression_release"`
 	// BaseRelease is the release this test was marked regressed against. It may not match the view's base release
 	// if the view uses release fallback and this test was flagged regressed against a prior release with better pass rate.
-	BaseRelease string         `json:"base_release"`
-	Component   string         `json:"component"`
-	Capability  string         `json:"capability"`
-	TestID      string         `json:"test_id" gorm:"not null"`
-	TestName    string         `json:"test_name" gorm:"not null;index:idx_test_regression_test_name"`
-	Variants    pq.StringArray `json:"variants" gorm:"not null;type:text[]"`
-	Opened      time.Time      `json:"opened" gorm:"not null"`
-	Closed      sql.NullTime   `json:"closed"`
-	Triages     []Triage       `json:"triages" gorm:"many2many:triage_regressions;"`
+	BaseRelease  string         `json:"base_release"`
+	Component    string         `json:"component"`
+	Capability   string         `json:"capability"`
+	CrossCompare bool           `json:"cross_compare" gorm:"not null;default:false"`
+	TestID       string         `json:"test_id" gorm:"not null"`
+	TestName     string         `json:"test_name" gorm:"not null;index:idx_test_regression_test_name"`
+	Variants     pq.StringArray `json:"variants" gorm:"not null;type:text[]"`
+	Opened       time.Time      `json:"opened" gorm:"not null"`
+	Closed       sql.NullTime   `json:"closed"`
+	Triages      []Triage       `json:"triages" gorm:"many2many:triage_regressions;"`
 	// LastFailure is the last failure in the sample we saw while this regression was open.
 	LastFailure sql.NullTime `json:"last_failure"`
 	// MaxFailures is the maximum number of failures we found in the reporting window while this regression was open.
@@ -229,8 +230,19 @@ type TestRegression struct {
 	// As the 7-day sample window slides, old runs roll off and new ones appear, but this list retains all of them.
 	JobRuns []RegressionJobRun `json:"job_runs,omitempty" gorm:"foreignKey:RegressionID;constraint:OnDelete:CASCADE;"`
 
+	// Views tracks which component readiness views this regression has been observed in.
+	Views []RegressionView `json:"views,omitempty" gorm:"foreignKey:TestRegressionID;constraint:OnDelete:CASCADE;"`
+
 	// Links contains HATEOAS-style links for this regression record (not stored in database)
 	Links map[string]string `json:"links,omitempty" gorm:"-"`
+}
+
+// RegressionView associates a regression with a component readiness view.
+// The Active flag tracks whether the regression currently appears in the view's component report.
+type RegressionView struct {
+	TestRegressionID uint   `json:"test_regression_id" gorm:"primaryKey"`
+	ViewName         string `json:"view_name" gorm:"primaryKey"`
+	Active           bool   `json:"active" gorm:"not null;default:true"`
 }
 
 // RegressionJobRun represents a single job run observed during the lifetime of a regression.

--- a/pkg/db/query/triage_queries.go
+++ b/pkg/db/query/triage_queries.go
@@ -8,7 +8,7 @@ import (
 
 func ListTriages(dbc *db.DB) ([]models.Triage, error) {
 	var triages []models.Triage
-	res := dbc.DB.Preload("Bug").Preload("Regressions.JobRuns").Preload("Regressions").Find(&triages)
+	res := dbc.DB.Preload("Bug").Preload("Regressions.JobRuns").Preload("Regressions.Views").Preload("Regressions").Find(&triages)
 	if res.Error != nil {
 		log.WithError(res.Error).Error("error listing all triages")
 	}
@@ -31,7 +31,7 @@ func ListOpenRegressions(dbc *db.DB, release string) ([]*models.TestRegression, 
 
 func ListRegressions(dbc *db.DB, release string) ([]models.TestRegression, error) {
 	var regressions []models.TestRegression
-	query := dbc.DB.Model(&models.TestRegression{}).Preload("Triages").Preload("JobRuns")
+	query := dbc.DB.Model(&models.TestRegression{}).Preload("Triages").Preload("JobRuns").Preload("Views")
 
 	if release != "" {
 		query = query.Where("test_regressions.release = ?", release)

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -61,6 +61,7 @@ import (
 	"github.com/openshift/sippy/pkg/testidentification"
 	"github.com/openshift/sippy/pkg/util"
 	"github.com/openshift/sippy/pkg/util/param"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // Mode defines the server mode of operation, OpenShift or upstream Kubernetes.
@@ -986,25 +987,29 @@ func (s *Server) jsonComponentReadinessViews(w http.ResponseWriter, req *http.Re
 }
 
 func (s *Server) getRegressedTestsForRegressions(req *http.Request, regressions []models.TestRegression) ([]componentreport.ReportTestSummary, error) {
-	baseRelease := req.URL.Query().Get("baseRelease")
-	sampleRelease := req.URL.Query().Get("sampleRelease")
-	if baseRelease == "" || sampleRelease == "" {
-		return nil, fmt.Errorf("baseRelease and sampleRelease are required")
+	// Collect active view names from the regressions' preloaded Views
+	viewNames := sets.New[string]()
+	for _, reg := range regressions {
+		for _, rv := range reg.Views {
+			if rv.Active {
+				viewNames.Insert(rv.ViewName)
+			}
+		}
 	}
-	matchingViews := componentreadiness.ViewsMatchingReleases(baseRelease, sampleRelease, s.views.ComponentReadiness)
+
 	var result []componentreport.ReportTestSummary
-	for _, view := range matchingViews {
+	for viewName := range viewNames {
 		reqWithView := req.Clone(req.Context())
 		urlCopy := *req.URL
 		reqWithView.URL = &urlCopy
 		q := reqWithView.URL.Query()
 		q.Del("baseRelease")
 		q.Del("sampleRelease")
-		q.Set("view", view.Name)
+		q.Set("view", viewName)
 		reqWithView.URL.RawQuery = q.Encode()
 		report, err := s.getComponentReportFromRequest(reqWithView)
 		if err != nil {
-			return nil, fmt.Errorf("error getting component report for view %s: %v", view.Name, err)
+			return nil, fmt.Errorf("error getting component report for view %s: %v", viewName, err)
 		}
 		for _, regression := range regressions {
 			regressedTest := componentreadiness.GetMatchingRegressedTestForRegression(regression, report)
@@ -1719,7 +1724,7 @@ func (s *Server) jsonGetTriageByID(w http.ResponseWriter, req *http.Request) {
 		RegressedTests: make(map[string][]*componentreport.ReportTestSummary),
 	}
 
-	views := componentreadiness.GetViewsForTriage(triage, s.views.ComponentReadiness)
+	views := componentreadiness.GetViewsForTriage(triage)
 	for _, view := range views {
 		// Set the view in the request so that we can obtain the component report to get the regressed test(s) for display
 		q := req.URL.Query()
@@ -1834,14 +1839,14 @@ func (s *Server) jsonTriagePotentialMatchingRegressions(w http.ResponseWriter, r
 		failureResponse(w, http.StatusNotFound, "triage not found")
 		return
 	}
-	sampleRelease := req.URL.Query().Get("sampleRelease")
-	if sampleRelease == "" {
-		failureResponse(w, http.StatusBadRequest, "no sampleRelease provided")
+	viewName := req.URL.Query().Get("view")
+	if viewName == "" {
+		failureResponse(w, http.StatusBadRequest, "no view provided")
 		return
 	}
-	baseRelease := req.URL.Query().Get("baseRelease")
-	if baseRelease == "" {
-		failureResponse(w, http.StatusBadRequest, "no baseRelease provided")
+	view, ok := componentreadiness.FindViewByName(viewName, s.views.ComponentReadiness)
+	if !ok {
+		failureResponse(w, http.StatusBadRequest, fmt.Sprintf("view not found: %s", viewName))
 		return
 	}
 	allReleases, err := s.getReleases(req.Context())
@@ -1849,7 +1854,7 @@ func (s *Server) jsonTriagePotentialMatchingRegressions(w http.ResponseWriter, r
 		failureResponse(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	regressions, err := componentreadiness.ListRegressions(s.db, sampleRelease, s.views.ComponentReadiness, allReleases, s.crTimeRoundingFactor, req)
+	regressions, err := componentreadiness.ListRegressions(s.db, view.SampleRelease.Name, s.views.ComponentReadiness, allReleases, s.crTimeRoundingFactor, req)
 	if err != nil {
 		failureResponse(w, http.StatusInternalServerError, err.Error())
 		return

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -61,7 +61,6 @@ import (
 	"github.com/openshift/sippy/pkg/testidentification"
 	"github.com/openshift/sippy/pkg/util"
 	"github.com/openshift/sippy/pkg/util/param"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // Mode defines the server mode of operation, OpenShift or upstream Kubernetes.
@@ -987,35 +986,21 @@ func (s *Server) jsonComponentReadinessViews(w http.ResponseWriter, req *http.Re
 }
 
 func (s *Server) getRegressedTestsForRegressions(req *http.Request, regressions []models.TestRegression) ([]componentreport.ReportTestSummary, error) {
-	// Collect active view names from the regressions' preloaded Views
-	viewNames := sets.New[string]()
-	for _, reg := range regressions {
-		for _, rv := range reg.Views {
-			if rv.Active {
-				viewNames.Insert(rv.ViewName)
-			}
-		}
+	viewName := req.URL.Query().Get("view")
+	if viewName == "" {
+		return nil, fmt.Errorf("view parameter is required")
+	}
+
+	report, err := s.getComponentReportFromRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("error getting component report for view %s: %v", viewName, err)
 	}
 
 	var result []componentreport.ReportTestSummary
-	for viewName := range viewNames {
-		reqWithView := req.Clone(req.Context())
-		urlCopy := *req.URL
-		reqWithView.URL = &urlCopy
-		q := reqWithView.URL.Query()
-		q.Del("baseRelease")
-		q.Del("sampleRelease")
-		q.Set("view", viewName)
-		reqWithView.URL.RawQuery = q.Encode()
-		report, err := s.getComponentReportFromRequest(reqWithView)
-		if err != nil {
-			return nil, fmt.Errorf("error getting component report for view %s: %v", viewName, err)
-		}
-		for _, regression := range regressions {
-			regressedTest := componentreadiness.GetMatchingRegressedTestForRegression(regression, report)
-			if regressedTest != nil {
-				result = append(result, *regressedTest)
-			}
+	for _, regression := range regressions {
+		regressedTest := componentreadiness.GetMatchingRegressedTestForRegression(regression, report)
+		if regressedTest != nil {
+			result = append(result, *regressedTest)
 		}
 	}
 	return result, nil

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -835,10 +835,10 @@ export function convertApiUrlToUiUrl(apiUrl) {
 // to the first "test_details:*" composite key (used by regression objects).
 export function getTestDetailsLink(links, viewName) {
   if (!links) return null
+  if (links['test_details']) return links['test_details']
   if (viewName) {
     return links[`test_details:${viewName}`] || null
   }
-  if (links['test_details']) return links['test_details']
   const key = Object.keys(links).find((k) => k.startsWith('test_details:'))
   return key ? links[key] : null
 }

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -829,12 +829,27 @@ export function convertApiUrlToUiUrl(apiUrl) {
   return result
 }
 
+// Extracts the test_details link from HATEOAS links. Prefers the plain
+// "test_details" key (used by regressed tests in component reports), then
+// tries "test_details:<viewName>" if a viewName is given, then falls back
+// to the first "test_details:*" composite key (used by regression objects).
+export function getTestDetailsLink(links, viewName) {
+  if (!links) return null
+  if (links['test_details']) return links['test_details']
+  if (viewName && links[`test_details:${viewName}`]) {
+    return links[`test_details:${viewName}`]
+  }
+  const key = Object.keys(links).find((k) => k.startsWith('test_details:'))
+  return key ? links[key] : null
+}
+
 // Construct a URL with all existing filters utilizing the necessary info from the regressed test.
 // We pass these arguments to the component that generates the test details report.
 export function generateTestDetailsReportLink(
   regressedTest,
   filterVals,
-  expandEnvironment
+  expandEnvironment,
+  viewName
 ) {
   // Generate the URL we would have created for comparison
   const environmentVal = formColumnName({ variants: regressedTest.variants })
@@ -859,18 +874,17 @@ export function generateTestDetailsReportLink(
     `&testName=${safeTestName}`
 
   const sortedGeneratedUrl = sortQueryParams(generatedUrl)
-  // Check if regressedTest.links.test_details is defined
-  if (regressedTest.links?.test_details) {
+  const testDetailsUrl = getTestDetailsLink(regressedTest.links, viewName)
+  if (testDetailsUrl) {
     // Compare the query parameters between the two URLs
     console.log(
       'Comparing query parameters between provided URL and generated URL:'
     )
-    compareUrlQueryParams(regressedTest.links.test_details, sortedGeneratedUrl)
+    compareUrlQueryParams(testDetailsUrl, sortedGeneratedUrl)
 
     // We are assuming the API query params are identical to the UI query params, but we have to adjust the host port and prefix from
     // http://localhost:8080/api/ to http://localhost:3000/sippy-ng/
     // This hack allows us to keep the param generation logic in one place. (server side)
-    const testDetailsUrl = regressedTest.links.test_details
     console.log('testDetailsUrl', testDetailsUrl)
     const modifiedUrl = convertApiUrlToUiUrl(testDetailsUrl)
     console.log('modifiedUrl', modifiedUrl)

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -835,10 +835,10 @@ export function convertApiUrlToUiUrl(apiUrl) {
 // to the first "test_details:*" composite key (used by regression objects).
 export function getTestDetailsLink(links, viewName) {
   if (!links) return null
-  if (links['test_details']) return links['test_details']
-  if (viewName && links[`test_details:${viewName}`]) {
-    return links[`test_details:${viewName}`]
+  if (viewName) {
+    return links[`test_details:${viewName}`] || null
   }
+  if (links['test_details']) return links['test_details']
   const key = Object.keys(links).find((k) => k.startsWith('test_details:'))
   return key ? links[key] : null
 }

--- a/sippy-ng/src/component_readiness/CompReadyUtils.test.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.test.js
@@ -73,19 +73,12 @@ describe('getTestDetailsLink', () => {
     expect(getTestDetailsLink(links)).toBeNull()
   })
 
-  test('viewName takes priority over plain test_details', () => {
+  test('plain test_details takes priority over view-specific keys', () => {
     const links = {
       test_details: '/api/plain',
       'test_details:4.22-main': '/api/main',
     }
-    expect(getTestDetailsLink(links, '4.22-main')).toBe('/api/main')
-  })
-
-  test('plain test_details used when no viewName specified', () => {
-    const links = {
-      test_details: '/api/plain',
-      'test_details:4.22-main': '/api/main',
-    }
+    expect(getTestDetailsLink(links, '4.22-main')).toBe('/api/plain')
     expect(getTestDetailsLink(links)).toBe('/api/plain')
   })
 })

--- a/sippy-ng/src/component_readiness/CompReadyUtils.test.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.test.js
@@ -1,5 +1,10 @@
 //import HelloWorld from './HelloWorld'
-import { dateEndFormat, dateFormat, formatLongDate } from './CompReadyUtils'
+import {
+  dateEndFormat,
+  dateFormat,
+  formatLongDate,
+  getTestDetailsLink,
+} from './CompReadyUtils'
 
 test('parses a query param start time without timezone', () => {
   let result = formatLongDate('2024-09-05 00:00:00', dateFormat)
@@ -29,4 +34,58 @@ test('parses an ISO8601 end time mid-day', () => {
 test('parses an ISO8601 end time', () => {
   let result = formatLongDate('2024-08-06T23:59:59Z', dateEndFormat)
   expect(result).toBe('2024-08-06 23:59:59')
+})
+
+describe('getTestDetailsLink', () => {
+  test('returns null for null links', () => {
+    expect(getTestDetailsLink(null)).toBeNull()
+  })
+
+  test('returns plain test_details key when present', () => {
+    const links = { test_details: '/api/test/details' }
+    expect(getTestDetailsLink(links)).toBe('/api/test/details')
+  })
+
+  test('returns exact view key when viewName matches', () => {
+    const links = {
+      'test_details:4.22-main': '/api/main',
+      'test_details:4.22-arm64': '/api/arm64',
+    }
+    expect(getTestDetailsLink(links, '4.22-arm64')).toBe('/api/arm64')
+  })
+
+  test('returns null when viewName is specified but key is missing', () => {
+    const links = {
+      'test_details:4.22-main': '/api/main',
+    }
+    expect(getTestDetailsLink(links, '4.22-arm64')).toBeNull()
+  })
+
+  test('falls back to first test_details: key when no viewName', () => {
+    const links = {
+      'test_details:4.22-main': '/api/main',
+    }
+    expect(getTestDetailsLink(links)).toBe('/api/main')
+  })
+
+  test('returns null when no matching keys exist', () => {
+    const links = { self: '/api/self' }
+    expect(getTestDetailsLink(links)).toBeNull()
+  })
+
+  test('viewName takes priority over plain test_details', () => {
+    const links = {
+      test_details: '/api/plain',
+      'test_details:4.22-main': '/api/main',
+    }
+    expect(getTestDetailsLink(links, '4.22-main')).toBe('/api/main')
+  })
+
+  test('plain test_details used when no viewName specified', () => {
+    const links = {
+      test_details: '/api/plain',
+      'test_details:4.22-main': '/api/main',
+    }
+    expect(getTestDetailsLink(links)).toBe('/api/plain')
+  })
 })

--- a/sippy-ng/src/component_readiness/ComponentReadinessIndicator.js
+++ b/sippy-ng/src/component_readiness/ComponentReadinessIndicator.js
@@ -11,6 +11,7 @@ import {
   useTheme,
 } from '@mui/material'
 import { COMPONENT_READINESS_THRESHOLDS } from '../constants'
+import { getTestDetailsLink } from './CompReadyUtils'
 import { Link } from 'react-router-dom'
 import { makeStyles } from '@mui/styles'
 import { relativeTime } from '../helpers'
@@ -254,14 +255,16 @@ export default function ComponentReadinessIndicator({ release }) {
                 <List className={classes.regressionsList}>
                   {regressions.recent.map((regression, index) => {
                     // Get the test details URL from the regression links
+                    const viewName = `${release}-main`
                     let testDetailsUrl = null
-                    if (regression.links?.test_details) {
-                      // Convert API URL to UI URL
-                      const apiIndex =
-                        regression.links.test_details.indexOf('/api/')
+                    const rawUrl = getTestDetailsLink(
+                      regression.links,
+                      viewName
+                    )
+                    if (rawUrl) {
+                      const apiIndex = rawUrl.indexOf('/api/')
                       if (apiIndex !== -1) {
-                        const pathAfterApi =
-                          regression.links.test_details.substring(apiIndex + 5)
+                        const pathAfterApi = rawUrl.substring(apiIndex + 5)
                         testDetailsUrl = '/' + pathAfterApi
                       }
                     }

--- a/sippy-ng/src/component_readiness/RegressionRedirect.js
+++ b/sippy-ng/src/component_readiness/RegressionRedirect.js
@@ -29,10 +29,9 @@ export default function RegressionRedirect() {
               .sort()
           : []
         const mainViewKey = detailKeys.find((k) => k.endsWith('-main'))
-        const testDetailsUrl = mainViewKey
-          ? regression.links[mainViewKey]
-          : detailKeys.length > 0
-          ? regression.links[detailKeys[0]]
+        const selectedKey = mainViewKey || detailKeys[0]
+        const testDetailsUrl = selectedKey
+          ? regression.links[selectedKey]
           : getTestDetailsLink(regression?.links)
         if (!testDetailsUrl) {
           setError('No test details link available for this regression.')

--- a/sippy-ng/src/component_readiness/RegressionRedirect.js
+++ b/sippy-ng/src/component_readiness/RegressionRedirect.js
@@ -23,13 +23,16 @@ export default function RegressionRedirect() {
         return response.json()
       })
       .then((regression) => {
-        const mainViewKey = regression?.links
-          ? Object.keys(regression.links).find(
-              (k) => k.startsWith('test_details:') && k.endsWith('-main')
-            )
-          : null
+        const detailKeys = regression?.links
+          ? Object.keys(regression.links)
+              .filter((k) => k.startsWith('test_details:'))
+              .sort()
+          : []
+        const mainViewKey = detailKeys.find((k) => k.endsWith('-main'))
         const testDetailsUrl = mainViewKey
           ? regression.links[mainViewKey]
+          : detailKeys.length > 0
+          ? regression.links[detailKeys[0]]
           : getTestDetailsLink(regression?.links)
         if (!testDetailsUrl) {
           setError('No test details link available for this regression.')

--- a/sippy-ng/src/component_readiness/RegressionRedirect.js
+++ b/sippy-ng/src/component_readiness/RegressionRedirect.js
@@ -1,4 +1,4 @@
-import { getRegressionAPIUrl } from './CompReadyUtils'
+import { getRegressionAPIUrl, getTestDetailsLink } from './CompReadyUtils'
 import { useNavigate, useParams } from 'react-router-dom'
 import Alert from '@mui/material/Alert'
 import React from 'react'
@@ -23,18 +23,24 @@ export default function RegressionRedirect() {
         return response.json()
       })
       .then((regression) => {
-        if (!regression?.links?.test_details) {
+        const mainViewKey = regression?.links
+          ? Object.keys(regression.links).find(
+              (k) => k.startsWith('test_details:') && k.endsWith('-main')
+            )
+          : null
+        const testDetailsUrl = mainViewKey
+          ? regression.links[mainViewKey]
+          : getTestDetailsLink(regression?.links)
+        if (!testDetailsUrl) {
           setError('No test details link available for this regression.')
           return
         }
-        const apiIndex = regression.links.test_details.indexOf('/api/')
+        const apiIndex = testDetailsUrl.indexOf('/api/')
         if (apiIndex === -1) {
           setError('Could not parse test details link.')
           return
         }
-        const pathAfterApi = regression.links.test_details.substring(
-          apiIndex + 5
-        )
+        const pathAfterApi = testDetailsUrl.substring(apiIndex + 5)
         let parsed
         try {
           parsed = new URL(pathAfterApi, window.location.origin)

--- a/sippy-ng/src/component_readiness/Triage.js
+++ b/sippy-ng/src/component_readiness/Triage.js
@@ -3,6 +3,7 @@ import { CheckCircle, Error as ErrorIcon } from '@mui/icons-material'
 import { CompReadyVarsContext } from './CompReadyVars'
 import { formatDateToSeconds, relativeTime } from '../helpers'
 import {
+  getTestDetailsLink,
   getTriagesAPIUrl,
   hasFailedFixRegression,
   jiraUrlPrefix,
@@ -90,7 +91,7 @@ export default function Triage({ id }) {
         test_id: rt.test_id,
         status: rt.status,
         explanations: rt.explanations || [],
-        test_details_api_url: rt.links?.test_details ?? null,
+        test_details_api_url: getTestDetailsLink(rt.links, view) ?? null,
         regression_id: rt.regression?.id,
         regression_opened: rt.regression?.opened,
         regression_closed: rt.regression?.closed?.valid

--- a/sippy-ng/src/component_readiness/TriagePotentialMatches.js
+++ b/sippy-ng/src/component_readiness/TriagePotentialMatches.js
@@ -128,8 +128,10 @@ export default function TriagePotentialMatches({
     })
     setAvailableViews(views)
 
-    if (!selectedView || !views.includes(selectedView)) {
-      if (views.length > 0) setSelectedView(views[0])
+    if (views.length === 0) {
+      setSelectedView('')
+    } else if (!selectedView || !views.includes(selectedView)) {
+      setSelectedView(views[0])
     }
   }, [triage.regressions, selectedView])
 
@@ -352,14 +354,15 @@ export default function TriagePotentialMatches({
       flex: 4,
       valueGetter: (params) => {
         const regressedTest = params.row.regressed_test
-        const viewToUse = view
+        const viewToUse = selectedView || view
         const filterVals = `?view=${viewToUse}`
         //TODO(sgoeddel): we should be able to get this link off of the regression,
         // and stop needing to get the regressedTest off the report at all
         const testDetailsUrl = generateTestDetailsReportLink(
           regressedTest,
           filterVals,
-          expandEnvironment
+          expandEnvironment,
+          viewToUse
         )
 
         return {

--- a/sippy-ng/src/component_readiness/TriagePotentialMatches.js
+++ b/sippy-ng/src/component_readiness/TriagePotentialMatches.js
@@ -89,12 +89,8 @@ export default function TriagePotentialMatches({
 }) {
   const classes = useStyles()
   const [isModalOpen, setIsModalOpen] = React.useState(false)
-  const [selectedBaseRelease, setSelectedBaseRelease] = React.useState('')
-  const [selectedSampleRelease, setSelectedSampleRelease] = React.useState('')
-  const [availableBaseReleases, setAvailableBaseReleases] = React.useState([])
-  const [availableSampleReleases, setAvailableSampleReleases] = React.useState(
-    []
-  )
+  const [selectedView, setSelectedView] = React.useState('')
+  const [availableViews, setAvailableViews] = React.useState([])
   const [potentialMatches, setPotentialMatches] = React.useState([])
   const [isLoading, setIsLoading] = React.useState(false)
   const [selectedRegressions, setSelectedRegressions] = React.useState([])
@@ -110,64 +106,52 @@ export default function TriagePotentialMatches({
     BooleanParam
   )
 
-  // Extract unique base vs sample releases from triage regressions; default to first regression's base/sample
+  // Extract unique active view names from triage regressions; default to first, preferring -main views
   React.useEffect(() => {
     if (!triage.regressions || triage.regressions.length === 0) return
 
-    const baseSet = new Set()
-    const sampleSet = new Set()
+    const viewSet = new Set()
     triage.regressions.forEach((regression) => {
-      const base = regression.base_release || regression.baseRelease
-      const sample = regression.release
-      if (base) baseSet.add(base)
-      if (sample) sampleSet.add(sample)
+      if (regression.views) {
+        regression.views.forEach((rv) => {
+          if (rv.active) viewSet.add(rv.view_name)
+        })
+      }
     })
 
-    // Use insertion order from regressions (no sort)
-    const availableBase = [...baseSet]
-    const availableSample = [...sampleSet]
-    setAvailableBaseReleases(availableBase)
-    setAvailableSampleReleases(availableSample)
+    const views = [...viewSet].sort((a, b) => {
+      const aMain = a.endsWith('-main')
+      const bMain = b.endsWith('-main')
+      if (aMain && !bMain) return -1
+      if (!aMain && bMain) return 1
+      return a.localeCompare(b)
+    })
+    setAvailableViews(views)
 
-    const needDefault =
-      (!selectedBaseRelease && !selectedSampleRelease) ||
-      !availableBase.includes(selectedBaseRelease) ||
-      !availableSample.includes(selectedSampleRelease)
-
-    if (needDefault) {
-      if (availableBase.length > 0) setSelectedBaseRelease(availableBase[0])
-      if (availableSample.length > 0)
-        setSelectedSampleRelease(availableSample[0])
+    if (!selectedView || !views.includes(selectedView)) {
+      if (views.length > 0) setSelectedView(views[0])
     }
-  }, [triage.regressions, selectedBaseRelease, selectedSampleRelease])
+  }, [triage.regressions, selectedView])
 
   React.useEffect(() => {
-    if (
-      autoOpenMatches === true &&
-      selectedBaseRelease !== '' &&
-      selectedSampleRelease !== ''
-    ) {
+    if (autoOpenMatches === true && selectedView !== '') {
       findPotentialMatches()
     }
-  }, [autoOpenMatches, selectedBaseRelease, selectedSampleRelease])
+  }, [autoOpenMatches, selectedView])
 
   React.useEffect(() => {
-    if (
-      selectedBaseRelease !== '' &&
-      selectedSampleRelease !== '' &&
-      isModalOpen
-    ) {
+    if (selectedView !== '' && isModalOpen) {
       findPotentialMatches()
     }
-  }, [selectedBaseRelease, selectedSampleRelease, isModalOpen])
+  }, [selectedView, isModalOpen])
 
   const findPotentialMatches = () => {
     setIsLoading(true)
     setIsModalOpen(true)
     fetch(
-      `${triage.links.potential_matches}?baseRelease=${encodeURIComponent(
-        selectedBaseRelease
-      )}&sampleRelease=${encodeURIComponent(selectedSampleRelease)}`
+      `${triage.links.potential_matches}?view=${encodeURIComponent(
+        selectedView
+      )}`
     )
       .then((response) => {
         if (response.status !== 200) {
@@ -483,35 +467,16 @@ export default function TriagePotentialMatches({
               <div className={classes.filterContainer}>
                 <div className={classes.filterSection}>
                   <FormControl size="small" className={classes.viewDropdown}>
-                    <InputLabel>Base Release</InputLabel>
+                    <InputLabel>View</InputLabel>
                     <Select
-                      value={selectedBaseRelease}
-                      label="Base Release"
-                      onChange={(event) =>
-                        setSelectedBaseRelease(event.target.value)
-                      }
-                      disabled={availableBaseReleases.length <= 1}
+                      value={selectedView}
+                      label="View"
+                      onChange={(event) => setSelectedView(event.target.value)}
+                      disabled={availableViews.length <= 1}
                     >
-                      {availableBaseReleases.map((releaseOption) => (
-                        <MenuItem key={releaseOption} value={releaseOption}>
-                          {releaseOption}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                  <FormControl size="small" className={classes.viewDropdown}>
-                    <InputLabel>Sample Release</InputLabel>
-                    <Select
-                      value={selectedSampleRelease}
-                      label="Sample Release"
-                      onChange={(event) =>
-                        setSelectedSampleRelease(event.target.value)
-                      }
-                      disabled={availableSampleReleases.length <= 1}
-                    >
-                      {availableSampleReleases.map((releaseOption) => (
-                        <MenuItem key={releaseOption} value={releaseOption}>
-                          {releaseOption}
+                      {availableViews.map((viewOption) => (
+                        <MenuItem key={viewOption} value={viewOption}>
+                          {viewOption}
                         </MenuItem>
                       ))}
                     </Select>

--- a/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
@@ -201,7 +201,8 @@ export default function TriagedRegressionTestList(props) {
                 url: generateTestDetailsReportLink(
                   rt,
                   props.filterVals,
-                  expandEnvironment
+                  expandEnvironment,
+                  viewName
                 ),
               }
             },

--- a/test/e2e/componentreadiness/regressiontracker/regressiontracker_test.go
+++ b/test/e2e/componentreadiness/regressiontracker/regressiontracker_test.go
@@ -22,7 +22,8 @@ import (
 )
 
 func cleanupAllRegressions(dbc *db.DB) {
-	// Delete all test regressions in the e2e postgres db.
+	// Delete regression views first to avoid FK constraint violations
+	dbc.DB.Where("1 = 1").Delete(&models.RegressionView{})
 	res := dbc.DB.Where("1 = 1").Delete(&models.TestRegression{})
 	if res.Error != nil {
 		log.Errorf("error deleting test regressions: %v", res.Error)
@@ -426,6 +427,429 @@ func Test_RegressionJobRuns(t *testing.T) {
 		var count int64
 		dbc.DB.Model(&models.RegressionJobRun{}).Where("regression_id = ?", reg.ID).Count(&count)
 		assert.Equal(t, int64(0), count, "job runs should be cascade deleted with regression")
+	})
+}
+
+func cleanupRegressionViews(dbc *db.DB) {
+	res := dbc.DB.Where("1 = 1").Delete(&models.RegressionView{})
+	if res.Error != nil {
+		log.Errorf("error deleting regression views: %v", res.Error)
+	}
+}
+
+func Test_RegressionViews(t *testing.T) {
+	dbc := util.CreateE2EPostgresConnection(t)
+	tracker := componentreadiness.NewPostgresRegressionStore(dbc, nil)
+	view := crview.View{
+		Name: "4.19-main",
+		SampleRelease: reqopts.RelativeRelease{
+			Release: reqopts.Release{
+				Name: "4.19",
+			},
+		},
+	}
+
+	newRegSummary := func(testID string) componentreport.ReportTestSummary {
+		return componentreport.ReportTestSummary{
+			TestComparison: testdetails.TestComparison{
+				BaseStats: &testdetails.ReleaseStats{Release: "4.18"},
+			},
+			Identification: crtest.Identification{
+				RowIdentification: crtest.RowIdentification{
+					Component:  "comp",
+					Capability: "cap",
+					TestName:   "view test " + testID,
+					TestID:     testID,
+				},
+				ColumnIdentification: crtest.ColumnIdentification{
+					Variants: map[string]string{"a": "b"},
+				},
+			},
+		}
+	}
+
+	t.Run("upsert creates a new regression view", func(t *testing.T) {
+		defer cleanupAllRegressions(dbc)
+		defer cleanupRegressionViews(dbc)
+
+		reg, err := tracker.OpenRegression(view, newRegSummary("upsert-create"))
+		require.NoError(t, err)
+
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-main")
+		require.NoError(t, err)
+
+		var rv models.RegressionView
+		res := dbc.DB.Where("test_regression_id = ? AND view_name = ?", reg.ID, "4.19-main").First(&rv)
+		require.NoError(t, res.Error)
+		assert.True(t, rv.Active, "newly upserted view should be active")
+	})
+
+	t.Run("upsert reactivates an inactive view", func(t *testing.T) {
+		defer cleanupAllRegressions(dbc)
+		defer cleanupRegressionViews(dbc)
+
+		reg, err := tracker.OpenRegression(view, newRegSummary("upsert-reactivate"))
+		require.NoError(t, err)
+
+		// Create and then deactivate
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-main")
+		require.NoError(t, err)
+		dbc.DB.Model(&models.RegressionView{}).
+			Where("test_regression_id = ? AND view_name = ?", reg.ID, "4.19-main").
+			Update("active", false)
+
+		// Verify it's inactive
+		var rv models.RegressionView
+		dbc.DB.Where("test_regression_id = ? AND view_name = ?", reg.ID, "4.19-main").First(&rv)
+		assert.False(t, rv.Active, "view should be inactive before re-upsert")
+
+		// Upsert again should reactivate
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-main")
+		require.NoError(t, err)
+
+		dbc.DB.Where("test_regression_id = ? AND view_name = ?", reg.ID, "4.19-main").First(&rv)
+		assert.True(t, rv.Active, "view should be reactivated after upsert")
+	})
+
+	t.Run("upsert is idempotent for active views", func(t *testing.T) {
+		defer cleanupAllRegressions(dbc)
+		defer cleanupRegressionViews(dbc)
+
+		reg, err := tracker.OpenRegression(view, newRegSummary("upsert-idempotent"))
+		require.NoError(t, err)
+
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-main")
+		require.NoError(t, err)
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-main")
+		require.NoError(t, err)
+
+		var count int64
+		dbc.DB.Model(&models.RegressionView{}).
+			Where("test_regression_id = ? AND view_name = ?", reg.ID, "4.19-main").
+			Count(&count)
+		assert.Equal(t, int64(1), count, "should have exactly one row, not duplicates")
+	})
+
+	t.Run("multiple views for one regression", func(t *testing.T) {
+		defer cleanupAllRegressions(dbc)
+		defer cleanupRegressionViews(dbc)
+
+		reg, err := tracker.OpenRegression(view, newRegSummary("multi-view"))
+		require.NoError(t, err)
+
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-main")
+		require.NoError(t, err)
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-arm64")
+		require.NoError(t, err)
+
+		var views []models.RegressionView
+		res := dbc.DB.Where("test_regression_id = ?", reg.ID).Find(&views)
+		require.NoError(t, res.Error)
+		assert.Len(t, views, 2, "regression should be associated with two views")
+	})
+
+	t.Run("deactivate rolled-off views removes views not in active map", func(t *testing.T) {
+		defer cleanupAllRegressions(dbc)
+		defer cleanupRegressionViews(dbc)
+
+		reg, err := tracker.OpenRegression(view, newRegSummary("deactivate-rolled-off"))
+		require.NoError(t, err)
+
+		// Associate with three views
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-main")
+		require.NoError(t, err)
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-arm64")
+		require.NoError(t, err)
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-ppc64le")
+		require.NoError(t, err)
+
+		// Only 4.19-main is still active
+		activeViewMap := map[uint][]string{
+			reg.ID: {"4.19-main"},
+		}
+		err = tracker.DeactivateRolledOffViews([]uint{reg.ID}, activeViewMap)
+		require.NoError(t, err)
+
+		var views []models.RegressionView
+		dbc.DB.Where("test_regression_id = ?", reg.ID).Order("view_name").Find(&views)
+		require.Len(t, views, 3, "all three view rows should still exist")
+
+		viewMap := map[string]bool{}
+		for _, v := range views {
+			viewMap[v.ViewName] = v.Active
+		}
+		assert.True(t, viewMap["4.19-main"], "4.19-main should remain active")
+		assert.False(t, viewMap["4.19-arm64"], "4.19-arm64 should be deactivated")
+		assert.False(t, viewMap["4.19-ppc64le"], "4.19-ppc64le should be deactivated")
+	})
+
+	t.Run("deactivate with empty active views deactivates all", func(t *testing.T) {
+		defer cleanupAllRegressions(dbc)
+		defer cleanupRegressionViews(dbc)
+
+		reg, err := tracker.OpenRegression(view, newRegSummary("deactivate-all"))
+		require.NoError(t, err)
+
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-main")
+		require.NoError(t, err)
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-arm64")
+		require.NoError(t, err)
+
+		// No active views for this regression
+		activeViewMap := map[uint][]string{}
+		err = tracker.DeactivateRolledOffViews([]uint{reg.ID}, activeViewMap)
+		require.NoError(t, err)
+
+		var activeCount int64
+		dbc.DB.Model(&models.RegressionView{}).
+			Where("test_regression_id = ? AND active = true", reg.ID).
+			Count(&activeCount)
+		assert.Equal(t, int64(0), activeCount, "all views should be deactivated")
+	})
+
+	t.Run("deactivate with empty regression IDs is a no-op", func(t *testing.T) {
+		err := tracker.DeactivateRolledOffViews([]uint{}, map[uint][]string{})
+		require.NoError(t, err)
+	})
+
+	t.Run("views are preloaded on regression queries", func(t *testing.T) {
+		defer cleanupAllRegressions(dbc)
+		defer cleanupRegressionViews(dbc)
+
+		reg, err := tracker.OpenRegression(view, newRegSummary("preload-test"))
+		require.NoError(t, err)
+
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-main")
+		require.NoError(t, err)
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-arm64")
+		require.NoError(t, err)
+
+		// Query the regression with Views preloaded
+		var loaded models.TestRegression
+		res := dbc.DB.Preload("Views").First(&loaded, reg.ID)
+		require.NoError(t, res.Error)
+		assert.Len(t, loaded.Views, 2, "views should be preloaded")
+
+		viewNames := make(map[string]bool)
+		for _, v := range loaded.Views {
+			viewNames[v.ViewName] = true
+		}
+		assert.True(t, viewNames["4.19-main"])
+		assert.True(t, viewNames["4.19-arm64"])
+	})
+
+	t.Run("regression view lifecycle: upsert, deactivate, re-upsert", func(t *testing.T) {
+		defer cleanupAllRegressions(dbc)
+		defer cleanupRegressionViews(dbc)
+
+		reg, err := tracker.OpenRegression(view, newRegSummary("lifecycle"))
+		require.NoError(t, err)
+
+		// Cycle 1: regression appears in both views
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-main")
+		require.NoError(t, err)
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-arm64")
+		require.NoError(t, err)
+
+		// Cycle 2: regression rolls off 4.19-arm64
+		activeViewMap := map[uint][]string{
+			reg.ID: {"4.19-main"},
+		}
+		err = tracker.DeactivateRolledOffViews([]uint{reg.ID}, activeViewMap)
+		require.NoError(t, err)
+
+		var rv models.RegressionView
+		dbc.DB.Where("test_regression_id = ? AND view_name = ?", reg.ID, "4.19-arm64").First(&rv)
+		assert.False(t, rv.Active, "arm64 should be inactive after deactivation")
+
+		// Cycle 3: regression reappears in 4.19-arm64
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-arm64")
+		require.NoError(t, err)
+
+		dbc.DB.Where("test_regression_id = ? AND view_name = ?", reg.ID, "4.19-arm64").First(&rv)
+		assert.True(t, rv.Active, "arm64 should be reactivated after upsert")
+	})
+
+	t.Run("regression views cascade delete with regression", func(t *testing.T) {
+		defer cleanupAllRegressions(dbc)
+		defer cleanupRegressionViews(dbc)
+
+		reg, err := tracker.OpenRegression(view, newRegSummary("cascade-delete"))
+		require.NoError(t, err)
+
+		err = tracker.UpsertRegressionView(reg.ID, "4.19-main")
+		require.NoError(t, err)
+
+		// Delete the regression
+		res := dbc.DB.Delete(&models.TestRegression{}, reg.ID)
+		require.NoError(t, res.Error)
+
+		// Views should be cascade deleted
+		var count int64
+		dbc.DB.Model(&models.RegressionView{}).Where("test_regression_id = ?", reg.ID).Count(&count)
+		assert.Equal(t, int64(0), count, "regression views should be cascade deleted with regression")
+	})
+}
+
+func Test_CrossCompareIsolation(t *testing.T) {
+	dbc := util.CreateE2EPostgresConnection(t)
+	tracker := componentreadiness.NewPostgresRegressionStore(dbc, nil)
+	rLog := log.WithField("test", "cross-compare-isolation")
+
+	standardView := crview.View{
+		Name: "4.19-main",
+		SampleRelease: reqopts.RelativeRelease{
+			Release: reqopts.Release{Name: "4.19"},
+		},
+		BaseRelease: reqopts.RelativeRelease{
+			Release: reqopts.Release{Name: "4.18"},
+		},
+	}
+
+	crossCompareView := crview.View{
+		Name: "4.19-ha-vs-two-node",
+		SampleRelease: reqopts.RelativeRelease{
+			Release: reqopts.Release{Name: "4.19"},
+		},
+		BaseRelease: reqopts.RelativeRelease{
+			Release: reqopts.Release{Name: "4.19"},
+		},
+		VariantOptions: reqopts.Variants{
+			VariantCrossCompare: []string{"Topology"},
+		},
+	}
+
+	testSummary := componentreport.ReportTestSummary{
+		TestComparison: testdetails.TestComparison{
+			BaseStats:   &testdetails.ReleaseStats{Release: "4.18"},
+			SampleStats: testdetails.ReleaseStats{Stats: crtest.NewTestStats(10, 5, 0, false)},
+		},
+		Identification: crtest.Identification{
+			RowIdentification: crtest.RowIdentification{
+				Component:  "networking",
+				Capability: "connectivity",
+				TestName:   "cross compare test",
+				TestID:     "cross-compare-test-id",
+			},
+			ColumnIdentification: crtest.ColumnIdentification{
+				Variants: map[string]string{"arch": "amd64", "network": "OVNKubernetes"},
+			},
+		},
+	}
+
+	makeReport := func(tests ...componentreport.ReportTestSummary) *componentreport.ComponentReport {
+		return &componentreport.ComponentReport{
+			Rows: []componentreport.ReportRow{
+				{
+					Columns: []componentreport.ReportColumn{
+						{RegressedTests: tests},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("OpenRegression sets CrossCompare from view config", func(t *testing.T) {
+		defer cleanupAllRegressions(dbc)
+
+		stdReg, err := tracker.OpenRegression(standardView, testSummary)
+		require.NoError(t, err)
+		assert.False(t, stdReg.CrossCompare, "standard view regression should have CrossCompare=false")
+
+		ccReg, err := tracker.OpenRegression(crossCompareView, testSummary)
+		require.NoError(t, err)
+		assert.True(t, ccReg.CrossCompare, "cross-compare view regression should have CrossCompare=true")
+	})
+
+	t.Run("SyncRegressionsForReport creates isolated regressions for same test", func(t *testing.T) {
+		defer cleanupAllRegressions(dbc)
+
+		report := makeReport(testSummary)
+
+		stdRegs, err := componentreadiness.SyncRegressionsForReport(tracker, standardView, rLog, report)
+		require.NoError(t, err)
+		require.Len(t, stdRegs, 1, "should open one regression for standard view")
+		assert.False(t, stdRegs[0].CrossCompare)
+
+		ccRegs, err := componentreadiness.SyncRegressionsForReport(tracker, crossCompareView, rLog, report)
+		require.NoError(t, err)
+		require.Len(t, ccRegs, 1, "should open one regression for cross-compare view")
+		assert.True(t, ccRegs[0].CrossCompare)
+
+		assert.NotEqual(t, stdRegs[0].ID, ccRegs[0].ID,
+			"standard and cross-compare regressions should be separate records")
+
+		// Verify both exist in the database
+		var allRegs []models.TestRegression
+		res := dbc.DB.Where("release = ? AND test_id = ?", "4.19", "cross-compare-test-id").Find(&allRegs)
+		require.NoError(t, res.Error)
+		assert.Len(t, allRegs, 2, "should have two separate regression records in the database")
+	})
+
+	t.Run("standard sync does not match cross-compare regressions", func(t *testing.T) {
+		defer cleanupAllRegressions(dbc)
+
+		// Pre-create a cross-compare regression
+		ccReg, err := tracker.OpenRegression(crossCompareView, testSummary)
+		require.NoError(t, err)
+		assert.True(t, ccReg.CrossCompare)
+
+		report := makeReport(testSummary)
+
+		// Sync with standard view — should NOT match the cross-compare regression
+		stdRegs, err := componentreadiness.SyncRegressionsForReport(tracker, standardView, rLog, report)
+		require.NoError(t, err)
+		require.Len(t, stdRegs, 1)
+		assert.NotEqual(t, ccReg.ID, stdRegs[0].ID,
+			"standard sync should have opened a new regression, not matched the cross-compare one")
+		assert.False(t, stdRegs[0].CrossCompare)
+	})
+
+	t.Run("cross-compare sync does not match standard regressions", func(t *testing.T) {
+		defer cleanupAllRegressions(dbc)
+
+		// Pre-create a standard regression
+		stdReg, err := tracker.OpenRegression(standardView, testSummary)
+		require.NoError(t, err)
+		assert.False(t, stdReg.CrossCompare)
+
+		report := makeReport(testSummary)
+
+		// Sync with cross-compare view — should NOT match the standard regression
+		ccRegs, err := componentreadiness.SyncRegressionsForReport(tracker, crossCompareView, rLog, report)
+		require.NoError(t, err)
+		require.Len(t, ccRegs, 1)
+		assert.NotEqual(t, stdReg.ID, ccRegs[0].ID,
+			"cross-compare sync should have opened a new regression, not matched the standard one")
+		assert.True(t, ccRegs[0].CrossCompare)
+	})
+
+	t.Run("re-sync reuses existing regression within same pool", func(t *testing.T) {
+		defer cleanupAllRegressions(dbc)
+
+		report := makeReport(testSummary)
+
+		// First sync for standard view
+		stdRegs1, err := componentreadiness.SyncRegressionsForReport(tracker, standardView, rLog, report)
+		require.NoError(t, err)
+		require.Len(t, stdRegs1, 1)
+
+		// Second sync for standard view should reuse the same regression
+		stdRegs2, err := componentreadiness.SyncRegressionsForReport(tracker, standardView, rLog, report)
+		require.NoError(t, err)
+		require.Len(t, stdRegs2, 1)
+		assert.Equal(t, stdRegs1[0].ID, stdRegs2[0].ID, "standard re-sync should reuse existing regression")
+
+		// First sync for cross-compare view
+		ccRegs1, err := componentreadiness.SyncRegressionsForReport(tracker, crossCompareView, rLog, report)
+		require.NoError(t, err)
+		require.Len(t, ccRegs1, 1)
+
+		// Second sync for cross-compare view should reuse the same regression
+		ccRegs2, err := componentreadiness.SyncRegressionsForReport(tracker, crossCompareView, rLog, report)
+		require.NoError(t, err)
+		require.Len(t, ccRegs2, 1)
+		assert.Equal(t, ccRegs1[0].ID, ccRegs2[0].ID, "cross-compare re-sync should reuse existing regression")
 	})
 }
 

--- a/test/e2e/componentreadiness/regressiontracker/regressiontracker_test.go
+++ b/test/e2e/componentreadiness/regressiontracker/regressiontracker_test.go
@@ -23,7 +23,10 @@ import (
 
 func cleanupAllRegressions(dbc *db.DB) {
 	// Delete regression views first to avoid FK constraint violations
-	dbc.DB.Where("1 = 1").Delete(&models.RegressionView{})
+	resView := dbc.DB.Where("1 = 1").Delete(&models.RegressionView{})
+	if resView.Error != nil {
+		log.Errorf("error deleting regression views: %v", resView.Error)
+	}
 	res := dbc.DB.Where("1 = 1").Delete(&models.TestRegression{})
 	if res.Error != nil {
 		log.Errorf("error deleting test regressions: %v", res.Error)
@@ -472,6 +475,7 @@ func Test_RegressionViews(t *testing.T) {
 		defer cleanupAllRegressions(dbc)
 		defer cleanupRegressionViews(dbc)
 
+		beforeCreate := time.Now()
 		reg, err := tracker.OpenRegression(view, newRegSummary("upsert-create"))
 		require.NoError(t, err)
 
@@ -482,6 +486,9 @@ func Test_RegressionViews(t *testing.T) {
 		res := dbc.DB.Where("test_regression_id = ? AND view_name = ?", reg.ID, "4.19-main").First(&rv)
 		require.NoError(t, res.Error)
 		assert.True(t, rv.Active, "newly upserted view should be active")
+		assert.False(t, rv.OpenedAt.IsZero(), "opened_at should be set")
+		assert.True(t, rv.OpenedAt.After(beforeCreate) || rv.OpenedAt.Equal(beforeCreate), "opened_at should be >= test start time")
+		assert.False(t, rv.ClosedAt.Valid, "closed_at should be null for a new view")
 	})
 
 	t.Run("upsert reactivates an inactive view", func(t *testing.T) {
@@ -563,6 +570,8 @@ func Test_RegressionViews(t *testing.T) {
 		err = tracker.UpsertRegressionView(reg.ID, "4.19-ppc64le")
 		require.NoError(t, err)
 
+		beforeDeactivate := time.Now()
+
 		// Only 4.19-main is still active
 		activeViewMap := map[uint][]string{
 			reg.ID: {"4.19-main"},
@@ -574,13 +583,17 @@ func Test_RegressionViews(t *testing.T) {
 		dbc.DB.Where("test_regression_id = ?", reg.ID).Order("view_name").Find(&views)
 		require.Len(t, views, 3, "all three view rows should still exist")
 
-		viewMap := map[string]bool{}
 		for _, v := range views {
-			viewMap[v.ViewName] = v.Active
+			if v.ViewName == "4.19-main" {
+				assert.True(t, v.Active, "4.19-main should remain active")
+				assert.False(t, v.ClosedAt.Valid, "4.19-main closed_at should remain null")
+			} else {
+				assert.False(t, v.Active, "%s should be deactivated", v.ViewName)
+				assert.True(t, v.ClosedAt.Valid, "%s closed_at should be set", v.ViewName)
+				assert.True(t, v.ClosedAt.Time.After(beforeDeactivate) || v.ClosedAt.Time.Equal(beforeDeactivate),
+					"%s closed_at should be >= deactivation time", v.ViewName)
+			}
 		}
-		assert.True(t, viewMap["4.19-main"], "4.19-main should remain active")
-		assert.False(t, viewMap["4.19-arm64"], "4.19-arm64 should be deactivated")
-		assert.False(t, viewMap["4.19-ppc64le"], "4.19-ppc64le should be deactivated")
 	})
 
 	t.Run("deactivate with empty active views deactivates all", func(t *testing.T) {
@@ -651,6 +664,10 @@ func Test_RegressionViews(t *testing.T) {
 		err = tracker.UpsertRegressionView(reg.ID, "4.19-arm64")
 		require.NoError(t, err)
 
+		var rv models.RegressionView
+		dbc.DB.Where("test_regression_id = ? AND view_name = ?", reg.ID, "4.19-arm64").First(&rv)
+		originalOpenedAt := rv.OpenedAt
+
 		// Cycle 2: regression rolls off 4.19-arm64
 		activeViewMap := map[uint][]string{
 			reg.ID: {"4.19-main"},
@@ -658,9 +675,9 @@ func Test_RegressionViews(t *testing.T) {
 		err = tracker.DeactivateRolledOffViews([]uint{reg.ID}, activeViewMap)
 		require.NoError(t, err)
 
-		var rv models.RegressionView
 		dbc.DB.Where("test_regression_id = ? AND view_name = ?", reg.ID, "4.19-arm64").First(&rv)
 		assert.False(t, rv.Active, "arm64 should be inactive after deactivation")
+		assert.True(t, rv.ClosedAt.Valid, "arm64 closed_at should be set after deactivation")
 
 		// Cycle 3: regression reappears in 4.19-arm64
 		err = tracker.UpsertRegressionView(reg.ID, "4.19-arm64")
@@ -668,6 +685,9 @@ func Test_RegressionViews(t *testing.T) {
 
 		dbc.DB.Where("test_regression_id = ? AND view_name = ?", reg.ID, "4.19-arm64").First(&rv)
 		assert.True(t, rv.Active, "arm64 should be reactivated after upsert")
+		assert.False(t, rv.ClosedAt.Valid, "arm64 closed_at should be cleared after re-upsert")
+		assert.True(t, rv.OpenedAt.After(originalOpenedAt),
+			"opened_at should be updated when regression reappears on a view")
 	})
 
 	t.Run("regression views cascade delete with regression", func(t *testing.T) {

--- a/test/e2e/componentreadiness/triage/triageapi_test.go
+++ b/test/e2e/componentreadiness/triage/triageapi_test.go
@@ -136,9 +136,11 @@ func Test_TriageAPI(t *testing.T) {
 
 		r := createTestRegressionWithDetails(t, tracker, view, "expanded-test-1", "component-expand", "capability-expand", "TestExpanded1", crtest.ExtremeRegression)
 		defer dbc.DB.Delete(r.Regression)
+		require.NoError(t, tracker.UpsertRegressionView(r.Regression.ID, view.Name))
 
 		r2 := createTestRegressionWithDetails(t, tracker, view, "expanded-test-2", "component-expand", "capability-expand", "TestExpanded2", crtest.SignificantRegression)
 		defer dbc.DB.Delete(r2.Regression)
+		require.NoError(t, tracker.UpsertRegressionView(r2.Regression.ID, view.Name))
 
 		// TODO(sgoeddel): If we ever have a need for another view available within e2e tests we could verify that we could get regressed_tests
 		// for multiple views at once here, but it isn't worth the overhead now.
@@ -538,6 +540,8 @@ func Test_RegressionAPI(t *testing.T) {
 
 	testRegression1 := createTestRegression(t, tracker, view, "faketestid1")
 	defer dbc.DB.Delete(testRegression1)
+	// Associate regression with view so HATEOAS links are generated
+	require.NoError(t, tracker.UpsertRegressionView(testRegression1.ID, view.Name))
 
 	testRegression2 := createTestRegression(t, tracker, view, "faketestid2")
 	defer dbc.DB.Delete(testRegression2)
@@ -568,13 +572,20 @@ func Test_RegressionAPI(t *testing.T) {
 		assert.Equal(t, testRegression1.TestName, foundRegression.TestName)
 		assert.Equal(t, testRegression1.Release, foundRegression.Release)
 
-		// Verify HATEOAS links are present
+		// Verify HATEOAS links are present - test_details links now use composite keys test_details:<view_name>
 		assert.NotNil(t, foundRegression.Links, "regression should have HATEOAS links")
-		assert.Contains(t, foundRegression.Links, "test_details", "regression should have test_details link")
-		require.NotEmpty(t, foundRegression.Links["test_details"], "test_details link should not be empty")
-		testDetailsHREF := foundRegression.Links["test_details"]
+		assert.Contains(t, foundRegression.Links, "self", "regression should have self link")
+
+		// Find any test_details link (format is test_details:<view_name>)
+		var testDetailsHREF string
+		for key, href := range foundRegression.Links {
+			if len(key) > len("test_details:") && key[:len("test_details:")] == "test_details:" {
+				testDetailsHREF = href
+				break
+			}
+		}
+		require.NotEmpty(t, testDetailsHREF, "regression should have at least one test_details:<view> link")
 		assert.Contains(t, testDetailsHREF, fmt.Sprintf("http://%s:%s/api/component_readiness/test_details", os.Getenv("SIPPY_ENDPOINT"), os.Getenv("SIPPY_API_PORT")), "test_details link should point to correct endpoint")
-		// Note: testId will be URL encoded, so we check for the encoded version
 		assert.Contains(t, testDetailsHREF, "testId=", "test_details link should contain testId parameter")
 	})
 	t.Run("error when both view and release are specified", func(t *testing.T) {
@@ -979,51 +990,61 @@ func Test_TriagePotentialMatchingRegressions(t *testing.T) {
 	// Regression 0: Linked to triage, has job runs run-1..run-4
 	testRegressions[0] = createTestRegressionWithDetails(t, tracker, view, "linked-test-1", "component-a", "capability-x", "TestSomething", crtest.ExtremeRegression)
 	defer dbc.DB.Delete(testRegressions[0].Regression)
+	require.NoError(t, tracker.UpsertRegressionView(testRegressions[0].Regression.ID, view.Name))
 	mergeJobRunsForRegression(t, tracker, testRegressions[0].Regression.ID, "run-1", "run-2", "run-3", "run-4")
 
 	// Regression 1: Linked to triage, has job runs run-10..run-13
 	testRegressions[1] = createTestRegressionWithDetails(t, tracker, view, "linked-test-2", "component-b", "capability-y", "TestAnotherOne", crtest.SignificantRegression)
 	defer dbc.DB.Delete(testRegressions[1].Regression)
+	require.NoError(t, tracker.UpsertRegressionView(testRegressions[1].Regression.ID, view.Name))
 	mergeJobRunsForRegression(t, tracker, testRegressions[1].Regression.ID, "run-10", "run-11", "run-12", "run-13")
 
 	// Regression 2: Match by similar name to "TestSomething" (edit distance 2)
 	testRegressions[2] = createTestRegressionWithDetails(t, tracker, view, "match-similar-name", "component-c", "capability-z", "TestSomthng", crtest.ExtremeTriagedRegression) // missing 'e' and 'i'
 	defer dbc.DB.Delete(testRegressions[2].Regression)
+	require.NoError(t, tracker.UpsertRegressionView(testRegressions[2].Regression.ID, view.Name))
 	mergeJobRunsForRegression(t, tracker, testRegressions[2].Regression.ID, "run-90")
 
 	// Regression 3: Match by job run overlap with regression 0 (shares run-1, run-2)
 	testRegressions[3] = createTestRegressionWithDetails(t, tracker, view, "match-overlap", "component-d", "capability-w", "TestDifferent", crtest.SignificantTriagedRegression)
 	defer dbc.DB.Delete(testRegressions[3].Regression)
+	require.NoError(t, tracker.UpsertRegressionView(testRegressions[3].Regression.ID, view.Name))
 	mergeJobRunsForRegression(t, tracker, testRegressions[3].Regression.ID, "run-1", "run-2", "run-50")
 
 	// Regression 4: Match by both similar name AND job run overlap
 	testRegressions[4] = createTestRegressionWithDetails(t, tracker, view, "match-both", "component-e", "capability-v", "TestAnoterOne", crtest.FixedRegression) // missing 'h' from "TestAnotherOne"
 	defer dbc.DB.Delete(testRegressions[4].Regression)
+	require.NoError(t, tracker.UpsertRegressionView(testRegressions[4].Regression.ID, view.Name))
 	mergeJobRunsForRegression(t, tracker, testRegressions[4].Regression.ID, "run-10", "run-11", "run-60") // overlap with regression 1
 
 	// Regression 5: Similar name to regression 0, no job run overlap
 	testRegressions[5] = createTestRegressionWithDetails(t, tracker, view, "match-name-only", "component-f", "capability-u", "TestSomthing", crtest.MissingSample) // edit distance 1
 	defer dbc.DB.Delete(testRegressions[5].Regression)
+	require.NoError(t, tracker.UpsertRegressionView(testRegressions[5].Regression.ID, view.Name))
 	mergeJobRunsForRegression(t, tracker, testRegressions[5].Regression.ID, "run-70")
 
 	// Regression 6: No match - different name, no overlapping job runs
 	testRegressions[6] = createTestRegressionWithDetails(t, tracker, view, "no-match-1", "component-g", "capability-t", "CompletelyDifferentTest", crtest.NotSignificant)
 	defer dbc.DB.Delete(testRegressions[6].Regression)
+	require.NoError(t, tracker.UpsertRegressionView(testRegressions[6].Regression.ID, view.Name))
 	mergeJobRunsForRegression(t, tracker, testRegressions[6].Regression.ID, "run-80", "run-81")
 
 	// Regression 7: No match - name too different (edit distance > 5), no overlap
 	testRegressions[7] = createTestRegressionWithDetails(t, tracker, view, "no-match-2", "component-h", "capability-s", "VeryDifferentTestName", crtest.MissingBasis)
 	defer dbc.DB.Delete(testRegressions[7].Regression)
+	require.NoError(t, tracker.UpsertRegressionView(testRegressions[7].Regression.ID, view.Name))
 	mergeJobRunsForRegression(t, tracker, testRegressions[7].Regression.ID, "run-82")
 
 	// Regression 8: Match by job run overlap only (shares run-3, run-4 with regression 0)
 	testRegressions[8] = createTestRegressionWithDetails(t, tracker, view, "match-overlap-only", "component-i", "capability-r", "TestUnrelated", crtest.MissingBasisAndSample)
 	defer dbc.DB.Delete(testRegressions[8].Regression)
+	require.NoError(t, tracker.UpsertRegressionView(testRegressions[8].Regression.ID, view.Name))
 	mergeJobRunsForRegression(t, tracker, testRegressions[8].Regression.ID, "run-3", "run-4")
 
 	// Regression 9: Similar name to "TestAnotherOne" (edit distance 1)
 	testRegressions[9] = createTestRegressionWithDetails(t, tracker, view, "match-similar-2", "component-j", "capability-q", "TestAnotheOne", crtest.SignificantImprovement) // missing 'r'
 	defer dbc.DB.Delete(testRegressions[9].Regression)
+	require.NoError(t, tracker.UpsertRegressionView(testRegressions[9].Regression.ID, view.Name))
 	mergeJobRunsForRegression(t, tracker, testRegressions[9].Regression.ID, "run-91")
 
 	// Add all test regressions to the component report cache
@@ -1056,7 +1077,7 @@ func Test_TriagePotentialMatchingRegressions(t *testing.T) {
 		require.Equal(t, 2, len(triageResponse.Regressions))
 
 		var potentialMatches []componentreadiness.PotentialMatchingRegression
-		endpoint := fmt.Sprintf("/api/component_readiness/triages/%d/matches?baseRelease=%s&sampleRelease=%s", triageResponse.ID, view.BaseRelease.Release.Name, view.SampleRelease.Release.Name)
+		endpoint := fmt.Sprintf("/api/component_readiness/triages/%d/matches?view=%s", triageResponse.ID, view.Name)
 		err = util.SippyGet(endpoint, &potentialMatches)
 		require.NoError(t, err)
 
@@ -1200,7 +1221,7 @@ func Test_TriagePotentialMatchingRegressions(t *testing.T) {
 		require.NoError(t, err)
 
 		var potentialMatches []componentreadiness.PotentialMatchingRegression
-		endpoint := fmt.Sprintf("/api/component_readiness/triages/%d/matches?baseRelease=%s&sampleRelease=%s", triageResponse.ID, view.BaseRelease.Release.Name, view.SampleRelease.Release.Name)
+		endpoint := fmt.Sprintf("/api/component_readiness/triages/%d/matches?view=%s", triageResponse.ID, view.Name)
 		err = util.SippyGet(endpoint, &potentialMatches)
 		require.NoError(t, err)
 
@@ -1214,7 +1235,7 @@ func Test_TriagePotentialMatchingRegressions(t *testing.T) {
 		assert.False(t, foundRegressionIDs[testRegressions[6].Regression.ID], "Linked regression should not appear in potential matches")
 	})
 
-	t.Run("empty potential matches when release pair does not match any view", func(t *testing.T) {
+	t.Run("error when view does not exist", func(t *testing.T) {
 		defer cleanupAllTriages(dbc)
 
 		triage := models.Triage{
@@ -1230,10 +1251,9 @@ func Test_TriagePotentialMatchingRegressions(t *testing.T) {
 		require.NoError(t, err)
 
 		var potentialMatches []componentreadiness.PotentialMatchingRegression
-		endpoint := fmt.Sprintf("/api/component_readiness/triages/%d/matches?baseRelease=no-such-base&sampleRelease=no-such-sample", triageResponse.ID)
+		endpoint := fmt.Sprintf("/api/component_readiness/triages/%d/matches?view=no-such-view", triageResponse.ID)
 		err = util.SippyGet(endpoint, &potentialMatches)
-		require.NoError(t, err)
-		assert.Empty(t, potentialMatches, "Non-matching release pair should return no potential matches")
+		require.Error(t, err, "Non-existent view should return an error")
 	})
 
 	t.Run("error when triage not found", func(t *testing.T) {


### PR DESCRIPTION
Adds regression_views junction table tracking which views each regression appears in, with per-view HATEOAS links and a CrossCompare flag to prevent identity collisions between standard and cross-compare views sharing the same sample release. Frontend updated to handle composite link keys and use view-based potential matches API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-view regression tracking with per-view test-details links (keys like test_details:<view>), a unified "View" selector in the UI, and Potential Matches API now accepts a single view parameter.

* **Bug Fixes**
  * Rolled-off view associations are deactivated correctly; standard and cross-compare regressions are isolated to prevent cross-contamination.

* **Documentation**
  * Added an implementation plan describing regression-view associations and cross-compare behavior.

* **Tests**
  * Expanded unit and end-to-end coverage for view associations, per-view links, deactivation, and cross-compare isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->