### PR TITLE
TRT-2660: Initialize Explanations slice to prevent null JSON serialization

### DIFF
--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -613,7 +613,7 @@ func (c *ComponentReportGenerator) generateComponentTestReport(basisStatusMap, s
 	keySet := sets.NewString(slices.Collect(maps.Keys(basisStatusMap))...)
 	keySet.Insert(slices.Collect(maps.Keys(sampleStatusMap))...)
 	for testKeyStr := range keySet {
-		var cellReport testdetails.TestComparison // The actual stats we return over the API
+		cellReport := testdetails.TestComparison{Explanations: []string{}} // The actual stats we return over the API
 		sampleStatus, sampleThere := sampleStatusMap[testKeyStr]
 		basisStatus, basisThere := basisStatusMap[testKeyStr]
 

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -443,6 +443,7 @@ func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(
 
 	testStats := testdetails.TestComparison{
 		RequiredConfidence: c.ReqOptions.AdvancedOption.Confidence,
+		Explanations:       []string{},
 		SampleStats: testdetails.ReleaseStats{
 			Release: c.ReqOptions.SampleRelease.Name,
 			Start:   &c.ReqOptions.SampleRelease.Start,

--- a/sippy-ng/src/component_readiness/CompSeverityIcon.js
+++ b/sippy-ng/src/component_readiness/CompSeverityIcon.js
@@ -19,7 +19,7 @@ export default function CompSeverityIcon(props) {
   )
 
   let toolTip = statusStr
-  if (explanations !== undefined && explanations.length > 0) {
+  if (explanations != null && explanations.length > 0) {
     toolTip = explanations.join(' ')
   }
 


### PR DESCRIPTION
## Summary
- Initialize `Explanations: []string{}` at both `TestComparison` creation sites (`component_report.go:616` and `test_details.go:444`) so Go serializes them as `[]` instead of `null`
- Add a defensive `!= null` check in `CompSeverityIcon.js` to guard against null explanations from the API

## Root Cause
`TestComparison` structs were created with a nil `Explanations` slice. Code paths in `assessComponentStatus` that don't append to `Explanations` (e.g. the "no regression" branch) left it nil. Go's JSON encoder serializes nil slices as `null`, causing the frontend to crash when accessing `explanations.length`.

## Test plan
- [x] `make lint` passes with 0 issues
- [x] `make test` passes (Go + Jest)
- [ ] CI e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of explanation fields in component readiness reports to ensure proper data initialization and prevent null reference issues in tooltip displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->