### PR TITLE
TRT-2660: Fix null explanations crash in regressed tests modal

### DIFF
--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -613,7 +613,7 @@ func (c *ComponentReportGenerator) generateComponentTestReport(basisStatusMap, s
 	keySet := sets.NewString(slices.Collect(maps.Keys(basisStatusMap))...)
 	keySet.Insert(slices.Collect(maps.Keys(sampleStatusMap))...)
 	for testKeyStr := range keySet {
-		var cellReport testdetails.TestComparison // The actual stats we return over the API
+		cellReport := testdetails.TestComparison{Explanations: []string{}} // The actual stats we return over the API
 		sampleStatus, sampleThere := sampleStatusMap[testKeyStr]
 		basisStatus, basisThere := basisStatusMap[testKeyStr]
 

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -613,7 +613,7 @@ func (c *ComponentReportGenerator) generateComponentTestReport(basisStatusMap, s
 	keySet := sets.NewString(slices.Collect(maps.Keys(basisStatusMap))...)
 	keySet.Insert(slices.Collect(maps.Keys(sampleStatusMap))...)
 	for testKeyStr := range keySet {
-		cellReport := testdetails.TestComparison{Explanations: []string{}} // The actual stats we return over the API
+		cellReport := testdetails.TestComparison{Explanations: []string{}}
 		sampleStatus, sampleThere := sampleStatusMap[testKeyStr]
 		basisStatus, basisThere := basisStatusMap[testKeyStr]
 

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -442,6 +442,7 @@ func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(
 	totalBase, totalSample, report, result, lastFailure := c.summarizeRecordedTestStats(baseStatus, sampleStatus, testKey)
 
 	testStats := testdetails.TestComparison{
+		Explanations:       []string{},
 		RequiredConfidence: c.ReqOptions.AdvancedOption.Confidence,
 		SampleStats: testdetails.ReleaseStats{
 			Release: c.ReqOptions.SampleRelease.Name,

--- a/sippy-ng/src/component_readiness/CompSeverityIcon.js
+++ b/sippy-ng/src/component_readiness/CompSeverityIcon.js
@@ -19,7 +19,7 @@ export default function CompSeverityIcon(props) {
   )
 
   let toolTip = statusStr
-  if (explanations !== undefined && explanations.length > 0) {
+  if (explanations != null && explanations.length > 0) {
     toolTip = explanations.join(' ')
   }
 


### PR DESCRIPTION
## Summary
- Initialize `Explanations` as `[]string{}` instead of `nil` at both `TestComparison` creation sites (`component_report.go:616`, `test_details.go:444`) so Go serializes it as JSON `[]` instead of `null`.
- Add a defensive `null` check in `CompSeverityIcon.js` (`!= null` catches both `null` and `undefined`).

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (14954 Go tests + JS tests)
- [ ] Open the regressed tests modal on the component readiness page and confirm it no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved consistency in how explanation fields are initialized across component readiness reports and UI components, ensuring proper handling of empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->