### PR TITLE
TRT-2626: Update CR views for 4.22 GA

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -3,8 +3,8 @@ component_readiness:
 - name: 5.0-main
   base_release:
     release: "4.22"
-    relative_start: now-30d
-    relative_end: now
+    relative_start: ga-30d
+    relative_end: ga
   sample_release:
     release: "5.0"
     relative_start: now-7d
@@ -92,8 +92,8 @@ component_readiness:
 - name: 5.0-rosa
   base_release:
     release: "4.22"
-    relative_start: now-30d
-    relative_end: now
+    relative_start: ga-30d
+    relative_end: ga
   sample_release:
     release: "5.0"
     relative_start: now-7d
@@ -178,8 +178,8 @@ component_readiness:
 - name: 5.0-main-mass-failure
   base_release:
     release: "4.22"
-    relative_start: now-30d
-    relative_end: now
+    relative_start: ga-30d
+    relative_end: ga
   sample_release:
     release: "5.0"
     relative_start: now-7d
@@ -271,8 +271,8 @@ component_readiness:
 - name: 5.0-hypershift-candidates
   base_release:
     release: "4.22"
-    relative_start: now-30d
-    relative_end: now
+    relative_start: ga-30d
+    relative_end: ga
   sample_release:
     release: "5.0"
     relative_start: now-7d
@@ -559,8 +559,8 @@ component_readiness:
 - name: 5.0-LP-Chaos--lpMainline
   base_release:
     release: "4.22"
-    relative_start: now-30d
-    relative_end: now
+    relative_start: ga-30d
+    relative_end: ga
   sample_release:
     release: "5.0"
     relative_start: now-30d
@@ -604,8 +604,8 @@ component_readiness:
 - name: 5.0-LP-Interop--lpMainline
   base_release:
     release: "4.22"
-    relative_start: now-30d
-    relative_end: now
+    relative_start: ga-30d
+    relative_end: ga
   sample_release:
     release: "5.0"
     relative_start: now-30d
@@ -649,8 +649,8 @@ component_readiness:
 - name: 5.0-LP-OCP-Compat--lpMainline
   base_release:
     release: "4.22"
-    relative_start: now-30d
-    relative_end: now
+    relative_start: ga-30d
+    relative_end: ga
   sample_release:
     release: "5.0"
     relative_start: now-30d
@@ -695,8 +695,8 @@ component_readiness:
 - name: 5.0-LP-OCP-Compat--lpGA
   base_release:
     release: "4.22"
-    relative_start: now-30d
-    relative_end: now
+    relative_start: ga-30d
+    relative_end: ga
   sample_release:
     release: "5.0"
     relative_start: now-30d
@@ -795,8 +795,8 @@ component_readiness:
 - name: 5.0-rarely-run-jobs
   base_release:
     release: "4.22"
-    relative_start: now-90d
-    relative_end: now
+    relative_start: ga-90d
+    relative_end: ga
   sample_release:
     release: "5.0"
       # need to look much further back for rarely run jobs
@@ -861,8 +861,8 @@ component_readiness:
 - name: 5.0-s390x
   base_release:
     release: "4.22"
-    relative_start: now-30d
-    relative_end: now
+    relative_start: ga-30d
+    relative_end: ga
   sample_release:
     release: "5.0"
     relative_start: now-7d
@@ -938,8 +938,8 @@ component_readiness:
 - name: 5.0-ppc64le
   base_release:
     release: "4.22"
-    relative_start: now-30d
-    relative_end: now
+    relative_start: ga-30d
+    relative_end: ga
   sample_release:
     release: "5.0"
     relative_start: now-7d
@@ -1225,14 +1225,14 @@ component_readiness:
     lifecycles:
     - blocking
   advanced_options:
-    minimum_failure: 3
+    minimum_failure: 4
     confidence: 95
-    pity_factor: 5
+    pity_factor: 10
     ignore_missing: false
     ignore_disruption: true
     flake_as_failure: false
-    pass_rate_required_new_tests: 95
-    include_multi_release_analysis: true
+    pass_rate_required_new_tests: 90
+    include_multi_release_analysis: false
   metrics:
     enabled: true
   regression_tracking:
@@ -1240,7 +1240,7 @@ component_readiness:
   prime_cache:
     enabled: true
   automate_jira:
-    enabled: true
+    enabled: false
 - name: 4.22-rosa
   base_release:
     release: "4.21"
@@ -1311,13 +1311,13 @@ component_readiness:
     lifecycles:
     - blocking
   advanced_options:
-    minimum_failure: 3
+    minimum_failure: 4
     confidence: 95
-    pity_factor: 5
+    pity_factor: 10
     ignore_missing: false
     ignore_disruption: true
     flake_as_failure: false
-    pass_rate_required_new_tests: 95
+    pass_rate_required_new_tests: 90
     include_multi_release_analysis: false
   metrics:
     enabled: false
@@ -1400,14 +1400,14 @@ component_readiness:
     lifecycles:
     - blocking
   advanced_options:
-    minimum_failure: 3
+    minimum_failure: 4
     confidence: 95
-    pity_factor: 5
+    pity_factor: 10
     ignore_missing: false
     ignore_disruption: true
     flake_as_failure: false
-    pass_rate_required_new_tests: 95
-    include_multi_release_analysis: true
+    pass_rate_required_new_tests: 90
+    include_multi_release_analysis: false
     key_test_names:
     - "install should succeed: overall"
     - "[sig-cluster-lifecycle] Cluster completes upgrade"
@@ -1474,14 +1474,14 @@ component_readiness:
       Topology:
       - external
   advanced_options:
-    minimum_failure: 3
+    minimum_failure: 4
     confidence: 95
-    pity_factor: 5
+    pity_factor: 10
     ignore_missing: false
     ignore_disruption: true
     flake_as_failure: false
-    pass_rate_required_new_tests: 95
-    include_multi_release_analysis: true
+    pass_rate_required_new_tests: 90
+    include_multi_release_analysis: false
 - name: 4.22-x86-vs-multi-arm
   base_release:
     release: "4.22"
@@ -1982,14 +1982,14 @@ component_readiness:
       - runc
       - crun
   advanced_options:
-    minimum_failure: 3
+    minimum_failure: 4
     confidence: 95
-    pity_factor: 5
+    pity_factor: 10
     ignore_missing: false
     ignore_disruption: true
     flake_as_failure: false
-    pass_rate_required_new_tests: 95
-    include_multi_release_analysis: true
+    pass_rate_required_new_tests: 90
+    include_multi_release_analysis: false
   metrics:
     enabled: true
   regression_tracking:
@@ -2059,14 +2059,14 @@ component_readiness:
       - runc
       - crun
   advanced_options:
-    minimum_failure: 3
+    minimum_failure: 4
     confidence: 95
-    pity_factor: 5
+    pity_factor: 10
     ignore_missing: false
     ignore_disruption: true
     flake_as_failure: false
-    pass_rate_required_new_tests: 95
-    include_multi_release_analysis: true
+    pass_rate_required_new_tests: 90
+    include_multi_release_analysis: false
   metrics:
     enabled: true
   regression_tracking:


### PR DESCRIPTION
Update CR views in preparation for the 4.22 GA release. Relax sensitivity thresholds and update the next development release's base_release dates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal testing and release configuration for version 4.22 and 5.0 variants, including adjustments to job execution windows and quality assurance thresholds to optimize the release pipeline.

---
**Note:** This is an internal infrastructure update with no direct user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->