### PR TITLE
TRT-1989: verify synthetic releases

### DIFF
--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -73,6 +73,7 @@ type ProwLoader struct {
 	syntheticTestManager         synthetictests.SyntheticTestManager
 	syntheticReleaseJobOverrides *releaseoverride.SyntheticReleaseOverrides
 	releases                     []string
+	releaseSet                   map[string]bool
 	config                       *v1config.SippyConfig
 	ghCommenter                  *commenter.GitHubCommenter
 	jobsImportedCount            atomic.Int32
@@ -112,11 +113,20 @@ func New(
 		syntheticReleaseJobOverrides: syntheticReleaseJobOverrides,
 		variantManager:               variantManager,
 		releases:                     releases,
+		releaseSet:                   toSet(releases),
 		config:                       config,
 		ghCommenter:                  ghCommenter,
 		promPusher:                   promPusher,
 		loadSince:                    loadSince,
 	}
+}
+
+func toSet(items []string) map[string]bool {
+	s := make(map[string]bool, len(items))
+	for _, item := range items {
+		s[item] = true
+	}
+	return s
 }
 
 var clusterDataDateTimeName = regexp.MustCompile(`cluster-data_(?P<DATE>.*)-(?P<TIME>.*).json`)
@@ -570,10 +580,20 @@ func (pl *ProwLoader) processProwJob(ctx context.Context, pj *prow.ProwJob) erro
 
 	// Synthetic release claims take priority over all other matching.
 	if release, ok := pl.syntheticReleaseJobOverrides.Lookup(pj.Spec.Job); ok {
-		if err := pl.prowJobToJobRun(ctx, pj, release); err != nil {
-			err = errors.Wrapf(err, "error converting prow job to job run: %s", pj.Spec.Job)
-			pjLog.WithError(err).Warning("prow import error")
-			return err
+
+		// make sure this is a known release
+		// default loads all known releases but
+		// explicit release can also be specified
+		// we should not process unknown releases
+		// in that case
+		if pl.releaseSet[release] {
+			if err := pl.prowJobToJobRun(ctx, pj, release); err != nil {
+				err = errors.Wrapf(err, "error converting prow job to job run: %s", pj.Spec.Job)
+				pjLog.WithError(err).Warning("prow import error")
+				return err
+			}
+		} else {
+			log.Warningf("known release not found for release %q", release)
 		}
 		return nil
 	}


### PR DESCRIPTION
ProwLoader passes in [specified release](https://github.com/neisw/sippy/blob/main/cmd/sippy/load.go#L454) when present or falls back to known bq releases.  In the former case partitions are only created for the specified releases.

Synthetic releases are not checking the specified releases which leads to errors when attempting to create jobs for releases that are not configured.

Adding a verification check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation of release configurations during job processing. The system now validates that release overrides reference existing, configured releases before processing jobs. Invalid release overrides trigger warnings and are skipped to prevent errors and maintain data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->