### PR TITLE
TRT-2651: Sync triage description with Jira summary on bug refresh

### DIFF
--- a/pkg/dataloader/bugloader/bugloader.go
+++ b/pkg/dataloader/bugloader/bugloader.go
@@ -255,10 +255,9 @@ func (bl *BugLoader) updateTriages(triages []models.Triage) {
 		}
 
 		updated := false
-		oldDescription := t.Description
 		if applyBugSummaryToTriageDescription(&t, bug.Summary) {
 			updated = true
-			logger.Infof("updating triage %d description from %q to %q", t.ID, oldDescription, bug.Summary)
+			logger.Infof("updated triage %d description from linked bug %d", t.ID, bug.ID)
 		}
 
 		// If the triage is not resolved, and it only contains regressions from a single release,

--- a/pkg/dataloader/bugloader/bugloader.go
+++ b/pkg/dataloader/bugloader/bugloader.go
@@ -212,6 +212,23 @@ var statusesForResolution = []string{
 	"Closed",
 }
 
+func triageBugLinked(t *models.Triage) bool {
+	return t.BugID != nil && t.Bug != nil && t.URL == t.Bug.URL
+}
+
+func skipTriageBugLoaderPass(resolved, bugLinked bool, triageDescription, bugSummary string) bool {
+	descriptionMatches := triageDescription == bugSummary
+	return resolved && bugLinked && descriptionMatches
+}
+
+func applyBugSummaryToTriageDescription(t *models.Triage, bugSummary string) bool {
+	if bugSummary == "" || t.Description == bugSummary {
+		return false
+	}
+	t.Description = bugSummary
+	return true
+}
+
 // updateTriages reconciles triage records with their associated bugs by:
 // 1. Linking triages to bug records and handling URL changes
 // 2. Auto-resolving triages when bugs reach "ON_QA" or higher status, only if the triage doesn't contain regressions from multiple releases
@@ -223,12 +240,6 @@ func (bl *BugLoader) updateTriages(triages []models.Triage) {
 			continue // If we have no URL, we can't do anything
 		}
 
