### PR TITLE
MPICT: Onboard Chaos variants for OCP 4.22

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -1627,6 +1627,52 @@ component_readiness:
     enabled: false
   regression_tracking:
     enabled: false
+- name: 4.22-LP-Chaos--lpGA
+  base_release:
+    release: "4.21"
+    relative_start: ga-30d
+    relative_end: ga
+  sample_release:
+    release: "4.22"
+    relative_start: now-30d
+    relative_end: now
+  variant_options:
+    column_group_by:
+      Architecture: { }
+      Network: { }
+      Platform: { }
+      Topology: { }
+    db_group_by:
+      Architecture: { }
+      FeatureSet: { }
+      Installer: { }
+      Network: { }
+      Platform: { }
+      Suite: { }
+      Topology: { }
+      Upgrade: { }
+    include_variants:
+      LayeredProduct:
+      - lp-chaos--ocp--lpGA
+      Network:
+      - ovn
+      Owner:
+      - mpict
+  advanced_options:
+    minimum_failure: 2
+    confidence: 95
+    pity_factor: 5
+    ignore_missing: false
+    ignore_disruption: true
+    flake_as_failure: false
+    pass_rate_required_new_tests: 95
+    include_multi_release_analysis: true
+  metrics:
+    enabled: false
+  regression_tracking:
+    enabled: true
+  prime_cache:
+    enabled: false
 - name: 4.22-LP-OCP-Compat--lpMainline
   base_release:
     release: "4.21"

--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -1284,6 +1284,7 @@ func setLayeredProduct(_ logrus.FieldLogger, variants map[string]string, jobName
 		{"-lpga-lp-ocp-compat-cr--oadp-", "lp-ocp-compat--oadp--lpGA"},
 		{"-lpga-lp-ocp-compat-cr--servicemesh-", "lp-ocp-compat--servicemesh--lpGA"},
 		{"-lpga-lp-ocp-compat-cr--operator-e2e-", "lp-ocp-compat--serverless--lpGA"},
+		{"-lpga-lp-chaos-cr--ocp-", "lp-chaos--ocp--lpGA"},
 		{"-coo-", "lp-interop-coo"},
 		{"-virt", "virt"},
 		{"-cnv", "virt"},


### PR DESCRIPTION
## Summary

Onboards **OCP LP chaos** jobs for **OCP 4.22** into Sippy Component Readiness, so chaos test results appear in CR dashboards and are attributed to the correct Layered Product variant.

## Changes

- **`pkg/variantregistry/ocp.go`** — Maps CI Operator job names containing `-lpga-lp-chaos-cr--ocp-` to the CR variant `lp-chaos--ocp--lpGA`
- **`config/views.yaml`** — Adds a new `4.22-LP-Chaos--lpGA` CR view that includes `lp-chaos--ocp--lpGA` under `LayeredProduct`, scoped to owner `mpict` and network `ovn`, with regression tracking enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure configuration and job classification patterns to support additional release variants and testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->