### PR TITLE
TRT-1989: add benchmarking db query tests

### DIFF
--- a/pkg/api/jobs.go
+++ b/pkg/api/jobs.go
@@ -252,27 +252,33 @@ func (jobs jobDetailAPIResult) limit(req *http.Request) jobDetailAPIResult {
 	return ret
 }
 
-// PrintJobDetailsReportFromDB renders the detailed list of runs for matching jobs.
-func PrintJobDetailsReportFromDB(w http.ResponseWriter, req *http.Request, dbc *db.DB, release, jobSearchStr string, reportEnd time.Time) error {
-	var start, end int
-
-	// List all ProwJobRuns for the given release in the last two weeks.
-	// TODO: 14 days matches orig API behavior, may want to add query params in future to control.
+// JobDetailsReport runs the job details query without HTTP response handling.
+func JobDetailsReport(dbc *db.DB, release, jobSearchStr string, reportEnd time.Time) ([]*models.ProwJobRun, error) {
 	since := reportEnd.Add(-14 * 24 * time.Hour)
-
 	prowJobRuns := make([]*models.ProwJobRun, 0)
 	res := dbc.DB.Joins("ProwJob").
 		Where("name LIKE ?", "%"+jobSearchStr+"%").
 		Where("timestamp > ?", since).
 		Where("release = ?", release).
-		Preload("Tests", "status = ?", 12). // Only pre-load test results with failure status.
+		Preload("Tests", "status = ?", 12).
 		Preload("Tests.Test").
 		Find(&prowJobRuns)
 	if res.Error != nil {
-		log.Errorf("error querying %s ProwJobRuns from db: %v", jobSearchStr, res.Error)
-		return res.Error
+		return nil, res.Error
 	}
 	log.WithFields(log.Fields{"prowJobRuns": len(prowJobRuns), "since": since}).Info("loaded ProwJobRuns from db")
+	return prowJobRuns, nil
+}
+
+// PrintJobDetailsReportFromDB renders the detailed list of runs for matching jobs.
+func PrintJobDetailsReportFromDB(w http.ResponseWriter, req *http.Request, dbc *db.DB, release, jobSearchStr string, reportEnd time.Time) error {
+	var start, end int
+
+	prowJobRuns, err := JobDetailsReport(dbc, release, jobSearchStr, reportEnd)
+	if err != nil {
+		log.Errorf("error querying %s ProwJobRuns from db: %v", jobSearchStr, err)
+		return err
+	}
 
 	jobDetails := map[string]*jobDetail{}
 	for _, pjr := range prowJobRuns {

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -9,20 +9,22 @@ import (
 	"github.com/openshift/sippy/pkg/api"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/query"
+	"github.com/openshift/sippy/pkg/filter"
 	log "github.com/sirupsen/logrus"
 )
 
 const benchmarkRelease = "4.22"
 const benchmarkTestName = "[Monitor:legacy-test-framework-invariants-pathological][sig-arch] events should not repeat pathologically for ns/kube-system"
+const benchmarkJobName = "periodic-ci-openshift-release-main-ci-4.22-e2e-aws-ovn"
 
 type benchmarkCase struct {
 	name string
 	fn   func(dbc *db.DB) error
 }
 
-func getBenchmarkCases() []benchmarkCase {
-	return []benchmarkCase{
-		{
+func getIndividualBenchmarkCases() map[string]benchmarkCase {
+	return map[string]benchmarkCase{
+		"FindTestsByRelease": {
 			name: "FindTestsByRelease",
 			fn: func(dbc *db.DB) error {
 				type testResult struct {
@@ -51,6 +53,11 @@ func getBenchmarkCases() []benchmarkCase {
 				return nil
 			},
 		},
+	}
+}
+
+func getBenchmarkCases() []benchmarkCase {
+	return []benchmarkCase{
 		{
 			name: "TestDurations",
 			fn: func(dbc *db.DB) error {
@@ -81,14 +88,80 @@ func getBenchmarkCases() []benchmarkCase {
 			name: "JobDetails",
 			fn: func(dbc *db.DB) error {
 				jobRuns, err := api.JobDetailsReport(dbc, benchmarkRelease,
-					"periodic-ci-openshift-release-master-ci-4.22-e2e-aws-ovn",
-					time.Now())
+					benchmarkJobName, time.Now())
 
 				if err == nil {
 					log.Printf("Found %d job runs", len(jobRuns))
 				}
 
 				return err
+			},
+		},
+		{
+			name: "TestAnalysisOverall",
+			fn: func(dbc *db.DB) error {
+				results, err := api.GetTestAnalysisOverallFromDB(dbc, nil,
+					benchmarkRelease, benchmarkTestName, time.Now())
+
+				if err == nil {
+					for group, rows := range results {
+						log.Printf("TestAnalysisOverall group %s: %d rows", group, len(rows))
+					}
+				}
+
+				return err
+			},
+		},
+		{
+			name: "TestAnalysisByJob",
+			fn: func(dbc *db.DB) error {
+				results, err := api.GetTestAnalysisByJobFromDB(dbc, nil,
+					benchmarkRelease, benchmarkTestName, time.Now())
+
+				if err == nil {
+					log.Printf("TestAnalysisByJob: %d groups", len(results))
+				}
+
+				return err
+			},
+		},
+		{
+			name: "TestAnalysisByJobWithVariantFilter",
+			fn: func(dbc *db.DB) error {
+				f := &filter.Filter{
+					Items: []filter.FilterItem{
+						{Field: "variants", Value: "aws", Not: false},
+					},
+				}
+				results, err := api.GetTestAnalysisByJobFromDB(dbc, f,
+					benchmarkRelease, benchmarkTestName, time.Now())
+
+				if err == nil {
+					log.Printf("TestAnalysisByJobWithVariantFilter: %d groups", len(results))
+				}
+
+				return err
+			},
+		},
+		{
+			name: "TestAnalysisPassRate",
+			fn: func(dbc *db.DB) error {
+				type passRate struct {
+					CurrentSuccesses   int
+					CurrentRuns        int
+					CurrentPassPercent float64
+				}
+				var result passRate
+				res := dbc.DB.Raw(query.QueryTestAnalysis,
+					time.Now().Add(-24*14*time.Hour),
+					benchmarkTestName,
+					[]string{benchmarkJobName}).Scan(&result)
+				if res.Error != nil {
+					return res.Error
+				}
+				log.Printf("TestAnalysisPassRate: %d/%d runs (%.1f%%)",
+					result.CurrentSuccesses, result.CurrentRuns, result.CurrentPassPercent)
+				return nil
 			},
 		},
 	}
@@ -115,7 +188,7 @@ func getBenchmarkDBClient(t *testing.T) *db.DB {
 
 func Test_BenchmarkIndividual(t *testing.T) {
 	dbc := getBenchmarkDBClient(t)
-	iterations := 1
+	iterations := 3
 	cases := getBenchmarkCases()
 
 	for _, bc := range cases {
@@ -136,6 +209,27 @@ func Test_BenchmarkIndividual(t *testing.T) {
 				bc.name, totalDuration, avg, iterations)
 		})
 	}
+}
+
+func Test_BenchmarkFindTestsByRelease(t *testing.T) {
+	dbc := getBenchmarkDBClient(t)
+	iterations := 1
+	bc := getIndividualBenchmarkCases()["FindTestsByRelease"]
+
+	var totalDuration time.Duration
+	for i := 0; i < iterations; i++ {
+		start := time.Now()
+		err := bc.fn(dbc)
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("iteration %d failed: %v", i+1, err)
+		}
+		totalDuration += elapsed
+		fmt.Printf("  %s iteration %d: %s\n", bc.name, i+1, elapsed)
+	}
+	avg := totalDuration / time.Duration(iterations)
+	fmt.Printf("  %s total: %s, avg: %s (%d iterations)\n",
+		bc.name, totalDuration, avg, iterations)
 }
 
 func Test_BenchmarkGroup(t *testing.T) {

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -117,7 +117,7 @@ func getIndividualBenchmarkCases() map[string]benchmarkCase {
 	}
 }
 
-func getBenchmarkCases() []benchmarkCase {
+func getBenchmarkCases(asOf time.Time) []benchmarkCase {
 	return []benchmarkCase{
 		{
 			name: "TestDurations",
@@ -149,7 +149,7 @@ func getBenchmarkCases() []benchmarkCase {
 			name: "JobDetails",
 			fn: func(dbc *db.DB) error {
 				jobRuns, err := api.JobDetailsReport(dbc, benchmarkRelease,
-					benchmarkJobName, time.Now())
+					benchmarkJobName, asOf)
 
 				if err == nil {
 					log.Printf("Found %d job runs", len(jobRuns))
@@ -162,7 +162,7 @@ func getBenchmarkCases() []benchmarkCase {
 			name: "TestAnalysisOverall",
 			fn: func(dbc *db.DB) error {
 				results, err := api.GetTestAnalysisOverallFromDB(dbc, nil,
-					benchmarkRelease, benchmarkTestName, time.Now())
+					benchmarkRelease, benchmarkTestName, asOf)
 
 				if err == nil {
 					for group, rows := range results {
@@ -177,7 +177,7 @@ func getBenchmarkCases() []benchmarkCase {
 			name: "TestAnalysisByJob",
 			fn: func(dbc *db.DB) error {
 				results, err := api.GetTestAnalysisByJobFromDB(dbc, nil,
-					benchmarkRelease, benchmarkTestName, time.Now())
+					benchmarkRelease, benchmarkTestName, asOf)
 
 				if err == nil {
 					log.Printf("TestAnalysisByJob: %d groups", len(results))
@@ -195,7 +195,7 @@ func getBenchmarkCases() []benchmarkCase {
 					},
 				}
 				results, err := api.GetTestAnalysisByJobFromDB(dbc, f,
-					benchmarkRelease, benchmarkTestName, time.Now())
+					benchmarkRelease, benchmarkTestName, asOf)
 
 				if err == nil {
 					log.Printf("TestAnalysisByJobWithVariantFilter: %d groups", len(results))
@@ -314,13 +314,23 @@ func getBenchmarkDBClient(t *testing.T) *db.DB {
 	if err != nil {
 		t.Fatalf("couldn't get DB client: %v", err)
 	}
+	sqlDB, err := dbc.DB.DB()
+	if err != nil {
+		t.Fatalf("couldn't get sql.DB handle: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Logf("failed to close DB client: %v", err)
+		}
+	})
 	return dbc
 }
 
 func Test_BenchmarkIndividual(t *testing.T) {
 	dbc := getBenchmarkDBClient(t)
+	asOf := time.Now().UTC()
 	iterations := 3
-	cases := getBenchmarkCases()
+	cases := getBenchmarkCases(asOf)
 
 	var results []benchmarkResult
 	for _, bc := range cases {
@@ -335,7 +345,10 @@ func Test_BenchmarkIndividual(t *testing.T) {
 func Test_BenchmarkFindTestsByRelease(t *testing.T) {
 	dbc := getBenchmarkDBClient(t)
 	iterations := 1
-	bc := getIndividualBenchmarkCases()["FindTestsByRelease"]
+	bc, ok := getIndividualBenchmarkCases()["FindTestsByRelease"]
+	if !ok {
+		t.Fatal("benchmark case \"FindTestsByRelease\" not found")
+	}
 
 	r := runBenchmarkCase(t, dbc, bc, iterations)
 	printSummaryTable([]benchmarkResult{r})
@@ -343,10 +356,11 @@ func Test_BenchmarkFindTestsByRelease(t *testing.T) {
 
 func Test_BenchmarkCombined(t *testing.T) {
 	dbc := getBenchmarkDBClient(t)
+	asOf := time.Now().UTC()
 	iterations := 3
 
 	var results []benchmarkResult
-	for _, bc := range getBenchmarkCases() {
+	for _, bc := range getBenchmarkCases(asOf) {
 		t.Run(bc.name, func(t *testing.T) {
 			r := runBenchmarkCase(t, dbc, bc, iterations)
 			results = append(results, r)
@@ -363,8 +377,9 @@ func Test_BenchmarkCombined(t *testing.T) {
 
 func Test_BenchmarkGroup(t *testing.T) {
 	dbc := getBenchmarkDBClient(t)
+	asOf := time.Now().UTC()
 	iterations := 1
-	cases := getBenchmarkCases()
+	cases := getBenchmarkCases(asOf)
 
 	group := benchmarkResult{name: "group"}
 	for i := 0; i < iterations; i++ {

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -324,7 +324,6 @@ func Test_BenchmarkIndividual(t *testing.T) {
 
 	var results []benchmarkResult
 	for _, bc := range cases {
-		bc := bc
 		t.Run(bc.name, func(t *testing.T) {
 			r := runBenchmarkCase(t, dbc, bc, iterations)
 			results = append(results, r)
@@ -348,14 +347,12 @@ func Test_BenchmarkCombined(t *testing.T) {
 
 	var results []benchmarkResult
 	for _, bc := range getBenchmarkCases() {
-		bc := bc
 		t.Run(bc.name, func(t *testing.T) {
 			r := runBenchmarkCase(t, dbc, bc, iterations)
 			results = append(results, r)
 		})
 	}
 	for name, bc := range getIndividualBenchmarkCases() {
-		bc := bc
 		t.Run(name, func(t *testing.T) {
 			r := runBenchmarkCase(t, dbc, bc, iterations)
 			results = append(results, r)

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -1,0 +1,162 @@
+package flags
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/openshift/sippy/pkg/api"
+	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/query"
+	log "github.com/sirupsen/logrus"
+)
+
+const benchmarkRelease = "4.22"
+const benchmarkTestName = "[Monitor:legacy-test-framework-invariants-pathological][sig-arch] events should not repeat pathologically for ns/kube-system"
+
+type benchmarkCase struct {
+	name string
+	fn   func(dbc *db.DB) error
+}
+
+func getBenchmarkCases() []benchmarkCase {
+	return []benchmarkCase{
+		{
+			name: "FindTestsByRelease",
+			fn: func(dbc *db.DB) error {
+				type testResult struct {
+					ID   uint
+					Name string
+				}
+				var results []testResult
+				res := dbc.DB.Raw(`
+					SELECT DISTINCT t.id, t.name
+					FROM tests t
+					JOIN prow_job_run_tests pjrt ON pjrt.test_id = t.id
+					JOIN prow_job_runs pjr ON pjr.id = pjrt.prow_job_run_id
+					JOIN prow_jobs pj ON pj.id = pjr.prow_job_id
+					WHERE pj.release = ?
+					  AND t.name LIKE ?
+					  AND pjrt.created_at > NOW() - INTERVAL '14 days'
+					ORDER BY t.name
+					LIMIT 20`, benchmarkRelease, "%events should not repeat%").Scan(&results)
+				if res.Error != nil {
+					return res.Error
+				}
+				log.Printf("Found %d tests matching pattern for release %s", len(results), benchmarkRelease)
+				for _, r := range results {
+					log.Printf("  [%d] %s", r.ID, r.Name)
+				}
+				return nil
+			},
+		},
+		{
+			name: "TestDurations",
+			fn: func(dbc *db.DB) error {
+				durations, err := query.TestDurations(dbc, benchmarkRelease,
+					benchmarkTestName, nil, nil)
+
+				if err == nil {
+					log.Printf("Found %d test durations", len(durations))
+				}
+
+				return err
+			},
+		},
+		{
+			name: "TestOutputs",
+			fn: func(dbc *db.DB) error {
+				testOutputs, err := query.TestOutputs(dbc, benchmarkRelease,
+					benchmarkTestName, nil, nil, 10)
+
+				if err == nil {
+					log.Printf("Found %d test outputs", len(testOutputs))
+				}
+
+				return err
+			},
+		},
+		{
+			name: "JobDetails",
+			fn: func(dbc *db.DB) error {
+				jobRuns, err := api.JobDetailsReport(dbc, benchmarkRelease,
+					"periodic-ci-openshift-release-master-ci-4.22-e2e-aws-ovn",
+					time.Now())
+
+				if err == nil {
+					log.Printf("Found %d job runs", len(jobRuns))
+				}
+
+				return err
+			},
+		},
+	}
+}
+
+func getBenchmarkDBClient(t *testing.T) *db.DB {
+	t.Helper()
+	dsn := os.Getenv("db_benchmarking_dsn")
+	if dsn == "" {
+		t.Skip("skipping: set db_benchmarking_dsn to run")
+	}
+
+	dbFlags := &PostgresFlags{
+		LogLevel: 4,
+		DSN:      dsn,
+	}
+
+	dbc, err := dbFlags.GetDBClient()
+	if err != nil {
+		t.Fatalf("couldn't get DB client: %v", err)
+	}
+	return dbc
+}
+
+func Test_BenchmarkIndividual(t *testing.T) {
+	dbc := getBenchmarkDBClient(t)
+	iterations := 1
+	cases := getBenchmarkCases()
+
+	for _, bc := range cases {
+		t.Run(bc.name, func(t *testing.T) {
+			var totalDuration time.Duration
+			for i := 0; i < iterations; i++ {
+				start := time.Now()
+				err := bc.fn(dbc)
+				elapsed := time.Since(start)
+				if err != nil {
+					t.Fatalf("iteration %d failed: %v", i+1, err)
+				}
+				totalDuration += elapsed
+				fmt.Printf("  %s iteration %d: %s\n", bc.name, i+1, elapsed)
+			}
+			avg := totalDuration / time.Duration(iterations)
+			fmt.Printf("  %s total: %s, avg: %s (%d iterations)\n",
+				bc.name, totalDuration, avg, iterations)
+		})
+	}
+}
+
+func Test_BenchmarkGroup(t *testing.T) {
+	dbc := getBenchmarkDBClient(t)
+	iterations := 1
+	cases := getBenchmarkCases()
+
+	var totalDuration time.Duration
+	for i := 0; i < iterations; i++ {
+		start := time.Now()
+		for _, bc := range cases {
+			err := bc.fn(dbc)
+			if err != nil {
+				t.Fatalf("group iteration %d, case %s failed: %v", i+1, bc.name, err)
+			}
+		}
+		elapsed := time.Since(start)
+		totalDuration += elapsed
+		fmt.Printf("  group iteration %d: %s\n", i+1, elapsed)
+	}
+	avg := totalDuration / time.Duration(iterations)
+	fmt.Printf("  group total: %s, avg: %s (%d iterations)\n",
+		totalDuration, avg, iterations)
+}

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -3,6 +3,8 @@ package flags
 import (
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,6 +22,65 @@ const benchmarkJobName = "periodic-ci-openshift-release-main-ci-4.22-e2e-aws-ovn
 type benchmarkCase struct {
 	name string
 	fn   func(dbc *db.DB) error
+}
+
+type benchmarkResult struct {
+	name       string
+	iterations int
+	total      time.Duration
+	avg        time.Duration
+	min        time.Duration
+	max        time.Duration
+}
+
+func printSummaryTable(results []benchmarkResult) {
+	nameWidth := 4
+	for _, r := range results {
+		if len(r.name) > nameWidth {
+			nameWidth = len(r.name)
+		}
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].avg > results[j].avg
+	})
+
+	header := fmt.Sprintf("  %-*s  %5s  %12s  %12s  %12s  %12s",
+		nameWidth, "Name", "Iters", "Total", "Avg", "Min", "Max")
+	fmt.Println()
+	fmt.Println(header)
+	fmt.Println("  " + strings.Repeat("-", len(header)-2))
+	for _, r := range results {
+		fmt.Printf("  %-*s  %5d  %12s  %12s  %12s  %12s\n",
+			nameWidth, r.name, r.iterations, r.total, r.avg, r.min, r.max)
+	}
+	fmt.Println()
+}
+
+func runBenchmarkCase(t *testing.T, dbc *db.DB, bc benchmarkCase, iterations int) benchmarkResult {
+	t.Helper()
+	result := benchmarkResult{
+		name:       bc.name,
+		iterations: iterations,
+	}
+	for i := 0; i < iterations; i++ {
+		start := time.Now()
+		err := bc.fn(dbc)
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("%s iteration %d failed: %v", bc.name, i+1, err)
+		}
+		result.total += elapsed
+		if i == 0 || elapsed < result.min {
+			result.min = elapsed
+		}
+		if elapsed > result.max {
+			result.max = elapsed
+		}
+		fmt.Printf("  %s iteration %d: %s\n", bc.name, i+1, elapsed)
+	}
+	result.avg = result.total / time.Duration(iterations)
+	return result
 }
 
 func getIndividualBenchmarkCases() map[string]benchmarkCase {
@@ -144,6 +205,76 @@ func getBenchmarkCases() []benchmarkCase {
 			},
 		},
 		{
+			name: "TestCountsByLookback14",
+			fn: func(dbc *db.DB) error {
+				jobRuns, testIDs, err := api.GetJobRunTestsCountByLookback(dbc, 14)
+				if err == nil {
+					log.Printf("TestCountsByLookback14: %d job runs, %d test IDs", jobRuns, testIDs)
+				}
+				return err
+			},
+		},
+		{
+			name: "TestCountsByLookback9",
+			fn: func(dbc *db.DB) error {
+				jobRuns, testIDs, err := api.GetJobRunTestsCountByLookback(dbc, 9)
+				if err == nil {
+					log.Printf("TestCountsByLookback9: %d job runs, %d test IDs", jobRuns, testIDs)
+				}
+				return err
+			},
+		},
+		{
+			name: "TestCountsByLookback14ForRelease",
+			fn: func(dbc *db.DB) error {
+				type counts struct {
+					JobRunsCount int64
+					TestIDsCount int64
+				}
+				var result counts
+				truncatedTime := time.Now().UTC().AddDate(0, 0, -14).Truncate(24 * time.Hour)
+				res := dbc.DB.Raw(`
+					SELECT count(distinct pjrt.prow_job_run_id) as job_runs_count,
+					       count(distinct pjrt.test_id) as test_ids_count
+					FROM prow_job_run_tests pjrt
+					JOIN prow_job_runs pjr ON pjr.id = pjrt.prow_job_run_id
+					JOIN prow_jobs pj ON pj.id = pjr.prow_job_id
+					WHERE pjrt.created_at > ?
+					  AND pj.release = ?`, truncatedTime, benchmarkRelease).Scan(&result)
+				if res.Error != nil {
+					return res.Error
+				}
+				log.Printf("TestCountsByLookback14ForRelease %s: %d job runs, %d test IDs",
+					benchmarkRelease, result.JobRunsCount, result.TestIDsCount)
+				return nil
+			},
+		},
+		{
+			name: "TestCountsByLookback9ForRelease",
+			fn: func(dbc *db.DB) error {
+				type counts struct {
+					JobRunsCount int64
+					TestIDsCount int64
+				}
+				var result counts
+				truncatedTime := time.Now().UTC().AddDate(0, 0, -9).Truncate(24 * time.Hour)
+				res := dbc.DB.Raw(`
+					SELECT count(distinct pjrt.prow_job_run_id) as job_runs_count,
+					       count(distinct pjrt.test_id) as test_ids_count
+					FROM prow_job_run_tests pjrt
+					JOIN prow_job_runs pjr ON pjr.id = pjrt.prow_job_run_id
+					JOIN prow_jobs pj ON pj.id = pjr.prow_job_id
+					WHERE pjrt.created_at > ?
+					  AND pj.release = ?`, truncatedTime, benchmarkRelease).Scan(&result)
+				if res.Error != nil {
+					return res.Error
+				}
+				log.Printf("TestCountsByLookback9ForRelease %s: %d job runs, %d test IDs",
+					benchmarkRelease, result.JobRunsCount, result.TestIDsCount)
+				return nil
+			},
+		},
+		{
 			name: "TestAnalysisPassRate",
 			fn: func(dbc *db.DB) error {
 				type passRate struct {
@@ -191,24 +322,15 @@ func Test_BenchmarkIndividual(t *testing.T) {
 	iterations := 3
 	cases := getBenchmarkCases()
 
+	var results []benchmarkResult
 	for _, bc := range cases {
+		bc := bc
 		t.Run(bc.name, func(t *testing.T) {
-			var totalDuration time.Duration
-			for i := 0; i < iterations; i++ {
-				start := time.Now()
-				err := bc.fn(dbc)
-				elapsed := time.Since(start)
-				if err != nil {
-					t.Fatalf("iteration %d failed: %v", i+1, err)
-				}
-				totalDuration += elapsed
-				fmt.Printf("  %s iteration %d: %s\n", bc.name, i+1, elapsed)
-			}
-			avg := totalDuration / time.Duration(iterations)
-			fmt.Printf("  %s total: %s, avg: %s (%d iterations)\n",
-				bc.name, totalDuration, avg, iterations)
+			r := runBenchmarkCase(t, dbc, bc, iterations)
+			results = append(results, r)
 		})
 	}
+	printSummaryTable(results)
 }
 
 func Test_BenchmarkFindTestsByRelease(t *testing.T) {
@@ -216,20 +338,30 @@ func Test_BenchmarkFindTestsByRelease(t *testing.T) {
 	iterations := 1
 	bc := getIndividualBenchmarkCases()["FindTestsByRelease"]
 
-	var totalDuration time.Duration
-	for i := 0; i < iterations; i++ {
-		start := time.Now()
-		err := bc.fn(dbc)
-		elapsed := time.Since(start)
-		if err != nil {
-			t.Fatalf("iteration %d failed: %v", i+1, err)
-		}
-		totalDuration += elapsed
-		fmt.Printf("  %s iteration %d: %s\n", bc.name, i+1, elapsed)
+	r := runBenchmarkCase(t, dbc, bc, iterations)
+	printSummaryTable([]benchmarkResult{r})
+}
+
+func Test_BenchmarkCombined(t *testing.T) {
+	dbc := getBenchmarkDBClient(t)
+	iterations := 3
+
+	var results []benchmarkResult
+	for _, bc := range getBenchmarkCases() {
+		bc := bc
+		t.Run(bc.name, func(t *testing.T) {
+			r := runBenchmarkCase(t, dbc, bc, iterations)
+			results = append(results, r)
+		})
 	}
-	avg := totalDuration / time.Duration(iterations)
-	fmt.Printf("  %s total: %s, avg: %s (%d iterations)\n",
-		bc.name, totalDuration, avg, iterations)
+	for name, bc := range getIndividualBenchmarkCases() {
+		bc := bc
+		t.Run(name, func(t *testing.T) {
+			r := runBenchmarkCase(t, dbc, bc, iterations)
+			results = append(results, r)
+		})
+	}
+	printSummaryTable(results)
 }
 
 func Test_BenchmarkGroup(t *testing.T) {
@@ -237,7 +369,7 @@ func Test_BenchmarkGroup(t *testing.T) {
 	iterations := 1
 	cases := getBenchmarkCases()
 
-	var totalDuration time.Duration
+	group := benchmarkResult{name: "group"}
 	for i := 0; i < iterations; i++ {
 		start := time.Now()
 		for _, bc := range cases {
@@ -247,10 +379,16 @@ func Test_BenchmarkGroup(t *testing.T) {
 			}
 		}
 		elapsed := time.Since(start)
-		totalDuration += elapsed
+		group.total += elapsed
+		group.iterations++
+		if i == 0 || elapsed < group.min {
+			group.min = elapsed
+		}
+		if elapsed > group.max {
+			group.max = elapsed
+		}
 		fmt.Printf("  group iteration %d: %s\n", i+1, elapsed)
 	}
-	avg := totalDuration / time.Duration(iterations)
-	fmt.Printf("  group total: %s, avg: %s (%d iterations)\n",
-		totalDuration, avg, iterations)
+	group.avg = group.total / time.Duration(iterations)
+	printSummaryTable([]benchmarkResult{group})
 }


### PR DESCRIPTION
Looking to establish a baseline set of tests we can use to measure improvement

```
 Name                                Iters         Total           Avg           Min           Max
  -------------------------------------------------------------------------------------------------
  FindTestsByRelease                      3  30m6.260896997s  10m2.086965665s  7m8.956459338s  13m54.105134029s
  TestCountsByLookback14                  3  26m4.9708992s  8m41.6569664s  6m51.339888996s  10m1.993869729s
  TestCountsByLookback9                   3  24m48.447204212s  8m16.14906807s  4m48.128529016s  11m4.697730186s
  TestCountsByLookback14ForRelease        3  17m29.976561737s  5m49.992187245s  2m8.018587826s  9m47.965995429s
  TestCountsByLookback9ForRelease         3  3m54.792689s  1m18.264229666s  1m11.77148312s  1m25.161766158s
  TestDurations                           3  8.732833483s  2.910944494s  249.591316ms  8.230737689s
  JobDetails                              3  1.981629314s  660.543104ms  326.283471ms  1.265402292s
  TestOutputs                             3  1.474160769s  491.386923ms  325.426977ms  815.316417ms
  TestAnalysisByJob                       3  1.468719267s  489.573089ms  184.192865ms   1.03508937s
  TestAnalysisOverall                     3  363.631699ms  121.210566ms   45.141912ms   267.40426ms
  TestAnalysisByJobWithVariantFilter      3   272.64706ms   90.882353ms   64.947656ms  133.927658ms
  TestAnalysisPassRate                    3  192.513312ms   64.171104ms   29.797289ms  127.053506ms
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized job-details reporting into a reusable helper that loads recent failed test results and surfaces query errors for clearer diagnostics.

* **Tests**
  * Added Postgres-backed benchmarking tests (individual, grouped, combined) with multiple iterations, per-iteration timings, and aggregate summaries to measure query/analysis performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->