### PR TITLE
Update aro classic releases to include current prow job names

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -42,14 +42,20 @@ releases:
     jobs:
       periodic-ci-Azure-ARO-RP-master-periodic-integration-e2e-parallel-csp: true
       periodic-ci-Azure-ARO-RP-master-periodic-integration-e2e-parallel-miwi: true
+      branch-ci-Azure-ARO-RP-master-e2e-integration-e2e-parallel-csp: true
+      branch-ci-Azure-ARO-RP-master-e2e-integration-e2e-parallel-miwi: true
   aro-classic-stage:
     jobs:
       periodic-ci-Azure-ARO-RP-master-periodic-stage-e2e-parallel-csp: true
       periodic-ci-Azure-ARO-RP-master-periodic-stage-e2e-parallel-miwi: true
+      branch-ci-Azure-ARO-RP-master-e2e-stage-e2e-parallel-csp: true
+      branch-ci-Azure-ARO-RP-master-e2e-stage-e2e-parallel-miwi: true
   aro-classic-production:
     jobs:
       periodic-ci-Azure-ARO-RP-master-periodic-prod-e2e-parallel-csp: true
       periodic-ci-Azure-ARO-RP-master-periodic-prod-e2e-parallel-miwi: true
+      branch-ci-Azure-ARO-RP-master-e2e-prod-e2e-parallel-csp: true
+      branch-ci-Azure-ARO-RP-master-e2e-prod-e2e-parallel-miwi: true
   rosa-stage:
     jobs:
       periodic-ci-openshift-release-main-osd-conformance-aws-k8s-conformance: true


### PR DESCRIPTION
Classic prow jobs had an adjustment from periodic to postsubmit jobs, with job name change: https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/sdp-pipelines/pullrequest/15616620?path=/classic/config.yaml&version=GBmain&line=1330&lineEnd=1331&lineStartColumn=4&lineEndColumn=93&type=2&lineStyle=plain&_a=files&iteration=19&base=0

Follow-up PR to https://github.com/openshift/sippy/pull/3500 to add the new job names in Sippy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled branch CI jobs for Classic ARO environments across development, staging, and production phases with additional csp and miwi variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->