### PR TITLE
TRT-2588: allow for the `release` to be updated on a `ProwJob` during load

### DIFF
--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -909,6 +909,10 @@ func (pl *ProwLoader) createOrUpdateProwJob(ctx context.Context, pj *prow.ProwJo
 			dbProwJob.Variants = newVariants
 			saveDB = true
 		}
+		if dbProwJob.Release != release {
+			dbProwJob.Release = release
+			saveDB = true
+		}
 		if len(dbProwJob.TestGridURL) == 0 {
 			dbProwJob.TestGridURL = pl.generateTestGridURL(release, pj.Spec.Job).String()
 			if len(dbProwJob.TestGridURL) > 0 {


### PR DESCRIPTION
This is particularly useful when updating a job from a standard OCP release to a synthetic release.

We are noticing that jobs that should be in the `rosa-stage` synthetic release are remaining in `4.22` (etc..) even when new runs come in. This is because the release is set the first time the job is seen, and then reused forever after. I considered doing a one-time data cleanup, but I think this problem will happen going forward as previously existing jobs get claimed on synthetic releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced job processing to detect and correct mismatches in release information during updates. Job records are now properly synchronized to maintain consistency with current release data, variants, and related metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->