### PR TITLE
Drop minFail hysteresis for open regressions

### DIFF
--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -806,10 +806,7 @@ func (c *ComponentReportGenerator) buildFisherExactTestStats(testStats *testdeta
 		basePass := testStats.BaseStats.Passes(opts.FlakeAsFailure)
 		basisPassPercentage := float64(basePass) / float64(testStats.BaseStats.Total())
 		effectivePityFactor := float64(opts.PityFactor) + testStats.PityAdjustment
-		effectiveMinimumFailure := opts.MinimumFailure + testStats.MinimumFailureAdjustment
-		if effectiveMinimumFailure < 0 {
-			effectiveMinimumFailure = 0
-		}
+		effectiveMinimumFailure := opts.MinimumFailure
 
 		// default starting status now that we know we have basis and sample
 		status = crtest.NotSignificant

--- a/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
+++ b/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
@@ -26,10 +26,6 @@ const (
 	// to adjust this to a smaller value so that, if a rate improvement is smaller than the openRegressionPityAdjustment,
 	// we still consider it regressed.
 	openRegressionPityAdjustment = -2
-	// openRegressionMinimumFailureAdjustment is used to adjust minimum failure requirement for regressed tests that have
-	// an open regression. The goal is to adjust this to a smaller value so that we will this test more strict than the ones
-	// without open regressions.
-	openRegressionMinimumFailureAdjustment = -1
 )
 
 var _ middleware.Middleware = &RegressionTracker{}
@@ -102,7 +98,6 @@ func (r *RegressionTracker) PreAnalysis(testKey crtest.Identification, testStats
 			// we were over 95% certain of a regression), we're going to only require 90% certainty to mark that test red.
 			testStats.RequiredConfidence = r.reqOptions.AdvancedOption.Confidence - openRegressionConfidenceAdjustment
 			testStats.PityAdjustment = openRegressionPityAdjustment
-			testStats.MinimumFailureAdjustment = openRegressionMinimumFailureAdjustment
 		}
 	}
 	return nil

