### PR TITLE
TRT-2647: rhcos10 default for 5.0

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -45,8 +45,6 @@ component_readiness:
       - virt
       Network:
       - ovn
-      OS:
-      - rhcos9
       Owner:
       - eng
       - service-delivery
@@ -135,8 +133,6 @@ component_readiness:
       - virt
       Network:
       - ovn
-      OS:
-      - rhcos9
       Owner:
       - eng
       - service-delivery
@@ -220,8 +216,6 @@ component_readiness:
       - virt
       Network:
       - ovn
-      OS:
-      - rhcos9
       Owner:
       - eng
       - service-delivery
@@ -405,7 +399,7 @@ component_readiness:
     flake_as_failure: false
   metrics:
     enabled: false
-- name: 5.0-techpreview-rhcos9-vs-rhcos10
+- name: 5.0-rhcos10-vs-rhcos9
   base_release:
     release: "5.0"
     relative_start: now-7d
@@ -435,6 +429,7 @@ component_readiness:
       - arm64
       - multi
       FeatureSet:
+      - default
       - techpreview
       Installer:
       - ipi
@@ -449,7 +444,7 @@ component_readiness:
       Network:
       - ovn
       OS:
-      - rhcos9
+      - rhcos10
       Owner:
       - eng
       Platform:
@@ -469,16 +464,18 @@ component_readiness:
       - crun
     compare_variants:
       OS:
-      - rhcos10
+      - rhcos9
     variant_cross_compare:
     - OS
   advanced_options:
-    minimum_failure: 3
+    minimum_failure: 4
     confidence: 95
-    pity_factor: 5
+    pity_factor: 10
     ignore_missing: false
     ignore_disruption: true
     flake_as_failure: false
+    pass_rate_required_new_tests: 90
+    include_multi_release_analysis: false
   metrics:
     enabled: false
   regression_tracking:
@@ -1557,84 +1554,6 @@ component_readiness:
     flake_as_failure: false
   metrics:
     enabled: false
-- name: 4.22-techpreview-rhcos9-vs-rhcos10
-  base_release:
-    release: "4.22"
-    relative_start: now-7d
-    relative_end: now
-  sample_release:
-    release: "4.22"
-    relative_start: now-7d
-    relative_end: now
-  variant_options:
-    column_group_by:
-      Network: { }
-      Platform: { }
-      Topology: { }
-    db_group_by:
-      Architecture: { }
-      FeatureSet: { }
-      Installer: { }
-      Network: { }
-      Platform: { }
-      Suite: { }
-      Topology: { }
-      Upgrade: { }
-      LayeredProduct: { }
-    include_variants:
-      Architecture:
-      - amd64
-      - arm64
-      - multi
-      FeatureSet:
-      - techpreview
-      Installer:
-      - ipi
-      - upi
-      JobTier:
-      - blocking
-      - informing
-      - standard
-      - candidate
-      LayeredProduct:
-      - none
-      Network:
-      - ovn
-      OS:
-      - rhcos9
-      Owner:
-      - eng
-      Platform:
-      - aws
-      - azure
-      - gcp
-      - metal
-      - vsphere
-      Topology:
-      - ha
-      - microshift
-      - single
-      CGroupMode:
-      - v2
-      ContainerRuntime:
-      - runc
-      - crun
-    compare_variants:
-      OS:
-      - rhcos10
-    variant_cross_compare:
-    - OS
-  advanced_options:
-    minimum_failure: 3
-    confidence: 95
-    pity_factor: 5
-    ignore_missing: false
-    ignore_disruption: true
-    flake_as_failure: false
-  metrics:
-    enabled: false
-  regression_tracking:
-    enabled: true
 - name: 4.22-ha-vs-single
   base_release:
     release: "4.22"

