### PR TITLE
Add the symptoms overview to test details report

### DIFF
--- a/sippy-ng/src/component_readiness/TestDetailsReport.js
+++ b/sippy-ng/src/component_readiness/TestDetailsReport.js
@@ -231,7 +231,10 @@ export default function TestDetailsReport(props) {
       setSymptomSummaries([])
       return
     }
-    fetch(process.env.REACT_APP_API_URL + '/api/jobs/symptoms')
+    const controller = new AbortController()
+    fetch(process.env.REACT_APP_API_URL + '/api/jobs/symptoms', {
+      signal: controller.signal,
+    })
       .then((r) => r.json())
       .then((allSymptoms) => {
         const lookup = {}
@@ -248,7 +251,12 @@ export default function TestDetailsReport(props) {
           .sort((a, b) => b.job_run_count - a.job_run_count)
         setSymptomSummaries(summaries)
       })
-      .catch(() => setSymptomSummaries([]))
+      .catch((err) => {
+        if (err.name !== 'AbortError') {
+          setSymptomSummaries([])
+        }
+      })
+    return () => controller.abort()
   }, [data])
 
   useEffect(() => {

--- a/sippy-ng/src/component_readiness/TestDetailsReport.js
+++ b/sippy-ng/src/component_readiness/TestDetailsReport.js
@@ -48,6 +48,7 @@ import TableBody from '@mui/material/TableBody'
 import TableCell from '@mui/material/TableCell'
 import TableRow from '@mui/material/TableRow'
 import TriagedTestsPanel from './TriagedTestsPanel'
+import TriageSymptoms from './TriageSymptoms'
 import UpsertTriageModal from './UpsertTriageModal'
 
 // Big query requests take a while so give the user the option to
@@ -112,6 +113,7 @@ export default function TestDetailsReport(props) {
   const [regressionId, setRegressionId] = React.useState(0)
   const [versions, setVersions] = React.useState({})
   const [triageEntries, setTriageEntries] = React.useState([])
+  const [symptomSummaries, setSymptomSummaries] = React.useState([])
   const releases = useContext(ReleasesContext)
   const hasSetContextRef = React.useRef(false)
 
@@ -208,6 +210,46 @@ export default function TestDetailsReport(props) {
         setIsLoaded(true)
       })
   }, [hasBeenTriaged, urlParams, testId])
