### PR TITLE
CORENET-6861: Make BGP jobs candidate

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -769,6 +769,9 @@ func (v *OCPVariantLoader) setJobTier(_ logrus.FieldLogger, variants map[string]
 		{[]string{"alibaba"}, "excluded"},
 		{[]string{"-osde2e-"}, "excluded"},
 
+		// OVN-Kubernetes BGP jobs; candidate tier to collect data while stabilizing
+		{[]string{"-bgp-"}, "candidate"},
+
 		// Experimental new jobs using nested vsphere lvl 2 environment,
 		// not ready to make release blocking yet.
 		{[]string{"-vsphere-host-groups"}, "candidate"},
@@ -807,7 +810,6 @@ func (v *OCPVariantLoader) setJobTier(_ logrus.FieldLogger, variants map[string]
 		{[]string{"aggregator-"}, "hidden"},
 		{[]string{"-out-of-change"}, "hidden"},
 		{[]string{"-sno-fips-recert"}, "hidden"},
-		{[]string{"-bgp-"}, "hidden"},
 		{[]string{"aggregated"}, "hidden"},
 		{[]string{"-cert-rotation-shutdown-"}, "hidden"}, // may want to go to rare at some point
 		{[]string{"-vsphere-insights-runtime"}, "hidden"},


### PR DESCRIPTION
Figured the bgp/evpn tests were showing up as hidden when we tried to link sippy jobs to feature gates: https://github.com/openshift/api/pull/2799#issuecomment-4325686689

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * BGP-related jobs previously classified as hidden are now classified as candidate, restoring expected visibility.
  * Job tier updated across multiple release variants to ensure consistent classification for both default and techpreview feature sets.
  * Improves discoverability and consistency of periodic CI job listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->