### PR TITLE
Pre-compute test statistics in matview to eliminate 3-scan self-join

### DIFF
--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -232,44 +232,16 @@ func LoadBugsForTest(dbc *db.DB, testName string, filterClosed bool) ([]models.B
 	return results, nil
 }
 
-// TestsByNURPAndStandardDeviation returns a test report for every test in the db matching the given substrings, separated by variant.
-// Result will include current and previous test rates such as passing, flaking, failing rates.
-// In addition, it includes the following calculated rates to help identify bad nurps.
-// working_average shows the average working percentage among all variants.
-// working_standard_deviation shows the standard deviation of the working percentage among variants. The number reflects how much working percentage differs among variants.
-// delta_from_working_average shows how much each variant differs from the working_average. This can be used to identify outliers.
-// passing_average shows the average passing percentage among all variants.
-// passing_standard_deviation shows the standard deviation of the passing percentage among variants. The number reflects how much passing percentage differs among variants.
-// delta_from_passing_average shows how much each variant differs from the passing_average. This can be used to identify outliers.
-// flake_average shows the average flake percentage among all variants.
-// flake_standard_deviation shows the standard deviation of the flake percentage among variants. The number reflects how much flake percentage differs among variants.
-// delta_from_flake_average shows how much each variant differs from the flake_average. This can be used to identify outliers.
+// TestsByNURPAndStandardDeviation returns a test report for every test in the db, separated by variant.
+// Each row includes current/previous test rates and cross-variant statistics (AVG, STDDEV, delta)
+// that are pre-computed in the matview. Only the deltas are computed at query time.
 func TestsByNURPAndStandardDeviation(dbc *db.DB, release, table string) *gorm.DB {
-	// 1. Create a virtual stats table. There is a single row for each test.
-	stats := dbc.DB.Table(table).
-		Select(`
-                 id                                                                             AS test_id,
-                 suite_name                                                                     AS stats_suite_name,
-                 avg((current_successes + current_flakes) * 100.0 / NULLIF(current_runs, 0))    AS working_average,
-                 stddev((current_successes + current_flakes) * 100.0 / NULLIF(current_runs, 0)) AS working_standard_deviation,
-                 avg(current_successes * 100.0 / NULLIF(current_runs, 0))                       AS passing_average,
-                 stddev(current_successes * 100.0 / NULLIF(current_runs, 0))                    AS passing_standard_deviation,
-                 avg(current_flakes * 100.0 / NULLIF(current_runs, 0))                          AS flake_average,
-                 stddev(current_flakes * 100.0 / NULLIF(current_runs, 0))                       AS flake_standard_deviation`).
-		Where(`release = ?`, release).
-		Group("id, suite_name")
-
-	// 2. Collect standard stats for all tests. Each row applies to one variant of a test.
-	passRates := dbc.DB.Table(table).
-		Select(`id as test_id, suite_name as pass_rate_suite_name, variants as pass_rate_variants, `+QueryTestPercentages).
-		Where(`release = ?`, release)
-
-	// 3. Join the tables to produce test report. Each row represent one variant of a test and contains all stats, both unique to the specific variant and average across all variants.
 	return dbc.DB.
 		Table(table).
-		Select("*, (current_working_percentage - working_average) as delta_from_working_average, (current_pass_percentage - passing_average) as delta_from_passing_average, (current_flake_percentage - flake_average) as delta_from_flake_average").
-		Joins(fmt.Sprintf(`INNER JOIN (?) as pass_rates on pass_rates.test_id = %s.id AND pass_rates.pass_rate_suite_name IS NOT DISTINCT FROM %s.suite_name AND pass_rates.pass_rate_variants = %s.variants`, table, table, table), passRates).
-		Joins(fmt.Sprintf(`JOIN (?) as stats ON stats.test_id = %s.id AND stats.stats_suite_name IS NOT DISTINCT FROM %s.suite_name`, table, table), stats).
+		Select(`*,
+			(current_working_percentage - working_average) AS delta_from_working_average,
+			(current_pass_percentage - passing_average) AS delta_from_passing_average,
+			(current_flake_percentage - flake_average) AS delta_from_flake_average`).
 		Where(`release = ?`, release).
 		Where(fmt.Sprintf("NOT ('never-stable'=any(%s.variants))", table))
 }

