### PR TITLE
Fix flakes filter labels showing as failures in TestTable

### DIFF
--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -850,7 +850,7 @@ function TestTable(props) {
     },
     current_flakes: {
       field: 'current_flakes',
-      headerName: 'Current failures',
+      headerName: 'Current flakes',
       type: 'number',
     },
     current_pass_percentage: {
@@ -882,7 +882,7 @@ function TestTable(props) {
     },
     previous_flakes: {
       field: 'previous_flakes',
-      headerName: 'Previous failures',
+      headerName: 'Previous flakes',
       type: 'number',
     },
     previous_pass_percentage: {


### PR DESCRIPTION
## Summary
- Fix `current_flakes` and `previous_flakes` filter dropdown entries in the Tests By Variant table — they were mislabeled as "Current failures" and "Previous failures"

## Test plan
- [x] Open Tests By Variant page, click the filter dropdown, verify "Current flakes" and "Previous flakes" appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed incorrect table column header labels that were displaying "Current failures" instead of "Current flakes" and "Previous failures" instead of "Previous flakes," ensuring metric labels now display accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->