### PR TITLE
TRT-2603: Show "Informing" lifecycle badge on test details assessment row

### DIFF
--- a/pkg/api/componentreadiness/dataprovider/bigquery/querygenerators.go
+++ b/pkg/api/componentreadiness/dataprovider/bigquery/querygenerators.go
@@ -598,6 +598,7 @@ func buildTestDetailsQuery(
 						SUM(adjusted_flake_count) AS flake_count,
 						ANY_VALUE(agg_labels.job_labels) AS job_labels,
 						ANY_VALUE(agg_failures.job_run_test_failure_count) AS job_run_test_failure_count,
+						COALESCE(NULLIF(ANY_VALUE(lifecycle), ''), 'blocking') AS lifecycle,
 					FROM deduped_testcases junit
 					INNER JOIN latest_component_mapping cm ON testsuite = cm.suite AND test_name = cm.name
 `, withClause, selectVariants)
@@ -1096,6 +1097,10 @@ func deserializeRowToJobRunTestReportStatus(row []bigquery.Value, schema bigquer
 		case col == "job_run_test_failure_count":
 			if row[i] != nil {
 				cts.TestFailures = int(row[i].(int64))
+			}
+		case col == "lifecycle":
+			if row[i] != nil {
+				cts.Lifecycle = row[i].(string)
 			}
 		case strings.HasPrefix(col, "variant_"):
 			variantName := col[len("variant_"):]

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -542,6 +542,9 @@ func (c *ComponentReportGenerator) assessTestStats(
 		if result.TestName == "" && jobRow.TestName != "" {
 			result.TestName = jobRow.TestName
 		}
+		if result.Lifecycle == "" && jobRow.Lifecycle != "" {
+			result.Lifecycle = jobRow.Lifecycle
+		}
 
 		*testStats = testStats.AddTestCount(jobRow.Count, flakeAsFailure)
 		*jobRunStatsList = append(*jobRunStatsList, c.getJobRunStats(jobRow))

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -542,8 +542,12 @@ func (c *ComponentReportGenerator) assessTestStats(
 		if result.TestName == "" && jobRow.TestName != "" {
 			result.TestName = jobRow.TestName
 		}
-		if result.Lifecycle == "" && jobRow.Lifecycle != "" {
-			result.Lifecycle = jobRow.Lifecycle
+		if result.Lifecycle != "informing" {
+			if jobRow.Lifecycle == "informing" {
+				result.Lifecycle = "informing"
+			} else if result.Lifecycle == "" && jobRow.Lifecycle != "" {
+				result.Lifecycle = jobRow.Lifecycle
+			}
 		}
 
 		*testStats = testStats.AddTestCount(jobRow.Count, flakeAsFailure)

--- a/pkg/apis/api/componentreport/crstatus/types.go
+++ b/pkg/apis/api/componentreport/crstatus/types.go
@@ -65,6 +65,7 @@ type TestJobRunRows struct {
 	JiraComponentID *big.Rat `bigquery:"jira_component_id"`
 	JobLabels       []string `bigquery:"-" json:"job_labels,omitempty"`
 	TestFailures    int      `bigquery:"-" json:"test_failures"`
+	Lifecycle       string   `bigquery:"lifecycle"`
 }
 
 // JobVariant defines a variant and the possible values.

--- a/pkg/apis/api/componentreport/testdetails/types.go
+++ b/pkg/apis/api/componentreport/testdetails/types.go
@@ -17,6 +17,9 @@ type Report struct {
 	JiraComponentID *big.Rat   `json:"jira_component_id"`
 	TestName        string     `json:"test_name"`
 	GeneratedAt     *time.Time `json:"generated_at"`
+	// Lifecycle is the test's lifecycle value from BigQuery (e.g. "blocking", "informing").
+	// Defaults to "blocking" when unset in the source data.
+	Lifecycle string `json:"lifecycle,omitempty"`
 
 	// Analyses is a list of potentially multiple analysis runs for this test.
 	// Callers can assume that the first in the list is somewhat authoritative, and should

--- a/sippy-ng/src/component_readiness/TestDetailsReport.js
+++ b/sippy-ng/src/component_readiness/TestDetailsReport.js
@@ -4,6 +4,7 @@ import {
   Alert,
   Box,
   Button,
+  Chip,
   Grid,
   Popover,
   Tab,
@@ -329,6 +330,8 @@ export default function TestDetailsReport(props) {
   const params = new URLSearchParams(url.search)
   const baseRelease = params.get('baseRelease')
 
+  const sampleIncludesInforming = data.lifecycle === 'informing'
+
   let isBaseOverride = false
   let baseReleaseTabLabel = baseRelease + ' Basis'
   let overrideReleaseTabLabel = ''
@@ -545,7 +548,7 @@ View the [test details report|${document.location.href}] for additional context.
               </IconButton>
             </TableCell>
           </TableRow>
-          {regressionId && (
+          {regressionId > 0 && (
             <TableRow>
               <TableCell>Regression ID:</TableCell>
               <TableCell>
@@ -575,7 +578,19 @@ View the [test details report|${document.location.href}] for additional context.
           <TableRow>
             <TableCell>Assessment:</TableCell>
             <TableCell>
-              <Tooltip title={statusStr}>{assessmentIcon}</Tooltip>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Tooltip title={statusStr}>{assessmentIcon}</Tooltip>
+                {sampleIncludesInforming && (
+                  <Tooltip title="Test has lifecycle: Informing in the sample">
+                    <Chip
+                      aria-label="Informing lifecycle"
+                      label="Informing"
+                      size="small"
+                      color="info"
+                    />
+                  </Tooltip>
+                )}
+              </Box>
             </TableCell>
           </TableRow>
           <TableRow>


### PR DESCRIPTION
Fetch the test's lifecycle value from BigQuery in the test details query and surface it in the API response. When lifecycle is "informing",display a chip next to the assessment icon on the test details report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test details report now includes a lifecycle field; missing/empty lifecycles are treated as "blocking".
  * UI shows an "Informing" chip with tooltip in test assessments when a sample includes informing lifecycle.

* **Bug Fixes**
  * Regression ID row now only displays for positive IDs (>0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->