### PR TITLE
TRT-1989: standardize lookback and partition begin grace

### DIFF
--- a/pkg/dataloader/prowloader/bigqueryjobs.go
+++ b/pkg/dataloader/prowloader/bigqueryjobs.go
@@ -26,8 +26,8 @@ func (pl *ProwLoader) fetchProwJobsFromOpenShiftBigQuery() ([]prow.ProwJob, []er
 		row := pl.dbc.DB.Table("prow_job_runs").Select("max(timestamp)").Row()
 		err := row.Scan(&lastProwJobRun)
 		if err != nil || lastProwJobRun.IsZero() {
-			log.WithError(err).Warn("no last prow job run found (new database?), importing last two weeks")
-			lastProwJobRun = time.Now().Add(-14 * 24 * time.Hour)
+			log.WithError(err).Warnf("no last prow job run found (new database?), importing previous %d days", DefaultLookbackDays)
+			lastProwJobRun = time.Now().AddDate(0, 0, -DefaultLookbackDays)
 		} else {
 			// adjust the last job run time, we're querying all jobs that have completed since our last recorded
 			// job START time, but we need to subtract our max job runtime in-case a job ended early and was our last

--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -123,11 +123,15 @@ func New(
 
 const DefaultLookbackDays = 14
 
-func (pl *ProwLoader) resolveLoadSince() time.Time {
-	if pl.loadSince != nil {
-		return *pl.loadSince
+func resolveFrom(since *time.Time, to time.Time) time.Time {
+	if since != nil {
+		return *since
 	}
-	return time.Now().AddDate(0, 0, -DefaultLookbackDays)
+	return to.AddDate(0, 0, -DefaultLookbackDays)
+}
+
+func (pl *ProwLoader) resolveLoadSince() time.Time {
+	return resolveFrom(pl.loadSince, time.Now())
 }
 
 func toSet(items []string) map[string]bool {
@@ -361,13 +365,7 @@ func getTestAnalysisByJobFromToDates(lastDailySummary, now time.Time, loadSince 
 
 	// If this is a new db, do an initial larger import:
 	if lastDailySummary.IsZero() {
-		var from time.Time
-		if loadSince != nil {
-			from = *loadSince
-		} else {
-			from = to.AddDate(0, 0, -DefaultLookbackDays)
-		}
-		return DaysBetween(from, to)
+		return DaysBetween(resolveFrom(loadSince, to), to)
 	}
 
 	ldsStr := lastDailySummary.UTC().Format("2006-01-02")

--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -121,6 +121,15 @@ func New(
 	}
 }
 
+const DefaultLookbackDays = 14
+
+func (pl *ProwLoader) resolveLoadSince() time.Time {
+	if pl.loadSince != nil {
+		return *pl.loadSince
+	}
+	return time.Now().AddDate(0, 0, -DefaultLookbackDays)
+}
+
 func toSet(items []string) map[string]bool {
 	s := make(map[string]bool, len(items))
 	for _, item := range items {
@@ -188,14 +197,7 @@ func (pl *ProwLoader) Errors() []error {
 //   - pl.loadSince if available, otherwise looks back one week
 //   - Creates partitions 2 days forward from now
 func (pl *ProwLoader) ensurePartitions() error {
-	// Determine start date
-	var startDate time.Time
-	if pl.loadSince != nil {
-		startDate = *pl.loadSince
-	} else {
-		// Look back one week if loadSince is not specified
-		startDate = time.Now().AddDate(0, 0, -7)
-	}
+	startDate := pl.resolveLoadSince()
 
 	// Create partitions 2 days forward from now
 	endDate := time.Now().AddDate(0, 0, 2)
@@ -203,7 +205,9 @@ func (pl *ProwLoader) ensurePartitions() error {
 	log.Infof("Ensuring partitions for releases %v from %s to %s",
 		pl.releases, startDate.Format("2006-01-02"), endDate.Format("2006-01-02"))
 
-	count, err := pl.dbc.EnsurePartitions(pl.releases, startDate, endDate, false)
+	// https://github.com/openshift/sippy/blob/main/pkg/dataloader/prowloader/prow.go#L473 bq imports based on modified time which can include job_run_start_time a day earlier
+	// add grace to ensure we have a valid partition for new dbs.
+	count, err := pl.dbc.EnsurePartitions(pl.releases, startDate.AddDate(0, 0, -1), endDate, false)
 	if err != nil {
 		return fmt.Errorf("failed to ensure partitions: %w", err)
 	}
@@ -352,12 +356,17 @@ type tempBQTestAnalysisByJobForDate struct {
 // pick up at that date the next time.
 //
 // At present in prod, each day takes about 20 minutes
-func getTestAnalysisByJobFromToDates(lastDailySummary, now time.Time) []string {
+func getTestAnalysisByJobFromToDates(lastDailySummary, now time.Time, loadSince *time.Time) []string {
 	to := now.UTC().Add(-32 * time.Hour)
 
 	// If this is a new db, do an initial larger import:
 	if lastDailySummary.IsZero() {
-		from := to.Add(-14 * 24 * time.Hour)
+		var from time.Time
+		if loadSince != nil {
+			from = *loadSince
+		} else {
+			from = to.AddDate(0, 0, -DefaultLookbackDays)
+		}
 		return DaysBetween(from, to)
 	}
 
@@ -418,7 +427,7 @@ func (pl *ProwLoader) loadDailyTestAnalysisByJob(ctx context.Context) error {
 	// Ignoring error, the function below handles the zero time if needed: (new db)
 	_ = row.Scan(&lastDailySummary)
 
-	importDates := getTestAnalysisByJobFromToDates(lastDailySummary, time.Now())
+	importDates := getTestAnalysisByJobFromToDates(lastDailySummary, time.Now(), pl.loadSince)
 	if len(importDates) == 0 {
 		log.Info("test analysis summary already completed today")
 		return nil

--- a/pkg/dataloader/prowloader/prow_test.go
+++ b/pkg/dataloader/prowloader/prow_test.go
@@ -173,7 +173,7 @@ func TestGetTestAnalysisByJobFromToDates(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dates := getTestAnalysisByJobFromToDates(tt.lastSummary, tt.now)
+			dates := getTestAnalysisByJobFromToDates(tt.lastSummary, tt.now, nil)
 			assert.Equal(t, tt.expectedDates, dates)
 		})
 	}


### PR DESCRIPTION
Adds a day of grace for partition start due to BQ modified_time vs. job_run_start_time based queries.
Standardizes the default lookback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized the default lookback period to 14 days for historical data imports.
* **Bug Fixes**
  * Adjusted partition start to begin one day earlier to improve date-boundary coverage.
  * Standardized fallback behavior and logging when no prior import timestamp is found.
* **Tests**
  * Updated tests to reflect the revised load-since handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->