### PR TITLE
Trt 1989 post migration

### DIFF
--- a/cmd/sippy/load.go
+++ b/cmd/sippy/load.go
@@ -125,9 +125,8 @@ func NewLoadCommand() *cobra.Command {
 			loaders := make([]dataloader.DataLoader, 0)
 			allErrs := []error{}
 
-			// Cancel syncing after 14 hours
-			// Default is 4 hour but increased for migration due to potential delay and backlog for syncing
-			ctx, cancel := context.WithTimeout(context.Background(), time.Hour*14)
+			// Cancel syncing after 4 hours
+			ctx, cancel := context.WithTimeout(context.Background(), time.Hour*4)
 			defer cancel()
 
 			start := time.Now()

--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -237,9 +237,8 @@ func (pl *ProwLoader) Load() {
 
 	// Ensure we have partitions for the new data
 	if err := pl.ensurePartitions(); err != nil {
-		log.WithError(err).Warning("failed to ensure partitions, continuing with load")
-		// Don't fail the entire load if partition creation fails
-		// Data will still be written if partitions exist or to DEFAULT partition
+		pl.errors = append(pl.errors, errors.Wrap(err, "failed to ensure partitions"))
+		return
 	}
 
 	// Clean up old partitions (detach partitions older than 100 days, drop detached partitions older than 110 days)

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -149,7 +149,8 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 	}
 
 	// Currently we need RunMigrations to run prior
-	// to AutoMigrate so expected tables GORM has dependencies exists
+	// to AutoMigrate so that tables GORM depends on exist
+	// prior to AutoMigrate
 	// As we migrate more of the JobRuns based tables the
 	// Dependencies change, and we likely need to run this first
 	for _, model := range modelsToMigrate {


### PR DESCRIPTION
- Reverts extended load context timeout back to regular value
- Returns error on partition creation to prevent loading
- Clarifies comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Load command now aborts when partition creation fails instead of continuing
  * Load command timeout reduced to 4 hours

* **Chores**
  * Updated documentation in schema update method

<!-- end of auto-generated comment: release notes by coderabbit.ai -->