### PR TITLE
Fix WebSocket chat proxy broken by status-capturing middleware

### DIFF
--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -2942,6 +2942,7 @@ func (w *statusCapturingResponseWriter) WriteHeader(code int) {
 	w.ResponseWriter.WriteHeader(code)
 }
 
+// Hijack delegates to the underlying ResponseWriter so gorilla/websocket can upgrade connections (e.g. /api/chat/stream).
 func (w *statusCapturingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if hj, ok := w.ResponseWriter.(http.Hijacker); ok {
 		return hj.Hijack()

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1,6 +1,7 @@
 package sippyserver
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -2939,6 +2940,13 @@ type statusCapturingResponseWriter struct {
 func (w *statusCapturingResponseWriter) WriteHeader(code int) {
 	w.status = code
 	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *statusCapturingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, fmt.Errorf("upstream ResponseWriter does not implement http.Hijacker")
 }
 
 func logRequestHandler(h http.Handler) http.Handler {

--- a/pkg/sippyserver/server_test.go
+++ b/pkg/sippyserver/server_test.go
@@ -2,8 +2,12 @@ package sippyserver
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/gorilla/websocket"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/db/models"
@@ -82,6 +86,29 @@ func TestValidateProwJobRun(t *testing.T) {
 		})
 	}
 
+}
+
+func TestLogRequestHandlerAllowsWebSocketUpgrade(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("WebSocket upgrade through logRequestHandler failed: %v", err)
+		}
+	})
+
+	srv := httptest.NewServer(logRequestHandler(inner))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("WebSocket dial through middleware stack failed: %v", err)
+	}
+	defer conn.Close()
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("expected 101 Switching Protocols, got %d", resp.StatusCode)
+	}
 }
 
 func TestEncodeDefaultHighRisk(t *testing.T) {


### PR DESCRIPTION
## Summary
- The `statusCapturingResponseWriter` introduced in 160d54da wraps `http.ResponseWriter` without implementing `http.Hijacker`, breaking WebSocket upgrades for the chat proxy endpoint (`/api/chat/stream`).
- Adds `Hijack()` method delegation to the wrapper so gorilla/websocket can upgrade connections.
- Adds a test that performs a real WebSocket upgrade through the `logRequestHandler` middleware to prevent future regressions.

## Test plan
- [x] `go test ./pkg/sippyserver/ -run TestLogRequestHandlerAllowsWebSocketUpgrade` passes
- [x] `go vet ./pkg/sippyserver/...` clean
- [ ] Verify WebSocket chat connects on sippy-auth after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Middleware now permits WebSocket and HTTP protocol upgrades while continuing to capture response status.
* **Tests**
  * Added an integration test verifying WebSocket upgrade succeeds and results in a 101 Switching Protocols response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->