--- a/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker_test.go
+++ b/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker_test.go
@@ -320,25 +320,22 @@ func TestRegressionTracker_PreAnalysis_Adjustments(t *testing.T) {
 	variantsStrSlice := utils.VariantsMapToStringSlice(testKey.Variants)
 
 	tests := []struct {
-		name                         string
-		hasOpenRegression            bool
-		expectedPityAdjustment       float64
-		expectedMinFailureAdjustment int
-		expectedRequiredConfidence   int
+		name                       string
+		hasOpenRegression          bool
+		expectedPityAdjustment     float64
+		expectedRequiredConfidence int
 	}{
 		{
-			name:                         "no open regression - no adjustments",
-			hasOpenRegression:            false,
-			expectedPityAdjustment:       0,
-			expectedMinFailureAdjustment: 0,
-			expectedRequiredConfidence:   95, // default confidence
+			name:                       "no open regression - no adjustments",
+			hasOpenRegression:          false,
+			expectedPityAdjustment:     0,
+			expectedRequiredConfidence: 95, // default confidence
 		},
 		{
-			name:                         "has open regression - adjustments applied",
-			hasOpenRegression:            true,
-			expectedPityAdjustment:       openRegressionPityAdjustment,            // -2
-			expectedMinFailureAdjustment: openRegressionMinimumFailureAdjustment,  // -1
-			expectedRequiredConfidence:   95 - openRegressionConfidenceAdjustment, // 90
+			name:                       "has open regression - adjustments applied",
+			hasOpenRegression:          true,
+			expectedPityAdjustment:     openRegressionPityAdjustment,            // -2
+			expectedRequiredConfidence: 95 - openRegressionConfidenceAdjustment, // 90
 		},
 	}
 
@@ -365,10 +362,9 @@ func TestRegressionTracker_PreAnalysis_Adjustments(t *testing.T) {
 
 			// Set up test stats
 			testStats := &testdetails.TestComparison{
-				ReportStatus:             crtest.SignificantRegression,
-				RequiredConfidence:       95,
-				PityAdjustment:           0,
-				MinimumFailureAdjustment: 0,
+				ReportStatus:       crtest.SignificantRegression,
+				RequiredConfidence: 95,
+				PityAdjustment:     0,
 			}
 
 			// Set up open regressions if needed
@@ -396,8 +392,6 @@ func TestRegressionTracker_PreAnalysis_Adjustments(t *testing.T) {
 			// Verify adjustments
 			assert.Equal(t, tt.expectedPityAdjustment, testStats.PityAdjustment,
 				"PityAdjustment should match expected value")
-			assert.Equal(t, tt.expectedMinFailureAdjustment, testStats.MinimumFailureAdjustment,
-				"MinimumFailureAdjustment should match expected value")
 			assert.Equal(t, tt.expectedRequiredConfidence, testStats.RequiredConfidence,
 				"RequiredConfidence should match expected value")
 
@@ -576,10 +570,9 @@ func TestRegressionTracker_PreAnalysis_RegressionMatching(t *testing.T) {
 			}
 
 			testStats := &testdetails.TestComparison{
-				ReportStatus:             crtest.SignificantRegression,
-				RequiredConfidence:       95,
-				PityAdjustment:           0,
-				MinimumFailureAdjustment: 0,
+				ReportStatus:       crtest.SignificantRegression,
+				RequiredConfidence: 95,
+				PityAdjustment:     0,
 			}
 
 			err := mw.PreAnalysis(tt.testKey, testStats)
@@ -590,13 +583,11 @@ func TestRegressionTracker_PreAnalysis_RegressionMatching(t *testing.T) {
 				assert.Equal(t, tt.expectedTestID, testStats.Regression.TestID, "Regression TestID should match")
 				// Verify adjustments are applied
 				assert.Equal(t, float64(openRegressionPityAdjustment), testStats.PityAdjustment)
-				assert.Equal(t, openRegressionMinimumFailureAdjustment, testStats.MinimumFailureAdjustment)
 				assert.Equal(t, 95-openRegressionConfidenceAdjustment, testStats.RequiredConfidence)
 			} else {
 				assert.Nil(t, testStats.Regression, "Regression should not be set")
 				// Verify no adjustments are applied
 				assert.Equal(t, float64(0), testStats.PityAdjustment)
-				assert.Equal(t, 0, testStats.MinimumFailureAdjustment)
 				assert.Equal(t, 95, testStats.RequiredConfidence)
 			}
 		})

--- a/pkg/apis/api/componentreport/testdetails/types.go
+++ b/pkg/apis/api/componentreport/testdetails/types.go
@@ -62,9 +62,6 @@ type TestComparison struct {
 	// PityAdjustment can be used to adjust the tolerance for failures for this particular test.
 	PityAdjustment float64 `json:"-"`
 
-	// MinimumFailureAdjustment can be used to adjust the tolerance for minimum number of failures for this particular test.
-	MinimumFailureAdjustment int `json:"-"`
-
 	// RequiredPassRateAdjustment can be used to adjust the tolerance for failures for a new test.
 	RequiredPassRateAdjustment float64 `json:"-"`
 


### PR DESCRIPTION
Dropping to a min of 2 failures once a regression is opened is proving
to be overly sensitive and difficult for obscure problems to clear. With
current monitoring levels we get bugs quickly once something has
regressed giving us a clear opportunity to decide if we push for release
blocker or not, despite clearing the regression.

Other hysteresis adjustments (confidence/pity) remain in play, we just
will require the minFail of 3 to remain for it to stay regressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified failure threshold logic in regression tracking by removing intermediate adjustment components
  * Corrected how minimum failure configurations are applied to test status reporting
  * Updated regression analysis to handle open regressions without additional failure adjustments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->