### PR TITLE
[WIP] SPIKE: Onboard LPComp for LP Interop Component Readiness (Sippy)

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -1611,6 +1611,7 @@ component_readiness:
       - lp-interop-odf
       - lp-interop-oadp
       - lp-interop-gitops
+      - lp-interop-lpcomp
       - lp-interop-serverless
       - lp-interop-servicemesh
       Network:

--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -1271,6 +1271,7 @@ func setLayeredProduct(_ logrus.FieldLogger, variants map[string]string, jobName
 		{"-lp-interop-cr-redhat-openshift-gitops", "lp-interop-gitops"},
 		{"-lp-interop-cr-fusion-access", "lp-interop-fusion-access"},
 		{"-lp-interop-cr-mta", "lp-interop-mta"},
+		{"-lp-interop-cr-lpcomp", "lp-interop-lpcomp"},
 		{"-lp-interop-cr-oadp", "lp-interop-oadp"},
 		{"-lp-interop-cr-servicemesh", "lp-interop-servicemesh"},
 		{"-lp-interop-cr-operator-e2e", "lp-interop-serverless"},


### PR DESCRIPTION
## Summary

Onboard **LPComp** for LP Interop Component Readiness (Sippy).

| Identifier | Value |
|------------|-------|
| LayeredProduct variant | `lp-interop-lpcomp` |
| Periodic substring | `-lp-interop-cr-lpcomp` |
| Mapped JUnit suite | `lp-ocp-compat--LPComp` |
| CR view | `4.22-LP-Interop` |
| DefaultJiraComponent | `LPComp` |

### Changes

- `pkg/variantregistry/ocp.go`: add `setLayeredProduct` entry after `-lp-interop-cr-mta`
- `config/views.yaml`: add `lp-interop-lpcomp` under `4.22-LP-Interop` → `LayeredProduct` (alphabetical)
- `pkg/db/suites.go`: **no change** — existing `^lp-ocp-compat--` pattern covers suite import

### Related PRs

- openshift-eng/ci-test-mapping: https://github.com/openshift-eng/ci-test-mapping/pull/722

### Maintainer `make`

`make update-variants` was attempted but failed locally (BigQuery service account required). TRT/maintainer should run before merge:

```bash
make update-variants
```

Source: [ocp-ci-docs] LP_Interop_CR_Agent_Playbook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new layered product variant with automatic classification and identification of associated jobs and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->