### PR TITLE
Update CR views for 4.21 GA

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -2351,14 +2351,14 @@ component_readiness:
       Topology:
       - external
   advanced_options:
-    minimum_failure: 3
+    minimum_failure: 4
     confidence: 95
-    pity_factor: 5
+    pity_factor: 10
     ignore_missing: false
     ignore_disruption: true
     flake_as_failure: false
-    pass_rate_required_new_tests: 95
-    include_multi_release_analysis: true
+    pass_rate_required_new_tests: 90
+    include_multi_release_analysis: false
 - name: 4.21-x86-vs-multi-arm
   base_release:
     release: "4.21"
@@ -2734,14 +2734,14 @@ component_readiness:
       - runc
       - crun
   advanced_options:
-    minimum_failure: 3
+    minimum_failure: 4
     confidence: 95
-    pity_factor: 5
+    pity_factor: 10
     ignore_missing: false
     ignore_disruption: true
     flake_as_failure: false
-    pass_rate_required_new_tests: 95
-    include_multi_release_analysis: true
+    pass_rate_required_new_tests: 90
+    include_multi_release_analysis: false
   metrics:
     enabled: true
   regression_tracking:
@@ -2810,14 +2810,14 @@ component_readiness:
       - runc
       - crun
   advanced_options:
-    minimum_failure: 3
+    minimum_failure: 4
     confidence: 95
-    pity_factor: 5
+    pity_factor: 10
     ignore_missing: false
     ignore_disruption: true
     flake_as_failure: false
-    pass_rate_required_new_tests: 95
-    include_multi_release_analysis: true
+    pass_rate_required_new_tests: 90
+    include_multi_release_analysis: false
   metrics:
     enabled: true
   regression_tracking:


### PR DESCRIPTION
Relax 4.21 CR view thresholds now that 4.21 is GA:

- Increase pity_factor to 10, minimum_failure to 4
- Decrease pass_rate_required_new_tests to 90
- Disable multi-release analysis for remaining 4.21 views

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated component readiness evaluation parameters, including failure tolerance thresholds and test pass rate requirements for specific build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->