### PR TITLE
Reduce Component Readiness updates from 6x/day to 2x/day

### DIFF
--- a/cmd/sippy/annotatejobruns.go
+++ b/cmd/sippy/annotatejobruns.go
@@ -173,7 +173,7 @@ Example run: sippy annotate-job-runs  --google-service-account-credential-file=f
 				bigQueryClient = f.CacheFlags.DecorateBiqQueryClientWithPersistentCache(bigQueryClient)
 			}
 
-			cacheOpts := cache.RequestOptions{CRTimeRoundingFactor: f.ComponentReadinessFlags.CRTimeRoundingFactor}
+			cacheOpts := cache.RequestOptions{CRTimeRoundingFactor: f.ComponentReadinessFlags.CRTimeRoundingFactor, CRTimeRoundingOffset: f.ComponentReadinessFlags.CRTimeRoundingOffset}
 
 			dbc, err := f.PostgresFlags.GetDBClient()
 			if err != nil {

--- a/cmd/sippy/automatejira.go
+++ b/cmd/sippy/automatejira.go
@@ -146,7 +146,7 @@ func NewAutomateJiraCommand() *cobra.Command {
 				log.WithError(err).Fatal("CRITICAL error getting BigQuery client which prevents regression tracking")
 			}
 
-			cacheOpts := cache.RequestOptions{CRTimeRoundingFactor: f.ComponentReadinessFlags.CRTimeRoundingFactor}
+			cacheOpts := cache.RequestOptions{CRTimeRoundingFactor: f.ComponentReadinessFlags.CRTimeRoundingFactor, CRTimeRoundingOffset: f.ComponentReadinessFlags.CRTimeRoundingOffset}
 
 			views, err := f.ComponentReadinessFlags.ParseViewsFile()
 			if err != nil {

--- a/cmd/sippy/component_readiness.go
+++ b/cmd/sippy/component_readiness.go
@@ -205,6 +205,7 @@ func (f *ComponentReadinessFlags) runServerMode() error {
 		nil,
 		cacheClient,
 		f.ComponentReadinessFlags.CRTimeRoundingFactor,
+		f.ComponentReadinessFlags.CRTimeRoundingOffset,
 		views,
 		config,
 		f.APIFlags.EnableWriteEndpoints,
@@ -220,7 +221,7 @@ func (f *ComponentReadinessFlags) runServerMode() error {
 			bigQueryClient,
 			crDataProvider,
 			time.Time{},
-			cache.NewStandardCROptions(f.ComponentReadinessFlags.CRTimeRoundingFactor),
+			cache.NewStandardCROptions(f.ComponentReadinessFlags.CRTimeRoundingFactor, f.ComponentReadinessFlags.CRTimeRoundingOffset),
 			views.ComponentReadiness)
 		if err != nil {
 			log.WithError(err).Error("error refreshing metrics")
@@ -240,7 +241,7 @@ func (f *ComponentReadinessFlags) runServerMode() error {
 						bigQueryClient,
 						crDataProvider,
 						time.Time{},
-						cache.NewStandardCROptions(f.ComponentReadinessFlags.CRTimeRoundingFactor),
+						cache.NewStandardCROptions(f.ComponentReadinessFlags.CRTimeRoundingFactor, f.ComponentReadinessFlags.CRTimeRoundingOffset),
 						views.ComponentReadiness)
 					if err != nil {
 						log.WithError(err).Error("error refreshing metrics")

--- a/cmd/sippy/load.go
+++ b/cmd/sippy/load.go
@@ -222,6 +222,7 @@ func NewLoadCommand() *cobra.Command {
 					rcl, err := regressioncacheloader.New(
 						dbc, bqc, config, views.ComponentReadiness, releaseConfigs,
 						f.ComponentReadinessFlags.CRTimeRoundingFactor,
+						f.ComponentReadinessFlags.CRTimeRoundingOffset,
 						regressionStore,
 					)
 					if err != nil {

--- a/cmd/sippy/seed_data.go
+++ b/cmd/sippy/seed_data.go
@@ -700,11 +700,11 @@ func syncRegressions(dbc *db.DB) error {
 	rLog := log.WithField("source", "seed-regression-sync")
 
 	for _, view := range views.ComponentReadiness {
-		baseRelease, err := utils.GetViewReleaseOptions(releases, "basis", view.BaseRelease, 0)
+		baseRelease, err := utils.GetViewReleaseOptions(releases, "basis", view.BaseRelease, 0, 0)
 		if err != nil {
 			return fmt.Errorf("error getting base release for view %s: %w", view.Name, err)
 		}
-		sampleRelease, err := utils.GetViewReleaseOptions(releases, "sample", view.SampleRelease, 0)
+		sampleRelease, err := utils.GetViewReleaseOptions(releases, "sample", view.SampleRelease, 0, 0)
 		if err != nil {
 			return fmt.Errorf("error getting sample release for view %s: %w", view.Name, err)
 		}

--- a/cmd/sippy/serve.go
+++ b/cmd/sippy/serve.go
@@ -196,6 +196,7 @@ func NewServeCommand() *cobra.Command {
 				pinnedDateTime,
 				cacheClient,
 				f.ComponentReadinessFlags.CRTimeRoundingFactor,
+				f.ComponentReadinessFlags.CRTimeRoundingOffset,
 				views,
 				config,
 				f.APIFlags.EnableWriteEndpoints,
@@ -211,7 +212,7 @@ func NewServeCommand() *cobra.Command {
 					bigQueryClient,
 					crDataProvider,
 					util.GetReportEnd(pinnedDateTime),
-					cache.NewStandardCROptions(f.ComponentReadinessFlags.CRTimeRoundingFactor),
+					cache.NewStandardCROptions(f.ComponentReadinessFlags.CRTimeRoundingFactor, f.ComponentReadinessFlags.CRTimeRoundingOffset),
 					views.ComponentReadiness)
 				if err != nil {
 					log.WithError(err).Error("error refreshing metrics")
@@ -231,7 +232,7 @@ func NewServeCommand() *cobra.Command {
 								bigQueryClient,
 								crDataProvider,
 								util.GetReportEnd(pinnedDateTime),
-								cache.NewStandardCROptions(f.ComponentReadinessFlags.CRTimeRoundingFactor),
+								cache.NewStandardCROptions(f.ComponentReadinessFlags.CRTimeRoundingFactor, f.ComponentReadinessFlags.CRTimeRoundingOffset),
 								views.ComponentReadiness)
 							if err != nil {
 								log.WithError(err).Error("error refreshing metrics")

--- a/pkg/api/cache.go
+++ b/pkg/api/cache.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/openshift/sippy/pkg/apis/cache"
+	"github.com/openshift/sippy/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -143,7 +144,8 @@ func CalculateRoundedCacheDuration(cacheOptions cache.RequestOptions) time.Durat
 	if cacheOptions.CRTimeRoundingFactor > 0 {
 		now := time.Now().UTC()
 		// Only cache until the next rounding duration
-		cacheDuration = now.Truncate(cacheOptions.CRTimeRoundingFactor).Add(cacheOptions.CRTimeRoundingFactor).Sub(now)
+		truncated := util.TruncateAligned(now, cacheOptions.CRTimeRoundingFactor, cacheOptions.CRTimeRoundingOffset)
+		cacheDuration = truncated.Add(cacheOptions.CRTimeRoundingFactor).Sub(now)
 	}
 	return cacheDuration
 }

--- a/pkg/api/componentreadiness/dataprovider/bigquery/releasedates.go
+++ b/pkg/api/componentreadiness/dataprovider/bigquery/releasedates.go
@@ -34,7 +34,7 @@ func (c *releaseDateQuerier) QueryReleaseDates(ctx context.Context) ([]crtest.Re
 	for _, release := range releases {
 		timeRange := crtest.ReleaseTimeRange{Release: release.Release}
 		if release.GADate != nil {
-			prior := util.AdjustReleaseTime(*release.GADate, true, "30", c.reqOptions.CacheOption.CRTimeRoundingFactor)
+			prior := util.AdjustReleaseTime(*release.GADate, true, "30", c.reqOptions.CacheOption.CRTimeRoundingFactor, c.reqOptions.CacheOption.CRTimeRoundingOffset)
 			timeRange.Start = &prior
 			timeRange.End = release.GADate
 		}

--- a/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
+++ b/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
@@ -340,6 +340,7 @@ type fallbackTestQueryReleasesGeneratorCacheKey struct {
 	VariantDBGroupBy sets.String
 	// CRTimeRoundingFactor is used by GetReleaseDatesFromBigQuery
 	CRTimeRoundingFactor time.Duration
+	CRTimeRoundingOffset time.Duration
 	// KeyTestNames affects the BuildComponentReportQuery results via filtering logic
 	KeyTestNames []string
 }
@@ -354,6 +355,7 @@ func (f *fallbackTestQueryReleasesGenerator) getCacheKey() fallbackTestQueryRele
 		BaseEnd:              f.BaseEnd,
 		VariantDBGroupBy:     f.ReqOptions.VariantOption.DBGroupBy,
 		CRTimeRoundingFactor: f.ReqOptions.CacheOption.CRTimeRoundingFactor,
+		CRTimeRoundingOffset: f.ReqOptions.CacheOption.CRTimeRoundingOffset,
 		KeyTestNames:         f.ReqOptions.AdvancedOption.KeyTestNames,
 	}
 }

--- a/pkg/api/componentreadiness/queryparamparser_test.go
+++ b/pkg/api/componentreadiness/queryparamparser_test.go
@@ -446,7 +446,7 @@ func TestParseComponentReportRequest(t *testing.T) {
 			// path/body are irrelevant at this point in time, we only parse query params in the func being tested
 			req, err := http.NewRequest("GET", "https://example.com/path?"+params.Encode(), nil)
 			require.NoError(t, err)
-			options, _, err := utils.ParseComponentReportRequest(views, releases, req, allJobVariants, time.Duration(0))
+			options, _, err := utils.ParseComponentReportRequest(views, releases, req, allJobVariants, time.Duration(0), time.Duration(0))
 
 			if tc.errMessage != "" {
 				require.Error(t, err)

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/testdetails"
 	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/util"
 	"github.com/openshift/sippy/pkg/util/sets"
 	"github.com/sirupsen/logrus"
 
@@ -271,16 +272,17 @@ func (c *ComponentReportGenerator) GenerateDetailsReportForTest(
 			report.Links = make(map[string]string)
 		}
 
-		// Calculate default sample date range: 7 days ago to now, rounded to nearest 4 hours EST
+		// Calculate default sample date range: 7 days ago to now, rounded to nearest rounding factor
 		roundingFactor := c.ReqOptions.CacheOption.CRTimeRoundingFactor
 		if roundingFactor == 0 {
-			roundingFactor = 4 * time.Hour // default from flags/component_readiness.go
+			roundingFactor = 12 * time.Hour // default from flags/component_readiness.go
 		}
+		roundingOffset := c.ReqOptions.CacheOption.CRTimeRoundingOffset
 
 		// Create updated sample release options with the newer date range
 		// End time: now, rounded down to nearest rounding factor
 		now := time.Now().UTC()
-		newSampleEnd := now.Truncate(roundingFactor)
+		newSampleEnd := util.TruncateAligned(now, roundingFactor, roundingOffset)
 
 		// Start time: 7 days before the end time, rounded to start of day
 		newSampleStart := newSampleEnd.Add(-7 * 24 * time.Hour)

--- a/pkg/api/componentreadiness/triage.go
+++ b/pkg/api/componentreadiness/triage.go
@@ -307,7 +307,7 @@ func DeleteTriage(dbc *gorm.DB, id int) error {
 
 // ListRegressions lists all regressions for the provided view OR release.
 // When view is set, it is resolved to that view's sample release and filtering is by release.
-func ListRegressions(dbc *db.DB, release string, views []crview.View, releases []v1.Release, crTimeRoundingFactor time.Duration, req *http.Request) ([]models.TestRegression, error) {
+func ListRegressions(dbc *db.DB, release string, views []crview.View, releases []v1.Release, crTimeRoundingFactor, crTimeRoundingOffset time.Duration, req *http.Request) ([]models.TestRegression, error) {
 	var regressions []models.TestRegression
 	var err error
 	regressions, err = query.ListRegressions(dbc, release)
@@ -317,14 +317,14 @@ func ListRegressions(dbc *db.DB, release string, views []crview.View, releases [
 
 	// Add HATEOAS links to each regression
 	for i := range regressions {
-		InjectRegressionHATEOASLinks(&regressions[i], views, releases, crTimeRoundingFactor, sippyapi.GetBaseURL(req), sippyapi.GetBaseFrontendURL(req))
+		InjectRegressionHATEOASLinks(&regressions[i], views, releases, crTimeRoundingFactor, crTimeRoundingOffset, sippyapi.GetBaseURL(req), sippyapi.GetBaseFrontendURL(req))
 	}
 
 	return regressions, err
 }
 
 // GetRegression returns the regression with the matching ID
-func GetRegression(dbc *db.DB, id int, views []crview.View, releases []v1.Release, crTimeRoundingFactor time.Duration, req *http.Request) (*models.TestRegression, error) {
+func GetRegression(dbc *db.DB, id int, views []crview.View, releases []v1.Release, crTimeRoundingFactor, crTimeRoundingOffset time.Duration, req *http.Request) (*models.TestRegression, error) {
 	regression := &models.TestRegression{}
 	res := dbc.DB.Preload("Triages").Preload("JobRuns").Preload("Views").First(regression, id)
 	if res.Error != nil {
@@ -333,7 +333,7 @@ func GetRegression(dbc *db.DB, id int, views []crview.View, releases []v1.Releas
 		}
 		log.WithError(res.Error).Errorf("error looking up existing regression record: %d", id)
 	} else {
-		InjectRegressionHATEOASLinks(regression, views, releases, crTimeRoundingFactor, sippyapi.GetBaseURL(req), sippyapi.GetBaseFrontendURL(req))
+		InjectRegressionHATEOASLinks(regression, views, releases, crTimeRoundingFactor, crTimeRoundingOffset, sippyapi.GetBaseURL(req), sippyapi.GetBaseFrontendURL(req))
 	}
 	return regression, res.Error
 }
@@ -796,7 +796,7 @@ func injectHATEOASLinks(triage *models.Triage, baseURL string) {
 
 // InjectRegressionHATEOASLinks adds restful links clients can follow for this regression record.
 // Per-view test_details links use composite keys: test_details:<view_name>.
-func InjectRegressionHATEOASLinks(regression *models.TestRegression, views []crview.View, releases []v1.Release, crTimeRoundingFactor time.Duration, baseAPIURL, baseFrontendURL string) {
+func InjectRegressionHATEOASLinks(regression *models.TestRegression, views []crview.View, releases []v1.Release, crTimeRoundingFactor, crTimeRoundingOffset time.Duration, baseAPIURL, baseFrontendURL string) {
 	regression.Links = map[string]string{
 		"self": fmt.Sprintf(regressionLink, baseAPIURL, regression.ID),
 	}
@@ -810,7 +810,7 @@ func InjectRegressionHATEOASLinks(regression *models.TestRegression, views []crv
 			log.Errorf("view %s not found in config for regression %d", rv.ViewName, regression.ID)
 			continue
 		}
-		testDetailsURL, err := generateTestDetailsURLFromRegression(regression, view, releases, crTimeRoundingFactor, baseFrontendURL)
+		testDetailsURL, err := generateTestDetailsURLFromRegression(regression, view, releases, crTimeRoundingFactor, crTimeRoundingOffset, baseFrontendURL)
 		if err != nil {
 			log.WithError(err).Errorf("failed to generate test details URL for regression %d and view: %s", regression.ID, view.Name)
 			continue
@@ -830,18 +830,18 @@ func FindViewByName(name string, views []crview.View) (crview.View, bool) {
 
 // generateTestDetailsURLFromRegression extracts the required data from a regression and view
 // and calls the GenerateTestDetailsURL function.
-func generateTestDetailsURLFromRegression(regression *models.TestRegression, view crview.View, releases []v1.Release, crTimeRoundingFactor time.Duration, baseURL string) (string, error) {
+func generateTestDetailsURLFromRegression(regression *models.TestRegression, view crview.View, releases []v1.Release, crTimeRoundingFactor, crTimeRoundingOffset time.Duration, baseURL string) (string, error) {
 	if regression == nil {
 		return "", fmt.Errorf("regression cannot be nil")
 	}
 
 	// Get base and sample release options from the view
-	baseReleaseOpts, err := utils.GetViewReleaseOptions(releases, "basis", view.BaseRelease, crTimeRoundingFactor)
+	baseReleaseOpts, err := utils.GetViewReleaseOptions(releases, "basis", view.BaseRelease, crTimeRoundingFactor, crTimeRoundingOffset)
 	if err != nil {
 		return "", fmt.Errorf("failed to get base release options: %w", err)
 	}
 
-	sampleReleaseOpts, err := utils.GetViewReleaseOptions(releases, "sample", view.SampleRelease, crTimeRoundingFactor)
+	sampleReleaseOpts, err := utils.GetViewReleaseOptions(releases, "sample", view.SampleRelease, crTimeRoundingFactor, crTimeRoundingOffset)
 	if err != nil {
 		return "", fmt.Errorf("failed to get sample release options: %w", err)
 	}

--- a/pkg/api/componentreadiness/triage_test.go
+++ b/pkg/api/componentreadiness/triage_test.go
@@ -766,7 +766,7 @@ func TestInjectRegressionHATEOASLinks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			InjectRegressionHATEOASLinks(tt.regression, views, releases, 0, "http://api", "http://frontend")
+			InjectRegressionHATEOASLinks(tt.regression, views, releases, 0, 0, "http://api", "http://frontend")
 
 			assert.Contains(t, tt.regression.Links, "self")
 

--- a/pkg/api/componentreadiness/utils/queryparamparser.go
+++ b/pkg/api/componentreadiness/utils/queryparamparser.go
@@ -23,7 +23,7 @@ func ParseComponentReportRequest(
 	releases []v1.Release,
 	req *http.Request,
 	allJobVariants crtest.JobVariants,
-	crTimeRoundingFactor time.Duration,
+	crTimeRoundingFactor, crTimeRoundingOffset time.Duration,
 ) (
 	opts reqopts.RequestOptions,
 	warnings []string,
@@ -41,11 +41,11 @@ func ParseComponentReportRequest(
 		opts.VariantOption = view.VariantOptions
 		opts.AdvancedOption = view.AdvancedOptions
 		opts.TestFilters = view.TestFilters
-		opts.BaseRelease, err = GetViewReleaseOptions(releases, "basis", view.BaseRelease, crTimeRoundingFactor)
+		opts.BaseRelease, err = GetViewReleaseOptions(releases, "basis", view.BaseRelease, crTimeRoundingFactor, crTimeRoundingOffset)
 		if err != nil {
 			return
 		}
-		opts.SampleRelease, err = GetViewReleaseOptions(releases, "sample", view.SampleRelease, crTimeRoundingFactor)
+		opts.SampleRelease, err = GetViewReleaseOptions(releases, "sample", view.SampleRelease, crTimeRoundingFactor, crTimeRoundingOffset)
 		if err != nil {
 			return
 		}
@@ -160,13 +160,13 @@ func ParseComponentReportRequest(
 
 	// Date ranges override view defaults
 	if hasDateRangeInURL(req, "baseStartTime", "baseEndTime") {
-		opts.BaseRelease, err = parseDateRange(releases, req, opts.BaseRelease, "baseStartTime", "baseEndTime", crTimeRoundingFactor)
+		opts.BaseRelease, err = parseDateRange(releases, req, opts.BaseRelease, "baseStartTime", "baseEndTime", crTimeRoundingFactor, crTimeRoundingOffset)
 		if err != nil {
 			return
 		}
 	}
 	if hasDateRangeInURL(req, "sampleStartTime", "sampleEndTime") {
-		opts.SampleRelease, err = parseDateRange(releases, req, opts.SampleRelease, "sampleStartTime", "sampleEndTime", crTimeRoundingFactor)
+		opts.SampleRelease, err = parseDateRange(releases, req, opts.SampleRelease, "sampleStartTime", "sampleEndTime", crTimeRoundingFactor, crTimeRoundingOffset)
 		if err != nil {
 			return
 		}
@@ -210,7 +210,7 @@ func ParseComponentReportRequest(
 		}
 	}
 
-	opts.CacheOption = cache.NewStandardCROptions(crTimeRoundingFactor)
+	opts.CacheOption = cache.NewStandardCROptions(crTimeRoundingFactor, crTimeRoundingOffset)
 	opts.CacheOption.ForceRefresh, err = ParseBoolArg(req, "forceRefresh", false)
 	if err != nil {
 		return
@@ -241,16 +241,16 @@ func GetViewReleaseOptions(
 	releases []v1.Release,
 	releaseType string,
 	viewRelease reqopts.RelativeRelease,
-	roundingFactor time.Duration,
+	roundingFactor, roundingOffset time.Duration,
 ) (reqopts.Release, error) {
 
 	var err error
 	opts := reqopts.Release{Name: viewRelease.Name}
-	opts.Start, err = util.ParseCRReleaseTime(releases, opts.Name, viewRelease.RelativeStart, true, nil, roundingFactor)
+	opts.Start, err = util.ParseCRReleaseTime(releases, opts.Name, viewRelease.RelativeStart, true, nil, roundingFactor, roundingOffset)
 	if err != nil {
 		return opts, fmt.Errorf("%s start time %q in wrong format: %v", releaseType, viewRelease.RelativeStart, err)
 	}
-	opts.End, err = util.ParseCRReleaseTime(releases, opts.Name, viewRelease.RelativeEnd, false, nil, roundingFactor)
+	opts.End, err = util.ParseCRReleaseTime(releases, opts.Name, viewRelease.RelativeEnd, false, nil, roundingFactor, roundingOffset)
 	if err != nil {
 		return opts, fmt.Errorf("%s start time %q in wrong format: %v", releaseType, viewRelease.RelativeEnd, err)
 	}
@@ -411,18 +411,18 @@ func parseAdvancedOptions(req *http.Request) (advancedOption reqopts.Advanced, e
 func parseDateRange(allReleases []v1.Release, req *http.Request,
 	releaseOpts reqopts.Release,
 	startName string, endName string,
-	roundingFactor time.Duration,
+	roundingFactor, roundingOffset time.Duration,
 ) (reqopts.Release, error) {
 	var err error
 
 	timeStr := req.URL.Query().Get(startName)
-	releaseOpts.Start, err = util.ParseCRReleaseTime(allReleases, releaseOpts.Name, timeStr, true, nil, roundingFactor)
+	releaseOpts.Start, err = util.ParseCRReleaseTime(allReleases, releaseOpts.Name, timeStr, true, nil, roundingFactor, roundingOffset)
 	if err != nil {
 		return releaseOpts, errors.New(startName + " in wrong format")
 	}
 
 	timeStr = req.URL.Query().Get(endName)
-	releaseOpts.End, err = util.ParseCRReleaseTime(allReleases, releaseOpts.Name, timeStr, false, nil, roundingFactor)
+	releaseOpts.End, err = util.ParseCRReleaseTime(allReleases, releaseOpts.Name, timeStr, false, nil, roundingFactor, roundingOffset)
 	if err != nil {
 		return releaseOpts, errors.New(endName + " in wrong format")
 	}

--- a/pkg/api/componentreadiness/utils/utils_test.go
+++ b/pkg/api/componentreadiness/utils/utils_test.go
@@ -55,12 +55,12 @@ func TestGenerateTestDetailsURL(t *testing.T) {
 
 	// Helper function to get release options from view
 	getBaseReleaseOpts := func() reqopts.Release {
-		opts, err := GetViewReleaseOptions(releases, "basis", testView.BaseRelease, 0)
+		opts, err := GetViewReleaseOptions(releases, "basis", testView.BaseRelease, 0, 0)
 		require.NoError(t, err)
 		return opts
 	}
 	getSampleReleaseOpts := func() reqopts.Release {
-		opts, err := GetViewReleaseOptions(releases, "sample", testView.SampleRelease, 0)
+		opts, err := GetViewReleaseOptions(releases, "sample", testView.SampleRelease, 0, 0)
 		require.NoError(t, err)
 		return opts
 	}
@@ -245,9 +245,9 @@ func TestGenerateTestDetailsURL(t *testing.T) {
 		}
 
 		// Get release options from the real-world view
-		baseReleaseOpts, err := GetViewReleaseOptions(releases, "basis", realWorldView.BaseRelease, time.Hour)
+		baseReleaseOpts, err := GetViewReleaseOptions(releases, "basis", realWorldView.BaseRelease, time.Hour, 0)
 		require.NoError(t, err)
-		sampleReleaseOpts, err := GetViewReleaseOptions(releases, "sample", realWorldView.SampleRelease, time.Hour)
+		sampleReleaseOpts, err := GetViewReleaseOptions(releases, "sample", realWorldView.SampleRelease, time.Hour, 0)
 		require.NoError(t, err)
 
 		url, err := GenerateTestDetailsURL(
@@ -343,9 +343,9 @@ func TestGenerateTestDetailsURL(t *testing.T) {
 		}
 
 		// Get release options from the view with variants
-		baseReleaseOpts, err := GetViewReleaseOptions(releases, "basis", viewWithVariants.BaseRelease, 0)
+		baseReleaseOpts, err := GetViewReleaseOptions(releases, "basis", viewWithVariants.BaseRelease, 0, 0)
 		require.NoError(t, err)
-		sampleReleaseOpts, err := GetViewReleaseOptions(releases, "sample", viewWithVariants.SampleRelease, 0)
+		sampleReleaseOpts, err := GetViewReleaseOptions(releases, "sample", viewWithVariants.SampleRelease, 0, 0)
 		require.NoError(t, err)
 
 		url, err := GenerateTestDetailsURL(
@@ -416,9 +416,9 @@ func TestGenerateTestDetailsURL(t *testing.T) {
 			},
 		}
 
-		baseReleaseOpts, err := GetViewReleaseOptions(releases, "basis", viewWithCrossCompare.BaseRelease, 0)
+		baseReleaseOpts, err := GetViewReleaseOptions(releases, "basis", viewWithCrossCompare.BaseRelease, 0, 0)
 		require.NoError(t, err)
-		sampleReleaseOpts, err := GetViewReleaseOptions(releases, "sample", viewWithCrossCompare.SampleRelease, 0)
+		sampleReleaseOpts, err := GetViewReleaseOptions(releases, "sample", viewWithCrossCompare.SampleRelease, 0, 0)
 		require.NoError(t, err)
 
 		url, err := GenerateTestDetailsURL(

--- a/pkg/apis/cache/cache.go
+++ b/pkg/apis/cache/cache.go
@@ -23,8 +23,11 @@ type RequestOptions struct {
 	Expiry time.Duration
 
 	// CRTimeRoundingFactor is used to round cache expiration time to the nearest time boundary of blocks that size.
-	// for example, when set to 4 hours, the day is divided into 4-hour blocks and the TTL will be at the next boundary.
+	// for example, when set to 12 hours, the day is divided into 12-hour blocks and the TTL will be at the next boundary.
 	CRTimeRoundingFactor time.Duration
+	// CRTimeRoundingOffset shifts the rounding boundaries by this duration.
+	// For example, 4h shifts 12h boundaries from 00:00/12:00 UTC to 04:00/16:00 UTC.
+	CRTimeRoundingOffset time.Duration
 
 	// SkipCacheWrites will disable setting keys in the cache. Used in some scenarios where a lot of data is in play and serves no purpose being in the cache.
 	SkipCacheWrites bool
@@ -41,9 +44,10 @@ type RequestOptions struct {
 
 var StandardStableAgeCR = time.Hour * 24 * 7    // age at which component readiness data should be considered "stable"
 var StandardStableExpiryCR = time.Hour * 24 * 7 // how long to cache stable component readiness data
-func NewStandardCROptions(crTimeRoundingFactor time.Duration) RequestOptions {
+func NewStandardCROptions(crTimeRoundingFactor, crTimeRoundingOffset time.Duration) RequestOptions {
 	return RequestOptions{
 		CRTimeRoundingFactor: crTimeRoundingFactor,
+		CRTimeRoundingOffset: crTimeRoundingOffset,
 		StableAge:            StandardStableAgeCR,
 		StableExpiry:         StandardStableExpiryCR,
 	}

--- a/pkg/componentreadiness/jiraautomator/jiraautomator.go
+++ b/pkg/componentreadiness/jiraautomator/jiraautomator.go
@@ -114,12 +114,12 @@ func NewJiraAutomator(
 }
 
 func (j JiraAutomator) getRequestOptionForView(view crview.View) (reqopts.RequestOptions, error) {
-	baseRelease, err := utils.GetViewReleaseOptions(j.releases, "basis", view.BaseRelease, j.cacheOptions.CRTimeRoundingFactor)
+	baseRelease, err := utils.GetViewReleaseOptions(j.releases, "basis", view.BaseRelease, j.cacheOptions.CRTimeRoundingFactor, j.cacheOptions.CRTimeRoundingOffset)
 	if err != nil {
 		return reqopts.RequestOptions{}, err
 	}
 
-	sampleRelease, err := utils.GetViewReleaseOptions(j.releases, "sample", view.SampleRelease, j.cacheOptions.CRTimeRoundingFactor)
+	sampleRelease, err := utils.GetViewReleaseOptions(j.releases, "sample", view.SampleRelease, j.cacheOptions.CRTimeRoundingFactor, j.cacheOptions.CRTimeRoundingOffset)
 	if err != nil {
 		return reqopts.RequestOptions{}, err
 	}

--- a/pkg/dataloader/crcacheloader/crcacheloader.go
+++ b/pkg/dataloader/crcacheloader/crcacheloader.go
@@ -39,6 +39,7 @@ type ComponentReadinessCacheLoader struct {
 	dataProvider         dataprovider.DataProvider
 	config               *v1.SippyConfig
 	crTimeRoundingFactor time.Duration
+	crTimeRoundingOffset time.Duration
 }
 
 func New(
@@ -48,7 +49,7 @@ func New(
 	config *v1.SippyConfig,
 	views *sippytypes.SippyViews,
 	releases []apiv1.Release,
-	crTimeRoundingFactor time.Duration) *ComponentReadinessCacheLoader {
+	crTimeRoundingFactor, crTimeRoundingOffset time.Duration) *ComponentReadinessCacheLoader {
 
 	return &ComponentReadinessCacheLoader{
 		dbc:                  dbc,
@@ -60,6 +61,7 @@ func New(
 		dataProvider:         bqprovider.NewBigQueryProvider(bqClient),
 		config:               config,
 		crTimeRoundingFactor: crTimeRoundingFactor,
+		crTimeRoundingOffset: crTimeRoundingOffset,
 	}
 }
 
@@ -71,12 +73,13 @@ func (l *ComponentReadinessCacheLoader) Load() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Hour*1)
 	defer cancel()
 	// This command should be called in a kube cronjob matching the time rounding factor.
-	// Today we push our Sample end time out to the next even 4 hour interval UTC, i.e. 4am, 8am, 12pm, 4pm, etc.
+	// We push our Sample end time out to the next rounding boundary (e.g. every 12h at 04:00/16:00 UTC).
 	// We then use the delta to that time when caching as the duration for that key.
-	// This command should be run in a kube cronjob then at those precise times meaning all but the most unlucky
-	// requests between say 4:00:00am and 4:00:45am, should always hit the cache.
+	// This command should be run in a kube cronjob at those precise times meaning all but the most unlucky
+	// requests should always hit the cache.
 	cacheOpts := cache.RequestOptions{
 		CRTimeRoundingFactor: l.crTimeRoundingFactor,
+		CRTimeRoundingOffset: l.crTimeRoundingOffset,
 		RefreshRecent:        true,                         // always refresh recent data with the standard expiry
 		StableAge:            cache.StandardStableAgeCR,    // but data a week old is unlikely to change
 		StableExpiry:         cache.StandardStableExpiryCR, // so cache it for longer
@@ -237,13 +240,13 @@ func (l *ComponentReadinessCacheLoader) buildGenerator(
 ) (*componentreadiness.ComponentReportGenerator, error) {
 
 	baseRelease, err := utils.GetViewReleaseOptions(
-		l.releases, "basis", view.BaseRelease, cacheOpts.CRTimeRoundingFactor)
+		l.releases, "basis", view.BaseRelease, cacheOpts.CRTimeRoundingFactor, cacheOpts.CRTimeRoundingOffset)
 	if err != nil {
 		return nil, err
 	}
 
 	sampleRelease, err := utils.GetViewReleaseOptions(
-		l.releases, "sample", view.SampleRelease, cacheOpts.CRTimeRoundingFactor)
+		l.releases, "sample", view.SampleRelease, cacheOpts.CRTimeRoundingFactor, cacheOpts.CRTimeRoundingOffset)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dataloader/regressioncacheloader/regressioncacheloader.go
+++ b/pkg/dataloader/regressioncacheloader/regressioncacheloader.go
@@ -49,6 +49,7 @@ type RegressionCacheLoader struct {
 	config               *configv1.SippyConfig
 	releases             []apiv1.Release
 	crTimeRoundingFactor time.Duration
+	crTimeRoundingOffset time.Duration
 
 	// Regression tracking deps
 	regressionStore componentreadiness.RegressionStore
@@ -61,6 +62,7 @@ func New(
 	views []crview.View,
 	releases []apiv1.Release,
 	crTimeRoundingFactor time.Duration,
+	crTimeRoundingOffset time.Duration,
 	regressionStore componentreadiness.RegressionStore,
 ) (*RegressionCacheLoader, error) {
 	if regressionStore == nil {
@@ -74,6 +76,7 @@ func New(
 		views:                views,
 		releases:             releases,
 		crTimeRoundingFactor: crTimeRoundingFactor,
+		crTimeRoundingOffset: crTimeRoundingOffset,
 		regressionStore:      regressionStore,
 		logger:               log.WithField("loader", "regression-cache"),
 	}, nil
@@ -93,6 +96,7 @@ func (l *RegressionCacheLoader) Load() {
 
 	cacheOpts := cache.RequestOptions{
 		CRTimeRoundingFactor: l.crTimeRoundingFactor,
+		CRTimeRoundingOffset: l.crTimeRoundingOffset,
 		RefreshRecent:        true,
 		StableAge:            cache.StandardStableAgeCR,
 		StableExpiry:         cache.StandardStableExpiryCR,
@@ -480,13 +484,13 @@ func (l *RegressionCacheLoader) buildGenerator(
 ) (*componentreadiness.ComponentReportGenerator, error) {
 
 	baseRelease, err := utils.GetViewReleaseOptions(
-		l.releases, "basis", view.BaseRelease, cacheOpts.CRTimeRoundingFactor)
+		l.releases, "basis", view.BaseRelease, cacheOpts.CRTimeRoundingFactor, cacheOpts.CRTimeRoundingOffset)
 	if err != nil {
 		return nil, err
 	}
 
 	sampleRelease, err := utils.GetViewReleaseOptions(
-		l.releases, "sample", view.SampleRelease, cacheOpts.CRTimeRoundingFactor)
+		l.releases, "sample", view.SampleRelease, cacheOpts.CRTimeRoundingFactor, cacheOpts.CRTimeRoundingOffset)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flags/component_readiness.go
+++ b/pkg/flags/component_readiness.go
@@ -12,14 +12,16 @@ import (
 )
 
 var (
-	defaultCRTimeRoundingFactor = 4 * time.Hour
-	maxCRTimeRoundingFactor     = 12 * time.Hour
+	defaultCRTimeRoundingFactor = 12 * time.Hour
+	maxCRTimeRoundingFactor     = 24 * time.Hour
+	defaultCRTimeRoundingOffset = 4 * time.Hour // aligned one hour before EST midnight/noon (04:00/16:00 UTC)
 )
 
 // ComponentReadinessFlags holds configuration information for serving ComponentReadiness.
 type ComponentReadinessFlags struct {
 	ComponentReadinessViewsFile string
 	CRTimeRoundingFactor        time.Duration
+	CRTimeRoundingOffset        time.Duration
 	CORSAllowedOrigin           string
 }
 
@@ -31,6 +33,8 @@ func (f *ComponentReadinessFlags) BindFlags(fs *pflag.FlagSet) {
 	factorUsage := fmt.Sprintf("Set the rounding factor for component readiness release time. The time will be rounded down to the nearest multiple of the factor. Maximum value is %v", maxCRTimeRoundingFactor)
 	fs.StringVar(&f.ComponentReadinessViewsFile, "views", "", "Optional yaml file for predefined Component Readiness views")
 	fs.DurationVar(&f.CRTimeRoundingFactor, "component-readiness-time-rounding-factor", defaultCRTimeRoundingFactor, factorUsage)
+	offsetUsage := "Shift rounding boundaries by this duration. With a 12h factor: 0 aligns to 00:00/12:00 UTC, 4h aligns to 04:00/16:00 UTC, 5h aligns to 05:00/17:00 UTC (midnight/noon EST). The cronjob schedule must match these boundaries."
+	fs.DurationVar(&f.CRTimeRoundingOffset, "component-readiness-time-rounding-offset", defaultCRTimeRoundingOffset, offsetUsage)
 	fs.StringVar(&f.CORSAllowedOrigin, "cors-allowed-origin", "*", "Optional allowed origin for CORS")
 }
 

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -206,13 +206,13 @@ func updateComponentReadinessMetricsForView(ctx context.Context, provider datapr
 	logger.Info("generating report for view")
 
 	baseRelease, err := utils.GetViewReleaseOptions(
-		releases, "basis", view.BaseRelease, cacheOptions.CRTimeRoundingFactor)
+		releases, "basis", view.BaseRelease, cacheOptions.CRTimeRoundingFactor, cacheOptions.CRTimeRoundingOffset)
 	if err != nil {
 		return err
 	}
 
 	sampleRelease, err := utils.GetViewReleaseOptions(
-		releases, "sample", view.SampleRelease, cacheOptions.CRTimeRoundingFactor)
+		releases, "sample", view.SampleRelease, cacheOptions.CRTimeRoundingFactor, cacheOptions.CRTimeRoundingOffset)
 	if err != nil {
 		return err
 	}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -88,6 +88,7 @@ func NewServer(
 	pinnedDateTime *time.Time,
 	cacheClient cache.Cache,
 	crTimeRoundingFactor time.Duration,
+	crTimeRoundingOffset time.Duration,
 	views *apitype.SippyViews,
 	config *v1.SippyConfig,
 	enableWriteEndpoints bool,
@@ -112,6 +113,7 @@ func NewServer(
 		gcsBucket:            gcsBucket,
 		cache:                cacheClient,
 		crTimeRoundingFactor: crTimeRoundingFactor,
+		crTimeRoundingOffset: crTimeRoundingOffset,
 		views:                views,
 		config:               config,
 		enableWriteAPIs:      enableWriteEndpoints,
@@ -171,6 +173,7 @@ type Server struct {
 	gcsBucket            string
 	cache                cache.Cache
 	crTimeRoundingFactor time.Duration
+	crTimeRoundingOffset time.Duration
 	capabilities         []string
 	views                *apitype.SippyViews
 	config               *v1.SippyConfig
@@ -967,7 +970,7 @@ func (s *Server) jsonComponentReadinessViews(w http.ResponseWriter, req *http.Re
 	viewsCopy := make([]crview.View, len(s.views.ComponentReadiness))
 	copy(viewsCopy, s.views.ComponentReadiness)
 	for i := range viewsCopy {
-		rro, err := utils.GetViewReleaseOptions(allReleases, "basis", viewsCopy[i].BaseRelease, s.crTimeRoundingFactor)
+		rro, err := utils.GetViewReleaseOptions(allReleases, "basis", viewsCopy[i].BaseRelease, s.crTimeRoundingFactor, s.crTimeRoundingOffset)
 		if err != nil {
 			failureResponse(w, http.StatusBadRequest, err.Error())
 			return
@@ -975,7 +978,7 @@ func (s *Server) jsonComponentReadinessViews(w http.ResponseWriter, req *http.Re
 		viewsCopy[i].BaseRelease.Start = rro.Start
 		viewsCopy[i].BaseRelease.End = rro.End
 
-		rro, err = utils.GetViewReleaseOptions(allReleases, "sample", viewsCopy[i].SampleRelease, s.crTimeRoundingFactor)
+		rro, err = utils.GetViewReleaseOptions(allReleases, "sample", viewsCopy[i].SampleRelease, s.crTimeRoundingFactor, s.crTimeRoundingOffset)
 		if err != nil {
 			failureResponse(w, http.StatusBadRequest, err.Error())
 			return
@@ -1023,7 +1026,7 @@ func (s *Server) getComponentReportFromRequest(req *http.Request) (componentrepo
 		return componentreport.ComponentReport{}, err
 	}
 
-	options, warnings, err := utils.ParseComponentReportRequest(s.views.ComponentReadiness, allReleases, req, allJobVariants, s.crTimeRoundingFactor)
+	options, warnings, err := utils.ParseComponentReportRequest(s.views.ComponentReadiness, allReleases, req, allJobVariants, s.crTimeRoundingFactor, s.crTimeRoundingOffset)
 
 	if err != nil {
 		return componentreport.ComponentReport{}, err
@@ -1077,7 +1080,7 @@ func (s *Server) jsonComponentReportTestDetailsFromBigQuery(w http.ResponseWrite
 		return
 	}
 
-	reqOptions, _, err := utils.ParseComponentReportRequest(s.views.ComponentReadiness, allReleases, req, allJobVariants, s.crTimeRoundingFactor)
+	reqOptions, _, err := utils.ParseComponentReportRequest(s.views.ComponentReadiness, allReleases, req, allJobVariants, s.crTimeRoundingFactor, s.crTimeRoundingOffset)
 
 	if err != nil {
 		failureResponse(w, http.StatusBadRequest, err.Error())
@@ -1853,7 +1856,7 @@ func (s *Server) jsonTriagePotentialMatchingRegressions(w http.ResponseWriter, r
 		failureResponse(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	regressions, err := componentreadiness.ListRegressions(s.db, view.SampleRelease.Name, s.views.ComponentReadiness, allReleases, s.crTimeRoundingFactor, req)
+	regressions, err := componentreadiness.ListRegressions(s.db, view.SampleRelease.Name, s.views.ComponentReadiness, allReleases, s.crTimeRoundingFactor, s.crTimeRoundingOffset, req)
 	if err != nil {
 		failureResponse(w, http.StatusInternalServerError, err.Error())
 		return
@@ -1926,7 +1929,7 @@ func (s *Server) jsonGetRegressions(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	regressions, err := componentreadiness.ListRegressions(s.db, release, views, allReleases, s.crTimeRoundingFactor, req)
+	regressions, err := componentreadiness.ListRegressions(s.db, release, views, allReleases, s.crTimeRoundingFactor, s.crTimeRoundingOffset, req)
 	if err != nil {
 		failureResponse(w, http.StatusInternalServerError, err.Error())
 		return
@@ -1952,7 +1955,7 @@ func (s *Server) jsonGetRegressionByID(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	regression, err := componentreadiness.GetRegression(s.db, regressionID, s.views.ComponentReadiness, allReleases, s.crTimeRoundingFactor, req)
+	regression, err := componentreadiness.GetRegression(s.db, regressionID, s.views.ComponentReadiness, allReleases, s.crTimeRoundingFactor, s.crTimeRoundingOffset, req)
 	if err != nil {
 		failureResponse(w, http.StatusInternalServerError, err.Error())
 		return
@@ -1989,7 +1992,7 @@ func (s *Server) jsonRegressionPotentialMatchingTriages(w http.ResponseWriter, r
 		failureResponse(w, http.StatusInternalServerError, fmt.Sprintf("error getting releases: %v", err))
 		return
 	}
-	regression, err := componentreadiness.GetRegression(s.db, regressionID, s.views.ComponentReadiness, allReleases, s.crTimeRoundingFactor, req)
+	regression, err := componentreadiness.GetRegression(s.db, regressionID, s.views.ComponentReadiness, allReleases, s.crTimeRoundingFactor, s.crTimeRoundingOffset, req)
 	if err != nil {
 		failureResponse(w, http.StatusInternalServerError, fmt.Sprintf("error getting regression: %v", err))
 	}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -11,6 +11,16 @@ import (
 	v1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 )
 
+// TruncateAligned rounds t down to the nearest multiple of factor, aligned to a
+// timezone offset. For example, with factor=12h and offset=4h,
+// boundaries land at 04:00 and 16:00 UTC.
+func TruncateAligned(t time.Time, factor, offset time.Duration) time.Time {
+	if factor <= 0 {
+		return t
+	}
+	return t.Add(-offset).Truncate(factor).Add(offset)
+}
+
 type FailureGroupStats struct {
 	Count      int
 	CountPrev  int
@@ -115,7 +125,7 @@ var releaseRelativeRE = regexp.MustCompile(`^(now|ga|end)(?:-([0-9]+)([d]))?$`)
 // For isStart=false we would round up to 23:59:59.
 //
 // endTime must be specified if your timeStr uses the end directive. (end-90d) Otherwise it is not required or used.
-func ParseCRReleaseTime(allReleases []v1.Release, release, timeStr string, isStart bool, endTime *time.Time, crTimeRoundingFactor time.Duration) (time.Time, error) {
+func ParseCRReleaseTime(allReleases []v1.Release, release, timeStr string, isStart bool, endTime *time.Time, crTimeRoundingFactor, crTimeRoundingOffset time.Duration) (time.Time, error) {
 
 	var relTime time.Time
 
@@ -147,7 +157,7 @@ func ParseCRReleaseTime(allReleases []v1.Release, release, timeStr string, isSta
 			}
 			relTime = *endTime
 		}
-		return AdjustReleaseTime(relTime, isStart, matches[2], crTimeRoundingFactor), nil
+		return AdjustReleaseTime(relTime, isStart, matches[2], crTimeRoundingFactor, crTimeRoundingOffset), nil
 	}
 
 	// Parse as a fully qualified timestamp:
@@ -160,12 +170,12 @@ func ParseCRReleaseTime(allReleases []v1.Release, release, timeStr string, isSta
 	// Apply the rounding factor:
 	now := time.Now().UTC()
 	if crTimeRoundingFactor > 0 && now.Format("2006-01-02") == relTime.Format("2006-01-02") {
-		relTime = now.Truncate(crTimeRoundingFactor)
+		relTime = TruncateAligned(now, crTimeRoundingFactor, crTimeRoundingOffset)
 	}
 	return relTime, nil
 }
 
-func AdjustReleaseTime(relTime time.Time, isStart bool, daysAdjustment string, crTimeRoundingFactor time.Duration) time.Time {
+func AdjustReleaseTime(relTime time.Time, isStart bool, daysAdjustment string, crTimeRoundingFactor, crTimeRoundingOffset time.Duration) time.Time {
 	// adjust by number of days:
 	adjustDays, _ := strconv.ParseInt(daysAdjustment, 10, 64)
 	adjustDur := time.Duration(adjustDays) * 24 * time.Hour
@@ -178,7 +188,7 @@ func AdjustReleaseTime(relTime time.Time, isStart bool, daysAdjustment string, c
 		// Apply the rounding factor if using today:
 		now := time.Now().UTC()
 		if crTimeRoundingFactor > 0 && now.Format("2006-01-02") == relTime.Format("2006-01-02") {
-			relTime = now.Truncate(crTimeRoundingFactor)
+			relTime = TruncateAligned(now, crTimeRoundingFactor, crTimeRoundingOffset)
 		} else {
 			// otherwise round up to end of day
 			relTime = time.Date(relTime.Year(), relTime.Month(), relTime.Day(), 23, 59, 59, 0, time.UTC)

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -54,9 +54,9 @@ func TestParseCRReleaseTime(t *testing.T) {
 		{
 			name:           "now end date with cache rounding",
 			timeStr:        "now",
-			roundingFactor: 4 * time.Hour,
+			roundingFactor: 12 * time.Hour,
 			isStart:        false,
-			expectedTime:   now.Truncate(4 * time.Hour),
+			expectedTime:   now.Truncate(12 * time.Hour),
 		},
 		{
 			name:         "now-7d start date",
@@ -122,13 +122,94 @@ func TestParseCRReleaseTime(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resultTime, err := ParseCRReleaseTime(releases, tt.release, tt.timeStr, tt.isStart, tt.endTime, tt.roundingFactor)
+			resultTime, err := ParseCRReleaseTime(releases, tt.release, tt.timeStr, tt.isStart, tt.endTime, tt.roundingFactor, 0)
 			if tt.expectedErr {
 				require.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expectedTime, resultTime)
 			}
+		})
+	}
+}
+
+func TestTruncateAligned(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    time.Time
+		factor   time.Duration
+		offset   time.Duration
+		expected time.Time
+	}{
+		{
+			name:     "zero factor returns input unchanged",
+			input:    time.Date(2025, 6, 2, 10, 30, 0, 0, time.UTC),
+			factor:   0,
+			offset:   4 * time.Hour,
+			expected: time.Date(2025, 6, 2, 10, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "zero offset behaves like Truncate",
+			input:    time.Date(2025, 6, 2, 10, 30, 0, 0, time.UTC),
+			factor:   12 * time.Hour,
+			offset:   0,
+			expected: time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "before first boundary truncates to previous day",
+			input:    time.Date(2025, 6, 2, 3, 0, 0, 0, time.UTC),
+			factor:   12 * time.Hour,
+			offset:   4 * time.Hour,
+			expected: time.Date(2025, 6, 1, 16, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "mid-morning truncates to 04:00 UTC",
+			input:    time.Date(2025, 6, 2, 10, 0, 0, 0, time.UTC),
+			factor:   12 * time.Hour,
+			offset:   4 * time.Hour,
+			expected: time.Date(2025, 6, 2, 4, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "evening truncates to 16:00 UTC",
+			input:    time.Date(2025, 6, 2, 20, 0, 0, 0, time.UTC),
+			factor:   12 * time.Hour,
+			offset:   4 * time.Hour,
+			expected: time.Date(2025, 6, 2, 16, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "exactly on first boundary returns boundary",
+			input:    time.Date(2025, 6, 2, 4, 0, 0, 0, time.UTC),
+			factor:   12 * time.Hour,
+			offset:   4 * time.Hour,
+			expected: time.Date(2025, 6, 2, 4, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "exactly on second boundary returns boundary",
+			input:    time.Date(2025, 6, 2, 16, 0, 0, 0, time.UTC),
+			factor:   12 * time.Hour,
+			offset:   4 * time.Hour,
+			expected: time.Date(2025, 6, 2, 16, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "one second before boundary truncates to previous",
+			input:    time.Date(2025, 6, 2, 3, 59, 59, 0, time.UTC),
+			factor:   12 * time.Hour,
+			offset:   4 * time.Hour,
+			expected: time.Date(2025, 6, 1, 16, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "4h factor with no offset gives UTC-aligned boundaries",
+			input:    time.Date(2025, 6, 2, 10, 30, 0, 0, time.UTC),
+			factor:   4 * time.Hour,
+			offset:   0,
+			expected: time.Date(2025, 6, 2, 8, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := TruncateAligned(tt.input, tt.factor, tt.offset)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/test/e2e/componentreadiness/componentreadiness_test.go
+++ b/test/e2e/componentreadiness/componentreadiness_test.go
@@ -75,7 +75,8 @@ func TestRegressionCacheLoader(t *testing.T) {
 		&configv1.SippyConfig{},
 		sippyViews.ComponentReadiness,
 		releaseConfigs,
-		4*time.Hour, // default CRTimeRoundingFactor
+		12*time.Hour, // default CRTimeRoundingFactor
+		4*time.Hour,  // default CRTimeRoundingOffset
 		regressionStore,
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
This is tuned for two updates around midnight and noon EST, technically
04:00 and 16:00 UTC. This will cut costs considerably, and matches the
expectation that QSE would look once or twice a day tops. This is not
our rapid regression detection mechanism, and most of the 4h updates
were probably going to waste.

Should merge with https://github.com/openshift/continuous-release-jobs/pull/1804


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CLI flag to configure a component-readiness time-rounding offset.

* **Improvements**
  * Time-rounding now uses both a rounding factor and an offset, improving alignment of release time calculations, cache expiration boundaries, component-readiness reports, and related metrics and URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->