### PR TITLE
TRT-2664: Fix devcontainer for OpenShift UID compatibility and venv setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -44,9 +44,11 @@ RUN ARCH=$(uname -m) && \
     ln -s /opt/google-cloud-sdk/bin/bq /usr/local/bin/bq
 
 RUN groupadd -g 1000 vscode && \
-    useradd -u 1000 -g 1000 -m -s /bin/bash vscode && \
+    useradd -u 1000 -g 0 -G 1000 -m -s /bin/bash vscode && \
     echo "vscode ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/vscode && \
     git config --system --add safe.directory /workspace
+
+RUN chgrp -R 0 /home/vscode && chmod -R g=u /home/vscode
 
 ENV GOPATH=/home/vscode/go
 ENV PATH="/home/vscode/.local/bin:${GOPATH}/bin:/usr/local/go/bin:${PATH}"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -16,9 +16,8 @@ echo "==> Installing Claude Code..."
 curl -fsSL https://claude.ai/install.sh | sh
 
 echo "==> Setting up MCP server venv..."
-python3 -m venv mcp/.venv
-mcp/.venv/bin/pip install --upgrade pip -q
-mcp/.venv/bin/pip install -r mcp/requirements.txt -q
+uv venv --clear mcp/.venv
+uv pip install --python mcp/.venv/bin/python3 -r mcp/requirements.txt -q
 
 echo "==> Building sippy and seeding database..."
 make sippy


### PR DESCRIPTION
Set primary group to root (GID 0) for OpenShift random UID support, keeping vscode as supplementary group for local dev. Switch MCP venv setup from python3 -m venv to uv (already installed) to avoid ensurepip dependency issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container configuration and setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->