### PR TITLE
Remove osde2e rosa-hcp nightly job from customizations

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -48,8 +48,6 @@ releases:
       periodic-ci-openshift-osde2e-main-nightly-4.20-rosa-classic-sts: true
       periodic-ci-openshift-osde2e-main-nightly-4.21-rosa-classic-sts: true
       periodic-ci-openshift-osde2e-main-nightly-4.22-rosa-classic-sts: true
-      # ROSA HCP nightly (stage)
-      periodic-ci-openshift-osde2e-main-nightly-4.21-rosa-hcp: true
       # ROSA proxy tests (stage)
       periodic-ci-openshift-osde2e-main-rosa-stage-e2e-byo-vpc-proxy-install: true
       periodic-ci-openshift-osde2e-main-rosa-stage-e2e-byo-vpc-proxy-postinstall: true


### PR DESCRIPTION
## Summary
- Removes the `periodic-ci-openshift-osde2e-main-nightly-4.21-rosa-hcp` entry from `config/openshift-customizations.yaml`
- These osde2e rosa-hcp nightly tests (4.20-4.23) were removed in openshift/release#78884 as they are now handled by rosa-e2e

## Test plan
- [ ] Verify the job no longer appears in the rosa-stage release view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a nightly testing job for ROSA HCP 4.21 from the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->