### PR TITLE
WIP: Add MPEXOperator LP interop variant mapping and views

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -588,6 +588,7 @@ component_readiness:
       - lp-interop-acs
       - lp-interop-fusion-access
       - lp-interop-mta
+      - lp-interop-mpexoperator
       - lp-interop-quay
       - lp-interop-odf
       - lp-interop-oadp
@@ -1607,6 +1608,7 @@ component_readiness:
       - lp-interop-acs
       - lp-interop-fusion-access
       - lp-interop-mta
+      - lp-interop-mpexoperator
       - lp-interop-quay
       - lp-interop-odf
       - lp-interop-oadp
@@ -2360,6 +2362,7 @@ component_readiness:
       - lp-interop-acs
       - lp-interop-fusion-access
       - lp-interop-mta
+      - lp-interop-mpexoperator
       - lp-interop-quay
       - lp-interop-odf
       - lp-interop-oadp

--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -1271,6 +1271,7 @@ func setLayeredProduct(_ logrus.FieldLogger, variants map[string]string, jobName
 		{"-lp-interop-cr-redhat-openshift-gitops", "lp-interop-gitops"},
 		{"-lp-interop-cr-fusion-access", "lp-interop-fusion-access"},
 		{"-lp-interop-cr-mta", "lp-interop-mta"},
+		{"-lp-interop-cr-mpex-oprator", "lp-interop-mpexoperator"},
 		{"-lp-interop-cr-oadp", "lp-interop-oadp"},
 		{"-lp-interop-cr-servicemesh", "lp-interop-servicemesh"},
 		{"-lp-interop-cr-operator-e2e", "lp-interop-serverless"},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new LayeredProduct variant for interoperability testing with MPExOperator support
  * Extended test variant detection across OpenShift versions 5.0, 4.22, and 4.21 to support new interop job patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->