--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -222,67 +222,85 @@ FROM prow_job_runs
    JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id
 `
 const testReportMatView = `
-WITH open_bugs AS (
-  SELECT
-    test_id,
-    COUNT(DISTINCT bugs.id) AS open_bugs
-  FROM
-    bug_tests
-    INNER JOIN tests ON tests.id = bug_tests.test_id
-    INNER JOIN bugs ON bug_tests.bug_id = bugs.id
-  WHERE
-    LOWER(bugs.status) <> 'closed'
-  GROUP BY
-    test_id
-),
-pre_agg AS (
-  SELECT
-    prow_job_id,
-    test_id,
-    suite_id,
-    prow_job_run_release,
-    COUNT(*) FILTER (WHERE status = 1  AND prow_job_run_timestamp BETWEEN |||START||| AND |||BOUNDARY|||) AS previous_successes,
-    COUNT(*) FILTER (WHERE status = 13 AND prow_job_run_timestamp BETWEEN |||START||| AND |||BOUNDARY|||) AS previous_flakes,
-    COUNT(*) FILTER (WHERE status = 12 AND prow_job_run_timestamp BETWEEN |||START||| AND |||BOUNDARY|||) AS previous_failures,
-    COUNT(*) FILTER (WHERE prow_job_run_timestamp BETWEEN |||START||| AND |||BOUNDARY|||) AS previous_runs,
-    COUNT(*) FILTER (WHERE status = 1  AND prow_job_run_timestamp BETWEEN |||BOUNDARY||| AND |||END|||) AS current_successes,
-    COUNT(*) FILTER (WHERE status = 13 AND prow_job_run_timestamp BETWEEN |||BOUNDARY||| AND |||END|||) AS current_flakes,
-    COUNT(*) FILTER (WHERE status = 12 AND prow_job_run_timestamp BETWEEN |||BOUNDARY||| AND |||END|||) AS current_failures,
-    COUNT(*) FILTER (WHERE prow_job_run_timestamp BETWEEN |||BOUNDARY||| AND |||END|||) AS current_runs
-  FROM
-    prow_job_run_tests
-  WHERE
-    prow_job_run_timestamp >= |||START||| AND prow_job_run_timestamp <= |||END|||
-  GROUP BY
-    prow_job_id, test_id, suite_id, prow_job_run_release
-)
-SELECT
-    tests.id,
-    tests.name,
-    suites.name AS suite_name,
-    jira_components.name AS jira_component,
-    jira_components.id AS jira_component_id,
-    SUM(pre_agg.previous_successes)::bigint AS previous_successes,
-    SUM(pre_agg.previous_flakes)::bigint AS previous_flakes,
-    SUM(pre_agg.previous_failures)::bigint AS previous_failures,
-    SUM(pre_agg.previous_runs)::bigint AS previous_runs,
-    SUM(pre_agg.current_successes)::bigint AS current_successes,
-    SUM(pre_agg.current_flakes)::bigint AS current_flakes,
-    SUM(pre_agg.current_failures)::bigint AS current_failures,
-    SUM(pre_agg.current_runs)::bigint AS current_runs,
-    open_bugs.open_bugs AS open_bugs,
-    prow_jobs.variants,
-    pre_agg.prow_job_run_release AS release
-FROM
-    pre_agg
-    JOIN tests ON tests.id = pre_agg.test_id
-    LEFT JOIN open_bugs ON pre_agg.test_id = open_bugs.test_id
-    LEFT JOIN suites ON suites.id = pre_agg.suite_id
-    LEFT JOIN test_ownerships ON (tests.id = test_ownerships.test_id AND pre_agg.suite_id = test_ownerships.suite_id)
-    LEFT JOIN jira_components ON test_ownerships.jira_component = jira_components.name
-    JOIN prow_jobs ON pre_agg.prow_job_id = prow_jobs.id
-GROUP BY
-    tests.id, tests.name, jira_components.name, jira_components.id, suites.name, open_bugs.open_bugs, prow_jobs.variants, pre_agg.prow_job_run_release
+SELECT base.*,
+    COALESCE(base.current_successes * 100.0 / NULLIF(base.current_runs, 0), 0) AS current_pass_percentage,
+    COALESCE(base.current_failures * 100.0 / NULLIF(base.current_runs, 0), 0) AS current_failure_percentage,
+    COALESCE(base.current_flakes * 100.0 / NULLIF(base.current_runs, 0), 0) AS current_flake_percentage,
+    COALESCE((base.current_successes + base.current_flakes) * 100.0 / NULLIF(base.current_runs, 0), 0) AS current_working_percentage,
+    COALESCE(base.previous_successes * 100.0 / NULLIF(base.previous_runs, 0), 0) AS previous_pass_percentage,
+    COALESCE(base.previous_failures * 100.0 / NULLIF(base.previous_runs, 0), 0) AS previous_failure_percentage,
+    COALESCE(base.previous_flakes * 100.0 / NULLIF(base.previous_runs, 0), 0) AS previous_flake_percentage,
+    COALESCE((base.previous_successes + base.previous_flakes) * 100.0 / NULLIF(base.previous_runs, 0), 0) AS previous_working_percentage,
+    AVG((base.current_successes + base.current_flakes) * 100.0 / NULLIF(base.current_runs, 0)) OVER w AS working_average,
+    STDDEV((base.current_successes + base.current_flakes) * 100.0 / NULLIF(base.current_runs, 0)) OVER w AS working_standard_deviation,
+    AVG(base.current_successes * 100.0 / NULLIF(base.current_runs, 0)) OVER w AS passing_average,
+    STDDEV(base.current_successes * 100.0 / NULLIF(base.current_runs, 0)) OVER w AS passing_standard_deviation,
+    AVG(base.current_flakes * 100.0 / NULLIF(base.current_runs, 0)) OVER w AS flake_average,
+    STDDEV(base.current_flakes * 100.0 / NULLIF(base.current_runs, 0)) OVER w AS flake_standard_deviation
+FROM (
+    WITH open_bugs AS (
+      SELECT
+        test_id,
+        COUNT(DISTINCT bugs.id) AS open_bugs
+      FROM
+        bug_tests
+        INNER JOIN tests ON tests.id = bug_tests.test_id
+        INNER JOIN bugs ON bug_tests.bug_id = bugs.id
+      WHERE
+        LOWER(bugs.status) <> 'closed'
+      GROUP BY
+        test_id
+    ),
+    pre_agg AS (
+      SELECT
+        prow_job_id,
+        test_id,
+        suite_id,
+        prow_job_run_release,
+        COUNT(*) FILTER (WHERE status = 1  AND prow_job_run_timestamp BETWEEN |||START||| AND |||BOUNDARY|||) AS previous_successes,
+        COUNT(*) FILTER (WHERE status = 13 AND prow_job_run_timestamp BETWEEN |||START||| AND |||BOUNDARY|||) AS previous_flakes,
+        COUNT(*) FILTER (WHERE status = 12 AND prow_job_run_timestamp BETWEEN |||START||| AND |||BOUNDARY|||) AS previous_failures,
+        COUNT(*) FILTER (WHERE prow_job_run_timestamp BETWEEN |||START||| AND |||BOUNDARY|||) AS previous_runs,
+        COUNT(*) FILTER (WHERE status = 1  AND prow_job_run_timestamp BETWEEN |||BOUNDARY||| AND |||END|||) AS current_successes,
+        COUNT(*) FILTER (WHERE status = 13 AND prow_job_run_timestamp BETWEEN |||BOUNDARY||| AND |||END|||) AS current_flakes,
+        COUNT(*) FILTER (WHERE status = 12 AND prow_job_run_timestamp BETWEEN |||BOUNDARY||| AND |||END|||) AS current_failures,
+        COUNT(*) FILTER (WHERE prow_job_run_timestamp BETWEEN |||BOUNDARY||| AND |||END|||) AS current_runs
+      FROM
+        prow_job_run_tests
+      WHERE
+        prow_job_run_timestamp >= |||START||| AND prow_job_run_timestamp <= |||END|||
+      GROUP BY
+        prow_job_id, test_id, suite_id, prow_job_run_release
+    )
+    SELECT
+        tests.id,
+        tests.name,
+        suites.name AS suite_name,
+        jira_components.name AS jira_component,
+        jira_components.id AS jira_component_id,
+        SUM(pre_agg.previous_successes)::bigint AS previous_successes,
+        SUM(pre_agg.previous_flakes)::bigint AS previous_flakes,
+        SUM(pre_agg.previous_failures)::bigint AS previous_failures,
+        SUM(pre_agg.previous_runs)::bigint AS previous_runs,
+        SUM(pre_agg.current_successes)::bigint AS current_successes,
+        SUM(pre_agg.current_flakes)::bigint AS current_flakes,
+        SUM(pre_agg.current_failures)::bigint AS current_failures,
+        SUM(pre_agg.current_runs)::bigint AS current_runs,
+        open_bugs.open_bugs AS open_bugs,
+        prow_jobs.variants,
+        pre_agg.prow_job_run_release AS release
+    FROM
+        pre_agg
+        JOIN tests ON tests.id = pre_agg.test_id
+        LEFT JOIN open_bugs ON pre_agg.test_id = open_bugs.test_id
+        LEFT JOIN suites ON suites.id = pre_agg.suite_id
+        LEFT JOIN test_ownerships ON (tests.id = test_ownerships.test_id AND pre_agg.suite_id = test_ownerships.suite_id)
+        LEFT JOIN jira_components ON test_ownerships.jira_component = jira_components.name
+        JOIN prow_jobs ON pre_agg.prow_job_id = prow_jobs.id
+    GROUP BY
+        tests.id, tests.name, jira_components.name, jira_components.id, suites.name, open_bugs.open_bugs, prow_jobs.variants, pre_agg.prow_job_run_release
+) AS base
+WINDOW w AS (PARTITION BY base.id, base.suite_name, base.release)
 `
 
 const testAnalysisByVariantView = `


