### PR TITLE
Show symptom percentages of failures, not total runs

### DIFF
--- a/sippy-ng/src/component_readiness/TestDetailsReport.js
+++ b/sippy-ng/src/component_readiness/TestDetailsReport.js
@@ -217,12 +217,14 @@ export default function TestDetailsReport(props) {
       return
     }
     const counts = {}
-    let totalRuns = 0
+    let totalFailedRuns = 0
     for (const js of data.analyses[0].job_stats) {
       for (const run of js.sample_job_run_stats || []) {
-        totalRuns++
-        for (const sid of run.job_symptoms || []) {
-          counts[sid] = (counts[sid] || 0) + 1
+        if (run.test_stats?.failure_count > 0) {
+          totalFailedRuns++
+          for (const sid of run.job_symptoms || []) {
+            counts[sid] = (counts[sid] || 0) + 1
+          }
         }
       }
     }
@@ -241,7 +243,7 @@ export default function TestDetailsReport(props) {
         for (const s of allSymptoms) {
           lookup[s.id] = s.summary
         }
-        const total = totalRuns || 1
+        const total = totalFailedRuns || 1
         const summaries = symptomIds
           .map((id) => ({
             symptom: { id, summary: lookup[id] || id },

--- a/sippy-ng/src/component_readiness/TriageSymptoms.js
+++ b/sippy-ng/src/component_readiness/TriageSymptoms.js
@@ -61,7 +61,7 @@ export default function TriageSymptoms({
                   title={
                     showRegressions
                       ? 'Percentage of regressions in this triage exhibiting the symptom'
-                      : 'Percentage of sample job runs where the symptom was detected'
+                      : 'Percentage of failed job runs where the symptom was detected'
                   }
                 >
                   <span>Percentage</span>


### PR DESCRIPTION
I'm less interested in how many green runs showed a symptom, I want to know how many red one did.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected symptom detection percentage calculation to be based on failed job runs instead of all runs.
  * Updated percentage tooltip text for clarity regarding the metric's calculation basis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->