### PR TITLE
TRT-2588: support regexp patterns in synthetic release overrides

### DIFF
--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -44,6 +44,7 @@ import (
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/github/commenter"
+	"github.com/openshift/sippy/pkg/releaseoverride"
 	"github.com/openshift/sippy/pkg/synthetictests"
 	"github.com/openshift/sippy/pkg/testidentification"
 	"github.com/openshift/sippy/pkg/util"
@@ -71,7 +72,7 @@ type ProwLoader struct {
 	suiteCache                   map[string]*uint
 	suiteCacheLock               sync.RWMutex
 	syntheticTestManager         synthetictests.SyntheticTestManager
-	syntheticReleaseJobOverrides map[string]string
+	syntheticReleaseJobOverrides *releaseoverride.SyntheticReleaseOverrides
 	releases                     []string
 	config                       *v1config.SippyConfig
 	ghCommenter                  *commenter.GitHubCommenter
@@ -95,7 +96,7 @@ func New(
 	ghCommenter *commenter.GitHubCommenter,
 	promPusher *push.Pusher,
 	loadSince *time.Time,
-	syntheticReleaseJobOverrides map[string]string) *ProwLoader {
+	syntheticReleaseJobOverrides *releaseoverride.SyntheticReleaseOverrides) *ProwLoader {
 
 	return &ProwLoader{
 		ctx:                          ctx,
@@ -540,7 +541,7 @@ func (pl *ProwLoader) processProwJob(ctx context.Context, pj *prow.ProwJob) erro
 	})
 
 	// Synthetic release claims take priority over all other matching.
-	if release, ok := pl.syntheticReleaseJobOverrides[pj.Spec.Job]; ok {
+	if release, ok := pl.syntheticReleaseJobOverrides.Lookup(pj.Spec.Job); ok {
 		if err := pl.prowJobToJobRun(ctx, pj, release); err != nil {
 			err = errors.Wrapf(err, "error converting prow job to job run: %s", pj.Spec.Job)
 			pjLog.WithError(err).Warning("prow import error")

--- a/pkg/releaseoverride/override.go
+++ b/pkg/releaseoverride/override.go
@@ -1,0 +1,63 @@
+package releaseoverride
+
+import (
+	"fmt"
+	"regexp"
+)
+
+type regexpRelease struct {
+	pattern *regexp.Regexp
+	release string
+}
+
+// SyntheticReleaseOverrides holds both exact job-name overrides and compiled
+// regexp patterns from synthetic releases. Use New to construct one.
+type SyntheticReleaseOverrides struct {
+	exactMatches  map[string]string
+	regexpMatches []regexpRelease
+}
+
+// New creates an empty SyntheticReleaseOverrides.
+func New() *SyntheticReleaseOverrides {
+	return &SyntheticReleaseOverrides{exactMatches: map[string]string{}}
+}
+
+// AddExact registers an exact job-name → release mapping and returns an error
+// if the job was already claimed by a different release.
+func (s *SyntheticReleaseOverrides) AddExact(jobName, release string) error {
+	if existing, conflict := s.exactMatches[jobName]; conflict {
+		return fmt.Errorf(
+			"job %q is claimed by synthetic releases %q and %q",
+			jobName, existing, release,
+		)
+	}
+	s.exactMatches[jobName] = release
+	return nil
+}
+
+// AddRegexp compiles the pattern and associates it with the given release.
+func (s *SyntheticReleaseOverrides) AddRegexp(pattern, release string) error {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return err
+	}
+	s.regexpMatches = append(s.regexpMatches, regexpRelease{pattern: re, release: release})
+	return nil
+}
+
+// Lookup returns the synthetic release a job belongs to, checking exact names
+// first and then regexp patterns.
+func (s *SyntheticReleaseOverrides) Lookup(jobName string) (string, bool) {
+	if s == nil {
+		return "", false
+	}
+	if release, ok := s.exactMatches[jobName]; ok {
+		return release, true
+	}
+	for _, rr := range s.regexpMatches {
+		if rr.pattern.MatchString(jobName) {
+			return rr.release, true
+		}
+	}
+	return "", false
+}

--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -25,6 +25,7 @@ import (
 	v1 "github.com/openshift/sippy/pkg/apis/config/v1"
 	"github.com/openshift/sippy/pkg/dataloader/prowloader"
 	"github.com/openshift/sippy/pkg/dataloader/prowloader/gcs"
+	"github.com/openshift/sippy/pkg/releaseoverride"
 	"github.com/openshift/sippy/pkg/util"
 )
 
@@ -34,7 +35,7 @@ type OCPVariantLoader struct {
 	bqOpContext                  bqlabel.OperationalContext
 	config                       *v1.SippyConfig
 	views                        []crview.View
-	syntheticReleaseJobOverrides map[string]string
+	syntheticReleaseJobOverrides *releaseoverride.SyntheticReleaseOverrides
 	bigQueryProject              string
 	bigQueryDataSet              string
 	bigQueryTable                string
@@ -48,7 +49,7 @@ func NewOCPVariantLoader(
 	gcsClient *storage.Client,
 	config *v1.SippyConfig,
 	views []crview.View,
-	syntheticReleaseJobOverrides map[string]string,
+	syntheticReleaseJobOverrides *releaseoverride.SyntheticReleaseOverrides,
 ) *OCPVariantLoader {
 	return &OCPVariantLoader{
 		BigQueryClient:               bigQueryClient,
@@ -734,7 +735,7 @@ func (v *OCPVariantLoader) setRelease(logger logrus.FieldLogger, variants map[st
 	}
 
 	// Synthetic release claims take priority over other release logic.
-	if release, ok := v.syntheticReleaseJobOverrides[jobName]; ok {
+	if release, ok := v.syntheticReleaseJobOverrides.Lookup(jobName); ok {
 		variants[VariantRelease] = release
 	}
 }

--- a/pkg/variantregistry/snapshot.go
+++ b/pkg/variantregistry/snapshot.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crview"
 	v1 "github.com/openshift/sippy/pkg/apis/config/v1"
+	"github.com/openshift/sippy/pkg/releaseoverride"
 )
 
 // JobVariants is a map of jobs to variant key/value pairs
@@ -17,11 +18,11 @@ type JobVariants map[string]map[string]string
 type VariantSnapshot struct {
 	config                       *v1.SippyConfig
 	views                        []crview.View
-	syntheticReleaseJobOverrides map[string]string
+	syntheticReleaseJobOverrides *releaseoverride.SyntheticReleaseOverrides
 	log                          logrus.FieldLogger
 }
 
-func NewVariantSnapshot(config *v1.SippyConfig, views []crview.View, syntheticReleaseJobOverrides map[string]string, log logrus.FieldLogger) *VariantSnapshot {
+func NewVariantSnapshot(config *v1.SippyConfig, views []crview.View, syntheticReleaseJobOverrides *releaseoverride.SyntheticReleaseOverrides, log logrus.FieldLogger) *VariantSnapshot {
 	return &VariantSnapshot{
 		config:                       config,
 		views:                        views,

--- a/pkg/variantregistry/synthetic.go
+++ b/pkg/variantregistry/synthetic.go
@@ -5,19 +5,20 @@ import (
 
 	v1 "github.com/openshift/sippy/pkg/apis/config/v1"
 	sippyv1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
+	"github.com/openshift/sippy/pkg/releaseoverride"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-// BuildSyntheticReleaseJobOverrides builds a map of job names to release names for all
-// jobs explicitly listed in synthetic releases. This map is used to give
-// synthetic releases priority over name-based version matching when determining
-// which release a job belongs to.
+// BuildSyntheticReleaseJobOverrides builds overrides for all jobs and regexp
+// patterns listed in synthetic releases. These overrides give synthetic releases
+// priority over name-based version matching when determining which release a job
+// belongs to.
 //
 // releaseConfigs identifies which releases are synthetic (from BigQuery),
 // while the job-to-release mappings come from the YAML config.
-func BuildSyntheticReleaseJobOverrides(releases map[string]v1.ReleaseConfig, releaseConfigs []sippyv1.Release) (map[string]string, error) {
+func BuildSyntheticReleaseJobOverrides(releases map[string]v1.ReleaseConfig, releaseConfigs []sippyv1.Release) (*releaseoverride.SyntheticReleaseOverrides, error) {
 	syntheticSet := syntheticReleaseNames(releaseConfigs)
-	overrides := map[string]string{}
+	overrides := releaseoverride.New()
 	for releaseName, releaseCfg := range releases {
 		if !syntheticSet.Has(releaseName) {
 			continue
@@ -26,13 +27,17 @@ func BuildSyntheticReleaseJobOverrides(releases map[string]v1.ReleaseConfig, rel
 			if !enabled {
 				continue
 			}
-			if existing, conflict := overrides[jobName]; conflict {
+			if err := overrides.AddExact(jobName, releaseName); err != nil {
+				return nil, err
+			}
+		}
+		for _, expr := range releaseCfg.Regexp {
+			if err := overrides.AddRegexp(expr, releaseName); err != nil {
 				return nil, fmt.Errorf(
-					"job %q is claimed by synthetic releases %q and %q",
-					jobName, existing, releaseName,
+					"invalid regexp %q in synthetic release %q: %w",
+					expr, releaseName, err,
 				)
 			}
-			overrides[jobName] = releaseName
 		}
 	}
 	return overrides, nil

--- a/pkg/variantregistry/synthetic_test.go
+++ b/pkg/variantregistry/synthetic_test.go
@@ -5,6 +5,7 @@ import (
 
 	v1 "github.com/openshift/sippy/pkg/apis/config/v1"
 	sippyv1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
+	"github.com/openshift/sippy/pkg/releaseoverride"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -150,7 +151,122 @@ func TestBuildSyntheticReleaseJobOverrides(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.expectedOverrides, overrides)
+			// Verify each expected override is present via Lookup
+			for jobName, expectedRelease := range tt.expectedOverrides {
+				release, ok := overrides.Lookup(jobName)
+				assert.True(t, ok, "expected override for %q", jobName)
+				assert.Equal(t, expectedRelease, release)
+			}
+			// Verify no unexpected overrides by checking a job not in the map
+			_, ok := overrides.Lookup("not-a-real-job-name")
+			assert.False(t, ok)
 		})
 	}
+}
+
+func TestSyntheticReleaseOverridesRegexp(t *testing.T) {
+	tests := []struct {
+		name            string
+		releases        map[string]v1.ReleaseConfig
+		releaseConfigs  []sippyv1.Release
+		jobName         string
+		expectedRelease string
+		expectedMatch   bool
+	}{
+		{
+			name: "regexp matches job",
+			releases: map[string]v1.ReleaseConfig{
+				"rosa-stage": {
+					Regexp: []string{`^periodic-ci-openshift-online-rosa-e2e-main-.*`},
+				},
+			},
+			releaseConfigs:  []sippyv1.Release{{Release: "rosa-stage", Synthetic: true}},
+			jobName:         "periodic-ci-openshift-online-rosa-e2e-main-nightly-4.22",
+			expectedRelease: "rosa-stage",
+			expectedMatch:   true,
+		},
+		{
+			name: "regexp does not match job",
+			releases: map[string]v1.ReleaseConfig{
+				"rosa-stage": {
+					Regexp: []string{`^periodic-ci-openshift-online-rosa-e2e-main-.*`},
+				},
+			},
+			releaseConfigs: []sippyv1.Release{{Release: "rosa-stage", Synthetic: true}},
+			jobName:        "periodic-ci-openshift-release-master-nightly-4.22-e2e-aws-ovn",
+			expectedMatch:  false,
+		},
+		{
+			name: "exact match takes priority over regexp",
+			releases: map[string]v1.ReleaseConfig{
+				"rosa-stage": {
+					Jobs:   map[string]bool{"my-exact-job": true},
+					Regexp: []string{`^my-.*`},
+				},
+			},
+			releaseConfigs:  []sippyv1.Release{{Release: "rosa-stage", Synthetic: true}},
+			jobName:         "my-exact-job",
+			expectedRelease: "rosa-stage",
+			expectedMatch:   true,
+		},
+		{
+			name: "non-synthetic release regexp is ignored",
+			releases: map[string]v1.ReleaseConfig{
+				"4.22": {
+					Regexp: []string{`^periodic-ci-openshift-online-rosa-e2e-main-.*`},
+				},
+			},
+			releaseConfigs: []sippyv1.Release{{Release: "4.22", Synthetic: false}},
+			jobName:        "periodic-ci-openshift-online-rosa-e2e-main-nightly-4.22",
+			expectedMatch:  false,
+		},
+		{
+			name: "multiple regexp patterns",
+			releases: map[string]v1.ReleaseConfig{
+				"rosa-stage": {
+					Regexp: []string{
+						`^periodic-ci-openshift-online-rosa-e2e-main-.*`,
+						`^periodic-ci-openshift-release-main-nightly-.*-e2e-rosa-hcp-ovn$`,
+					},
+				},
+			},
+			releaseConfigs:  []sippyv1.Release{{Release: "rosa-stage", Synthetic: true}},
+			jobName:         "periodic-ci-openshift-release-main-nightly-4.19-e2e-rosa-hcp-ovn",
+			expectedRelease: "rosa-stage",
+			expectedMatch:   true,
+		},
+		{
+			name: "invalid regexp returns error",
+			releases: map[string]v1.ReleaseConfig{
+				"rosa-stage": {
+					Regexp: []string{`[invalid`},
+				},
+			},
+			releaseConfigs: []sippyv1.Release{{Release: "rosa-stage", Synthetic: true}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			overrides, err := BuildSyntheticReleaseJobOverrides(tt.releases, tt.releaseConfigs)
+			if tt.name == "invalid regexp returns error" {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			release, ok := overrides.Lookup(tt.jobName)
+			assert.Equal(t, tt.expectedMatch, ok)
+			if tt.expectedMatch {
+				assert.Equal(t, tt.expectedRelease, release)
+			}
+		})
+	}
+}
+
+func TestSyntheticReleaseOverridesLookupNil(t *testing.T) {
+	var overrides *releaseoverride.SyntheticReleaseOverrides
+	release, ok := overrides.Lookup("any-job")
+	assert.False(t, ok)
+	assert.Empty(t, release)
 }


### PR DESCRIPTION
Regexp entries in synthetic release configs were ignored by the override logic, causing jobs matched only by regexp (e.g. rosa-stage's e2e-rosa-hcp-ovn and rosa-e2e patterns) to stay in their OCP releases instead of moving to the synthetic release. Extract a new releaseoverride package so both variantregistry and prowloader can share the type without an import cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job-to-release mapping now supports both exact name matches and regex pattern matching for flexible assignment.
  * Enhanced error handling provides descriptive feedback for invalid regex patterns.

* **Chores**
  * Updated ROSA CI job configurations for release assignments and job tier classifications.

* **Tests**
  * Added test coverage for regex pattern matching, exact match precedence, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->