### PR TITLE
TRT-2703: update jobRunsReportMatView post partitioning

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -52,7 +52,23 @@ func (w log2LogrusWriter) Printf(msg string, args ...any) {
 	w.entry.Debugf(msg, args...)
 }
 
-func New(dsn string, logLevel gormlogger.LogLevel) (*DB, error) {
+type Option func(*options)
+
+type options struct {
+	enablePartitionwise bool
+}
+
+func WithPartitionwise(enable bool) Option {
+	return func(o *options) {
+		o.enablePartitionwise = enable
+	}
+}
+
+func New(dsn string, logLevel gormlogger.LogLevel, opts ...Option) (*DB, error) {
+	var cfg options
+	for _, o := range opts {
+		o(&cfg)
+	}
 	gormLogger := gormlogger.New(
 		log2LogrusWriter{entry: log.WithField("source", "gorm")},
 		gormlogger.Config{
@@ -73,6 +89,10 @@ func New(dsn string, logLevel gormlogger.LogLevel) (*DB, error) {
 	// partitions. Custom plans use actual parameter values for partition pruning.
 	pgxConfig.RuntimeParams["plan_cache_mode"] = "force_custom_plan"
 	pgxConfig.RuntimeParams["work_mem"] = "128MB"
+	if cfg.enablePartitionwise {
+		pgxConfig.RuntimeParams["enable_partitionwise_aggregate"] = "on"
+		pgxConfig.RuntimeParams["enable_partitionwise_join"] = "on"
+	}
 
 	connPool := stdlib.OpenDB(*pgxConfig)
 

--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -187,6 +187,7 @@ pull_requests AS (
                 prow_job_run_prow_pull_requests ON prow_job_run_prow_pull_requests.prow_pull_request_id = prow_pull_requests.id
         INNER JOIN
                 prow_job_runs ON prow_job_run_prow_pull_requests.prow_job_run_id = prow_job_runs.id
+        WHERE prow_job_runs."timestamp" >= CURRENT_TIMESTAMP - interval '90 days'
         GROUP BY prow_job_runs.id, prow_pull_requests.link, prow_pull_requests.sha, prow_pull_requests.org, prow_pull_requests.repo, prow_pull_requests.author
 )
 SELECT prow_job_runs.id,
@@ -208,7 +209,7 @@ SELECT prow_job_runs.id,
    test_results.flaked_test_names AS flaked_test_names,
    test_results.flaked_test_count AS test_flakes,
    test_results.failed_test_names AS failed_test_names,
-   COALESCE(test_results.failed_test_count, prow_job_runs.test_failures) AS test_failures,
+   test_results.failed_test_count AS test_failures,
    pull_requests.link as pull_request_link,
    pull_requests.sha as pull_request_sha,
    pull_requests.org as pull_request_org,

--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -156,22 +156,26 @@ func syncPostgresViews(db *gorm.DB, reportEnd *time.Time) error {
 const jobRunsReportMatView = `
 WITH failed_test_results AS (
 	SELECT prow_job_run_tests.prow_job_run_id,
+		prow_job_run_tests.prow_job_run_release,
 		array_agg(tests.id) AS test_ids,
 		count(tests.id) AS test_count,
 		array_agg(tests.name) AS test_names
 	FROM prow_job_run_tests
 		JOIN tests ON tests.id = prow_job_run_tests.test_id
 	WHERE prow_job_run_tests.status = 12
-	GROUP BY prow_job_run_tests.prow_job_run_id
+		AND prow_job_run_tests.prow_job_run_timestamp >= CURRENT_TIMESTAMP - interval '90 days'
+	GROUP BY prow_job_run_tests.prow_job_run_id, prow_job_run_tests.prow_job_run_release
 ), flaked_test_results AS (
 	SELECT prow_job_run_tests.prow_job_run_id,
+		prow_job_run_tests.prow_job_run_release,
 		array_agg(tests.id) AS test_ids,
 		count(tests.id) AS test_count,
 		array_agg(tests.name) AS test_names
 	FROM prow_job_run_tests
 		JOIN tests ON tests.id = prow_job_run_tests.test_id
 	WHERE prow_job_run_tests.status = 13
-	GROUP BY prow_job_run_tests.prow_job_run_id
+		AND prow_job_run_tests.prow_job_run_timestamp >= CURRENT_TIMESTAMP - interval '90 days'
+	GROUP BY prow_job_run_tests.prow_job_run_id, prow_job_run_tests.prow_job_run_release
 ),
 pull_requests AS (
 	SELECT
@@ -209,7 +213,7 @@ SELECT prow_job_runs.id,
    flaked_test_results.test_names AS flaked_test_names,
    flaked_test_results.test_count AS test_flakes,
    failed_test_results.test_names AS failed_test_names,
-   failed_test_results.test_count AS test_failures,
+   COALESCE(failed_test_results.test_count, prow_job_runs.test_failures) AS test_failures,
    pull_requests.link as pull_request_link,
    pull_requests.sha as pull_request_sha,
    pull_requests.org as pull_request_org,
@@ -217,7 +221,9 @@ SELECT prow_job_runs.id,
    pull_requests.author as pull_request_author
 FROM prow_job_runs
    LEFT JOIN failed_test_results ON failed_test_results.prow_job_run_id = prow_job_runs.id
+       AND failed_test_results.prow_job_run_release = prow_job_runs.prow_job_release
    LEFT JOIN flaked_test_results ON flaked_test_results.prow_job_run_id = prow_job_runs.id
+       AND flaked_test_results.prow_job_run_release = prow_job_runs.prow_job_release
    LEFT JOIN pull_requests ON pull_requests.id = prow_job_runs.id
    JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id
 `

--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -153,27 +153,22 @@ func syncPostgresViews(db *gorm.DB, reportEnd *time.Time) error {
 	return nil
 }
 
+// jobRunsReportMatView limits all data to a 90-day window. This is intentional:
+// prow_job_run_tests is heavily partitioned and scanning beyond 90 days is expensive
+// with no consumer needing older per-test failure/flake details in this view.
 const jobRunsReportMatView = `
-WITH failed_test_results AS (
+WITH test_results AS (
 	SELECT prow_job_run_tests.prow_job_run_id,
 		prow_job_run_tests.prow_job_run_release,
-		array_agg(tests.id) AS test_ids,
-		count(tests.id) AS test_count,
-		array_agg(tests.name) AS test_names
+		array_agg(tests.id)   FILTER (WHERE prow_job_run_tests.status = 12) AS failed_test_ids,
+		count(tests.id)       FILTER (WHERE prow_job_run_tests.status = 12) AS failed_test_count,
+		array_agg(tests.name) FILTER (WHERE prow_job_run_tests.status = 12) AS failed_test_names,
+		array_agg(tests.id)   FILTER (WHERE prow_job_run_tests.status = 13) AS flaked_test_ids,
+		count(tests.id)       FILTER (WHERE prow_job_run_tests.status = 13) AS flaked_test_count,
+		array_agg(tests.name) FILTER (WHERE prow_job_run_tests.status = 13) AS flaked_test_names
 	FROM prow_job_run_tests
 		JOIN tests ON tests.id = prow_job_run_tests.test_id
-	WHERE prow_job_run_tests.status = 12
-		AND prow_job_run_tests.prow_job_run_timestamp >= CURRENT_TIMESTAMP - interval '90 days'
-	GROUP BY prow_job_run_tests.prow_job_run_id, prow_job_run_tests.prow_job_run_release
-), flaked_test_results AS (
-	SELECT prow_job_run_tests.prow_job_run_id,
-		prow_job_run_tests.prow_job_run_release,
-		array_agg(tests.id) AS test_ids,
-		count(tests.id) AS test_count,
-		array_agg(tests.name) AS test_names
-	FROM prow_job_run_tests
-		JOIN tests ON tests.id = prow_job_run_tests.test_id
-	WHERE prow_job_run_tests.status = 13
+	WHERE prow_job_run_tests.status IN (12, 13)
 		AND prow_job_run_tests.prow_job_run_timestamp >= CURRENT_TIMESTAMP - interval '90 days'
 	GROUP BY prow_job_run_tests.prow_job_run_id, prow_job_run_tests.prow_job_run_release
 ),
@@ -210,22 +205,21 @@ SELECT prow_job_runs.id,
    prow_job_runs.id AS prow_id,
    prow_job_runs.cluster AS cluster,
    prow_job_runs.labels as labels,
-   flaked_test_results.test_names AS flaked_test_names,
-   flaked_test_results.test_count AS test_flakes,
-   failed_test_results.test_names AS failed_test_names,
-   COALESCE(failed_test_results.test_count, prow_job_runs.test_failures) AS test_failures,
+   test_results.flaked_test_names AS flaked_test_names,
+   test_results.flaked_test_count AS test_flakes,
+   test_results.failed_test_names AS failed_test_names,
+   COALESCE(test_results.failed_test_count, prow_job_runs.test_failures) AS test_failures,
    pull_requests.link as pull_request_link,
    pull_requests.sha as pull_request_sha,
    pull_requests.org as pull_request_org,
    pull_requests.repo as pull_request_repo,
    pull_requests.author as pull_request_author
 FROM prow_job_runs
-   LEFT JOIN failed_test_results ON failed_test_results.prow_job_run_id = prow_job_runs.id
-       AND failed_test_results.prow_job_run_release = prow_job_runs.prow_job_release
-   LEFT JOIN flaked_test_results ON flaked_test_results.prow_job_run_id = prow_job_runs.id
-       AND flaked_test_results.prow_job_run_release = prow_job_runs.prow_job_release
+   LEFT JOIN test_results ON test_results.prow_job_run_id = prow_job_runs.id
+       AND test_results.prow_job_run_release = prow_job_runs.prow_job_release
    LEFT JOIN pull_requests ON pull_requests.id = prow_job_runs.id
    JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id
+WHERE prow_job_runs."timestamp" >= CURRENT_TIMESTAMP - interval '90 days'
 `
 const testReportMatView = `
 WITH open_bugs AS (

--- a/pkg/flags/postgres.go
+++ b/pkg/flags/postgres.go
@@ -94,8 +94,9 @@ func (f *PostgresFlags) GetPinnedTime() *time.Time {
 
 // PostgresFlags contains the set of flags needed to connect to a postgres database.
 type PostgresFlags struct {
-	LogLevel logLevel
-	DSN      string
+	LogLevel            logLevel
+	DSN                 string
+	EnablePartitionwise bool
 
 	// pinnedTime should not be exported. Use GetPinnedTime() instead.
 	pinnedTime PinnedTime
@@ -117,10 +118,11 @@ func (f *PostgresFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.Var(&f.LogLevel, "db-log-level", "GORM database log level")
 	fs.StringVar(&f.DSN, "database-dsn", f.DSN, "Database DSN for connecting to Postgres")
 	fs.Var(&f.pinnedTime, "pinned-date-time", "Pin database results to a fixed end date/time")
+	fs.BoolVar(&f.EnablePartitionwise, "enable-partitionwise", false, "Enable PostgreSQL partitionwise aggregate and join optimizations")
 }
 
 func (f *PostgresFlags) GetDBClient() (*db.DB, error) {
-	dbc, err := db.New(f.DSN, logger.LogLevel(f.LogLevel))
+	dbc, err := db.New(f.DSN, logger.LogLevel(f.LogLevel), db.WithPartitionwise(f.EnablePartitionwise))
 	if err != nil {
 		log.WithError(err).Error("could not connect to db")
 		return nil, err

--- a/pkg/flags/postgres.go
+++ b/pkg/flags/postgres.go
@@ -124,8 +124,8 @@ func (f *PostgresFlags) BindFlags(fs *pflag.FlagSet) {
 func (f *PostgresFlags) GetDBClient() (*db.DB, error) {
 	dbc, err := db.New(f.DSN, logger.LogLevel(f.LogLevel), db.WithPartitionwise(f.EnablePartitionwise))
 	if err != nil {
-		log.WithError(err).Error("could not connect to db")
-		return nil, err
+		log.Error("could not connect to db")
+		return nil, fmt.Errorf("could not connect to db: %w", err)
 	}
 
 	return dbc, nil

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -1095,6 +1095,128 @@ func Test_BenchmarkSingleReleaseMatview(t *testing.T) {
 	printSummaryTable(t, results, connName)
 }
 
+func Test_BenchmarkJobRunsReportMatview(t *testing.T) {
+	dbc, connName := getBenchmarkDBClient(t)
+
+	var source db.PostgresView
+	for _, mv := range db.PostgresMatViews {
+		if mv.Name == "prow_job_runs_report_matview" {
+			source = mv
+			break
+		}
+	}
+	if source.Name == "" {
+		t.Fatal("prow_job_runs_report_matview not found in PostgresMatViews")
+	}
+
+	matviewName := "bench_job_runs_report"
+	viewDef := source.Definition
+	for k, v := range source.ReplaceStrings {
+		viewDef = strings.ReplaceAll(viewDef, k, v)
+	}
+	viewDef = strings.ReplaceAll(viewDef, "|||TIMENOW|||", "NOW()")
+
+	t.Cleanup(func() {
+		if err := dbc.DB.Exec(fmt.Sprintf("DROP MATERIALIZED VIEW IF EXISTS %s", matviewName)).Error; err != nil {
+			t.Logf("failed to drop materialized view %s during cleanup: %v", matviewName, err)
+		}
+	})
+	if err := dbc.DB.Exec(fmt.Sprintf("DROP MATERIALIZED VIEW IF EXISTS %s", matviewName)).Error; err != nil {
+		t.Fatalf("failed to drop pre-existing materialized view %s: %v", matviewName, err)
+	}
+
+	iterations := 3
+	var results []benchmarkResult
+
+	results = append(results, runBenchmarkCase(t, dbc, benchmarkCase{
+		name: "CreateMatview",
+		fn: func(dbc *db.DB) error {
+			if err := dbc.DB.Exec(fmt.Sprintf("DROP MATERIALIZED VIEW IF EXISTS %s", matviewName)).Error; err != nil {
+				return err
+			}
+			res := dbc.DB.Exec(fmt.Sprintf("CREATE MATERIALIZED VIEW %s AS %s WITH DATA", matviewName, viewDef))
+			if res.Error != nil {
+				return res.Error
+			}
+			var count int64
+			if err := dbc.DB.Raw(fmt.Sprintf("SELECT COUNT(*) FROM %s", matviewName)).Scan(&count).Error; err != nil {
+				return err
+			}
+			log.Printf("CreateMatview: %s populated with %d rows", matviewName, count)
+			return nil
+		},
+	}, iterations))
+
+	indexName := fmt.Sprintf("idx_%s", matviewName)
+	indexCols := strings.Join(source.IndexColumns, ", ")
+	results = append(results, runBenchmarkCase(t, dbc, benchmarkCase{
+		name: "CreateIndex",
+		fn: func(dbc *db.DB) error {
+			dbc.DB.Exec(fmt.Sprintf("DROP INDEX IF EXISTS %s", indexName))
+			res := dbc.DB.Exec(fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s(%s)", indexName, matviewName, indexCols))
+			return res.Error
+		},
+	}, iterations))
+
+	results = append(results, runBenchmarkCase(t, dbc, benchmarkCase{
+		name: "RefreshConcurrently",
+		fn: func(dbc *db.DB) error {
+			res := dbc.DB.Exec(fmt.Sprintf("REFRESH MATERIALIZED VIEW CONCURRENTLY %s", matviewName))
+			return res.Error
+		},
+	}, iterations))
+
+	results = append(results, runBenchmarkCase(t, dbc, benchmarkCase{
+		name: "QueryByRelease",
+		fn: func(dbc *db.DB) error {
+			var jobRuns []apitype.JobRun
+			res := dbc.DB.Table(matviewName).
+				Where("release = ?", benchmarkRelease).
+				Order("timestamp desc").
+				Limit(100).
+				Scan(&jobRuns)
+			if res.Error != nil {
+				return res.Error
+			}
+			log.Printf("QueryByRelease: %d rows from %s", len(jobRuns), matviewName)
+			return nil
+		},
+	}, iterations))
+
+	results = append(results, runBenchmarkCase(t, dbc, benchmarkCase{
+		name: "QueryByJob",
+		fn: func(dbc *db.DB) error {
+			var jobRuns []apitype.JobRun
+			res := dbc.DB.Table(matviewName).
+				Where("release = ? AND name = ?", benchmarkRelease, benchmarkJobName).
+				Order("timestamp desc").
+				Scan(&jobRuns)
+			if res.Error != nil {
+				return res.Error
+			}
+			log.Printf("QueryByJob: %d rows from %s", len(jobRuns), matviewName)
+			return nil
+		},
+	}, iterations))
+
+	results = append(results, runBenchmarkCase(t, dbc, benchmarkCase{
+		name: "CountWithFailures",
+		fn: func(dbc *db.DB) error {
+			var count int64
+			res := dbc.DB.Table(matviewName).
+				Where("release = ? AND test_failures > 0", benchmarkRelease).
+				Count(&count)
+			if res.Error != nil {
+				return res.Error
+			}
+			log.Printf("CountWithFailures: %d rows from %s", count, matviewName)
+			return nil
+		},
+	}, iterations))
+
+	printSummaryTable(t, results, connName)
+}
+
 func Test_BenchmarkRefreshData(t *testing.T) {
 	dbc, connName := getBenchmarkDBClient(t)
 

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/filter"
+	"github.com/openshift/sippy/pkg/sippyserver"
 	"github.com/openshift/sippy/pkg/util"
 	log "github.com/sirupsen/logrus"
 )
@@ -499,8 +500,9 @@ func getBenchmarkDBClient(t *testing.T) (*db.DB, string) {
 	}
 
 	dbFlags := &PostgresFlags{
-		LogLevel: 4,
-		DSN:      dsn,
+		LogLevel:            4,
+		DSN:                 dsn,
+		EnablePartitionwise: os.Getenv("enable_partitionwise") != "",
 	}
 
 	dbc, err := dbFlags.GetDBClient()
@@ -516,6 +518,11 @@ func getBenchmarkDBClient(t *testing.T) (*db.DB, string) {
 			t.Logf("failed to close DB client: %v", err)
 		}
 	})
+
+	if dbFlags.EnablePartitionwise {
+		t.Log("enabled partitionwise aggregate and join")
+	}
+
 	return dbc, extractConnectionName(dsn)
 }
 
@@ -1086,6 +1093,23 @@ func Test_BenchmarkSingleReleaseMatview(t *testing.T) {
 	}, 3))
 
 	printSummaryTable(t, results, connName)
+}
+
+func Test_BenchmarkRefreshData(t *testing.T) {
+	dbc, connName := getBenchmarkDBClient(t)
+
+	if err := dbc.UpdateSchema(nil); err != nil {
+		t.Fatalf("could not migrate db: %v", err)
+	}
+
+	r := runBenchmarkCase(t, dbc, benchmarkCase{
+		name: "RefreshData",
+		fn: func(dbc *db.DB) error {
+			sippyserver.RefreshData(dbc, nil, false)
+			return nil
+		},
+	}, 1)
+	printSummaryTable(t, []benchmarkResult{r}, connName)
 }
 
 func Test_BenchmarkAPI(t *testing.T) {

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -507,11 +507,11 @@ func getBenchmarkDBClient(t *testing.T) (*db.DB, string) {
 
 	dbc, err := dbFlags.GetDBClient()
 	if err != nil {
-		t.Fatalf("couldn't get DB client: %v", err)
+		t.Fatal("couldn't get DB client")
 	}
 	sqlDB, err := dbc.DB.DB()
 	if err != nil {
-		t.Fatalf("couldn't get sql.DB handle: %v", err)
+		t.Fatal("couldn't get sql.DB handle")
 	}
 	t.Cleanup(func() {
 		if err := sqlDB.Close(); err != nil {
@@ -1125,7 +1125,7 @@ func Test_BenchmarkJobRunsReportMatview(t *testing.T) {
 		t.Fatalf("failed to drop pre-existing materialized view %s: %v", matviewName, err)
 	}
 
-	iterations := 3
+	iterations := 1
 	var results []benchmarkResult
 
 	results = append(results, runBenchmarkCase(t, dbc, benchmarkCase{


### PR DESCRIPTION
Updates matview to be aware of release and prow_job_run_timestamps
Adds fallback to prow_job_runs.test_failures if we are missing failed_test_results.test_count
Adds option to enable partitionwise planning optimizations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option/flag (`--enable-partitionwise`) to enable PostgreSQL partitionwise aggregate/join optimizations.
* **Improvements**
  * Updated the job-runs report to consolidate failed and flaked results, restrict processing to the last 90 days, and improve grouping/joins for more accurate counts.
* **Tests**
  * Added benchmarks covering materialized-view creation/indexing/refresh and overall data-refresh performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->