### PR TITLE
MPIIT: Fix gitops job substring

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -1277,7 +1277,7 @@ func setLayeredProduct(_ logrus.FieldLogger, variants map[string]string, jobName
 		{"-lpmainline-lp-ocp-compat-cr--acs-", "lp-ocp-compat--acs--lpMainline"},
 		{"-lpga-lp-ocp-compat-cr--acs-", "lp-ocp-compat--acs--lpGA"},
 		{"-lpga-lp-ocp-compat-cr--odf-", "lp-ocp-compat--odf--lpGA"},
-		{"-lpga-lp-ocp-compat-cr--redhat-openshift-gitops-", "lp-ocp-compat--gitops--lpGA"},
+		{"-lpga-lp-ocp-compat-cr--gitops-", "lp-ocp-compat--gitops--lpGA"},
 		{"-lpga-lp-ocp-compat-cr--fusion-access-", "lp-ocp-compat--fusion-access--lpGA"},
 		{"-lpga-lp-ocp-compat-cr--mta-", "lp-ocp-compat--mta--lpGA"},
 		{"-lpga-lp-ocp-compat-cr--oadp-", "lp-ocp-compat--oadp--lpGA"},


### PR DESCRIPTION
### Fix GitOps lp-ocp-compat job classification in the variant registry.

The `setLayeredProduct` pattern for GitOps used `-lpga-lp-ocp-compat-cr--redhat-openshift-gitops-`, but actual Prow job names use the shorter slug `-lpga-lp-ocp-compat-cr--gitops-` (see job name below). 

Because of that mismatch, GitOps lp-ocp-compat jobs were classified with `LayeredProduct: none` instead of `lp-ocp-compat--gitops--lpGA`, so they did not appear in the **LP-OCP-Compat** Component Readiness views that already filter on `lp-ocp-compat--gitops--lpGA`.

### Ref: Periodic name in Openshift Ci Operator [[link]](https://github.com/openshift/release/blob/95adbef03211c5181dad6ac3397732d3335e6a45/ci-operator/jobs/redhat-developer/gitops-operator/redhat-developer-gitops-operator-v1.20-periodics.yaml#L121)
`periodic-ci-redhat-developer-gitops-operator-v1.20-gitops-ocp-4.22-lpGA-lp-ocp-compat-cr--gitops--aws`