### PR TITLE
TRT-2590: fix test_details UI filtering bug

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyVars.js
+++ b/sippy-ng/src/component_readiness/CompReadyVars.js
@@ -295,7 +295,9 @@ export const CompReadyVarsProvider = ({ children }) => {
     // Initialize includeVariantsCheckedItems
     setIncludeVariantsCheckedItems(
       convertParamToVariantItems(
-        params.includeVariant || defaultIncludeVariants
+        params.includeVariant ||
+          // when environment supplies the filter we don't want the default filter
+          (params.environment ? [] : defaultIncludeVariants)
       )
     )
 


### PR DESCRIPTION
Unlike the rest of CR, test_details expects the "environment" parameter to specify the variants for the filter and doesn't specify "includeVariant". However it still respects includeVariant if specified; and this generic UI useEffect hook gives includeVariant a default if not specified, which is used to construct the URL when parameters are modified. So basically the default filter would be added to the one intended.

This change prevents adding that default if environment is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed component readiness filtering when using environment parameters. When filtering by environment without explicitly selecting component variants, default variants are no longer automatically applied alongside the environment filter, ensuring environment-specific filtering works correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->