### PR TITLE
Add testlifecycle filter to several 5.0 views

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -315,6 +315,9 @@ component_readiness:
       - vsphere
       Topology:
       - external
+  test_filters:
+    lifecycles:
+    - blocking
   advanced_options:
     minimum_failure: 3
     confidence: 95
@@ -390,6 +393,9 @@ component_readiness:
       - multi
     variant_cross_compare:
     - Architecture
+  test_filters:
+    lifecycles:
+    - blocking
   advanced_options:
     minimum_failure: 3
     confidence: 95
@@ -467,6 +473,9 @@ component_readiness:
       - rhcos9
     variant_cross_compare:
     - OS
+  test_filters:
+    lifecycles:
+    - blocking
   advanced_options:
     minimum_failure: 4
     confidence: 95
@@ -915,6 +924,9 @@ component_readiness:
       ContainerRuntime:
       - runc
       - crun
+  test_filters:
+    lifecycles:
+    - blocking
   advanced_options:
     minimum_failure: 3
     confidence: 95
@@ -992,6 +1004,9 @@ component_readiness:
       ContainerRuntime:
       - runc
       - crun
+  test_filters:
+    lifecycles:
+    - blocking
   advanced_options:
     minimum_failure: 3
     confidence: 95


### PR DESCRIPTION
Saw informing tests regressed on the rhcos 10 vs 9 view


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated component readiness testing configurations to refine test filtering for multiple component versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->