### PR TITLE
Add pre-filtered collapsed matview for default test results

### DIFF
--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	gosort "sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/bigquery"
@@ -30,6 +31,8 @@ import (
 const (
 	testReport7dMatView          = "prow_test_report_7d_matview"
 	testReport2dMatView          = "prow_test_report_2d_matview"
+	testReport7dCollapsedMatView = "prow_test_report_7d_collapsed_matview"
+	testReport2dCollapsedMatView = "prow_test_report_2d_collapsed_matview"
 	payloadFailedTests14dMatView = "payload_test_failures_14d_matview"
 )
 
@@ -444,6 +447,40 @@ func (spec *TestResultsSpec) buildTestsResultsFromPostgres(ctx context.Context, 
 	return result, nil
 }
 
+// variantFiltersCoveredByCollapsedMatview returns true if all variant filter items
+// are "NOT has entry" exclusions for values that are already pre-excluded in the
+// collapsed matview. When true, these filters can be dropped and the collapsed
+// matview used directly.
+// variantFiltersCoveredByCollapsedMatview returns true if the variant filters
+// exactly match the exclusions baked into the collapsed matview. Every filter
+// item must be a "NOT has entry" for one of the pre-excluded values, and every
+// pre-excluded value must have a corresponding filter item.
+func variantFiltersCoveredByCollapsedMatview(variantFilter *filter.Filter) bool {
+	if variantFilter == nil || len(variantFilter.Items) == 0 {
+		return false
+	}
+
+	matched := make(map[string]bool)
+	for _, item := range variantFilter.Items {
+		if !item.Not || item.Operator != filter.OperatorHasEntry {
+			return false
+		}
+		found := false
+		for _, excluded := range db.CollapsedVariantExclusions {
+			if item.Value == excluded {
+				matched[excluded] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return len(matched) == len(db.CollapsedVariantExclusions)
+}
+
 func (spec *TestResultsSpec) buildTestsResultsPGGenerator(ctx context.Context, dbc *db.DB, matview string) (result testResults, errs []error) {
 	now := time.Now()
 
@@ -457,20 +494,39 @@ func (spec *TestResultsSpec) buildTestsResultsPGGenerator(ctx context.Context, d
 		nameFilter, variantFilter = rawFilter.Split([]string{"name"})
 	}
 
+	// When collapsing and the variant filters are only the default exclusions (never-stable,
+	// aggregated), use the pre-filtered collapsed matview which has these exclusions baked in
+	// and the GROUP BY pre-computed. This reduces query time from ~5s to ~430ms.
+	useCollapsedMatview := spec.Collapse && variantFiltersCoveredByCollapsedMatview(variantFilter)
+	if useCollapsedMatview {
+		collapsedMatview := testReport7dCollapsedMatView
+		if spec.Period == "twoDay" {
+			collapsedMatview = testReport2dCollapsedMatView
+		}
+		matview = collapsedMatview
+	}
+
 	rawQuery := dbc.DB.WithContext(ctx).
 		Table(matview).
 		Where("release = ?", spec.Release)
 
 	// Collapse groups the test results together -- otherwise we return the test results per-variant combo (NURP+)
-	variantSelect := ""
+	testMetadataColumns := []string{"suite_name", "name", "jira_component", "jira_component_id"}
+	var variantColumns []string
 	if spec.Collapse {
-		rawQuery = rawQuery.Select(`suite_name,name,jira_component,jira_component_id,` + query.QueryTestSummer).Group("suite_name,name,jira_component,jira_component_id")
+		if useCollapsedMatview {
+			rawQuery = rawQuery.Select(strings.Join(append(testMetadataColumns, query.QueryTestFields), ","))
+		} else {
+			rawQuery = rawQuery.Select(strings.Join(append(testMetadataColumns, query.QueryTestSummer), ",")).Group(strings.Join(testMetadataColumns, ","))
+		}
 	} else {
 		rawQuery = query.TestsByNURPAndStandardDeviation(dbc, spec.Release, matview)
-		variantSelect = "suite_name, variants," +
-			"delta_from_working_average, working_average, working_standard_deviation, " +
-			"delta_from_passing_average, passing_average, passing_standard_deviation, " +
-			"delta_from_flake_average, flake_average, flake_standard_deviation, "
+		variantColumns = []string{
+			"suite_name", "variants",
+			"delta_from_working_average", "working_average", "working_standard_deviation",
+			"delta_from_passing_average", "passing_average", "passing_standard_deviation",
+			"delta_from_flake_average", "flake_average", "flake_standard_deviation",
+		}
 	}
 
 	// Apply name and variant filters via dimension table lookups rather than directly on
@@ -480,14 +536,20 @@ func (spec *TestResultsSpec) buildTestsResultsPGGenerator(ctx context.Context, d
 		testSubquery := nameFilter.ToSQL(dbc.DB.Model(&models.Test{}).Select("id"), apitype.Test{})
 		rawQuery = rawQuery.Where("id IN (?)", testSubquery)
 	}
-	if variantFilter != nil && len(variantFilter.Items) > 0 {
+	// Variant filters are already applied in the collapsed matview; only apply them
+	// when using the base matview.
+	if !useCollapsedMatview && variantFilter != nil && len(variantFilter.Items) > 0 {
 		rawQuery = variantFilter.ToSQL(rawQuery, apitype.Test{})
 	}
 
 	testReports := make([]apitype.Test, 0)
 	// FIXME: Add test id to matview, for now generate with ROW_NUMBER OVER
+	selectColumns := []string{"ROW_NUMBER() OVER() as id"}
+	selectColumns = append(selectColumns, testMetadataColumns...)
+	selectColumns = append(selectColumns, variantColumns...)
+	selectColumns = append(selectColumns, query.QueryTestSummarizer)
 	processedResults := dbc.DB.Table("(?) as results", rawQuery).
-		Select(`ROW_NUMBER() OVER() as id, suite_name, name, jira_component, jira_component_id,` + variantSelect + query.QueryTestSummarizer).
+		Select(strings.Join(selectColumns, ",")).
 		Where("current_runs > 0 or previous_runs > 0")
 
 	finalResults := dbc.DB.Table("(?) as final_results", processedResults)

--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -27,6 +28,7 @@ var PostgresMatViews = []PostgresView{
 		Name:         "prow_test_report_2d_matview",
 		Definition:   testReportMatView,
 		IndexColumns: []string{"release", "name", "id", "variants", "suite_name"},
+		RefreshPhase: 1, // avoid CPU overload from refreshing concurrently with the 7d matview
 		ReplaceStrings: map[string]string{
 			"|||START|||":    "|||TIMENOW||| - INTERVAL '9 DAY'",
 			"|||BOUNDARY|||": "|||TIMENOW||| - INTERVAL '2 DAY'",
@@ -52,6 +54,24 @@ var PostgresMatViews = []PostgresView{
 		IndexColumns: []string{"period", "prow_job_id", "test_name"},
 		ReplaceStrings: map[string]string{
 			"|||BY|||": "hour",
+		},
+	},
+	{
+		Name:         "prow_test_report_7d_collapsed_matview",
+		Definition:   testReportCollapsedMatView,
+		IndexColumns: []string{"release", "id", "suite_name", "jira_component", "jira_component_id"},
+		RefreshPhase: 2, // reads from prow_test_report_7d_matview, which refreshes in phase 0
+		ReplaceStrings: map[string]string{
+			"|||SOURCE|||": "prow_test_report_7d_matview",
+		},
+	},
+	{
+		Name:         "prow_test_report_2d_collapsed_matview",
+		Definition:   testReportCollapsedMatView,
+		IndexColumns: []string{"release", "id", "suite_name", "jira_component", "jira_component_id"},
+		RefreshPhase: 2, // reads from prow_test_report_2d_matview, which refreshes in phase 1
+		ReplaceStrings: map[string]string{
+			"|||SOURCE|||": "prow_test_report_2d_matview",
 		},
 	},
 	{
@@ -83,6 +103,32 @@ type PostgresView struct {
 	// replaced if changes are made to these values. IndexColumns are required as we need them defined to be able to
 	// refresh materialized views concurrently. (avoiding locking reads for several minutes while we update)
 	IndexColumns []string
+	// RefreshPhase controls the order in which matviews are refreshed. All matviews
+	// in phase 0 refresh first (concurrently), then all in phase 1, and so on.
+	// Use this when a matview reads from another matview and needs it to be up-to-date.
+	// The default zero value means phase 0.
+	RefreshPhase int
+}
+
+// RefreshByPhase groups matviews by RefreshPhase and calls refreshFn for each
+// phase in order. All matviews in a phase are passed to refreshFn together
+// (the caller is responsible for concurrent execution within a phase).
+func RefreshByPhase(matviews []PostgresView, refreshFn func([]PostgresView)) {
+	sorted := make([]PostgresView, len(matviews))
+	copy(sorted, matviews)
+	slices.SortFunc(sorted, func(a, b PostgresView) int {
+		return a.RefreshPhase - b.RefreshPhase
+	})
+
+	for i := 0; i < len(sorted); {
+		phase := sorted[i].RefreshPhase
+		j := i
+		for j < len(sorted) && sorted[j].RefreshPhase == phase {
+			j++
+		}
+		refreshFn(sorted[i:j])
+		i = j
+	}
 }
 
 func syncPostgresMaterializedViews(db *gorm.DB, reportEnd *time.Time) error {
@@ -303,6 +349,35 @@ FROM (
 ) AS base
 WINDOW w AS (PARTITION BY base.id, base.suite_name, base.release)
 `
+
+// CollapsedVariantExclusions lists the variant values that are pre-excluded in
+// the collapsed matview. The API checks incoming variant filters against this
+// list to decide whether the collapsed matview can be used.
+var CollapsedVariantExclusions = []string{"never-stable", "aggregated"}
+
+var testReportCollapsedMatView = buildCollapsedMatViewSQL()
+
+func buildCollapsedMatViewSQL() string {
+	var clauses []string
+	for _, v := range CollapsedVariantExclusions {
+		clauses = append(clauses, fmt.Sprintf("NOT ('%s' = any(variants))", v))
+	}
+	return `
+SELECT suite_name, name, id, jira_component, jira_component_id, release,
+    SUM(current_runs)::bigint AS current_runs,
+    SUM(current_successes)::bigint AS current_successes,
+    SUM(current_failures)::bigint AS current_failures,
+    SUM(current_flakes)::bigint AS current_flakes,
+    SUM(previous_runs)::bigint AS previous_runs,
+    SUM(previous_successes)::bigint AS previous_successes,
+    SUM(previous_failures)::bigint AS previous_failures,
+    SUM(previous_flakes)::bigint AS previous_flakes,
+    (array_agg(open_bugs))[1] AS open_bugs
+FROM |||SOURCE|||
+WHERE ` + strings.Join(clauses, "\n  AND ") + `
+GROUP BY suite_name, name, id, jira_component, jira_component_id, release
+`
+}
 
 const testAnalysisByVariantView = `
 SELECT

--- a/pkg/db/views_test.go
+++ b/pkg/db/views_test.go
@@ -1,0 +1,57 @@
+package db
+
+import (
+	"testing"
+)
+
+func TestMatviewSourcesRefreshBeforeDependents(t *testing.T) {
+	phaseByName := make(map[string]int)
+	for _, mv := range PostgresMatViews {
+		phaseByName[mv.Name] = mv.RefreshPhase
+	}
+
+	for _, mv := range PostgresMatViews {
+		for _, v := range mv.ReplaceStrings {
+			sourcePhase, ok := phaseByName[v]
+			if !ok {
+				continue
+			}
+			if sourcePhase >= mv.RefreshPhase {
+				t.Errorf("%s (phase %d) reads from %s (phase %d), but source must be in an earlier phase",
+					mv.Name, mv.RefreshPhase, v, sourcePhase)
+			}
+		}
+	}
+}
+
+func TestRefreshByPhase(t *testing.T) {
+	matviews := []PostgresView{
+		{Name: "c", RefreshPhase: 2},
+		{Name: "a1", RefreshPhase: 0},
+		{Name: "b1", RefreshPhase: 1},
+		{Name: "a2", RefreshPhase: 0},
+		{Name: "b2", RefreshPhase: 1},
+	}
+
+	var callOrder [][]string
+	RefreshByPhase(matviews, func(phase []PostgresView) {
+		var names []string
+		for _, mv := range phase {
+			names = append(names, mv.Name)
+		}
+		callOrder = append(callOrder, names)
+	})
+
+	if len(callOrder) != 3 {
+		t.Fatalf("expected 3 phases, got %d", len(callOrder))
+	}
+	if len(callOrder[0]) != 2 {
+		t.Errorf("phase 0: expected 2 matviews, got %d", len(callOrder[0]))
+	}
+	if len(callOrder[1]) != 2 {
+		t.Errorf("phase 1: expected 2 matviews, got %d", len(callOrder[1]))
+	}
+	if len(callOrder[2]) != 1 || callOrder[2][0] != "c" {
+		t.Errorf("phase 2: expected [c], got %v", callOrder[2])
+	}
+}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
-	sorting "sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -290,45 +289,10 @@ func refreshMaterializedViews(dbc *db.DB, cacheClient cache.Cache, refreshMatvie
 		}(lookback)
 	}
 	wg.Wait()
-	// create a channel for work "tasks"
-	ch := make(chan string)
-
-	wg = sync.WaitGroup{}
-
-	// allow concurrent workers for refreshing matviews in parallel
-	for t := 0; t < 2; t++ {
-		wg.Add(1)
-		go refreshMatview(dbc, cacheClient, refreshMatviewOnlyIfEmpty, ch, &wg)
-	}
-
-	// Sort materialized views so prow_test_report_2d_matview runs last to avoid CPU overload
-	sortedMatViews := make([]db.PostgresView, len(db.PostgresMatViews))
-	copy(sortedMatViews, db.PostgresMatViews)
-	sorting.SliceStable(sortedMatViews, func(i, j int) bool {
-		// Move prow_test_report_2d_matview to the end
-		if sortedMatViews[i].Name == "prow_test_report_2d_matview" {
-			return false
-		}
-		if sortedMatViews[j].Name == "prow_test_report_2d_matview" {
-			return true
-		}
-
-		// Move prow_test_report_7d_matview to the beginning
-		if sortedMatViews[i].Name == "prow_test_report_7d_matview" {
-			return true
-		}
-		if sortedMatViews[j].Name == "prow_test_report_7d_matview" {
-			return false
-		}
-		return false
+	db.RefreshByPhase(db.PostgresMatViews, func(phaseMatViews []db.PostgresView) {
+		log.Infof("refreshing %d materialized views", len(phaseMatViews))
+		refreshMatviews(dbc, cacheClient, refreshMatviewOnlyIfEmpty, phaseMatViews)
 	})
-
-	for _, pmv := range sortedMatViews {
-		ch <- pmv.Name
-	}
-
-	close(ch)
-	wg.Wait()
 
 	allElapsed := time.Since(allStart)
 	log.WithField("elapsed", allElapsed).Info("refreshed all materialized views")
@@ -342,6 +306,20 @@ func refreshMaterializedViews(dbc *db.DB, cacheClient cache.Cache, refreshMatvie
 			log.Info("successfully pushed metrics to prometheus gateway")
 		}
 	}
+}
+
+func refreshMatviews(dbc *db.DB, cacheClient cache.Cache, refreshMatviewOnlyIfEmpty bool, matviews []db.PostgresView) {
+	ch := make(chan string)
+	wg := sync.WaitGroup{}
+	for t := 0; t < 2; t++ {
+		wg.Add(1)
+		go refreshMatview(dbc, cacheClient, refreshMatviewOnlyIfEmpty, ch, &wg)
+	}
+	for _, pmv := range matviews {
+		ch <- pmv.Name
+	}
+	close(ch)
+	wg.Wait()
 }
 
 func refreshMatview(dbc *db.DB, cacheClient cache.Cache, refreshMatviewOnlyIfEmpty bool, ch chan string, wg *sync.WaitGroup) {


### PR DESCRIPTION
## Summary
- Adds a pre-filtered collapsed materialized view (`prow_test_report_7d_collapsed_matview` and 2d variant) that pre-aggregates test results with `never-stable` and `aggregated` variants excluded
- When the API detects the default variant filters (exactly `NOT has entry 'never-stable'` AND `NOT has entry 'aggregated'`), it reads from this matview directly — no GROUP BY, no variant filtering needed
- Falls back to the base matview with GROUP BY for any other variant filter combination
- Adds `RefreshPhase` to `PostgresView` for ordered matview refresh — the collapsed matviews refresh after the base matviews they read from

## Benchmarks (staging, warm, release 4.21 with default filters)

| Approach | Time | vs baseline |
|----------|------|-------------|
| Before (with #3632) | ~5,300ms | baseline |
| **With collapsed matview (this PR)** | **<500ms** | **~10x** |

Collapsed matview refresh cost: ~19s per matview (reads from already-refreshed base matview)

## How it works

The collapsed matview definition is built from `CollapsedVariantExclusions` — a single Go slice that drives both the matview SQL WHERE clause and the API's filter matching logic, ensuring they stay in sync.

`variantFiltersCoveredByCollapsedMatview()` checks that every variant filter item is a `NOT has entry` for a pre-excluded value, and that every pre-excluded value has a corresponding filter. Only an exact match uses the collapsed matview; any other combination falls back to the base matview.

## Test plan
- [x] `go vet ./...` passes
- [x] `make test` passes (Go + Jest)
- [x] Matview phase ordering tests pass
- [x] Tested locally with sippy frontend against staging database
- [x] All Tests page loads in <1s with default filters
- [x] Tests By Variant page still works correctly
- [x] Non-default filters correctly fall back to base matview

### Manual Testing
I deployed sippy locally pointing at the staging DB.
The All Tests default query took <1s. For comparison, prod sippy took  5.17s.

Adding a variant filter or removing one of the default variant filters had comparable times with prod sippy. This is expected given that the collapsed matview is not used in those scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for pre-collapsed test report views to optimize query performance when filtering with specific variant combinations.

* **Improvements**
  * Refactored materialized view refresh orchestration to use a phased approach, improving background data synchronization efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->