### PR TITLE
OCPNODE-4125: Promote non-techpreview disruptive longrunning jobs to standard tier for component readiness

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -803,8 +803,10 @@ func (v *OCPVariantLoader) setJobTier(_ logrus.FieldLogger, variants map[string]
 		// GCP multi-operator periodic jobs are not yet stable enough for component readiness
 		{[]string{"e2e-gcp-multi-operator-periodic"}, "candidate"},
 
-		// Disruptive longrunning jobs promoted to candidate while stabilizing
-		{[]string{"-disruptive-longrunning"}, "candidate"},
+		// Disruptive longrunning jobs: non-techpreview promoted to standard,
+		// techpreview to candidate while stabilizing
+		{[]string{"-disruptive-longrunning-techpreview"}, "candidate"},
+		{[]string{"-disruptive-longrunning"}, "standard"},
 
 		// Hidden jobs
 		{[]string{"-cilium"}, "hidden"},

--- a/pkg/variantregistry/ocp_test.go
+++ b/pkg/variantregistry/ocp_test.go
@@ -2103,7 +2103,7 @@ func TestVariantSyncer(t *testing.T) {
 				VariantInstaller:        "ipi",
 				VariantPlatform:         "aws",
 				VariantProcedure:        "none",
-				VariantJobTier:          "candidate",
+				VariantJobTier:          "standard",
 				VariantNetwork:          "ovn",
 				VariantNetworkStack:     "ipv4",
 				VariantOwner:            "eng",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated job-tier classification to recognize disruptive long-running jobs, assigning tech-preview and standard tiers and ensuring these rules take precedence over hidden-job patterns.
  * Adjusted several job entries from candidate to standard to reflect the new tiering.
* **Tests**
  * Updated expectations to match the new job-tier assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->