+
+  useEffect(() => {
+    if (!data.analyses || !data.analyses[0]?.job_stats) {
+      setSymptomSummaries([])
+      return
+    }
+    const counts = {}
+    let totalRuns = 0
+    for (const js of data.analyses[0].job_stats) {
+      for (const run of js.sample_job_run_stats || []) {
+        totalRuns++
+        for (const sid of run.job_symptoms || []) {
+          counts[sid] = (counts[sid] || 0) + 1
+        }
+      }
+    }
+    const symptomIds = Object.keys(counts)
+    if (symptomIds.length === 0) {
+      setSymptomSummaries([])
+      return
+    }
+    fetch(process.env.REACT_APP_API_URL + '/api/jobs/symptoms')
+      .then((r) => r.json())
+      .then((allSymptoms) => {
+        const lookup = {}
+        for (const s of allSymptoms) {
+          lookup[s.id] = s.summary
+        }
+        const total = totalRuns || 1
+        const summaries = symptomIds
+          .map((id) => ({
+            symptom: { id, summary: lookup[id] || id },
+            job_run_count: counts[id],
+            percentage: (counts[id] / total) * 100,
+          }))
+          .sort((a, b) => b.job_run_count - a.job_run_count)
+        setSymptomSummaries(summaries)
+      })
+      .catch(() => setSymptomSummaries([]))
+  }, [data])
 
   useEffect(() => {
     let tmpRelease = {}
@@ -601,6 +643,7 @@ View the [test details report|${document.location.href}] for additional context.
           </TableRow>
         </TableBody>
       </Table>
+      <TriageSymptoms symptomSummaries={symptomSummaries} />
       {isBaseOverride ? (
         <Fragment>
           <Tabs

--- a/sippy-ng/src/component_readiness/TriageSymptoms.js
+++ b/sippy-ng/src/component_readiness/TriageSymptoms.js
@@ -21,6 +21,10 @@ export default function TriageSymptoms({
   symptomFilter,
   setSymptomFilter,
 }) {
+  const showRegressions =
+    symptomSummaries?.length > 0 &&
+    symptomSummaries[0].regression_count !== undefined
+
   return (
     <>
       <Tooltip
@@ -45,18 +49,32 @@ export default function TriageSymptoms({
                   <span>Symptom</span>
                 </Tooltip>
               </TableCell>
-              <TableCell>
-                <Tooltip title="Number of regressions in this triage where the symptom was detected">
-                  <span>Regressions</span>
-                </Tooltip>
-              </TableCell>
+              {showRegressions && (
+                <TableCell>
+                  <Tooltip title="Number of regressions in this triage where the symptom was detected">
+                    <span>Regressions</span>
+                  </Tooltip>
+                </TableCell>
+              )}
               <TableCell sx={{ minWidth: 120 }}>
-                <Tooltip title="Percentage of regressions in this triage exhibiting the symptom">
+                <Tooltip
+                  title={
+                    showRegressions
+                      ? 'Percentage of regressions in this triage exhibiting the symptom'
+                      : 'Percentage of sample job runs where the symptom was detected'
+                  }
+                >
                   <span>Percentage</span>
                 </Tooltip>
               </TableCell>
               <TableCell>
-                <Tooltip title="Total number of failed job runs across all regressions where the symptom was detected">
+                <Tooltip
+                  title={
+                    showRegressions
+                      ? 'Total number of failed job runs across all regressions where the symptom was detected'
+                      : 'Number of failed job runs where the symptom was detected'
+                  }
+                >
                   <span>Failed Runs</span>
                 </Tooltip>
               </TableCell>
@@ -76,34 +94,36 @@ export default function TriageSymptoms({
                     }}
                   />
                 </TableCell>
-                <TableCell>
-                  <Box display="flex" alignItems="center" gap={1}>
-                    {ss.regression_count}
-                    <Tooltip title="Filter regressions to this symptom">
-                      <IconButton
-                        size="small"
-                        aria-label={`Filter regressions to ${
-                          ss.symptom.summary || ss.symptom.id
-                        }`}
-                        aria-pressed={symptomFilter === ss.symptom.id}
-                        onClick={() =>
-                          setSymptomFilter(
+                {showRegressions && (
+                  <TableCell>
+                    <Box display="flex" alignItems="center" gap={1}>
+                      {ss.regression_count}
+                      <Tooltip title="Filter regressions to this symptom">
+                        <IconButton
+                          size="small"
+                          aria-label={`Filter regressions to ${
+                            ss.symptom.summary || ss.symptom.id
+                          }`}
+                          aria-pressed={symptomFilter === ss.symptom.id}
+                          onClick={() =>
+                            setSymptomFilter(
+                              symptomFilter === ss.symptom.id
+                                ? null
+                                : ss.symptom.id
+                            )
+                          }
+                          color={
                             symptomFilter === ss.symptom.id
-                              ? null
-                              : ss.symptom.id
-                          )
-                        }
-                        color={
-                          symptomFilter === ss.symptom.id
-                            ? 'primary'
-                            : 'default'
-                        }
-                      >
-                        <FilterList fontSize="small" />
-                      </IconButton>
-                    </Tooltip>
-                  </Box>
-                </TableCell>
+                              ? 'primary'
+                              : 'default'
+                          }
+                        >
+                          <FilterList fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    </Box>
+                  </TableCell>
+                )}
                 <TableCell>
                   <Box display="flex" alignItems="center" gap={1}>
                     <LinearProgress
@@ -129,5 +149,5 @@ export default function TriageSymptoms({
 TriageSymptoms.propTypes = {
   symptomSummaries: PropTypes.array,
   symptomFilter: PropTypes.string,
-  setSymptomFilter: PropTypes.func.isRequired,
+  setSymptomFilter: PropTypes.func,
 }


### PR DESCRIPTION
Previously just on the triage page, but also super useful on test
details reports as well. Drops the regressions column and instead just
gives the percentage of failed runs showing the symptom within this test
details report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test detail reports now show symptom summaries sorted by prevalence across runs.
  * Regression info appears as an additional table column only when regression data is present.
  * Symptom rows include a contextual filter control and tooltips that adapt to available data.
* **Bug Fixes**
  * Symptom summaries are cleared when job stats are missing or metadata fetch fails for more reliable displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->