### PR TITLE
TRT-2703: enable-partitionwise true by default

### DIFF
--- a/pkg/flags/postgres.go
+++ b/pkg/flags/postgres.go
@@ -118,7 +118,7 @@ func (f *PostgresFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.Var(&f.LogLevel, "db-log-level", "GORM database log level")
 	fs.StringVar(&f.DSN, "database-dsn", f.DSN, "Database DSN for connecting to Postgres")
 	fs.Var(&f.pinnedTime, "pinned-date-time", "Pin database results to a fixed end date/time")
-	fs.BoolVar(&f.EnablePartitionwise, "enable-partitionwise", false, "Enable PostgreSQL partitionwise aggregate and join optimizations")
+	fs.BoolVar(&f.EnablePartitionwise, "enable-partitionwise", true, "Enable PostgreSQL partitionwise aggregate and join optimizations")
 }
 
 func (f *PostgresFlags) GetDBClient() (*db.DB, error) {


### PR DESCRIPTION
Ran benchmarking to compare with the flag on and off.  We see improvement in the API benchmark tests and no indication of degradation.  Proposal is to enable by default

## All Benchmarks Today (2026-06-15)

| Time | Type | Tests | Baseline | Partitionwise | Change | Impact |
|------|------|-------|----------|---------------|--------|--------|
| 15:47 | **API Endpoints** | 7 | 28.85s | 8.18s | **-71.64%** | 🚀 Massive Win |
| 16:22 | **Test Suite** | 23 | 171.39s | 169.55s | -1.08% | ✅ Minor Win |
| 16:44 | **Matview Queries** | 8 | 2.16s | 2.14s | -1.04% | ✅ No Impact |
| 18:44 | **Matview Refresh #1** | 1 | 1233.50s | 1307.24s | **+5.98%** | ⚠️ Slower |
| 22:04 | **Matview Refresh #2** | 1 | 1336.28s | 1221.09s | **-8.62%** | ✅ Faster |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Partitionwise query execution is now enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->