### PR TITLE
Add collapsed matview for default test results API path

### DIFF
--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -29,6 +29,8 @@ import (
 const (
 	testReport7dMatView          = "prow_test_report_7d_matview"
 	testReport2dMatView          = "prow_test_report_2d_matview"
+	testReport7dCollapsedMatView = "prow_test_report_7d_collapsed_matview"
+	testReport2dCollapsedMatView = "prow_test_report_2d_collapsed_matview"
 	payloadFailedTests14dMatView = "payload_test_failures_14d_matview"
 )
 
@@ -424,16 +426,23 @@ const testResultsCacheDuration = time.Hour
 
 func (spec *TestResultsSpec) buildTestsResultsFromPostgres(ctx context.Context, dbc *db.DB, cacheClient cache.Cache) (testResults, error) {
 	matview := testReport7dMatView
+	collapsedMatview := testReport7dCollapsedMatView
 	if spec.Period == "twoDay" {
 		matview = testReport2dMatView
+		collapsedMatview = testReport2dCollapsedMatView
+	}
+
+	queryMatview := matview
+	if spec.Collapse {
+		queryMatview = collapsedMatview
 	}
 
 	generator := func(ctx context.Context) (testResults, []error) {
-		return spec.buildTestsResultsPGGenerator(ctx, dbc, matview)
+		return spec.buildTestsResultsPGGenerator(ctx, dbc, queryMatview)
 	}
 	result, errs := GetDataFromCacheOrMatview(ctx, cacheClient,
 		NewCacheSpec(spec, "PostgresTestsResults~", nil),
-		matview, testResultsCacheDuration,
+		queryMatview, testResultsCacheDuration,
 		generator,
 		testResults{},
 	)
@@ -451,7 +460,12 @@ func (spec *TestResultsSpec) buildTestsResultsPGGenerator(ctx context.Context, d
 	// assembled our final temporary table.
 	var rawFilter, processedFilter *filter.Filter
 	if spec.Filter != nil {
-		rawFilter, processedFilter = spec.Filter.Split([]string{"name", "variants"})
+		// The collapsed matview has no variants column, so only split on name.
+		rawFields := []string{"name", "variants"}
+		if spec.Collapse {
+			rawFields = []string{"name"}
+		}
+		rawFilter, processedFilter = spec.Filter.Split(rawFields)
 	}
 
 	rawQuery := dbc.DB.WithContext(ctx).
@@ -461,7 +475,7 @@ func (spec *TestResultsSpec) buildTestsResultsPGGenerator(ctx context.Context, d
 	// Collapse groups the test results together -- otherwise we return the test results per-variant combo (NURP+)
 	variantSelect := ""
 	if spec.Collapse {
-		rawQuery = rawQuery.Select(`suite_name,name,jira_component,jira_component_id,` + query.QueryTestSummer).Group("suite_name,name,jira_component,jira_component_id")
+		rawQuery = rawQuery.Select(`suite_name,name,jira_component,jira_component_id,` + query.QueryTestFields)
 	} else {
 		rawQuery = query.TestsByNURPAndStandardDeviation(dbc, spec.Release, matview)
 		variantSelect = "suite_name, variants," +

--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -27,6 +28,7 @@ var PostgresMatViews = []PostgresView{
 		Name:         "prow_test_report_2d_matview",
 		Definition:   testReportMatView,
 		IndexColumns: []string{"release", "name", "id", "variants", "suite_name"},
+		RefreshPhase: 1, // avoid CPU overload from refreshing concurrently with the 7d matview
 		ReplaceStrings: map[string]string{
 			"|||START|||":    "|||TIMENOW||| - INTERVAL '9 DAY'",
 			"|||BOUNDARY|||": "|||TIMENOW||| - INTERVAL '2 DAY'",
@@ -52,6 +54,24 @@ var PostgresMatViews = []PostgresView{
 		IndexColumns: []string{"period", "prow_job_id", "test_name"},
 		ReplaceStrings: map[string]string{
 			"|||BY|||": "hour",
+		},
+	},
+	{
+		Name:         "prow_test_report_7d_collapsed_matview",
+		Definition:   testReportCollapsedMatView,
+		IndexColumns: []string{"release", "name", "suite_name", "jira_component", "jira_component_id"},
+		RefreshPhase: 2, // reads from prow_test_report_7d_matview, which refreshes in phase 0
+		ReplaceStrings: map[string]string{
+			"|||SOURCE|||": "prow_test_report_7d_matview",
+		},
+	},
+	{
+		Name:         "prow_test_report_2d_collapsed_matview",
+		Definition:   testReportCollapsedMatView,
+		IndexColumns: []string{"release", "name", "suite_name", "jira_component", "jira_component_id"},
+		RefreshPhase: 2, // reads from prow_test_report_2d_matview, which refreshes in phase 1
+		ReplaceStrings: map[string]string{
+			"|||SOURCE|||": "prow_test_report_2d_matview",
 		},
 	},
 	{
@@ -83,6 +103,32 @@ type PostgresView struct {
 	// replaced if changes are made to these values. IndexColumns are required as we need them defined to be able to
 	// refresh materialized views concurrently. (avoiding locking reads for several minutes while we update)
 	IndexColumns []string
+	// RefreshPhase controls the order in which matviews are refreshed. All matviews
+	// in phase 0 refresh first (concurrently), then all in phase 1, and so on.
+	// Use this when a matview reads from another matview and needs it to be up-to-date.
+	// The default zero value means phase 0.
+	RefreshPhase int
+}
+
+// RefreshByPhase groups matviews by RefreshPhase and calls refreshFn for each
+// phase in order. All matviews in a phase are passed to refreshFn together
+// (the caller is responsible for concurrent execution within a phase).
+func RefreshByPhase(matviews []PostgresView, refreshFn func([]PostgresView)) {
+	sorted := make([]PostgresView, len(matviews))
+	copy(sorted, matviews)
+	slices.SortFunc(sorted, func(a, b PostgresView) int {
+		return a.RefreshPhase - b.RefreshPhase
+	})
+
+	for i := 0; i < len(sorted); {
+		phase := sorted[i].RefreshPhase
+		j := i
+		for j < len(sorted) && sorted[j].RefreshPhase == phase {
+			j++
+		}
+		refreshFn(sorted[i:j])
+		i = j
+	}
 }
 
 func syncPostgresMaterializedViews(db *gorm.DB, reportEnd *time.Time) error {
@@ -283,6 +329,21 @@ FROM
     JOIN prow_jobs ON pre_agg.prow_job_id = prow_jobs.id
 GROUP BY
     tests.id, tests.name, jira_components.name, jira_components.id, suites.name, open_bugs.open_bugs, prow_jobs.variants, pre_agg.prow_job_run_release
+`
+
+const testReportCollapsedMatView = `
+SELECT suite_name, name, jira_component, jira_component_id, release,
+    SUM(current_runs)::bigint AS current_runs,
+    SUM(current_successes)::bigint AS current_successes,
+    SUM(current_failures)::bigint AS current_failures,
+    SUM(current_flakes)::bigint AS current_flakes,
+    SUM(previous_runs)::bigint AS previous_runs,
+    SUM(previous_successes)::bigint AS previous_successes,
+    SUM(previous_failures)::bigint AS previous_failures,
+    SUM(previous_flakes)::bigint AS previous_flakes,
+    (array_agg(open_bugs))[1] AS open_bugs
+FROM |||SOURCE|||
+GROUP BY suite_name, name, jira_component, jira_component_id, release
 `
 
 const testAnalysisByVariantView = `

--- a/pkg/db/views_test.go
+++ b/pkg/db/views_test.go
@@ -1,0 +1,57 @@
+package db
+
+import (
+	"testing"
+)
+
+func TestMatviewSourcesRefreshBeforeDependents(t *testing.T) {
+	phaseByName := make(map[string]int)
+	for _, mv := range PostgresMatViews {
+		phaseByName[mv.Name] = mv.RefreshPhase
+	}
+
+	for _, mv := range PostgresMatViews {
+		for _, v := range mv.ReplaceStrings {
+			sourcePhase, ok := phaseByName[v]
+			if !ok {
+				continue
+			}
+			if sourcePhase >= mv.RefreshPhase {
+				t.Errorf("%s (phase %d) reads from %s (phase %d), but source must be in an earlier phase",
+					mv.Name, mv.RefreshPhase, v, sourcePhase)
+			}
+		}
+	}
+}
+
+func TestRefreshByPhase(t *testing.T) {
+	matviews := []PostgresView{
+		{Name: "c", RefreshPhase: 2},
+		{Name: "a1", RefreshPhase: 0},
+		{Name: "b1", RefreshPhase: 1},
+		{Name: "a2", RefreshPhase: 0},
+		{Name: "b2", RefreshPhase: 1},
+	}
+
+	var callOrder [][]string
+	RefreshByPhase(matviews, func(phase []PostgresView) {
+		var names []string
+		for _, mv := range phase {
+			names = append(names, mv.Name)
+		}
+		callOrder = append(callOrder, names)
+	})
+
+	if len(callOrder) != 3 {
+		t.Fatalf("expected 3 phases, got %d", len(callOrder))
+	}
+	if len(callOrder[0]) != 2 {
+		t.Errorf("phase 0: expected 2 matviews, got %d", len(callOrder[0]))
+	}
+	if len(callOrder[1]) != 2 {
+		t.Errorf("phase 1: expected 2 matviews, got %d", len(callOrder[1]))
+	}
+	if len(callOrder[2]) != 1 || callOrder[2][0] != "c" {
+		t.Errorf("phase 2: expected [c], got %v", callOrder[2])
+	}
+}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
-	sorting "sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -290,45 +289,10 @@ func refreshMaterializedViews(dbc *db.DB, cacheClient cache.Cache, refreshMatvie
 		}(lookback)
 	}
 	wg.Wait()
-	// create a channel for work "tasks"
-	ch := make(chan string)
-
-	wg = sync.WaitGroup{}
-
-	// allow concurrent workers for refreshing matviews in parallel
-	for t := 0; t < 2; t++ {
-		wg.Add(1)
-		go refreshMatview(dbc, cacheClient, refreshMatviewOnlyIfEmpty, ch, &wg)
-	}
-
-	// Sort materialized views so prow_test_report_2d_matview runs last to avoid CPU overload
-	sortedMatViews := make([]db.PostgresView, len(db.PostgresMatViews))
-	copy(sortedMatViews, db.PostgresMatViews)
-	sorting.SliceStable(sortedMatViews, func(i, j int) bool {
-		// Move prow_test_report_2d_matview to the end
-		if sortedMatViews[i].Name == "prow_test_report_2d_matview" {
-			return false
-		}
-		if sortedMatViews[j].Name == "prow_test_report_2d_matview" {
-			return true
-		}
-
-		// Move prow_test_report_7d_matview to the beginning
-		if sortedMatViews[i].Name == "prow_test_report_7d_matview" {
-			return true
-		}
-		if sortedMatViews[j].Name == "prow_test_report_7d_matview" {
-			return false
-		}
-		return false
+	db.RefreshByPhase(db.PostgresMatViews, func(phaseMatViews []db.PostgresView) {
+		log.Infof("refreshing %d materialized views", len(phaseMatViews))
+		refreshMatviews(dbc, cacheClient, refreshMatviewOnlyIfEmpty, phaseMatViews)
 	})
-
-	for _, pmv := range sortedMatViews {
-		ch <- pmv.Name
-	}
-
-	close(ch)
-	wg.Wait()
 
 	allElapsed := time.Since(allStart)
 	log.WithField("elapsed", allElapsed).Info("refreshed all materialized views")
@@ -342,6 +306,20 @@ func refreshMaterializedViews(dbc *db.DB, cacheClient cache.Cache, refreshMatvie
 			log.Info("successfully pushed metrics to prometheus gateway")
 		}
 	}
+}
+
+func refreshMatviews(dbc *db.DB, cacheClient cache.Cache, refreshMatviewOnlyIfEmpty bool, matviews []db.PostgresView) {
+	ch := make(chan string)
+	wg := sync.WaitGroup{}
+	for t := 0; t < 2; t++ {
+		wg.Add(1)
+		go refreshMatview(dbc, cacheClient, refreshMatviewOnlyIfEmpty, ch, &wg)
+	}
+	for _, pmv := range matviews {
+		ch <- pmv.Name
+	}
+	close(ch)
+	wg.Wait()
 }
 
 func refreshMatview(dbc *db.DB, cacheClient cache.Cache, refreshMatviewOnlyIfEmpty bool, ch chan string, wg *sync.WaitGroup) {


### PR DESCRIPTION
## Summary
- Adds a pre-collapsed materialized view (`prow_test_report_7d_collapsed_matview` and 2d variant) that pre-aggregates test results by `(suite_name, name, jira_component, jira_component_id, release)`, collapsing all variant combinations
- The `/api/tests` endpoint with `collapse=true` (the default "All Tests" page) reads from this matview directly instead of doing SUM + GROUP BY on the full per-variant matview
- Adds `RefreshPhase` field to `PostgresView` to control matview refresh ordering — all matviews in phase 0 refresh concurrently, then phase 1, etc.
- Moves `prow_test_report_2d_matview` to phase 1 (previously handled by sort-based ordering) to avoid CPU overload from refreshing concurrently with the 7d matview
- Collapsed matviews refresh in phase 2 after the base matviews they read from

## Benchmarks (staging, warm)

| Release | Rows | Before | After | Speedup |
|---------|------|--------|-------|---------|
| 4.18 | 290K → 7K | 2,115ms | 6ms | **360x** |
| 5.0 | 911K → 27K | 5,162ms | 24ms | **211x** |

Collapsed matview refresh cost: **~36s** (reads from already-refreshed base matview)

## Details

The base matview has ~5M rows (one per test × variant-combo × release). The collapsed matview reduces this to ~148K rows by summing counts across all variant combinations per test. This is the same aggregation the API currently does at query time on every request.

The `RefreshPhase` field replaces the previous sort-based ordering that ensured the 2d matview didn't refresh concurrently with the 7d matview. Matviews are sorted by phase and processed in a single pass — each phase's matviews refresh concurrently, then the next phase begins:
- **Phase 0**: 7d matview + other independent matviews
- **Phase 1**: 2d matview (avoids CPU overload with 7d)
- **Phase 2**: Collapsed matviews (read from base matviews completed in phases 0 and 1)

## Test plan
- [x] `go vet ./...` passes
- [x] `make test` passes (Go + Jest)
- [x] Row counts verified on staging (7,227 rows match for 4.18)
- [x] Spot-checked values match between current GROUP BY and collapsed matview
- [ ] Deploy to staging and verify All Tests page loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)