### PR TITLE
TRT-2693: releasefallback panic

### DIFF
--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -277,7 +277,7 @@ func (c *ComponentReportGenerator) getCache() cache.Cache {
 func (c *ComponentReportGenerator) initializeMiddleware() {
 	c.middlewares = middleware.List{}
 	// Initialize all our middleware applicable to this request.
-	if c.ReqOptions.AdvancedOption.IncludeMultiReleaseAnalysis {
+	if c.ReqOptions.AdvancedOption.IncludeMultiReleaseAnalysis && c.ReqOptions.SampleRelease.PullRequestOptions == nil {
 		c.middlewares = append(c.middlewares, releasefallback.NewReleaseFallbackMiddleware(c.dataProvider, c.ReqOptions, c.releaseConfigs))
 	}
 	if c.dbc != nil {

--- a/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
+++ b/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/openshift/sippy/pkg/api/componentreadiness/middleware"
+	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crstatus"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crtest"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
@@ -53,14 +54,14 @@ type RegressionTracker struct {
 func (r *RegressionTracker) Query(ctx context.Context, wg *sync.WaitGroup, allJobVariants crtest.JobVariants, baseStatusCh, sampleStatusCh chan map[string]crstatus.TestStatus, errCh chan error) {
 	err := r.ensureRegressionsLoaded()
 	if err != nil {
-		errCh <- err
+		utils.EnqueueAsync(wg, errCh, err)
 	}
 }
 
 func (r *RegressionTracker) QueryTestDetails(ctx context.Context, wg *sync.WaitGroup, errCh chan error, allJobVariants crtest.JobVariants) {
 	err := r.ensureRegressionsLoaded()
 	if err != nil {
-		errCh <- err
+		utils.EnqueueAsync(wg, errCh, err)
 	}
 }
 

--- a/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
+++ b/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
@@ -46,7 +46,7 @@ func NewReleaseFallbackMiddleware(
 
 // ReleaseFallback middleware allows us to use the best pass rate data from the past
 // several releases for our basis instead of just the requested basis. This helps prevent
-// minor gradual degredation of quality, and also simplifies the process of accepting
+// minor gradual degradation of quality, and also simplifies the process of accepting
 // intentional regressions shortly before release, as we'll then automatically use the data
 // from prior releases.
 //
@@ -81,7 +81,6 @@ func (r *ReleaseFallback) Query(ctx context.Context, wg *sync.WaitGroup, allJobV
 			r.log.Infof("Context canceled while fetching fallback query status")
 			return
 		default:
-			// TODO: should we pass the same wg through rather than using another?
 			errs := r.getFallbackBaseQueryStatus(ctx, allJobVariants, r.reqOptions.BaseRelease.Name, r.reqOptions.BaseRelease.Start, r.reqOptions.BaseRelease.End)
 			if len(errs) > 0 {
 				for _, err := range errs {
@@ -195,9 +194,15 @@ func (r *ReleaseFallback) QueryTestDetails(ctx context.Context, wg *sync.WaitGro
 
 	// Lookup all release dates, we're going to need them
 	timeRanges, errs := r.dataProvider.QueryReleaseDates(ctx, r.reqOptions)
-	for _, err := range errs {
-		errCh <- err
-	}
+	defer func() {
+		wg.Add(1)
+		go func() { // method is called synchronously, would block on writing channel
+			for _, err := range errs {
+				errCh <- err
+			}
+			wg.Done()
+		}()
+	}()
 	if errs != nil {
 		return
 	}
@@ -226,7 +231,7 @@ func (r *ReleaseFallback) QueryTestDetails(ctx context.Context, wg *sync.WaitGro
 
 		start, end, err := utils.FindStartEndTimesForRelease(timeRanges, release)
 		if err != nil {
-			errCh <- err
+			errs = append(errs, err)
 			return
 		}
 
@@ -244,10 +249,10 @@ func (r *ReleaseFallback) QueryTestDetails(ctx context.Context, wg *sync.WaitGro
 				fallbackReqOpts.BaseRelease.End = *end
 				fallbackReqOpts.TestIDOptions = testIDOpts
 
-				baseStatus, errs := r.dataProvider.QueryBaseJobRunTestStatus(ctx, fallbackReqOpts, allJobVariants)
+				baseStatus, bsErrs := r.dataProvider.QueryBaseJobRunTestStatus(ctx, fallbackReqOpts, allJobVariants)
 
-				for _, err := range errs {
-					errCh <- err
+				for _, bsErr := range bsErrs {
+					errCh <- bsErr
 				}
 
 				// Now that we've queried all the results for a fallback release, we need to chop them up into
@@ -275,7 +280,7 @@ func (r *ReleaseFallback) QueryTestDetails(ctx context.Context, wg *sync.WaitGro
 
 				r.baseOverrideMutex.Unlock()
 
-				r.log.Infof("queried fallback base override job run test status: %d jobs, %d errors", len(r.baseOverrideStatus), len(errs))
+				r.log.Infof("queried fallback base override job run test status: %d jobs, %d errors", len(r.baseOverrideStatus), len(bsErrs))
 			}
 		}()
 	}

--- a/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
+++ b/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
@@ -194,16 +194,8 @@ func (r *ReleaseFallback) QueryTestDetails(ctx context.Context, wg *sync.WaitGro
 
 	// Lookup all release dates, we're going to need them
 	timeRanges, errs := r.dataProvider.QueryReleaseDates(ctx, r.reqOptions)
-	defer func() {
-		wg.Add(1)
-		go func() { // method is called synchronously, would block on writing channel
-			for _, err := range errs {
-				errCh <- err
-			}
-			wg.Done()
-		}()
-	}()
 	if errs != nil {
+		utils.EnqueueAsync(wg, errCh, errs...)
 		return
 	}
 
@@ -231,7 +223,7 @@ func (r *ReleaseFallback) QueryTestDetails(ctx context.Context, wg *sync.WaitGro
 
 		start, end, err := utils.FindStartEndTimesForRelease(timeRanges, release)
 		if err != nil {
-			errs = append(errs, err)
+			utils.EnqueueAsync(wg, errCh, err)
 			return
 		}
 

--- a/pkg/api/componentreadiness/utils/utils.go
+++ b/pkg/api/componentreadiness/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -336,4 +337,15 @@ func GenerateTestDetailsURL(
 
 	u.RawQuery = params.Encode()
 	return u.String(), nil
+}
+
+// EnqueueAsync is a helper function to asynchronously enqueue something (like errors) on a channel from a synchronous context.
+func EnqueueAsync[T any](wg *sync.WaitGroup, channel chan T, things ...T) {
+	wg.Add(1)
+	go func() {
+		for _, thing := range things {
+			channel <- thing
+		}
+		wg.Done()
+	}()
 }

--- a/pkg/api/componentreadiness/utils/utils.go
+++ b/pkg/api/componentreadiness/utils/utils.go
@@ -34,9 +34,13 @@ func PreviousRelease(release string, releaseConfigs []sippyv1.Release) (string, 
 // The start time is calculated as 30 days before the GA date, and the end time is the GA date.
 func FindStartEndTimesForRelease(timeRanges []crtest.ReleaseTimeRange, release string) (*time.Time, *time.Time, error) {
 	for _, r := range timeRanges {
-		if r.Release == release {
-			return r.Start, r.End, nil
+		if r.Release != release {
+			continue
 		}
+		if r.Start == nil || r.End == nil {
+			return nil, nil, fmt.Errorf("release %s has no GA date", release)
+		}
+		return r.Start, r.End, nil
 	}
 	return nil, nil, fmt.Errorf("release %s not found", release)
 }


### PR DESCRIPTION
When requesting release dates for old releases, report releases without a GA date as an error instead of empty dates, and then handle those errors properly.

When requesting CR for a PR sample, don't compare against fallback releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of release date info to prevent processing when dates are missing.
  * Improved error collection and asynchronous handling during multi-release analysis to reduce lost errors and improve reliability.
  * Adjusted multi-release analysis gating so fallback processing only runs when appropriate options are present.

* **Documentation**
  * Fixed a typo in release-fallback documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->