--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -1325,8 +1325,11 @@ func setOS(_ logrus.FieldLogger, variants map[string]string, jobName string) {
 	switch {
 	case variants[VariantReleaseMajor] == "4":
 		variants[VariantOS] = "rhcos9"
-	case variants[VariantReleaseMajor] == "5" || isMainBranch:
-		// OCP 5 currently defaults to rhcos9. Update this when the default changes.
+	case (variants[VariantReleaseMajor] == "5" || isMainBranch) &&
+		(variants[VariantUpgrade] == VariantNoValue || variants[VariantFromReleaseMajor] == "5"):
+		variants[VariantOS] = "rhcos10"
+	case (variants[VariantReleaseMajor] == "5" || isMainBranch) &&
+		variants[VariantFromReleaseMajor] != "5":
 		variants[VariantOS] = "rhcos9"
 	default:
 		variants[VariantOS] = "unknown"

--- a/pkg/variantregistry/ocp_test.go
+++ b/pkg/variantregistry/ocp_test.go
@@ -55,7 +55,7 @@ func TestVariantSyncer(t *testing.T) {
 				VariantContainerRuntime: "crun",
 				VariantCGroupMode:       "v2",
 				VariantLayeredProduct:   VariantNoValue,
-				VariantOS:               "rhcos9",
+				VariantOS:               "rhcos10",
 			},
 		},
 		{
@@ -86,7 +86,7 @@ func TestVariantSyncer(t *testing.T) {
 				VariantContainerRuntime: "crun",
 				VariantCGroupMode:       "v2",
 				VariantLayeredProduct:   VariantNoValue,
-				VariantOS:               "rhcos9",
+				VariantOS:               "rhcos10",
 			},
 		},
 		{
@@ -148,7 +148,7 @@ func TestVariantSyncer(t *testing.T) {
 				VariantContainerRuntime: "crun",
 				VariantCGroupMode:       "v2",
 				VariantLayeredProduct:   VariantNoValue,
-				VariantOS:               "rhcos9",
+				VariantOS:               "rhcos10",
 			},
 		},
 		{
@@ -1184,7 +1184,7 @@ func TestVariantSyncer(t *testing.T) {
 				VariantSecurityMode:   VariantDefaultValue,
 				VariantCGroupMode:     "v2",
 				VariantLayeredProduct: VariantNoValue,
-				VariantOS:             "rhcos9",
+				VariantOS:             "rhcos10",
 			},
 		},
 		{
@@ -2146,7 +2146,7 @@ func TestVariantSyncer(t *testing.T) {
 				VariantContainerRuntime: "crun",
 				VariantCGroupMode:       "v2",
 				VariantLayeredProduct:   VariantNoValue,
-				VariantOS:               "rhcos9",
+				VariantOS:               "rhcos10",
 			},
 		},
 		{
@@ -2174,7 +2174,7 @@ func TestVariantSyncer(t *testing.T) {
 				VariantContainerRuntime: "crun",
 				VariantCGroupMode:       "v2",
 				VariantLayeredProduct:   VariantNoValue,
-				VariantOS:               "rhcos9",
+				VariantOS:               "rhcos10",
 			},
 		},
 		{
@@ -2674,6 +2674,112 @@ func TestAdjustJobTierBasedOnView(t *testing.T) {
 			}
 			loader.adjustJobTierBasedOnView(jLog, "test-job", variants)
 			assert.Equal(t, tt.expectedTier, variants[VariantJobTier])
+		})
+	}
+}
+
+func TestSetOS(t *testing.T) {
+	tests := []struct {
+		name       string
+		jobName    string
+		variants   map[string]string
+		expectedOS string
+	}{
+		{
+			name:    "5.x non-upgrade defaults to rhcos10",
+			jobName: "periodic-ci-openshift-release-master-nightly-5.0-e2e-aws-ovn",
+			variants: map[string]string{
+				VariantReleaseMajor: "5",
+				VariantUpgrade:      VariantNoValue,
+			},
+			expectedOS: "rhcos10",
+		},
+		{
+			name:    "5-to-5 upgrade defaults to rhcos10",
+			jobName: "periodic-ci-openshift-release-master-ci-5.1-upgrade-from-stable-5.0-e2e-aws-upgrade",
+			variants: map[string]string{
+				VariantReleaseMajor:     "5",
+				VariantUpgrade:          "minor",
+				VariantFromReleaseMajor: "5",
+			},
+			expectedOS: "rhcos10",
+		},
+		{
+			name:    "5.x upgrade from 4.x defaults to rhcos9",
+			jobName: "periodic-ci-openshift-release-master-ci-5.0-upgrade-from-stable-4.22-e2e-aws-upgrade",
+			variants: map[string]string{
+				VariantReleaseMajor:     "5",
+				VariantUpgrade:          "major",
+				VariantFromReleaseMajor: "4",
+			},
+			expectedOS: "rhcos9",
+		},
+		{
+			name:    "main branch non-upgrade defaults to rhcos10",
+			jobName: "periodic-ci-openshift-release-main-nightly-e2e-aws-ovn",
+			variants: map[string]string{
+				VariantReleaseMajor: "5",
+				VariantUpgrade:      VariantNoValue,
+			},
+			expectedOS: "rhcos10",
+		},
+		{
+			name:    "main branch upgrade from 4.x defaults to rhcos9",
+			jobName: "periodic-ci-openshift-release-main-ci-upgrade-from-stable-4.22-e2e-aws-upgrade",
+			variants: map[string]string{
+				VariantReleaseMajor:     "5",
+				VariantUpgrade:          "major",
+				VariantFromReleaseMajor: "4",
+			},
+			expectedOS: "rhcos9",
+		},
+		{
+			name:    "4.x defaults to rhcos9",
+			jobName: "periodic-ci-openshift-release-master-nightly-4.17-e2e-aws-ovn",
+			variants: map[string]string{
+				VariantReleaseMajor: "4",
+				VariantUpgrade:      VariantNoValue,
+			},
+			expectedOS: "rhcos9",
+		},
+		{
+			name:    "explicit rhcos10 in job name overrides version logic",
+			jobName: "periodic-ci-openshift-release-master-nightly-4.17-e2e-aws-ovn-rhcos10",
+			variants: map[string]string{
+				VariantReleaseMajor: "4",
+				VariantUpgrade:      VariantNoValue,
+			},
+			expectedOS: "rhcos10",
+		},
+		{
+			name:    "explicit rhcos9 in job name overrides version logic",
+			jobName: "periodic-ci-openshift-release-master-nightly-5.0-e2e-aws-ovn-rhcos9",
+			variants: map[string]string{
+				VariantReleaseMajor: "5",
+				VariantUpgrade:      VariantNoValue,
+			},
+			expectedOS: "rhcos9",
+		},
+		{
+			name:    "explicit rhcos9-10 in job name",
+			jobName: "periodic-ci-openshift-release-master-nightly-5.0-e2e-aws-ovn-rhcos9-10",
+			variants: map[string]string{
+				VariantReleaseMajor: "5",
+				VariantUpgrade:      VariantNoValue,
+			},
+			expectedOS: "rhcos9-10",
+		},
+	}
+
+	jLog := logrus.WithField("test", "TestSetOS")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			variants := make(map[string]string)
+			for k, v := range tt.variants {
+				variants[k] = v
+			}
+			setOS(jLog, variants, tt.jobName)
+			assert.Equal(t, tt.expectedOS, variants[VariantOS])
 		})
 	}
 }

--- a/pkg/variantregistry/ocp_test.go
+++ b/pkg/variantregistry/ocp_test.go
@@ -390,7 +390,7 @@ func TestVariantSyncer(t *testing.T) {
 				VariantContainerRuntime: "crun",
 				VariantCGroupMode:       "v2",
 				VariantLayeredProduct:   VariantNoValue,
-				VariantOS:               "rhcos9",
+				VariantOS:               "rhcos10",
 			},
 		},
 		{


### PR DESCRIPTION
A lot of obscure non-core ocp jobs are flipping to 10 with this, ARO for example. I don't think it matters right now, but we may need to refine further in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * Revised component readiness test variants for OCP 5: removed strict OS constraints and replaced a tech-preview comparison with an updated RH cos10-vs-rhcos9 scenario; removed a deprecated OCP 4.22 tech-preview variant.

* **Improvements**
  * Smarter default OS selection for OCP 5 jobs: defaults now vary by job type and upgrade context.

* **Tests**
  * Added and updated unit tests to cover OS selection across releases and upgrade/non-upgrade cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->