### PR TITLE
Add finalized classic release prow jobs

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -42,18 +42,21 @@ releases:
     jobs:
       periodic-ci-Azure-ARO-RP-master-periodic-integration-e2e-parallel-csp: true
       periodic-ci-Azure-ARO-RP-master-periodic-integration-e2e-parallel-miwi: true
+      branch-ci-Azure-ARO-RP-master-e2e-integration-e2e-parallel: true
       branch-ci-Azure-ARO-RP-master-e2e-integration-e2e-parallel-csp: true
       branch-ci-Azure-ARO-RP-master-e2e-integration-e2e-parallel-miwi: true
   aro-classic-stage:
     jobs:
       periodic-ci-Azure-ARO-RP-master-periodic-stage-e2e-parallel-csp: true
       periodic-ci-Azure-ARO-RP-master-periodic-stage-e2e-parallel-miwi: true
+      branch-ci-Azure-ARO-RP-master-e2e-stage-e2e-parallel: true
       branch-ci-Azure-ARO-RP-master-e2e-stage-e2e-parallel-csp: true
       branch-ci-Azure-ARO-RP-master-e2e-stage-e2e-parallel-miwi: true
   aro-classic-production:
     jobs:
       periodic-ci-Azure-ARO-RP-master-periodic-prod-e2e-parallel-csp: true
       periodic-ci-Azure-ARO-RP-master-periodic-prod-e2e-parallel-miwi: true
+      branch-ci-Azure-ARO-RP-master-e2e-prod-e2e-parallel: true
       branch-ci-Azure-ARO-RP-master-e2e-prod-e2e-parallel-csp: true
       branch-ci-Azure-ARO-RP-master-e2e-prod-e2e-parallel-miwi: true
   rosa-stage:


### PR DESCRIPTION
Classic prow jobs are changing to be one prow job in a validation step (as opposed to 2 separate non-validation steps).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled additional parallel end-to-end testing jobs across integration, staging, and production environments to enhance test coverage and validation during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->