### PR TITLE
Fix variant registry OS fallback for jobs without cluster data

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -1306,12 +1306,31 @@ func setLayeredProduct(_ logrus.FieldLogger, variants map[string]string, jobName
 	}
 }
 
-func (os clusterDataOS) setOS(_ logrus.FieldLogger, variants map[string]string, _ string) {
+func (os clusterDataOS) setOS(_ logrus.FieldLogger, variants map[string]string, jobName string) {
 	resolved := os
+	if resolved.Default == "" && resolved.ControlPlane == "" && resolved.Workers == "" && len(resolved.Additional) == 0 {
+		resolved = osFromJobName(jobName)
+	}
 	if resolved.Default == "" {
 		resolved.Default = defaultOSForReleaseMajor(variants[VariantReleaseMajor])
 	}
 	variants[VariantOS] = resolved.resolve()
+}
+
+// osFromJobName infers OS variant from the job name when cluster data is unavailable.
+// Match rhcos9-10 before rhcos9 to avoid a false partial match.
+func osFromJobName(jobName string) clusterDataOS {
+	lower := strings.ToLower(jobName)
+	if strings.Contains(lower, "rhcos9-10") {
+		return clusterDataOS{ControlPlane: "rhel-9", Workers: "rhel-10"}
+	}
+	if strings.Contains(lower, "rhcos10") {
+		return clusterDataOS{Default: "rhel-10"}
+	}
+	if strings.Contains(lower, "rhcos9") {
+		return clusterDataOS{Default: "rhel-9"}
+	}
+	return clusterDataOS{}
 }
 
 func defaultOSForReleaseMajor(major string) string { //nolint:unparam

--- a/pkg/variantregistry/ocp_test.go
+++ b/pkg/variantregistry/ocp_test.go
@@ -2378,6 +2378,7 @@ func TestSetOS(t *testing.T) {
 	tests := []struct {
 		name          string
 		releaseMajor  string
+		jobName       string
 		clusterDataOS clusterDataOS
 		expectedOS    string
 	}{
@@ -2390,6 +2391,29 @@ func TestSetOS(t *testing.T) {
 			name:         "no cluster data with release major 5 defaults to rhcos9",
 			releaseMajor: "5",
 			expectedOS:   "rhcos9",
+		},
+		{
+			name:       "no cluster data falls back to rhcos10 from job name",
+			jobName:    "periodic-ci-openshift-release-main-nightly-4.22-e2e-aws-ovn-single-node-rhcos10-techpreview",
+			expectedOS: "rhcos10",
+		},
+		{
+			name:       "no cluster data falls back to rhcos9 from job name",
+			jobName:    "periodic-ci-openshift-release-main-nightly-4.22-e2e-aws-ovn-rhcos9",
+			expectedOS: "rhcos9",
+		},
+		{
+			name:       "no cluster data falls back to rhcos9-10 from job name",
+			jobName:    "periodic-ci-openshift-release-main-nightly-4.22-e2e-aws-ovn-rhcos9-10",
+			expectedOS: "rhcos9-10",
+		},
+		{
+			name:    "cluster data takes precedence over job name",
+			jobName: "periodic-ci-openshift-release-main-nightly-4.22-e2e-aws-ovn-rhcos9",
+			clusterDataOS: clusterDataOS{
+				Default: "rhel-10",
+			},
+			expectedOS: "rhcos10",
 		},
 		{
 			name: "mix of rhcos9 and rhcos10 in cp and workers produces rhcos9-10",
@@ -2613,8 +2637,54 @@ func TestSetOS(t *testing.T) {
 			if tt.releaseMajor != "" {
 				variants[VariantReleaseMajor] = tt.releaseMajor
 			}
-			tt.clusterDataOS.setOS(logrus.WithField("test", "TestSetOS"), variants, "")
+			tt.clusterDataOS.setOS(logrus.WithField("test", "TestSetOS"), variants, tt.jobName)
 			assert.Equal(t, tt.expectedOS, variants[VariantOS])
+		})
+	}
+}
+
+func TestOsFromJobName(t *testing.T) {
+	tests := []struct {
+		name     string
+		jobName  string
+		expected clusterDataOS
+	}{
+		{
+			name:     "rhcos10 in job name",
+			jobName:  "periodic-ci-openshift-release-main-nightly-4.22-e2e-aws-ovn-single-node-rhcos10-techpreview",
+			expected: clusterDataOS{Default: "rhel-10"},
+		},
+		{
+			name:     "rhcos9 in job name",
+			jobName:  "periodic-ci-openshift-release-main-nightly-4.22-e2e-aws-ovn-rhcos9",
+			expected: clusterDataOS{Default: "rhel-9"},
+		},
+		{
+			name:     "rhcos9-10 in job name sets cp and workers",
+			jobName:  "periodic-ci-openshift-release-main-nightly-4.22-e2e-aws-ovn-rhcos9-10",
+			expected: clusterDataOS{ControlPlane: "rhel-9", Workers: "rhel-10"},
+		},
+		{
+			name:     "rhcos9-10 is not confused with rhcos9",
+			jobName:  "periodic-ci-openshift-release-main-nightly-4.22-e2e-aws-ovn-rhcos9-10-techpreview",
+			expected: clusterDataOS{ControlPlane: "rhel-9", Workers: "rhel-10"},
+		},
+		{
+			name:     "no rhcos indicator returns empty",
+			jobName:  "periodic-ci-openshift-release-main-nightly-4.22-e2e-aws-ovn",
+			expected: clusterDataOS{},
+		},
+		{
+			name:     "case insensitive matching",
+			jobName:  "some-job-RHCOS10-test",
+			expected: clusterDataOS{Default: "rhel-10"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := osFromJobName(tt.jobName)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- When the variant registry can't load cluster data for a job (no successful run, GCS issues), the OS variant always defaulted to `rhcos9` regardless of the job name.
- Now infers OS from the job name (`rhcos9`, `rhcos10`, `rhcos9-10`) as a fallback before the hard-coded default. Cluster data still takes precedence when available.
- Matches `rhcos9-10` before `rhcos9` to avoid false partial matches.

## Test plan
- [x] Unit tests for `osFromJobName` covering all patterns, ordering edge case, case insensitivity
- [x] Unit tests for `setOS` fallback behavior (job name used when no cluster data, cluster data wins when present)
- [x] All existing variant registry tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved system resilience by enabling OS variant resolution when cluster data is unavailable
  * Enhanced support for inferring operating system configuration from job parameters
  * Added support for RHEL 9 and RHEL 10 operating system variant combinations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->