### PR TITLE
OCPBUGS-85294: Moved vsphere hybrid env jobs to candidate tier

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -767,6 +767,9 @@ func (v *OCPVariantLoader) setJobTier(_ logrus.FieldLogger, variants map[string]
 		// not ready to make release blocking yet.
 		{[]string{"-vsphere-host-groups"}, "candidate"},
 
+		// vSphere hybrid-env jobs are not yet stable enough for component readiness
+		{[]string{"-hybrid-env"}, "candidate"},
+
 		// All 4.19/4.20 MCO jobs default to candidate
 		{[]string{"machine-config-operator-release-4.19"}, "candidate"},
 		{[]string{"machine-config-operator-release-4.20"}, "candidate"},


### PR DESCRIPTION
OCPBUGS-85294

### Changes
- Moved vsphere hybrid env jobs to candidate job tier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added job tier classification for vSphere hybrid-environment configurations to categorize jobs as candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->