### PR TITLE
Add MPEXOperator LP interop variant mapping (4.22)

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -1606,6 +1606,7 @@ component_readiness:
       - lp-interop-acs-latest
       - lp-interop-acs
       - lp-interop-fusion-access
+      - lp-interop-mpexoperator
       - lp-interop-mta
       - lp-interop-quay
       - lp-interop-odf

--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -1270,6 +1270,7 @@ func setLayeredProduct(_ logrus.FieldLogger, variants map[string]string, jobName
 		{"-lp-interop-cr-odf", "lp-interop-odf"},
 		{"-lp-interop-cr-redhat-openshift-gitops", "lp-interop-gitops"},
 		{"-lp-interop-cr-fusion-access", "lp-interop-fusion-access"},
+		{"-lp-interop-cr-mpex-oprator", "lp-interop-mpexoperator"},
 		{"-lp-interop-cr-mta", "lp-interop-mta"},
 		{"-lp-interop-cr-oadp", "lp-interop-oadp"},
 		{"-lp-interop-cr-servicemesh", "lp-interop-servicemesh"},


### PR DESCRIPTION
## Summary
- Register `-lp-interop-cr-mpex-oprator` → `lp-interop-mpexoperator` in `setLayeredProduct`
- Add `lp-interop-mpexoperator` to `4.22-LP-Interop` view in `config/views.yaml`

## Identifiers
| Field | Value |
|-------|-------|
| LayeredProduct | `lp-interop-mpexoperator` |
| Periodic substring | `-lp-interop-cr-mpex-oprator` |
| Mapped suite | `lp-ocp-compat--MPEXOperator` |
| OCP view | `4.22-LP-Interop` |

## Related PRs
- openshift-eng/ci-test-mapping: (open after ci-test-mapping PR is created)

## Maintainer steps (requester)
After merge, run in openshift/sippy:
```bash
make update-variants
```

## Source
[ocp-ci-docs] LP_Interop_CR_Agent_Playbook


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `lp-interop-mpexoperator` layered product variant, enabling automatic recognition of related deployment jobs and integration into the component readiness configuration system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->