-		resolved := t.Resolved.Valid
-		bugLinked := t.BugID != nil && t.URL == t.Bug.URL
-		if resolved && bugLinked {
-			continue // There is no action to take
-		}
-
 		var bug models.Bug
 		res := bl.dbc.DB.Where("url = ?", t.URL).First(&bug)
 		if res.Error != nil {
@@ -237,7 +248,19 @@ func (bl *BugLoader) updateTriages(triages []models.Triage) {
 			continue
 		}
 
+		resolved := t.Resolved.Valid
+		bugLinked := triageBugLinked(&t)
+		if skipTriageBugLoaderPass(resolved, bugLinked, t.Description, bug.Summary) {
+			continue // There is no action to take
+		}
+
 		updated := false
+		oldDescription := t.Description
+		if applyBugSummaryToTriageDescription(&t, bug.Summary) {
+			updated = true
+			logger.Infof("updating triage %d description from %q to %q", t.ID, oldDescription, bug.Summary)
+		}
+
 		// If the triage is not resolved, and it only contains regressions from a single release,
 		// then we should resolve it if the bug is at least in the "ON_QA" status
 		if !resolved && slices.Contains(statusesForResolution, bug.Status) {

--- a/pkg/dataloader/bugloader/bugloader_test.go
+++ b/pkg/dataloader/bugloader/bugloader_test.go
@@ -1,0 +1,138 @@
+package bugloader
+
+import (
+	"testing"
+
+	"github.com/openshift/sippy/pkg/db/models"
+)
+
+func TestSkipTriageBugLoaderPass(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name              string
+		resolved          bool
+		bugLinked         bool
+		triageDescription string
+		bugSummary        string
+		wantSkip          bool
+	}{
+		{
+			name:              "resolved linked matching skips",
+			resolved:          true,
+			bugLinked:         true,
+			triageDescription: "same",
+			bugSummary:        "same",
+			wantSkip:          true,
+		},
+		{
+			name:              "resolved linked mismatch does not skip",
+			resolved:          true,
+			bugLinked:         true,
+			triageDescription: "old",
+			bugSummary:        "new",
+			wantSkip:          false,
+		},
+		{
+			name:              "not resolved never skips",
+			resolved:          false,
+			bugLinked:         true,
+			triageDescription: "same",
+			bugSummary:        "same",
+			wantSkip:          false,
+		},
+		{
+			name:              "not linked never skips",
+			resolved:          true,
+			bugLinked:         false,
+			triageDescription: "same",
+			bugSummary:        "same",
+			wantSkip:          false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := skipTriageBugLoaderPass(tc.resolved, tc.bugLinked, tc.triageDescription, tc.bugSummary)
+			if got != tc.wantSkip {
+				t.Fatalf("skipTriageBugLoaderPass(...) = %v, want %v", got, tc.wantSkip)
+			}
+		})
+	}
+}
+
+func TestApplyBugSummaryToTriageDescription(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name          string
+		triageDesc    string
+		bugSummary    string
+		wantChanged   bool
+		wantFinalDesc string
+	}{
+		{
+			name:          "updates when summary differs",
+			triageDesc:    "old title",
+			bugSummary:    "new title",
+			wantChanged:   true,
+			wantFinalDesc: "new title",
+		},
+		{
+			name:          "no change when already matches",
+			triageDesc:    "same",
+			bugSummary:    "same",
+			wantChanged:   false,
+			wantFinalDesc: "same",
+		},
+		{
+			name:          "no change when summary empty",
+			triageDesc:    "user text",
+			bugSummary:    "",
+			wantChanged:   false,
+			wantFinalDesc: "user text",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tr := models.Triage{Description: tc.triageDesc}
+			changed := applyBugSummaryToTriageDescription(&tr, tc.bugSummary)
+			if changed != tc.wantChanged {
+				t.Fatalf("applyBugSummaryToTriageDescription changed=%v, want %v", changed, tc.wantChanged)
+			}
+			if tr.Description != tc.wantFinalDesc {
+				t.Fatalf("description = %q, want %q", tr.Description, tc.wantFinalDesc)
+			}
+		})
+	}
+}
+
+func TestTriageBugLinked(t *testing.T) {
+	t.Parallel()
+	id := uint(1)
+	url := "https://example/browse/X-1"
+	bug := &models.Bug{ID: id, URL: url}
+
+	t.Run("linked when ids and urls align", func(t *testing.T) {
+		t.Parallel()
+		tr := models.Triage{URL: url, BugID: &id, Bug: bug}
+		if !triageBugLinked(&tr) {
+			t.Fatal("expected linked")
+		}
+	})
+
+	t.Run("not linked when bug association missing", func(t *testing.T) {
+		t.Parallel()
+		tr := models.Triage{URL: url, BugID: &id, Bug: nil}
+		if triageBugLinked(&tr) {
+			t.Fatal("expected not linked")
+		}
+	})
+
+	t.Run("not linked when url mismatches bug url", func(t *testing.T) {
+		t.Parallel()
+		tr := models.Triage{URL: "https://other", BugID: &id, Bug: bug}
+		if triageBugLinked(&tr) {
+			t.Fatal("expected not linked")
+		}
+	})
+}

--- a/sippy-ng/src/component_readiness/TriageFields.js
+++ b/sippy-ng/src/component_readiness/TriageFields.js
@@ -250,6 +250,7 @@ export default function TriageFields({
           value={triageEntryData.description}
           onChange={handleTriageChange}
           fullWidth
+          helperText="If this triage is linked to a Jira bug in Sippy, this value may be replaced by the Jira issue summary when bug data is refreshed."
         />
         <Select
           name="type"


### PR DESCRIPTION
BugLoader updateTriages now copies Bug.Summary into Triage.Description when non-empty, refines the resolved/linked early-continue, and adds unit tests.

Component readiness triage form shows helper text that the description may match the Jira summary after refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helper text guidance to the triage description field for Jira-linked triages.

* **Bug Fixes / Refactor**
  * Improved internal triage update and linking behavior to make triage status and descriptions more consistent.

* **Tests**
  * Added unit tests covering triage linking, skip logic, and description update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->