### PR TITLE
Remove osde2e jobs from rosa-stage view

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -40,36 +40,7 @@ releases:
       branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel: true
   rosa-stage:
     jobs:
-      # ROSA Classic/STS nightly (stage)
-      periodic-ci-openshift-osde2e-main-nightly-4.16-rosa-classic-sts: true
-      periodic-ci-openshift-osde2e-main-nightly-4.17-rosa-classic-sts: true
-      periodic-ci-openshift-osde2e-main-nightly-4.18-rosa-classic-sts: true
-      periodic-ci-openshift-osde2e-main-nightly-4.19-rosa-classic-sts: true
-      periodic-ci-openshift-osde2e-main-nightly-4.20-rosa-classic-sts: true
-      periodic-ci-openshift-osde2e-main-nightly-4.21-rosa-classic-sts: true
-      periodic-ci-openshift-osde2e-main-nightly-4.22-rosa-classic-sts: true
-      # ROSA HCP nightly (stage)
-      periodic-ci-openshift-osde2e-main-nightly-4.21-rosa-hcp: true
-      # ROSA proxy tests (stage)
-      periodic-ci-openshift-osde2e-main-rosa-stage-e2e-byo-vpc-proxy-install: true
-      periodic-ci-openshift-osde2e-main-rosa-stage-e2e-byo-vpc-proxy-postinstall: true
-      # K8s conformance tests
       periodic-ci-openshift-release-main-osd-conformance-aws-k8s-conformance: true
-      # OSD-AWS nightly (stage, relevant to ROSA)
-      periodic-ci-openshift-osde2e-main-nightly-4.16-osd-aws: true
-      periodic-ci-openshift-osde2e-main-nightly-4.17-osd-aws: true
-      periodic-ci-openshift-osde2e-main-nightly-4.18-osd-aws: true
-      periodic-ci-openshift-osde2e-main-nightly-4.19-osd-aws: true
-      periodic-ci-openshift-osde2e-main-nightly-4.20-osd-aws: true
-      periodic-ci-openshift-osde2e-main-nightly-4.21-osd-aws: true
-      periodic-ci-openshift-osde2e-main-nightly-4.22-osd-aws: true
-      # OSD-AWS upgrades (stage)
-      periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-z-minus-1-to-latest-default-z: true
-      periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-y-minus-1-to-latest-default-y: true
-      periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-y-to-latest-y-plus-1: true
-      periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-y-plus-1-to-latest-y: true
-      # OSD-AWS informing (stage)
-      periodic-ci-openshift-osde2e-main-aws-stage-informing-default: true
     regexp:
       # rosa-e2e managed service validation + OCM FVT (current and future versioned jobs)
       - "^periodic-ci-openshift-online-rosa-e2e-main-.*"


### PR DESCRIPTION
## Summary
- Remove all 22 osde2e periodic jobs from the `rosa-stage` Sippy view (nightly, upgrade, proxy, informing)
- The rosa-stage dashboard should focus on rosa-e2e, conformance, and FVT jobs only
- Retained: K8s conformance explicit job, rosa-e2e regexp, HCP/STS conformance regexps

## Test plan
- [ ] Verify rosa-stage dashboard loads without errors after merge
- [ ] Confirm osde2e jobs no longer appear in the rosa-stage view
- [ ] Confirm rosa-e2e, conformance, and FVT jobs still appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing pipeline configuration for the release stage environment to streamline enabled validation jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->