### PR TITLE
TRT-2664: add SIPPY_E2E_REDIS_URL so redis works in agentic e2e testing

### DIFF
--- a/hack/agentic_setup.sh
+++ b/hack/agentic_setup.sh
@@ -10,6 +10,7 @@ export SIPPY_DATABASE_DSN="postgresql://postgres@localhost:5432/postgres?sslmode
 export SIPPY_SEED_DATABASE_DSN="${SIPPY_DATABASE_DSN}"
 export SIPPY_PRODLIKE_DATABASE_DSN="postgresql://postgres@localhost:5432/prodlike?sslmode=disable"
 export REDIS_URL="redis://localhost:6379"
+export SIPPY_E2E_REDIS_URL="redis://localhost:6379/1"
 
 echo "Starting services..."
 "${REPO_ROOT}/.devcontainer/init-services.sh"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * End-to-end testing configuration updated to use a separate Redis database instance for test operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->