### PR TITLE
Remove force refresh button from component readiness UI

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilities.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilities.js
@@ -78,11 +78,7 @@ export default function CompReadyEnvCapabilities(props) {
     setTriageActionTaken(false)
   }, [triageActionTaken, component, urlParams])
 
-  const fetchData = (fresh) => {
-    if (fresh) {
-      apiCallStr += '&forceRefresh=true'
-    }
-
+  const fetchData = () => {
     fetch(apiCallStr, { signal: abortController.signal })
       .then((response) => response.json())
       .then((data) => {
@@ -122,10 +118,6 @@ export default function CompReadyEnvCapabilities(props) {
       })
   }
 
-  const forceRefresh = () => {
-    setIsLoaded(false)
-    fetchData(true)
-  }
   const [searchRowRegexURL, setSearchRowRegexURL] = useQueryParam(
     'searchRow',
     StringParam
@@ -224,7 +216,6 @@ export default function CompReadyEnvCapabilities(props) {
         data={data}
         filterVals={filterVals}
         setTriageActionTaken={setTriageActionTaken}
-        forceRefresh={forceRefresh}
       />
       <br></br>
       <TableContainer component="div" className="cr-table-wrapper">

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapability.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapability.js
@@ -77,11 +77,7 @@ export default function CompReadyEnvCapability(props) {
     setTriageActionTaken(false)
   }, [triageActionTaken, urlParams, capability])
 
-  const fetchData = (fresh) => {
-    if (fresh) {
-      apiCallStr += '&forceRefresh=true'
-    }
-
+  const fetchData = () => {
     fetch(apiCallStr, { signal: abortController.signal })
       .then((response) => response.json())
       .then((data) => {
@@ -118,11 +114,6 @@ export default function CompReadyEnvCapability(props) {
         // Mark the attempt as finished whether successful or not.
         setIsLoaded(true)
       })
-  }
-
-  const forceRefresh = () => {
-    setIsLoaded(false)
-    fetchData(true)
   }
 
   if (fetchError !== '') {
@@ -219,7 +210,6 @@ export default function CompReadyEnvCapability(props) {
         data={data}
         filterVals={filterVals}
         setTriageActionTaken={setTriageActionTaken}
-        forceRefresh={forceRefresh}
       />
       <br></br>
       <TableContainer component="div" className="cr-table-wrapper">

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
@@ -118,11 +118,6 @@ export default function CompReadyEnvCapabilityTest(props) {
     `&testId=${safeTestId}` +
     (environment ? expandEnvironment(environment) : '')
 
-  const forceRefresh = () => {
-    setIsLoaded(false)
-    fetchData(true)
-  }
-
   useEffect(() => {
     setIsLoaded(false)
     if (!testId) return // wait until vars are initialized from params
@@ -130,11 +125,7 @@ export default function CompReadyEnvCapabilityTest(props) {
     setTriageActionTaken(false)
   }, [triageActionTaken, urlParams, testId])
 
-  const fetchData = (fresh) => {
-    if (fresh) {
-      apiCallStr += '&forceRefresh=true'
-    }
-
+  const fetchData = () => {
     fetch(apiCallStr, { signal: abortController.signal })
       .then((response) => response.json())
       .then((data) => {
@@ -213,7 +204,6 @@ export default function CompReadyEnvCapabilityTest(props) {
         data={data}
         filterVals={filterVals}
         setTriageActionTaken={setTriageActionTaken}
-        forceRefresh={forceRefresh}
       />
       <br></br>
       <TableContainer component="div" className="cr-table-wrapper">

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -329,7 +329,7 @@ export default function ComponentReadiness(props) {
     )
   }
 
-  const fetchData = (fresh) => {
+  const fetchData = () => {
     // prevent a slightly expensive duplicate request when user navs to /main with no query params,
     // and we're still in the process of setting the default view to use
     // Only skip if we have views AND we're in the process of setting a default view
@@ -346,9 +346,6 @@ export default function ComponentReadiness(props) {
 
     let formattedApiCallStr = showValuesForReport()
     console.log('fetchData api call str: ' + formattedApiCallStr)
-    if (fresh) {
-      formattedApiCallStr += '&forceRefresh=true'
-    }
     fetch(formattedApiCallStr, { signal: abortController.signal })
       .then((response) => {
         if (response.status !== 200) {
@@ -385,11 +382,6 @@ export default function ComponentReadiness(props) {
         // Mark the attempt as finished whether successful or not.
         setIsLoaded(true)
       })
-  }
-
-  const forceRefresh = () => {
-    setIsLoaded(false)
-    fetchData(true)
   }
 
   // Helper function to get only report-related parameters (excluding UI state params)
@@ -635,7 +627,6 @@ export default function ComponentReadiness(props) {
                           data={data}
                           filterVals={getUpdatedUrlParts(varsContext)}
                           setTriageActionTaken={setTriageActionTaken}
-                          forceRefresh={forceRefresh}
                         />
                         <TableContainer
                           component="div"

--- a/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
+++ b/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
@@ -21,7 +21,6 @@ import {
   HelpCenter,
   InsertLink,
   LocalHospital,
-  Refresh,
   ViewColumn,
   Widgets,
 } from '@mui/icons-material'
@@ -340,22 +339,6 @@ export default function ComponentReadinessToolBar(props) {
             )}
 
             <Box sx={{ flexGrow: 1 }} />
-            {props.forceRefresh ? (
-              <Box sx={{ display: { md: 'flex' } }}>
-                <IconButton
-                  size="large"
-                  aria-label="Force data refresh"
-                  color="inherit"
-                  onClick={props.forceRefresh}
-                >
-                  <Tooltip title="Force data refresh">
-                    <Refresh />
-                  </Tooltip>
-                </IconButton>
-              </Box>
-            ) : (
-              <></>
-            )}
             <Box sx={{ display: { md: 'flex' } }}>
               <IconButton
                 size="large"
@@ -458,7 +441,6 @@ ComponentReadinessToolBar.propTypes = {
   handleRedOnlyCheckboxChange: PropTypes.func,
   clearSearches: PropTypes.func,
   data: PropTypes.object,
-  forceRefresh: PropTypes.func,
   setTriageActionTaken: PropTypes.func,
   filterVals: PropTypes.string.isRequired,
 }


### PR DESCRIPTION
The backend still supports the forceRefresh query parameter, but the toolbar button is no longer needed. Removes the Refresh icon button, the forceRefresh callbacks, and the fresh parameter plumbing from fetchData in all component readiness page components.

We are removing this option as it is costly when used, and we have noticed that people are confused about what it does. The legitimate reasons to use this button are rare, and there are workarounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the manual "Force data refresh" button from Component Readiness tools. Data now refreshes automatically when relevant conditions change, eliminating the need for manual refresh actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->