### PR TITLE
Switch devcontainer to Fedora 43 with Chromium

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,8 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.fedoraproject.org/fedora:43
 
 ARG GOLANGCI_LINT_VERSION=1.64.8
 
-RUN dnf module enable nodejs:18 -y && \
-    dnf install -y --allowerasing \
+RUN dnf install -y \
     git \
     make \
     jq \
@@ -14,11 +13,13 @@ RUN dnf module enable nodejs:18 -y && \
     findutils \
     procps-ng \
     sudo \
-    go \
+    golang \
     npm \
-    python3.12 \
+    python3 \
     libstdc++ \
     postgresql \
+    chromium-headless \
+    which \
     && dnf clean all
 
 RUN ARCH=$(uname -m) && \
@@ -40,6 +41,7 @@ RUN groupadd -g 1000 vscode && \
 
 ENV GOPATH=/home/vscode/go
 ENV PATH="/home/vscode/.local/bin:${GOPATH}/bin:/usr/local/go/bin:${PATH}"
+ENV CHROME_PATH=/usr/lib64/chromium-browser/headless_shell
 
 USER vscode
 

--- a/.devcontainer/init-services.sh
+++ b/.devcontainer/init-services.sh
@@ -17,7 +17,7 @@ podman start sippy-redis 2>/dev/null || \
     podman run -d --name sippy-redis \
         --network sippy-net \
         -p 127.0.0.1:6379:6379 \
-        redis:7-alpine
+        docker.io/redis:7-alpine
 
 echo "Waiting for PostgreSQL..."
 pg_ready=false

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -13,12 +13,15 @@ echo "==> Installing frontend dependencies..."
 make npm
 
 echo "==> Setting up MCP server venv..."
-python3.12 -m venv mcp/.venv
+python3 -m venv mcp/.venv
 mcp/.venv/bin/pip install --upgrade pip -q
 mcp/.venv/bin/pip install -r mcp/requirements.txt -q
 
+echo "==> Configuring Playwright MCP server for Claude..."
+claude mcp add playwright -- npx @playwright/mcp@latest --executable-path /usr/lib64/chromium-browser/headless_shell
+
 echo "==> Building sippy and seeding database..."
-go build -mod=vendor -o ./sippy ./cmd/sippy/...
+make sippy
 ./sippy seed-data --init-database --database-dsn="$SIPPY_DATABASE_DSN"
 
 echo "==> Dev environment ready."


### PR DESCRIPTION
## Summary
- Switches devcontainer base image from UBI9 to Fedora 43 for better package availability
- Adds `chromium-headless` for browser automation (Claude Code Playwright MCP)
- Configures Playwright MCP server for Claude Code during post-create setup
- Fixes several compatibility issues (redis image path, python3 version, build shim)

## Test plan
- [x] `devcontainer up --workspace-folder . --docker-path podman` completes successfully
- [x] Chromium is available: `/usr/lib64/chromium-browser/headless_shell --no-sandbox --version`
- [x] Database is seeded: `psql -h sippy-postgres -U postgres -c '\dt'` shows tables
- [x] `claude` launches inside the container with Playwright MCP server configured
- [x] `make lint` and `make test` pass inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)