### PR TITLE
Add ARO classic (ARO-RP) prow jobs to sippy config

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -38,6 +38,18 @@ releases:
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-uksouth-e2e-parallel: true
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-e2e-parallel-ocp-nightly: true
       branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel: true
+  aro-classic-integration:
+    jobs:
+      periodic-ci-Azure-ARO-RP-master-periodic-integration-e2e-parallel-csp: true
+      periodic-ci-Azure-ARO-RP-master-periodic-integration-e2e-parallel-miwi: true
+  aro-classic-stage:
+    jobs:
+      periodic-ci-Azure-ARO-RP-master-periodic-stage-e2e-parallel-csp: true
+      periodic-ci-Azure-ARO-RP-master-periodic-stage-e2e-parallel-miwi: true
+  aro-classic-production:
+    jobs:
+      periodic-ci-Azure-ARO-RP-master-periodic-prod-e2e-parallel-csp: true
+      periodic-ci-Azure-ARO-RP-master-periodic-prod-e2e-parallel-miwi: true
   rosa-stage:
     jobs:
       # ROSA Classic/STS nightly (stage)


### PR DESCRIPTION
With Classic now using prow jobs as well, we want that data available via Sippy.

Added the following jobs to config:

  ```
aro-classic-integration:
    jobs:
      periodic-ci-Azure-ARO-RP-master-periodic-integration-e2e-parallel-csp: true
      periodic-ci-Azure-ARO-RP-master-periodic-integration-e2e-parallel-miwi: true
  aro-classic-stage:
    jobs:
      periodic-ci-Azure-ARO-RP-master-periodic-stage-e2e-parallel-csp: true
      periodic-ci-Azure-ARO-RP-master-periodic-stage-e2e-parallel-miwi: true
  aro-classic-production:
    jobs:
      periodic-ci-Azure-ARO-RP-master-periodic-prod-e2e-parallel-csp: true
      periodic-ci-Azure-ARO-RP-master-periodic-prod-e2e-parallel-miwi: true
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized deployment configuration for Azure Red Hat OpenShift environments.
  * Added new environment-specific configurations for classic deployments across integration, stage, and production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->