### PR TITLE
adding branch-ci aro-hcp prow jobs

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -23,10 +23,12 @@ releases:
     jobs:
       periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel: true
       periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel-ocp-nightly: true
+      branch-ci-Azure-ARO-HCP-main-e2e-integration-e2e-parallel: true
   aro-stage:
     jobs:
       periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel: true
       periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel-ocp-nightly: true
+      branch-ci-Azure-ARO-HCP-main-e2e-stage-e2e-parallel: true
   aro-production:
     jobs:
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-e2e-parallel: true
@@ -35,6 +37,7 @@ releases:
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-centralindia-e2e-parallel: true
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-uksouth-e2e-parallel: true
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-e2e-parallel-ocp-nightly: true
+      branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel: true
   rosa-stage:
     jobs:
       # ROSA Classic/STS nightly (stage)

--- a/config/openshift.yaml
+++ b/config/openshift.yaml
@@ -17053,10 +17053,12 @@ releases:
             - ^pull-ci-Azure-ARO-HCP-main.*
     aro-integration:
         jobs:
+            branch-ci-Azure-ARO-HCP-main-e2e-integration-e2e-parallel: true
             periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel: true
             periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel-ocp-nightly: true
     aro-production:
         jobs:
+            branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel: true
             periodic-ci-Azure-ARO-HCP-main-periodic-create-aro-hcp-in-prod-uksouth: true
             periodic-ci-Azure-ARO-HCP-main-periodic-prod-brazilsouth-e2e-parallel: true
             periodic-ci-Azure-ARO-HCP-main-periodic-prod-centralindia-e2e-parallel: true
@@ -17065,6 +17067,7 @@ releases:
             periodic-ci-Azure-ARO-HCP-main-periodic-prod-uksouth-e2e-parallel: true
     aro-stage:
         jobs:
+            branch-ci-Azure-ARO-HCP-main-e2e-stage-e2e-parallel: true
             periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel: true
             periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel-ocp-nightly: true
     automation:


### PR DESCRIPTION
Adding branch-ci aro-hcp prow jobs as deployment e2e has migrated to them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled parallel execution for E2E tests across integration, staging, and production release environments for Azure ARO HCP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->