### PR TITLE
NO-JIRA: Upgrade to Go 1.25 and golangci-lint v2.10.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.fedoraproject.org/fedora:43
 
-ARG GOLANGCI_LINT_VERSION=1.64.8
+ARG GOLANGCI_LINT_VERSION=2.10.1
 
 RUN dnf install -y \
     git \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,7 +39,7 @@
       "settings": {
         "go.gopath": "/home/vscode/go",
         "go.lintTool": "golangci-lint",
-        "go.lintFlags": ["--fast"],
+        "go.lintFlags": ["--fast-only"],
         "editor.formatOnSave": true,
         "[go]": {
           "editor.defaultFormatter": "golang.go"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,139 +1,160 @@
 ---
+version: "2"
+
 run:
   concurrency: 6
-  deadline: 10m
-  skip-dirs:
-    - sippy-ng/node_modules
+  timeout: 10m
+
 linters:
-  disable-all: true
+  default: none
   enable:
     - copyloopvar
     - errcheck
     # - goconst  # [lmeyer] I cannot see a way to configure this sanely
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - revive
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
-linters-settings:
-  gofmt:
-    simplify: false # do not require the -s flag
-  gocritic:
-    disable-all: true # let's only enable ones we opt in to, not random new ones
-    enabled-checks:
-      # Diagnostic
-      - argOrder
-      - badCond
-      - caseOrder
-      - codegenComment
-      - commentedOutCode
-      - deprecatedComment
-      - dupArg
-      - dupBranchBody
-      - dupCase
-      - dupSubExpr
-      - exitAfterDefer
-      - flagDeref
-      - flagName
-      - nilValReturn
-      - octalLiteral
-      - offBy1
-      - sloppyReassign
-      - weakCond
+  settings:
+    gocritic:
+      disable-all: true # let's only enable ones we opt in to, not random new ones
+      enabled-checks:
+        # Diagnostic
+        - argOrder
+        - badCond
+        - caseOrder
+        - codegenComment
+        - commentedOutCode
+        - deprecatedComment
+        - dupArg
+        - dupBranchBody
+        - dupCase
+        - dupSubExpr
+        - exitAfterDefer
+        - flagDeref
+        - flagName
+        - nilValReturn
+        - octalLiteral
+        - offBy1
+        - sloppyReassign
+        - weakCond
 
-      # Performance
-      - equalFold
-      - indexAlloc
-      - rangeExprCopy
+        # Performance
+        - equalFold
+        - indexAlloc
+        - rangeExprCopy
 
-      # Style
-      - assignOp
-      - boolExprSimplify
-      - captLocal
-      - commentFormatting
-      - commentedOutImport
-      - defaultCaseOrder
-      - docStub
-      - elseif
-      - emptyFallthrough
-      - hexLiteral
-      - methodExprCall
-      - regexpMust
-      - singleCaseSwitch
-      - sloppyLen
-      - switchTrue
-      - typeAssertChain
-      - typeSwitchVar
-      - underef
-      - unlabelStmt
-      - unlambda
-      - unslice
-      - valSwap
-      - wrapperFunc
-      - yodaStyleExpr
+        # Style
+        - assignOp
+        - boolExprSimplify
+        - captLocal
+        - commentFormatting
+        - commentedOutImport
+        - defaultCaseOrder
+        - docStub
+        - elseif
+        - emptyFallthrough
+        - hexLiteral
+        - methodExprCall
+        - regexpMust
+        - singleCaseSwitch
+        - sloppyLen
+        - switchTrue
+        - typeAssertChain
+        - typeSwitchVar
+        - underef
+        - unlabelStmt
+        - unlambda
+        - unslice
+        - valSwap
+        - wrapperFunc
+        - yodaStyleExpr
 
-      # Opinionated
-      - initClause
-      - nestingReduce
-      - paramTypeCombine
-      - ptrToRefParam
-      - typeUnparen
-      - unnecessaryBlock
-  revive:
+        # Opinionated
+        - initClause
+        - nestingReduce
+        - paramTypeCombine
+        - ptrToRefParam
+        - typeUnparen
+        - unnecessaryBlock
+    revive:
+      rules:
+        - name: atomic
+        - name: blank-imports
+        - name: bool-literal-in-expr
+        - name: call-to-gc
+        - name: confusing-naming
+        - name: constant-logical-expr
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: deep-exit
+        - name: defer
+        - name: dot-imports
+        - name: duplicated-imports
+        - name: early-return
+        - name: empty-block
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: get-return
+        - name: identical-branches
+        - name: if-return
+        - name: import-shadowing
+        - name: imports-blacklist
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: modifies-parameter
+        - name: modifies-value-receiver
+        - name: package-comments
+        - name: range
+        - name: range-val-address
+        - name: range-val-in-closure
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: string-of-int
+        - name: struct-tag
+        - name: superfluous-else
+        - name: time-naming
+        - name: unconditional-recursion
+        - name: unexported-naming
+        - name: unnecessary-stmt
+        - name: unreachable-code
+        # TODO: Enable these in the future
+        # - name: unused-parameter
+        # - name: unused-receiver
+        - name: var-declaration
+        - name: var-naming
+        - name: waitgroup-by-value
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      - name: atomic
-      - name: blank-imports
-      - name: bool-literal-in-expr
-      - name: call-to-gc
-      - name: confusing-naming
-      - name: constant-logical-expr
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: deep-exit
-      - name: defer
-      - name: dot-imports
-      - name: duplicated-imports
-      - name: early-return
-      - name: empty-block
-      - name: error-naming
-      - name: error-return
-      - name: error-strings
-      - name: errorf
-      - name: get-return
-      - name: identical-branches
-      - name: if-return
-      - name: import-shadowing
-      - name: imports-blacklist
-      - name: increment-decrement
-      - name: indent-error-flow
-      - name: modifies-parameter
-      - name: modifies-value-receiver
-      - name: package-comments
-      - name: range
-      - name: range-val-address
-      - name: range-val-in-closure
-      - name: receiver-naming
-      - name: redefines-builtin-id
-      - name: string-of-int
-      - name: struct-tag
-      - name: superfluous-else
-      - name: time-naming
-      - name: unconditional-recursion
-      - name: unexported-naming
-      - name: unnecessary-stmt
-      - name: unreachable-code
-      # TODO: Enable these in the future
-      # - name: unused-parameter
-      # - name: unused-receiver
-      - name: var-declaration
-      - name: var-naming
-      - name: waitgroup-by-value
+      - linters: [revive]
+        text: "var-naming: avoid meaningless package names" # pkg/api, pkg/util, pkg/api/componentreadiness/utils
+      - linters: [revive]
+        text: "var-naming: avoid package names that conflict" # pkg/sippyserver/metrics, pkg/version
+    paths:
+      - sippy-ng/node_modules
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: false # do not require the -s flag
+  exclusions:
+    generated: lax
+    paths:
+      - sippy-ng/node_modules

--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -4,7 +4,7 @@
 # [1] https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image
 #
 FROM registry.access.redhat.com/ubi9/ubi:latest
-ARG GOLANGCI_LINT_VERSION="1.64.8"
+ARG GOLANGCI_LINT_VERSION="2.10.1"
 RUN curl -Lso /tmp/golangci-lint.rpm \
           "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64.rpm" && \
       dnf module enable nodejs:18 -y && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/sippy
 
-go 1.24
+go 1.25
 
 require (
 	cloud.google.com/go v0.115.0

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -28,6 +28,6 @@ else
   $DOCKER run --rm \
     --volume "${PWD}:/go/src/github.com/openshift/sippy${VOLUME_OPTION}" \
     --workdir /go/src/github.com/openshift/sippy \
-    docker.io/golangci/golangci-lint:v1.64.8 \
+    docker.io/golangci/golangci-lint:v2.10.1 \
     golangci-lint --timeout 10m "${@}"
 fi

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -12,7 +12,7 @@ func RespondWithJSON(statusCode int, w http.ResponseWriter, data interface{}) {
 	w.WriteHeader(statusCode)
 
 	if jsonString, ok := data.(string); ok {
-		fmt.Fprint(w, jsonString)
+		fmt.Fprint(w, jsonString) //nolint:gosec // G705: jsonString is pre-marshaled JSON from internal sources, response Content-Type is application/json
 		return
 	}
 

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -138,7 +138,7 @@ func (c *ComponentReportGenerator) PostAnalysis(report *crtype.ComponentReport) 
 				if err := c.middlewares.PostAnalysis(testKey, &report.Rows[ri].Columns[ci].RegressedTests[rti].TestComparison); err != nil {
 					return err
 				}
-				if newStatus := report.Rows[ri].Columns[ci].RegressedTests[rti].TestComparison.ReportStatus; rti == 0 || newStatus < worstStatus {
+				if newStatus := report.Rows[ri].Columns[ci].RegressedTests[rti].ReportStatus; rti == 0 || newStatus < worstStatus {
 					worstStatus = newStatus
 				}
 			}

--- a/pkg/api/componentreadiness/dataprovider/postgres/provider.go
+++ b/pkg/api/componentreadiness/dataprovider/postgres/provider.go
@@ -379,9 +379,9 @@ func (p *PostgresProvider) queryTestStatus(ctx context.Context, release string, 
 		existing, exists := result[keyStr]
 		if exists {
 			// Merge counts for same test+variant combo from different job runs
-			existing.Count.TotalCount += row.TotalCount
-			existing.Count.SuccessCount += row.SuccessCount
-			existing.Count.FlakeCount += row.FlakeCount
+			existing.TotalCount += row.TotalCount
+			existing.SuccessCount += row.SuccessCount
+			existing.FlakeCount += row.FlakeCount
 			if row.LastFailure != nil && (existing.LastFailure.IsZero() || row.LastFailure.After(existing.LastFailure)) {
 				existing.LastFailure = *row.LastFailure
 			}

--- a/pkg/api/componentreadiness/triage.go
+++ b/pkg/api/componentreadiness/triage.go
@@ -365,7 +365,7 @@ func GetTriagePotentialMatches(triage *models.Triage, allRegressions []models.Te
 			PotentialMatch: determinePotentialMatch(reg, triage),
 		}
 		if match.PotentialMatch != nil {
-			match.ConfidenceLevel = match.PotentialMatch.calculateConfidenceLevel()
+			match.ConfidenceLevel = match.calculateConfidenceLevel()
 			match.Links = map[string]string{
 				"self":   fmt.Sprintf(potentialMatchesLink, baseURL, triage.ID),
 				"triage": fmt.Sprintf(triageLink, baseURL, triage.ID),
@@ -464,7 +464,7 @@ func GetRegressionPotentialMatchingTriages(regression models.TestRegression, tri
 			PotentialMatch: determinePotentialMatch(regression, &triage),
 		}
 		if match.PotentialMatch != nil {
-			confidenceLevel := match.PotentialMatch.calculateConfidenceLevel()
+			confidenceLevel := match.calculateConfidenceLevel()
 			// A triage that is resolved is much less likely to be a proper match, it should never have a confidence level higher than 5
 			if match.Triage.Resolved.Valid && confidenceLevel > 5 {
 				confidenceLevel = 5

--- a/pkg/api/componentreadiness/utils/queryparamparser.go
+++ b/pkg/api/componentreadiness/utils/queryparamparser.go
@@ -85,10 +85,10 @@ func ParseComponentReportRequest(
 
 	// Test filters override view defaults
 	if testCaps := req.URL.Query()["testCapabilities"]; len(testCaps) > 0 {
-		opts.TestFilters.Capabilities = testCaps
+		opts.Capabilities = testCaps
 	}
 	if testLifecycles := req.URL.Query()["testLifecycles"]; len(testLifecycles) > 0 {
-		opts.TestFilters.Lifecycles = testLifecycles
+		opts.Lifecycles = testLifecycles
 	}
 
 	// Variant options - merge with view defaults

--- a/pkg/api/jobartifacts/apitypes.go
+++ b/pkg/api/jobartifacts/apitypes.go
@@ -44,8 +44,8 @@ type MatchedContent struct {
 // Matched returns true and text from the first match if there is any in the MatchedContent.
 // This could get more complicated with more matcher types, but for now we only have line matches.
 func (m MatchedContent) Matched() (string, bool) {
-	if m.ContentLineMatches != nil && len(m.ContentLineMatches.Matches) > 0 {
-		return m.ContentLineMatches.Matches[0].Match, true
+	if m.ContentLineMatches != nil && len(m.Matches) > 0 {
+		return m.Matches[0].Match, true
 	}
 	return "", false
 }

--- a/pkg/api/jobartifacts/content_line_matcher.go
+++ b/pkg/api/jobartifacts/content_line_matcher.go
@@ -35,10 +35,10 @@ func (m *lineMatcher) GetCacheKey() string {
 
 func (m *lineMatcher) PostProcessMatch(fullArtifact JobRunArtifact) JobRunArtifact {
 	artifact := fullArtifact
-	if fullArtifact.MatchedContent.ContentLineMatches == nil {
+	if fullArtifact.ContentLineMatches == nil {
 		return artifact // no matches to process
 	}
-	clMatches := fullArtifact.MatchedContent.ContentLineMatches
+	clMatches := fullArtifact.ContentLineMatches
 	trimmed := &ContentLineMatches{
 		Matches:   []ContentLineMatch{},
 		Truncated: clMatches.Truncated,
@@ -65,7 +65,7 @@ func (m *lineMatcher) PostProcessMatch(fullArtifact JobRunArtifact) JobRunArtifa
 			After:  afterLines,
 		})
 	}
-	artifact.MatchedContent.ContentLineMatches = trimmed
+	artifact.ContentLineMatches = trimmed
 	return artifact
 }
 

--- a/pkg/api/jobartifacts/content_line_matcher_test.go
+++ b/pkg/api/jobartifacts/content_line_matcher_test.go
@@ -14,8 +14,8 @@ func TestMatchLineWithStringMatcher(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader("this is a test line\nanother line\n"))
 	matches, err := matcher.GetMatches(reader)
 	assert.NoError(t, err)
-	assert.Len(t, matches.ContentLineMatches.Matches, 1)
-	assert.Equal(t, "this is a test line\n", matches.ContentLineMatches.Matches[0].Match)
+	assert.Len(t, matches.Matches, 1)
+	assert.Equal(t, "this is a test line\n", matches.Matches[0].Match)
 }
 
 func TestMatchLineWithRegexMatcher(t *testing.T) {
@@ -24,8 +24,8 @@ func TestMatchLineWithRegexMatcher(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader("this is a test line\nanother line\n"))
 	matches, err := matcher.GetMatches(reader)
 	assert.NoError(t, err)
-	assert.Len(t, matches.ContentLineMatches.Matches, 1)
-	assert.Equal(t, "this is a test line\n", matches.ContentLineMatches.Matches[0].Match)
+	assert.Len(t, matches.Matches, 1)
+	assert.Equal(t, "this is a test line\n", matches.Matches[0].Match)
 }
 
 func TestMatchLineWithContext(t *testing.T) {
@@ -33,11 +33,11 @@ func TestMatchLineWithContext(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader("line before\nthis is a test line\nline after\nanother line\n"))
 	matches, err := matcher.GetMatches(reader)
 	assert.NoError(t, err)
-	assert.Len(t, matches.ContentLineMatches.Matches, 1)
-	assert.Equal(t, "this is a test line\n", matches.ContentLineMatches.Matches[0].Match)
-	assert.Equal(t, []string{"line before\n"}, matches.ContentLineMatches.Matches[0].Before)
+	assert.Len(t, matches.Matches, 1)
+	assert.Equal(t, "this is a test line\n", matches.Matches[0].Match)
+	assert.Equal(t, []string{"line before\n"}, matches.Matches[0].Before)
 	// although we said to capture 1 line after, we actually capture up to the max and then trim them later
-	assert.Equal(t, []string{"line after\n", "another line\n"}, matches.ContentLineMatches.Matches[0].After)
+	assert.Equal(t, []string{"line after\n", "another line\n"}, matches.Matches[0].After)
 }
 
 func TestLinesAfterMatches(t *testing.T) {
@@ -45,7 +45,7 @@ func TestLinesAfterMatches(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader("test before\ntest line\ntest after\nanother line\n"))
 	matches, err := matcher.GetMatches(reader)
 	assert.NoError(t, err)
-	m := matches.ContentLineMatches.Matches
+	m := matches.Matches
 	assert.Len(t, m, 3)
 	// although we said to capture 2 lines after, we actually capture up to the max and then trim them later
 	assert.Equal(t, 3, len(m[0].After))
@@ -58,7 +58,7 @@ func TestMatchLineWithMultipleMatches(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader("this is a test line\nanother test line\n"))
 	matches, err := matcher.GetMatches(reader)
 	assert.NoError(t, err)
-	lineMatches := matches.ContentLineMatches.Matches
+	lineMatches := matches.Matches
 	assert.Len(t, lineMatches, 2)
 	assert.Equal(t, "this is a test line\n", lineMatches[0].Match)
 	assert.Equal(t, []string{"this is a test line\n"}, lineMatches[1].Before)
@@ -72,8 +72,8 @@ func TestMatchLineWithMaxFileMatches(t *testing.T) {
 	matches, err := matcher.GetMatches(reader)
 	assert.NoError(t, err)
 	// we return up to the max matches even though we only asked for 3 (matches will be trimmed in post-processing)
-	assert.Len(t, matches.ContentLineMatches.Matches, maxFileMatches)
-	assert.True(t, matches.ContentLineMatches.Truncated)
+	assert.Len(t, matches.Matches, maxFileMatches)
+	assert.True(t, matches.Truncated)
 }
 
 func TestPostProcessMatch(t *testing.T) {
@@ -107,7 +107,7 @@ func TestPostProcessMatch(t *testing.T) {
 	}
 
 	processedArtifact := matcher.PostProcessMatch(fullArtifact)
-	processedMatches := processedArtifact.MatchedContent.ContentLineMatches
+	processedMatches := processedArtifact.ContentLineMatches
 
 	assert.Len(t, processedMatches.Matches, 2)
 	assert.True(t, processedMatches.Truncated)

--- a/pkg/api/jobartifacts/query.go
+++ b/pkg/api/jobartifacts/query.go
@@ -70,7 +70,7 @@ func (q *JobArtifactQuery) queryJobArtifacts(ctx context.Context, jobRunID int64
 	_ = q.SetJobRunCache(ctx, jobRunID, jobRunResponse)
 	if q.ContentMatcher != nil {
 		for i := range jobRunResponse.Artifacts {
-			jobRunResponse.Artifacts[i] = q.ContentMatcher.PostProcessMatch(jobRunResponse.Artifacts[i])
+			jobRunResponse.Artifacts[i] = q.PostProcessMatch(jobRunResponse.Artifacts[i])
 		}
 	}
 
@@ -186,7 +186,7 @@ func (q *JobArtifactQuery) getFileContentMatches(ctx context.Context, jobRunID i
 		return
 	}
 
-	matches, err := q.ContentMatcher.GetMatches(reader)
+	matches, err := q.GetMatches(reader)
 	if err != nil {
 		artifact.Error = err.Error()
 	}
@@ -274,7 +274,7 @@ func (q *JobArtifactQuery) CacheKeyForJobRun(jobRunID int64) string {
 		"pathGlob": q.PathGlob,
 	}
 	if q.ContentMatcher != nil {
-		key["contentMatcher"] = q.ContentMatcher.GetCacheKey()
+		key["contentMatcher"] = q.GetCacheKey()
 	}
 
 	jsonBytes, err := json.Marshal(key)
@@ -300,7 +300,7 @@ func (q *JobArtifactQuery) SetJobRunCache(ctx context.Context, jobRunID int64, r
 	}
 
 	// set the cache with the serialized response
-	if err := q.Cache.Set(ctx, q.CacheKeyForJobRun(jobRunID), serialized, cacheExpiration); err != nil {
+	if err := q.Set(ctx, q.CacheKeyForJobRun(jobRunID), serialized, cacheExpiration); err != nil {
 		logger.WithError(err).Error("failed to set job run cache")
 		return err
 	}
@@ -315,7 +315,7 @@ func (q *JobArtifactQuery) GetCachedJobRun(ctx context.Context, jobRunID int64) 
 	}
 
 	// retrieve bytes from the cache if they exist
-	jsonBytes, err := q.Cache.Get(ctx, q.CacheKeyForJobRun(jobRunID), cacheExpiration)
+	jsonBytes, err := q.Get(ctx, q.CacheKeyForJobRun(jobRunID), cacheExpiration)
 	if err != nil {
 		logger.WithError(err).Debug("failed to get job run cache entry")
 		return

--- a/pkg/api/jobartifacts/query_test.go
+++ b/pkg/api/jobartifacts/query_test.go
@@ -52,14 +52,14 @@ func TestFunctional_FilterContent(t *testing.T) {
 	query := baseTestingJAQ(t, "", NewStringMatcher("ClusterVersion:", 0, 0, maxFileMatches))
 	artifact := query.getFileContentMatches(ctx, 1898704060324777984, &storage.ObjectAttrs{Name: filePath})
 	assert.Empty(t, artifact.Error)
-	assert.False(t, artifact.MatchedContent.ContentLineMatches.Truncated, "expected no need for truncating the content matches")
-	assert.Equal(t, 2, len(artifact.MatchedContent.ContentLineMatches.Matches), "expected content to match with two lines")
+	assert.False(t, artifact.Truncated, "expected no need for truncating the content matches")
+	assert.Equal(t, 2, len(artifact.Matches), "expected content to match with two lines")
 
 	query.ContentMatcher = NewStringMatcher("error:", 0, 0, maxFileMatches)
 	artifact = query.getFileContentMatches(ctx, 1898704060324777984, &storage.ObjectAttrs{Name: filePath})
 	assert.Empty(t, artifact.Error)
-	assert.True(t, artifact.MatchedContent.ContentLineMatches.Truncated, "expected to truncate content matches")
-	assert.Equal(t, maxFileMatches, len(artifact.MatchedContent.ContentLineMatches.Matches), "expected content to match with many lines")
+	assert.True(t, artifact.Truncated, "expected to truncate content matches")
+	assert.Equal(t, maxFileMatches, len(artifact.Matches), "expected content to match with many lines")
 }
 
 func TestFunctional_GzipContent(t *testing.T) {
@@ -68,9 +68,9 @@ func TestFunctional_GzipContent(t *testing.T) {
 	query := baseTestingJAQ(t, "", NewStringMatcher("error", 0, 0, maxFileMatches))
 	artifact := query.getFileContentMatches(context.Background(), 1909930323508989952, &storage.ObjectAttrs{Name: filePath, ContentType: "application/gzip"})
 	assert.Empty(t, artifact.Error)
-	assert.True(t, artifact.MatchedContent.ContentLineMatches.Truncated, "expected a lot of matches")
+	assert.True(t, artifact.Truncated, "expected a lot of matches")
 	assert.Contains(t,
-		artifact.MatchedContent.ContentLineMatches.Matches[0].Match,
+		artifact.Matches[0].Match,
 		"localhost kernel: GPT: Use GNU Parted to correct GPT errors.",
 		"expected to scan uncompressed text")
 }

--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -109,7 +109,7 @@ func GetPayloadStreamTestFailures(dbc *db.DB, release, stream, arch string, filt
 				lastPhaseCount++
 			}
 
-			if !(p.Phase == result.LastPhase) || i == len(lastPayloads)-1 {
+			if p.Phase != result.LastPhase || i == len(lastPayloads)-1 {
 				// We'll stop looking after this is set.
 				result.LastPhaseCount = lastPhaseCount
 			}

--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -295,10 +295,7 @@ func makeTestsResultsSpec(w http.ResponseWriter, req *http.Request, release stri
 	// combos. Uncollapsed results shows you the per-NURP+ result for each test (currently approx. 50,000 rows: filtering
 	// is advised)
 	collapseStr := req.URL.Query().Get("collapse")
-	collapse := true
-	if collapseStr == "false" {
-		collapse = false
-	}
+	collapse := collapseStr != "false"
 
 	overallStr := req.URL.Query().Get("overall")
 	includeOverall := !collapse

--- a/pkg/bigquery/bqlabel/labels.go
+++ b/pkg/bigquery/bqlabel/labels.go
@@ -119,7 +119,7 @@ func sanitizeLabelValue(value string) string {
 	// Replace invalid characters with underscores
 	runes := []rune(value)
 	for idx, r := range runes {
-		if !(unicode.IsLower(r) || unicode.IsDigit(r) || r == '_' || r == '-') {
+		if !unicode.IsLower(r) && !unicode.IsDigit(r) && r != '_' && r != '-' {
 			runes[idx] = '_'
 		}
 	}

--- a/pkg/bigquery/client.go
+++ b/pkg/bigquery/client.go
@@ -46,7 +46,7 @@ func New(ctx context.Context, opCtx bqlabel.OperationalContext, c cache.Cache, c
 
 // LoggedRead is a wrapper around the bigquery Read method that logs the query being executed
 func LoggedRead(ctx context.Context, q *bigquery.Query) (*bigquery.RowIterator, error) {
-	log.Debugf("Querying BQ with Parameters: %v\n%v", q.Parameters, q.QueryConfig.Q)
+	log.Debugf("Querying BQ with Parameters: %v\n%v", q.Parameters, q.Q)
 	return q.Read(ctx)
 }
 

--- a/pkg/dataloader/jiraloader/jiraloader.go
+++ b/pkg/dataloader/jiraloader/jiraloader.go
@@ -317,7 +317,7 @@ func queryJiraAPI(issueID, authorization string) (*v1jira.Issue, error) {
 		req.Header.Add("Authorization", authorization)
 	}
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // G704: URL is hardcoded to redhat.atlassian.net Jira API with issue key from Jira's own response
 	if err != nil {
 		return nil, err
 	}
@@ -380,7 +380,7 @@ func jiraRequest(apiURL, authorization string) ([]byte, error) {
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // G704: URL is hardcoded to redhat.atlassian.net Jira API, pagination token is url.QueryEscape'd
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dataloader/prowloader/gcs/gcs_authentication.go
+++ b/pkg/dataloader/prowloader/gcs/gcs_authentication.go
@@ -76,7 +76,7 @@ func getTokenFromWeb(config *oauth2.Config) *oauth2.Token {
 
 // Retrieves a token from a local file.
 func tokenFromFile(file string) (*oauth2.Token, error) {
-	f, err := os.Open(file)
+	f, err := os.Open(file) //nolint:gosec // G703: file is filepath.Join(homeDir, "gcp-token.json") — hardcoded filename, not user input
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func tokenFromFile(file string) (*oauth2.Token, error) {
 // Saves a token to a file path.
 func saveToken(path string, token *oauth2.Token) {
 	fmt.Printf("Saving credential file to: %s\n", path)
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec // G703: path is filepath.Join(homeDir, "gcp-token.json") — hardcoded filename, not user input
 	if err != nil {
 		log.Errorf("Unable to cache oauth token: %v", err)
 		return

--- a/pkg/dataloader/releaseloader/releasesync.go
+++ b/pkg/dataloader/releaseloader/releasesync.go
@@ -264,9 +264,10 @@ func releaseDetailsToDB(rs ReleaseStream, tag ReleaseTag, details ReleaseDetails
 		}
 	}
 
-	if release.Phase == "Accepted" {
+	switch release.Phase {
+	case "Accepted":
 		release.Forced = failedBlocking
-	} else if release.Phase == "Rejected" {
+	case "Rejected":
 		release.Forced = !failedBlocking
 	}
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -274,6 +274,6 @@ func ParseGormLogLevel(logLevel string) (gormlogger.LogLevel, error) {
 	case "silent":
 		return gormlogger.Silent, nil
 	default:
-		return gormlogger.Info, fmt.Errorf("Unknown gorm LogLevel: %s", logLevel)
+		return gormlogger.Info, fmt.Errorf("unknown gorm LogLevel: %s", logLevel)
 	}
 }

--- a/pkg/filter/filterable.go
+++ b/pkg/filter/filterable.go
@@ -446,9 +446,10 @@ func (filters Filter) ToSQL(db *gorm.DB, filterable Filterable) *gorm.DB {
 	orFilterParams := []interface{}{}
 
 	for _, f := range filters.Items {
-		if filters.LinkOperator == LinkOperatorAnd || filters.LinkOperator == "" {
+		switch filters.LinkOperator {
+		case LinkOperatorAnd, "":
 			db = f.andFilterToSQL(db, filterable)
-		} else if filters.LinkOperator == LinkOperatorOr {
+		case LinkOperatorOr:
 			q, p := f.orFilterToSQL(db, filterable)
 			orFilters = append(orFilters, q)
 			if p != nil {

--- a/pkg/flags/postgres.go
+++ b/pkg/flags/postgres.go
@@ -104,7 +104,7 @@ type PostgresFlags struct {
 func NewPostgresDatabaseFlags() *PostgresFlags {
 	dsn := os.Getenv("SIPPY_DATABASE_DSN")
 	if dsn == "" {
-		dsn = "postgresql://postgres:password@localhost:5432/postgres"
+		dsn = "postgresql://postgres:password@localhost:5432/postgres" //nolint:gosec // G101: dev default DSN, not a real credential
 	}
 
 	return &PostgresFlags{

--- a/pkg/sippyclient/client.go
+++ b/pkg/sippyclient/client.go
@@ -78,7 +78,7 @@ func (c *Client) Get(ctx context.Context, path string, result interface{}) error
 	}
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := c.HTTPClient.Do(req)
+	resp, err := c.HTTPClient.Do(req) //nolint:gosec // G704: BaseURL is set at init from --server-url flag (default localhost:8080), path is hardcoded API route
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
@@ -119,7 +119,7 @@ func (c *Client) Delete(ctx context.Context, path string) error {
 		req.Header.Set("Authorization", "Bearer "+c.Token)
 	}
 
-	resp, err := c.HTTPClient.Do(req)
+	resp, err := c.HTTPClient.Do(req) //nolint:gosec // G704: BaseURL is set at init from --server-url flag, not from HTTP request
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
@@ -157,7 +157,7 @@ func (c *Client) doJSONRequest(ctx context.Context, method, path string, body, r
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := c.HTTPClient.Do(req)
+	resp, err := c.HTTPClient.Do(req) //nolint:gosec // G704: BaseURL is set at init from --server-url flag, not from HTTP request
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}

--- a/pkg/sippyserver/chatproxy.go
+++ b/pkg/sippyserver/chatproxy.go
@@ -37,7 +37,7 @@ func NewChatProxy(chatAPIURL string) (*ChatProxy, error) {
 	}
 
 	// Create HTTP reverse proxy
-	httpProxy := httputil.NewSingleHostReverseProxy(targetURL)
+	httpProxy := httputil.NewSingleHostReverseProxy(targetURL) //nolint:gosec // G704: targetURL is from --chat-api CLI flag set at server startup
 
 	// Modify the director to handle the path rewriting
 	originalDirector := httpProxy.Director
@@ -72,7 +72,7 @@ func (cp *ChatProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Handle regular HTTP request
-	cp.httpProxy.ServeHTTP(w, r)
+	cp.httpProxy.ServeHTTP(w, r) //nolint:gosec // G704: proxy target is fixed at init from --chat-api CLI flag, request path is rewritten not proxied raw
 }
 
 // isWebSocketUpgrade checks if the request is a WebSocket upgrade request

--- a/pkg/sippyserver/parameters.go
+++ b/pkg/sippyserver/parameters.go
@@ -123,7 +123,8 @@ func splitJobAndJobRunFilters(fil *filter.Filter) (*filter.Filter, *filter.Filte
 		LinkOperator: fil.LinkOperator,
 	}
 	for _, f := range fil.Items {
-		if f.Field == "timestamp" {
+		switch f.Field {
+		case "timestamp":
 			ms, err := strconv.ParseInt(f.Value, 0, 64)
 			if err != nil {
 				return nil, nil, err
@@ -131,9 +132,9 @@ func splitJobAndJobRunFilters(fil *filter.Filter) (*filter.Filter, *filter.Filte
 
 			f.Value = time.Unix(0, ms*int64(time.Millisecond)).Format("2006-01-02T15:04:05-0700")
 			jobRunsFilter.Items = append(jobRunsFilter.Items, f)
-		} else if f.Field == "cluster" {
+		case "cluster":
 			jobRunsFilter.Items = append(jobRunsFilter.Items, f)
-		} else {
+		default:
 			jobFilter.Items = append(jobFilter.Items, f)
 		}
 	}

--- a/pkg/sippyserver/pr_commenting_processor.go
+++ b/pkg/sippyserver/pr_commenting_processor.go
@@ -528,7 +528,7 @@ func buildNewTestRisksComment(sb *strings.Builder, jobRisks []*JobNewTestRisks, 
 
 	if len(notableJobRisks) > 0 {
 		SortByJobNameNT(notableJobRisks)
-		sb.WriteString(fmt.Sprintf("New Test Risks for sha: %s\n\n", sha))
+		fmt.Fprintf(sb, "New Test Risks for sha: %s\n\n", sha)
 		sb.WriteString("| Job Name | New Test Risk |\n|:---|:---|\n")
 		rows := 0
 		for _, jr := range notableJobRisks {
@@ -537,25 +537,25 @@ func buildNewTestRisksComment(sb *strings.Builder, jobRisks []*JobNewTestRisks, 
 				if rows > commentRowLimit {
 					continue // limit comment size, just count rows
 				}
-				sb.WriteString(fmt.Sprintf("|%s|**%s** - *%q* **%s**|\n",
-					jr.JobName, risk.Level.Name, risk.TestName, risk.Reason))
+				fmt.Fprintf(sb, "|%s|**%s** - *%q* **%s**|\n",
+					jr.JobName, risk.Level.Name, risk.TestName, risk.Reason)
 			}
 		}
 		if rows > commentRowLimit {
-			sb.WriteString(fmt.Sprintf("| | *(...showing %d of %d rows)* |\n", commentRowLimit, rows))
+			fmt.Fprintf(sb, "| | *(...showing %d of %d rows)* |\n", commentRowLimit, rows)
 		}
 		sb.WriteString("\n")
 	}
 
 	if len(testSummaries) > 0 {
-		sb.WriteString(fmt.Sprintf("New tests seen in this PR at sha: %s\n\n", sha))
+		fmt.Fprintf(sb, "New tests seen in this PR at sha: %s\n\n", sha)
 		for idx, test := range testSummaries {
 			if idx >= commentRowLimit {
-				sb.WriteString(fmt.Sprintf("* *(...showing %d of %d tests)*", idx, len(testSummaries)))
+				fmt.Fprintf(sb, "* *(...showing %d of %d tests)*", idx, len(testSummaries))
 				break // limit comment size
 			}
-			sb.WriteString(fmt.Sprintf("- *%q* [Total: %d, Pass: %d, Fail: %d, Flake: %d]\n",
-				test.TestName, test.Runs, test.Runs-test.Failures, test.Failures, test.Flakes))
+			fmt.Fprintf(sb, "- *%q* [Total: %d, Pass: %d, Fail: %d, Flake: %d]\n",
+				test.TestName, test.Runs, test.Runs-test.Failures, test.Failures, test.Flakes)
 		}
 		sb.WriteString("\n")
 	}
@@ -563,7 +563,7 @@ func buildNewTestRisksComment(sb *strings.Builder, jobRisks []*JobNewTestRisks, 
 
 func buildRiskAnalysisComment(sb *strings.Builder, riskAnalyses []RiskAnalysisSummary, sha string) {
 	SortByJobNameRA(riskAnalyses)
-	sb.WriteString(fmt.Sprintf("Job Failure Risk Analysis for sha: %s\n\n", sha))
+	fmt.Fprintf(sb, "Job Failure Risk Analysis for sha: %s\n\n", sha)
 	sb.WriteString("| Job Name | Failure Risk |\n|:---|:---|\n")
 
 	// don't want the comment to be too large so if we have a high number of jobs to analyze
@@ -575,7 +575,7 @@ func buildRiskAnalysisComment(sb *strings.Builder, riskAnalyses []RiskAnalysisSu
 
 	for idx, analysis := range riskAnalyses {
 		if idx >= commentRowLimit {
-			sb.WriteString(fmt.Sprintf("\nShowing %d of %d jobs analysis", commentRowLimit, len(riskAnalyses)))
+			fmt.Fprintf(sb, "\nShowing %d of %d jobs analysis", commentRowLimit, len(riskAnalyses))
 			break // top 20 should be more than enough
 		}
 
@@ -585,34 +585,34 @@ func buildRiskAnalysisComment(sb *strings.Builder, riskAnalyses []RiskAnalysisSu
 		}
 
 		var riskSb strings.Builder
-		riskSb.WriteString(fmt.Sprintf("**%s**", analysis.RiskLevel.Name))
+		fmt.Fprintf(&riskSb, "**%s**", analysis.RiskLevel.Name)
 
 		// if we don't have any TestRiskAnalysis use the OverallReasons
 		if len(analysis.TestRiskAnalysis) == 0 {
 			for j, r := range analysis.OverallReasons {
 				if j > maxSubRows {
-					riskSb.WriteString(fmt.Sprintf("<br>Showing %d of %d test risk reasons", j, len(analysis.OverallReasons)))
+					fmt.Fprintf(&riskSb, "<br>Showing %d of %d test risk reasons", j, len(analysis.OverallReasons))
 					break
 				}
-				riskSb.WriteString(fmt.Sprintf("<br>%s", r))
+				fmt.Fprintf(&riskSb, "<br>%s", r)
 			}
 		} else {
 
 			for i, t := range analysis.TestRiskAnalysis {
 				if i > maxSubRows {
-					riskSb.WriteString(fmt.Sprintf("<br>---<br>Showing %d of %d test results", i, len(analysis.TestRiskAnalysis)))
+					fmt.Fprintf(&riskSb, "<br>---<br>Showing %d of %d test results", i, len(analysis.TestRiskAnalysis))
 					break
 				}
 				if i > 0 {
 					riskSb.WriteString("<br>---")
 				}
-				riskSb.WriteString(fmt.Sprintf("<br>*%s*", t.Name))
+				fmt.Fprintf(&riskSb, "<br>*%s*", t.Name)
 				for j, r := range t.Risk.Reasons {
 					if j > maxSubRows {
-						riskSb.WriteString(fmt.Sprintf("<br>Showing %d of %d test risk reasons", j, len(t.Risk.Reasons)))
+						fmt.Fprintf(&riskSb, "<br>Showing %d of %d test risk reasons", j, len(t.Risk.Reasons))
 						break
 					}
-					riskSb.WriteString(fmt.Sprintf("<br>%s", r))
+					fmt.Fprintf(&riskSb, "<br>%s", r)
 				}
 
 				// Do we have open bugs?  Stack them vertically to preserve real estate
@@ -627,11 +627,11 @@ func buildRiskAnalysisComment(sb *strings.Builder, riskAnalyses []RiskAnalysisSu
 						riskSb.WriteString("Open Bugs")
 					}
 					// prevent the openshift-ci bot from detecting JIRA references in the link by replacing - with html escaped sequence
-					riskSb.WriteString(fmt.Sprintf("<br>[%s](%s)", strings.ReplaceAll(html.EscapeString(b.Summary), "-", "&#45;"), b.URL))
+					fmt.Fprintf(&riskSb, "<br>[%s](%s)", strings.ReplaceAll(html.EscapeString(b.Summary), "-", "&#45;"), b.URL)
 				}
 			}
 		}
-		sb.WriteString(fmt.Sprintf("|%s|%s|\n", tableKey, riskSb.String()))
+		fmt.Fprintf(sb, "|%s|%s|\n", tableKey, riskSb.String())
 	}
 }
 

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -2254,7 +2254,7 @@ func (s *Server) Serve() {
 				if !os.IsNotExist(err) {
 					w.WriteHeader(http.StatusNotFound)
 					w.Header().Set("Content-Type", "text/plain")
-					if _, err := w.Write([]byte(fmt.Sprintf("404 Not Found: %s", fullPath))); err != nil {
+					if _, err := fmt.Fprintf(w, "404 Not Found: %s", fullPath); err != nil { //nolint:gosec // G705: Content-Type is text/plain (set on line above), browsers will not execute script in plain text
 						log.WithError(err).Warningf("could not write response")
 					}
 					return

--- a/test/e2e/componentreadiness/componentreadiness_test.go
+++ b/test/e2e/componentreadiness/componentreadiness_test.go
@@ -128,7 +128,7 @@ func TestRegressionCacheLoader(t *testing.T) {
 			t.Skip("no regressed tests in report, nothing to verify")
 		}
 
-		release := sippyViews.ComponentReadiness[0].SampleRelease.Release.Name
+		release := sippyViews.ComponentReadiness[0].SampleRelease.Name
 
 		for _, regTest := range regressedTests {
 			// Look up the regression in the database by test_id and release

--- a/test/e2e/componentreadiness/triage/triageapi_test.go
+++ b/test/e2e/componentreadiness/triage/triageapi_test.go
@@ -179,7 +179,7 @@ func Test_TriageAPI(t *testing.T) {
 
 		// Verify the expanded triage contains the regressed tests with correct status values
 		require.NotNil(t, expandedTriage.Triage, "ExpandedTriage should contain a Triage")
-		assert.Equal(t, triageResponse.ID, expandedTriage.Triage.ID, "ExpandedTriage should have the same ID as the created triage")
+		assert.Equal(t, triageResponse.ID, expandedTriage.ID, "ExpandedTriage should have the same ID as the created triage")
 		expectedViewKey := view.Name
 		require.Contains(t, expandedTriage.RegressedTests, expectedViewKey, "ExpandedTriage should contain regressed tests for view %q", expectedViewKey)
 		regressedTestsForView := expandedTriage.RegressedTests[expectedViewKey]
@@ -189,7 +189,7 @@ func Test_TriageAPI(t *testing.T) {
 		statusMap := make(map[uint]crtest.Status)
 		for _, regressedTest := range regressedTestsForView {
 			if regressedTest != nil && regressedTest.Regression != nil {
-				statusMap[regressedTest.Regression.ID] = regressedTest.TestComparison.ReportStatus
+				statusMap[regressedTest.Regression.ID] = regressedTest.ReportStatus
 			}
 		}
 
@@ -682,7 +682,7 @@ func Test_RegressionAPI(t *testing.T) {
 	jiraBug := createBug(t, dbc.DB)
 	defer dbc.DB.Delete(jiraBug)
 
-	release := view.SampleRelease.Release.Name
+	release := view.SampleRelease.Name
 
 	t.Run("list regressions", func(t *testing.T) {
 		defer cleanupAllTriages(dbc)
@@ -1239,7 +1239,7 @@ func Test_TriagePotentialMatchingRegressions(t *testing.T) {
 			regressionID := match.RegressedTest.Regression.ID
 			foundRegressionIDs[regressionID] = true
 			confidenceLevels[regressionID] = match.ConfidenceLevel
-			statusMap[regressionID] = match.RegressedTest.TestComparison.ReportStatus
+			statusMap[regressionID] = match.RegressedTest.ReportStatus
 			if len(match.SimilarlyNamedTests) > 0 {
 				matchesBySimilarName[regressionID] = match.SimilarlyNamedTests
 			}

--- a/test/e2e/util/e2erequest.go
+++ b/test/e2e/util/e2erequest.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -39,10 +40,12 @@ func BuildE2EURL(apiPath string) string {
 }
 
 func SippyGet(path string, data interface{}) error {
-	req, err := http.Get(BuildE2EURL(path))
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := client.Get(BuildE2EURL(path)) //nolint:gosec // G704: URL is constructed from test helper's hardcoded localhost base URL
 	if err != nil {
 		return err
 	}
+	defer req.Body.Close()
 
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
@@ -76,7 +79,7 @@ func sippyMutatingRequest(method, path string, bodyData, responseData interface{
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Forwarded-User", "developer")
-	client := &http.Client{}
+	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req) //nolint:gosec // G704: URL is constructed from test helper's hardcoded localhost base URL
 	if err != nil {
 		return err

--- a/test/e2e/util/e2erequest.go
+++ b/test/e2e/util/e2erequest.go
@@ -49,7 +49,7 @@ func SippyGet(path string, data interface{}) error {
 		return err
 	}
 	if req.StatusCode != http.StatusOK {
-		return fmt.Errorf("Sippy API request failed with code %d: %s", req.StatusCode, string(body))
+		return fmt.Errorf("sippy API request failed with code %d: %s", req.StatusCode, string(body))
 	}
 	err = json.Unmarshal(body, data)
 	if err != nil {
@@ -77,7 +77,7 @@ func sippyMutatingRequest(method, path string, bodyData, responseData interface{
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Forwarded-User", "developer")
 	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // G704: URL is constructed from test helper's hardcoded localhost base URL
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func sippyMutatingRequest(method, path string, bodyData, responseData interface{
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Sippy API request failed with code %d: %s", resp.StatusCode, string(body))
+		return fmt.Errorf("sippy API request failed with code %d: %s", resp.StatusCode, string(body))
 	}
 
 	if responseData != nil {


### PR DESCRIPTION
Migrate .golangci.yml from v1 to v2 format:
- Add version: "2", rename deadline→timeout, move skip-dirs to exclusions
- Move gofmt/goimports to formatters section, remove gosimple (merged into staticcheck) and typecheck (now built-in)
- Add exclusion presets to restore v1's implicit default exclusions
- Exclude revive var-naming package name complaints for existing packages

Update golangci-lint from v1.64.8 to v2.10.1 in Dockerfile.buildroot, devcontainer, and hack/go-lint.sh. Change --fast to --fast-only in devcontainer.json.

Fix all new lint findings: simplify embedded field selectors (QF1008), apply De Morgan's law (QF1001), convert if/else to switch (QF1003), use fmt.Fprintf (QF1012), lowercase error strings (ST1005), merge conditional assignments (QF1007). Add targeted //nolint:gosec for taint analysis false positives (G703/G704/G705) with per-line justifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to 1.25.
  * Upgraded golangci-lint to 2.10.1 across build and devcontainer setups.
  * Adjusted VS Code devcontainer lint flags and linter configuration structure.

* **Bug Fixes**
  * Fixed status aggregation and several field-reference issues affecting readiness, artifact matching, and test-result counts.
  * Improved error reporting for HTTP request helpers.

* **Refactor**
  * General code cleanups: logging, formatting, lint annotations, and minor control-flow simplifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->