### PR TITLE
Drop fallback release queries from 3 to 1.

### DIFF
--- a/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
+++ b/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
@@ -25,6 +25,8 @@ import (
 const (
 	// consider fallback data good for 7 days
 	fallbackQueryTimeRoundingOverride = 24 * 7 * time.Hour
+
+	defaultFallbackReleases = 1
 )
 
 var _ middleware.Middleware = &ReleaseFallback{}
@@ -365,10 +367,7 @@ func (f *fallbackTestQueryReleasesGenerator) getTestFallbackReleases(ctx context
 		return nil, errs
 	}
 
-	// currently gets current base plus previous 3
-	// current base is just for testing but use could be
-	// extended to no longer require the base query
-	selectedTimeRanges := calculateFallbackReleases(f.BaseRelease, timeRanges, f.releaseConfigs)
+	selectedTimeRanges := calculateDefaultFallbackReleases(f.BaseRelease, timeRanges, f.releaseConfigs)
 
 	for _, crRelease := range selectedTimeRanges {
 
@@ -404,12 +403,15 @@ func (f *fallbackTestQueryReleasesGenerator) getTestFallbackReleases(ctx context
 	return &f.CachedFallbackTestStatuses, nil
 }
 
-func calculateFallbackReleases(startingRelease string, timeRanges []crtest.ReleaseTimeRange, releaseConfigs []v1.Release) []*crtest.ReleaseTimeRange {
+func calculateDefaultFallbackReleases(startingRelease string, timeRanges []crtest.ReleaseTimeRange, releaseConfigs []v1.Release) []*crtest.ReleaseTimeRange {
+	return calculateFallbackReleases(startingRelease, timeRanges, releaseConfigs, defaultFallbackReleases)
+}
+
+func calculateFallbackReleases(startingRelease string, timeRanges []crtest.ReleaseTimeRange, releaseConfigs []v1.Release, maxReleases int) []*crtest.ReleaseTimeRange {
 	var selectedTimeRanges []*crtest.ReleaseTimeRange
 	fallbackRelease := startingRelease
 
-	// Get up to 3 fallback releases
-	for i := 0; i < 3; i++ {
+	for i := 0; i < maxReleases; i++ {
 		var crRelease *crtest.ReleaseTimeRange
 
 		var err error

--- a/pkg/api/componentreadiness/middleware/releasefallback/releasefallback_test.go
+++ b/pkg/api/componentreadiness/middleware/releasefallback/releasefallback_test.go
@@ -215,7 +215,7 @@ func TestCalculateFallbackReleases(t *testing.T) {
 		{Release: "4.16", PreviousRelease: ""},
 	}
 
-	fallbackReleases := calculateFallbackReleases("4.20", allTimeRanges, releaseConfigs)
+	fallbackReleases := calculateFallbackReleases("4.20", allTimeRanges, releaseConfigs, 3)
 	for i := range expectedTimeRanges {
 		assert.Equal(t, expectedTimeRanges[i].Release, fallbackReleases[i].Release)
 		assert.Equal(t, expectedTimeRanges[i].Start, fallbackReleases[i].Start)


### PR DESCRIPTION
This change stops checking 4 total prior releases for basis, and instead
checks only 2. Based on the data I can see and observed behavior, we are
not benefiting much from being this sensitive. Flakes are not at true
consistent rates, if there's a problem, we will typically see it at some
point in time and now have many people monitoring for problems.

Data shows that less 2-4% of regressions matched beyond the prior two
base releases, and this does not account for those that also would have
matched against a newer one, we just found a better pass percentage by
going further. (I do not have this data)

Reducing to just check our base release plus one fallback will save
considerable query costs, and still catch over 96% of regressions we
catch today, factoring in those that would still match we're probably
around 98-99%.

Testing is preserved for 3 so we can keep the functionality if we want it again. 

Data from regression tracker on what release we matched against:

sippy_openshift=> select base_release, count(base_release) from test_regressions where release='4.21' and base_release != '4.21' group by base_release order by base_release;
 base_release | count
--------------+-------
 4.17         |   170
 4.18         |   100
 4.19         |   481
 4.20         |  5764
(4 rows)

sippy_openshift=> select base_release, count(base_release) from test_regressions where release='4.22' and base_release != '4.22' group by base_release order by base_release;
 base_release | count
--------------+-------
 4.18         |    26
 4.19         |   131
 4.20         |   649
 4.21         |  2923
(4 rows)

sippy_openshift=> select base_release, count(base_release) from test_regressions where release='5.0' and base_release != '5.0' group by base_release order by base_release;
 base_release | count
--------------+-------
 4.19         |    11
 4.20         |    20
 4.21         |   529
 4.22         |   795
(4 rows)