### PR DESCRIPTION
## Summary
- Enriches `prow_test_report_7d_matview` (and 2d) with pre-computed percentage and cross-variant statistics columns via window functions
- Simplifies `TestsByNURPAndStandardDeviation` from a 3-scan self-join to a simple SELECT with pre-computed columns
- Targets the `/api/tests?collapse=false` endpoint ("Tests By Variant"), which is the most expensive query in production

## Benchmarks (staging, warm)

| Release | Rows | Before | After | Speedup |
|---------|------|--------|-------|---------|
| 4.18 | 290K | 5,925ms | 641ms | **9.2x** |
| 5.0 | 911K | 8,723ms | 2,196ms | **4.0x** |

Matview refresh cost: **+5%** (~21s on a ~7 min refresh, every 2 hours)

## Details

The existing matview stores raw counts per (test, variant-combo, release). The `collapse=false` API path previously scanned the matview three times:
1. `stats` subquery: AVG/STDDEV grouped by test
2. `passRates` subquery: per-row percentage calculations
3. Main query: JOIN both subqueries back to the matview

This change wraps the matview definition with an outer SELECT that pre-computes all percentage and statistical columns using window functions (`PARTITION BY id, suite_name, release`). The API query then reads these directly.

Other matview consumers (`TestReportsByVariant`, `TestReportExcludeVariants`, health endpoint, feature gates) are unaffected — they aggregate raw counts and ignore the extra columns.

## Test plan
- [x] `go vet ./...` passes
- [x] `make test` passes (Go + Jest)
- [x] Row counts verified on staging
- [x] EXPLAIN ANALYZE benchmarked on staging for 4.18 and 5.0 releases
- [ ] Deploy to staging and verify Tests By Variant page loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized database query logic to leverage precomputed statistics, reducing computation overhead at query time.

* **Bug Fixes**
  * Enhanced accuracy of statistical calculations for test metrics by utilizing precomputed aggregates and derived delta measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->