### PR TITLE
NO-JIRA: Fix sidebar unrolling first product group on every navigation

### DIFF
--- a/sippy-ng/src/components/Sidebar.js
+++ b/sippy-ng/src/components/Sidebar.js
@@ -39,7 +39,7 @@ import ListItem from '@mui/material/ListItem'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
 import PropTypes from 'prop-types'
-import React, { Fragment, useEffect, useMemo } from 'react'
+import React, { Fragment, useEffect, useMemo, useRef } from 'react'
 import SearchIcon from '@mui/icons-material/Search'
 import SippyLogo from './SippyLogo'
 
@@ -76,6 +76,7 @@ export default function Sidebar(props) {
 
   const [openReleases, setOpenReleases] = React.useState({})
   const [openGroups, setOpenGroups] = React.useState({})
+  const initialPathRef = useRef(location.pathname)
 
   const productGroups = useMemo(
     () =>
@@ -87,7 +88,7 @@ export default function Sidebar(props) {
   )
 
   useEffect(() => {
-    const parts = location.pathname.split('/')
+    const parts = initialPathRef.current.split('/')
     const tmpOpenReleases = {}
     const tmpOpenGroups = {}
 
@@ -122,7 +123,7 @@ export default function Sidebar(props) {
 
     setOpenGroups(tmpOpenGroups)
     setOpenReleases(tmpOpenReleases)
-  }, [location, productGroups, props.defaultRelease])
+  }, [productGroups, props.defaultRelease])
 
   function handleGroupClick(product) {
     setOpenGroups((prev) => ({ ...prev, [product]: !prev[product] }))


### PR DESCRIPTION
## Summary

- When expanding any product group other than the first one (e.g. HCP) in the Releases sidebar, then expanding a release within it and clicking on a menu item like "Tests" or "Jobs", the first product group (OCP) would unexpectedly expand even though the user never interacted with it.
- The correct view loads in the main area, but the sidebar state resets: the first product always unrolls, which is disorienting and makes navigating non-OCP releases tedious.
- Fixed by ensuring the sidebar expand/collapse state is only initialized once (on mount), not reset on every navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed sidebar state to remain stable during navigation, preventing unintended re-initialization of expanded/collapsed release groups when switching routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->