### PR TITLE
Strip variant filters when querying collapsed matview

### DIFF
--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -460,12 +460,12 @@ func (spec *TestResultsSpec) buildTestsResultsPGGenerator(ctx context.Context, d
 	// assembled our final temporary table.
 	var rawFilter, processedFilter *filter.Filter
 	if spec.Filter != nil {
-		// The collapsed matview has no variants column, so only split on name.
-		rawFields := []string{"name", "variants"}
+		filterToSplit := spec.Filter
 		if spec.Collapse {
-			rawFields = []string{"name"}
+			// The collapsed matview has no variants column, so strip variant filters.
+			_, filterToSplit = spec.Filter.Split([]string{"variants"})
 		}
-		rawFilter, processedFilter = spec.Filter.Split(rawFields)
+		rawFilter, processedFilter = filterToSplit.Split([]string{"name", "variants"})
 	}
 
 	rawQuery := dbc.DB.WithContext(ctx).


### PR DESCRIPTION
## Summary
- Fix 500 error on `/api/tests` with `collapse=true` (the default "All Tests" page)
- The collapsed matview has no `variants` column, but the frontend sends default variant filters (e.g. `not variants has entry 'never-stable'`)
- These filters were being moved to the processed filter stage, which also doesn't have the column
- Now strips variant filters entirely when using the collapsed matview

Fixes the regression introduced by #3626.

## Test plan
- [x] `go vet ./...` passes
- [ ] Load the All Tests page and verify it returns data without 500 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test result generation logic for filter processing when collapse functionality is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->