### PR TITLE
Optimize unknown-tests query with NOT EXISTS and partition pruning

### DIFF
--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -175,8 +175,9 @@ func JobsRunsReportFromDB(dbc *db.DB, filterOpts *filter.FilterOptions, release 
 }
 
 // FetchJobRun returns a single job run loaded from postgres and populated with the ProwJob and test results.
-// If unknownTests is true, all tests not registered in test_ownerships are loaded; otherwise any failed tests are loaded.
-func FetchJobRun(dbc *db.DB, jobRunID int64, unknownTests bool, preloads []string, logger *log.Entry) (*models.ProwJobRun, error) {
+// If onlyNewTests is true, only new tests are loaded: those not registered in test_ownerships and not
+// previously seen in a merged pull request. Otherwise any failed tests are loaded.
+func FetchJobRun(dbc *db.DB, jobRunID int64, onlyNewTests bool, preloads []string, logger *log.Entry) (*models.ProwJobRun, error) {
 	jobRun := &models.ProwJobRun{}
 
 	// Load the ProwJobRun, ProwJob, and (failed|unknown) tests:
@@ -184,24 +185,50 @@ func FetchJobRun(dbc *db.DB, jobRunID int64, unknownTests bool, preloads []strin
 	q := dbc.DB.Joins("ProwJob").
 		Preload("PullRequests")
 
-	if len(preloads) > 0 {
-		for _, preload := range preloads {
-			q = q.Preload(preload)
-		}
+	// Tests are loaded separately with partition pruning keys, so
+	// split any Tests-related preloads from the main query.
+	otherPreloads, testPreloads := splitTestPreloads(preloads)
+	for _, preload := range otherPreloads {
+		q = q.Preload(preload)
 	}
 
-	if unknownTests {
-		// this doesn't establish that the tests are new, but it does filter out any that sippy registers
-		q = q.Preload("Tests", "test_id not in (select test_id from test_ownerships)")
-	} else { // load only failures
-		q = q.Preload("Tests", "status = ?", sippyprocessingv1.TestStatusFailure)
-	}
-	res := q.Preload("Tests.Test").
-		Preload("Tests.Suite").
-		First(jobRun, jobRunID)
+	// Load the job run first, then query tests separately with partition
+	// pruning keys for performance on the heavily partitioned
+	// prow_job_run_tests table (~3,500 partitions).
+	res := q.First(jobRun, jobRunID)
 	if res.Error != nil {
 		return nil, res.Error
 	}
+
+	var tests []models.ProwJobRunTest
+	testQuery := dbc.DB.
+		Where("prow_job_run_id = ? AND prow_job_run_release = ? AND prow_job_run_timestamp = ?",
+			jobRun.ID, jobRun.ProwJobRelease, jobRun.Timestamp)
+
+	if onlyNewTests {
+		// A test is "new" if it is not registered in test_ownerships and has
+		// not appeared in any job run associated with a merged pull request.
+		testQuery = testQuery.
+			Where("NOT EXISTS (SELECT 1 FROM test_ownerships tow WHERE tow.test_id = prow_job_run_tests.test_id)").
+			Where(`NOT EXISTS (
+				SELECT 1 FROM prow_job_run_tests t2
+				INNER JOIN prow_job_run_prow_pull_requests prmap ON prmap.prow_job_run_id = t2.prow_job_run_id
+				INNER JOIN prow_pull_requests prs ON prs.id = prmap.prow_pull_request_id
+				WHERE t2.test_id = prow_job_run_tests.test_id
+				  AND t2.prow_job_run_release = prow_job_run_tests.prow_job_run_release
+				  AND prs.merged_at IS NOT NULL)`)
+	} else {
+		testQuery = testQuery.Where("status = ?", sippyprocessingv1.TestStatusFailure)
+	}
+
+	testQuery = testQuery.Preload("Test").Preload("Suite")
+	for _, preload := range testPreloads {
+		testQuery = testQuery.Preload(preload)
+	}
+	if err := testQuery.Find(&tests).Error; err != nil {
+		return nil, err
+	}
+	jobRun.Tests = tests
 
 	jobRunTestCount, err := query.JobRunTestCount(dbc, jobRunID, jobRun.ProwJobRelease, jobRun.Timestamp)
 	if err != nil { // should be unusual
@@ -211,6 +238,20 @@ func FetchJobRun(dbc *db.DB, jobRunID int64, unknownTests bool, preloads []strin
 	jobRun.TestCount = jobRunTestCount
 
 	return jobRun, nil
+}
+
+// splitTestPreloads separates Tests-related preloads (e.g. "Tests.ProwJobRunTestOutput")
+// from other preloads. Tests-related preloads are returned with the "Tests." prefix stripped
+// so they can be applied to the manual test query.
+func splitTestPreloads(preloads []string) (other, testRelated []string) {
+	for _, p := range preloads {
+		if strings.HasPrefix(p, "Tests.") {
+			testRelated = append(testRelated, strings.TrimPrefix(p, "Tests."))
+		} else {
+			other = append(other, p)
+		}
+	}
+	return
 }
 
 // findReleaseMatchJobNames looks for the first matches with a common root job name specific to the

--- a/pkg/api/job_runs_test.go
+++ b/pkg/api/job_runs_test.go
@@ -313,6 +313,48 @@ func getTestRisk(result apitype.ProwJobRunRiskAnalysis, testName string) *apityp
 
 }
 
+func TestSplitTestPreloads(t *testing.T) {
+	tests := []struct {
+		name                string
+		preloads            []string
+		expectedOther       []string
+		expectedTestRelated []string
+	}{
+		{
+			name:                "nil preloads",
+			preloads:            nil,
+			expectedOther:       nil,
+			expectedTestRelated: nil,
+		},
+		{
+			name:                "no Tests-related preloads",
+			preloads:            []string{"PullRequests", "Annotations"},
+			expectedOther:       []string{"PullRequests", "Annotations"},
+			expectedTestRelated: nil,
+		},
+		{
+			name:                "only Tests-related preloads",
+			preloads:            []string{"Tests.ProwJobRunTestOutput", "Tests.Suite"},
+			expectedOther:       nil,
+			expectedTestRelated: []string{"ProwJobRunTestOutput", "Suite"},
+		},
+		{
+			name:                "mixed preloads",
+			preloads:            []string{"PullRequests", "Tests.ProwJobRunTestOutput", "Annotations"},
+			expectedOther:       []string{"PullRequests", "Annotations"},
+			expectedTestRelated: []string{"ProwJobRunTestOutput"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			other, testRelated := splitTestPreloads(tc.preloads)
+			assert.Equal(t, tc.expectedOther, other)
+			assert.Equal(t, tc.expectedTestRelated, testRelated)
+		})
+	}
+}
+
 func TestSubSliceEqual(t *testing.T) {
 
 	tests := []struct {

--- a/pkg/sippyserver/pr_new_tests_worker.go
+++ b/pkg/sippyserver/pr_new_tests_worker.go
@@ -6,11 +6,9 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	sippyApi "github.com/openshift/sippy/pkg/api"
 	apiModels "github.com/openshift/sippy/pkg/apis/api"
@@ -64,20 +62,6 @@ func SortByJobNameNT(risks []*JobNewTestRisks) {
 	})
 }
 
-type NewTestFilter interface {
-	// IsNewTest given a candidate test determines if it is really new with this PR
-	IsNewTest(logger *logrus.Entry, test models.ProwJobRunTest) (bool, error)
-}
-
-// pgNewTestFilter queries postgres to determine if a test is new. We can share
-// a single instance between workers and cache results so we are not constantly
-// querying postgres for the same test.
-type pgNewTestFilter struct {
-	dbc         *db.DB
-	notNewTests sets.Set[uint] // cache of test names that turn out not to be new
-	nnTmutex    *sync.Mutex    // protect notNewTests from concurrent access
-}
-
 type JobRunFilter interface {
 	// OnlyLatestSha filters out runs that are not against the PR's latest sha
 	OnlyLatestSha(entry *logrus.Entry, info prJobInfo) []*prow.ProwJob
@@ -92,27 +76,18 @@ type pgJobRunFilter struct {
 
 // NewTestsWorker analyzes PR jobs looking for new tests and determining their risks.
 type NewTestsWorker struct {
-	dbc           *db.DB
-	newTestFilter NewTestFilter
-	jobRunFilter  JobRunFilter
-	fetchJobRun   func(dbc *db.DB, jobRunID int64, unknownTests bool, preloads []string, logger *logrus.Entry) (*models.ProwJobRun, error)
+	dbc          *db.DB
+	jobRunFilter JobRunFilter
+	fetchJobRun  func(dbc *db.DB, jobRunID int64, onlyNewTests bool, preloads []string, logger *logrus.Entry) (*models.ProwJobRun, error)
 }
 
 // StandardNewTestsWorker is a convenience method to create a NewTestsWorker with standard filters
 func StandardNewTestsWorker(dbc *db.DB) *NewTestsWorker {
-	_, ntw := internalNewTestsWorker(dbc)
-	return ntw
-}
-func internalNewTestsWorker(dbc *db.DB) (*pgNewTestFilter, *NewTestsWorker) {
-	ntf := &pgNewTestFilter{dbc: dbc, notNewTests: sets.Set[uint]{}, nnTmutex: &sync.Mutex{}}
-	jrf := &pgJobRunFilter{dbc: dbc, historicalTestCount: map[uint]int{}}
-	ntw := &NewTestsWorker{
-		dbc:           dbc,
-		newTestFilter: ntf,
-		jobRunFilter:  jrf,
-		fetchJobRun:   sippyApi.FetchJobRun,
+	return &NewTestsWorker{
+		dbc:          dbc,
+		jobRunFilter: &pgJobRunFilter{dbc: dbc, historicalTestCount: map[uint]int{}},
+		fetchJobRun:  sippyApi.FetchJobRun,
 	}
-	return ntf, ntw // for tests it can be useful to have these explicitly
 }
 
 // analyzeRisks processes one job's runs looking for new tests and assessing their risk
@@ -331,72 +306,15 @@ func (ntw *NewTestsWorker) getNewTestsForJobRun(logger *logrus.Entry, prowjob *p
 	}
 
 	for _, test := range jobRun.Tests {
-		test.ProwJobRun = *jobRun // sometimes handy for a test to know whence it came
-		if isNew, err := ntw.newTestFilter.IsNewTest(logger, test); err != nil {
-			logger.WithError(err).Error("Error checking if test is new")
-			return nil, err // if this errors, it muddies this job's analysis, so throw it out
-		} else if isNew {
-			newTests = append(newTests, NewTest{
-				JobName:  prowjob.Spec.Job,
-				JobRunID: jobRun.ID,
-				TestName: test.Test.Name,
-				Success:  test.Status == int(spv1.TestStatusSuccess) || test.Status == int(spv1.TestStatusFlake),
-				Failure:  test.Status == int(spv1.TestStatusFailure) || test.Status == int(spv1.TestStatusFlake),
-			})
-		}
+		newTests = append(newTests, NewTest{
+			JobName:  prowjob.Spec.Job,
+			JobRunID: jobRun.ID,
+			TestName: test.Test.Name,
+			Success:  test.Status == int(spv1.TestStatusSuccess) || test.Status == int(spv1.TestStatusFlake),
+			Failure:  test.Status == int(spv1.TestStatusFailure) || test.Status == int(spv1.TestStatusFlake),
+		})
 	}
 	return newTests, nil
-}
-
-/*
-IsNewTest queries postgres to determine if a test not registered in `test_ownerships`
-is in fact new. For various $reasons, not all tests that we import in sippy are registered
-in that table, so we need additional verification to prevent flagging the same test as
-"new" over and over again.
-
-The search strategy is to look for instances of the test that ran against
-PRs that merged before the test under consideration began. If there are any,
-we can cache that test name as not new. If there are none, then consider this
-a new test.
-Records for PRs and potential PR comments are both created/updated at the same time,
-so this should be a reasonably robust strategy, though not infallible.
-*/
-func (ntf *pgNewTestFilter) IsNewTest(logger *logrus.Entry, testRun models.ProwJobRunTest) (bool, error) {
-	logger = logger.WithField("func", "IsNewTest").WithField("test", testRun.Test.Name)
-	ntf.nnTmutex.Lock()
-	if ntf.notNewTests.Has(testRun.TestID) {
-		// some past query found a PR that merged with this test.
-		logger.Debug("Test previously cached as not new")
-		ntf.nnTmutex.Unlock()
-		return false, nil
-	}
-	ntf.nnTmutex.Unlock()
-
-	pjpr := models.ProwPullRequest{}
-	res := ntf.dbc.DB.
-		Table("prow_job_run_tests as t").
-		Joins("INNER JOIN prow_job_run_prow_pull_requests as prmap on prmap.prow_job_run_id = t.prow_job_run_id").
-		Joins("INNER JOIN prow_pull_requests as prs on prs.id = prmap.prow_pull_request_id").
-		Where("t.test_id = ?", testRun.TestID).
-		Where("t.prow_job_run_release = ?", testRun.ProwJobRunRelease).
-		Where("merged_at is not null").
-		Select("org, repo, number, sha, merged_at").
-		Limit(1).Find(&pjpr) // any result demonstrates this is not new
-	if res.Error != nil {
-		logger.WithError(res.Error).Error("Error querying for PRs that included this test.")
-		return false, res.Error
-	}
-	if pjpr.MergedAt != nil {
-		// means such a record was found, so this is not new
-		logger.Debugf("Test ran in previously-merged PR %s/%s#%d@%s", pjpr.Org, pjpr.Repo, pjpr.Number, pjpr.SHA)
-		ntf.nnTmutex.Lock()
-		ntf.notNewTests.Insert(testRun.TestID) // do not need to look up next time
-		ntf.nnTmutex.Unlock()
-		return false, nil
-	}
-	// query succeeded but no such record was found, so this is new
-	logger.Debug("Test has not run in any previously-merged PR, considering it new.")
-	return true, nil
 }
 
 // summarizeNewTestRisks looks at all the risks spread across jobs and consolidates the stats;

--- a/pkg/sippyserver/pr_new_tests_worker_test.go
+++ b/pkg/sippyserver/pr_new_tests_worker_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/apis/prow"
@@ -79,8 +77,24 @@ func TestAssessJobRisks(t *testing.T) {
 	if !assert.True(t, numRuns > 1, "Expected at least 2 job runs") {
 		return
 	}
-	// skippingNewTestFilter alternately filters out new tests found to simulate missing tests
-	ntw.newTestFilter = &skippingNewTestFilter{newTestFilter: ntw.newTestFilter, sawPrevious: map[string]bool{}}
+	// Wrap fetchJobRun to alternately drop new tests, simulating a test missing in some runs
+	realFetch := ntw.fetchJobRun
+	sawPrevious := map[string]bool{}
+	ntw.fetchJobRun = func(dbc *db.DB, jobRunID int64, onlyNewTests bool, preloads []string, logger *logrus.Entry) (*models.ProwJobRun, error) {
+		jr, err := realFetch(dbc, jobRunID, onlyNewTests, preloads, logger)
+		if err != nil || jr == nil {
+			return jr, err
+		}
+		var filtered []models.ProwJobRunTest
+		for _, test := range jr.Tests {
+			sawPrevious[test.Test.Name] = !sawPrevious[test.Test.Name]
+			if sawPrevious[test.Test.Name] {
+				filtered = append(filtered, test)
+			}
+		}
+		jr.Tests = filtered
+		return jr, nil
+	}
 	jobRisks = ntw.assessJobRisks(logger, jobRuns)
 	failed, ok = jobRisks["a failed test that has never been seen before"]
 	if assert.True(t, ok, "Should have found failed test") {
@@ -115,8 +129,19 @@ func TestAssessCrossJobRisks(t *testing.T) {
 		return
 	}
 
-	// run just the new test analysis, but only find new tests in one job
-	ntw.newTestFilter = &oneJobNewTestFilter{newTestFilter: ntw.newTestFilter, jobName: "pull-ci-openshift-origin-master-e2e-aws-ovn-single-node"}
+	// Wrap fetchJobRun to only return new tests for one specific job
+	targetJob := "pull-ci-openshift-origin-master-e2e-aws-ovn-single-node"
+	realFetch := ntw.fetchJobRun
+	ntw.fetchJobRun = func(dbc *db.DB, jobRunID int64, onlyNewTests bool, preloads []string, logger *logrus.Entry) (*models.ProwJobRun, error) {
+		jr, err := realFetch(dbc, jobRunID, onlyNewTests, preloads, logger)
+		if err != nil || jr == nil {
+			return jr, err
+		}
+		if jr.ProwJob.Name != targetJob {
+			jr.Tests = nil
+		}
+		return jr, nil
+	}
 	for idx, jobInfo := range completedJobs {
 		completedJobs[idx].prowJobRuns = aw.buildProwJobRuns(logger, jobInfo.bucketPrefix)
 		completedJobs[idx].prShaSum = "8849ed78d4c51e2add729a68a2cbf8551c6d60c9" // so we can check whether runs are against the expected PR commit
@@ -224,14 +249,13 @@ func TestUnit_getNewTestsForJobRun(t *testing.T) {
 	}
 	tests := []struct {
 		name          string
-		fetchJobRun   func(dbc *db.DB, jobRunID int64, unknownTests bool, preloads []string, logger *logrus.Entry) (*models.ProwJobRun, error)
-		testFilter    NewTestFilter
+		fetchJobRun   func(dbc *db.DB, jobRunID int64, onlyNewTests bool, preloads []string, logger *logrus.Entry) (*models.ProwJobRun, error)
 		expectedTests []NewTest
 		expectedError error
 	}{
 		{
 			name: "successful fetch",
-			fetchJobRun: func(dbc *db.DB, jobRunID int64, unknownTests bool, preloads []string, logger *logrus.Entry) (*models.ProwJobRun, error) {
+			fetchJobRun: func(dbc *db.DB, jobRunID int64, onlyNewTests bool, preloads []string, logger *logrus.Entry) (*models.ProwJobRun, error) {
 				pjr := models.ProwJobRun{
 					ProwJobRelease: "4.12",
 					Tests: []models.ProwJobRunTest{
@@ -243,31 +267,16 @@ func TestUnit_getNewTestsForJobRun(t *testing.T) {
 				pjr.ID = 12345 // Gorm model ID for some reason can't be put in the struct literal
 				return &pjr, nil
 			},
-			testFilter: &oneNewTestFilter{}, // filters to only "test2"
 			expectedTests: []NewTest{
+				{JobName: "test-jobRun", JobRunID: 12345, TestName: "test1", Success: true, Failure: false},
 				{JobName: "test-jobRun", JobRunID: 12345, TestName: "test2", Success: false, Failure: true},
+				{JobName: "test-jobRun", JobRunID: 12345, TestName: "test3", Success: true, Failure: true},
 			},
 			expectedError: nil,
 		},
 		{
-			name: "error on filtering",
-			fetchJobRun: func(dbc *db.DB, jobRunID int64, unknownTests bool, preloads []string, logger *logrus.Entry) (*models.ProwJobRun, error) {
-				pjr := models.ProwJobRun{
-					ProwJobRelease: "4.12",
-					Tests: []models.ProwJobRunTest{
-						{ProwJobID: 1, ProwJobRunRelease: "4.12", Test: models.Test{Name: "test1"}, Status: int(v1.TestStatusSuccess)},
-					},
-				}
-				pjr.ID = 12345 // Gorm model ID for some reason can't be put in the struct literal
-				return &pjr, nil
-			},
-			testFilter:    &errorNewTestFilter{}, // mocks a failure in the filter
-			expectedTests: nil,
-			expectedError: errors.New("filter error"),
-		},
-		{
 			name: "jobRun run not found",
-			fetchJobRun: func(dbc *db.DB, jobRunID int64, unknownTests bool, preloads []string, logger *logrus.Entry) (*models.ProwJobRun, error) {
+			fetchJobRun: func(dbc *db.DB, jobRunID int64, onlyNewTests bool, preloads []string, logger *logrus.Entry) (*models.ProwJobRun, error) {
 				return nil, gorm.ErrRecordNotFound
 			},
 			expectedTests: nil,
@@ -275,7 +284,7 @@ func TestUnit_getNewTestsForJobRun(t *testing.T) {
 		},
 		{
 			name: "error fetching jobRun run",
-			fetchJobRun: func(dbc *db.DB, jobRunID int64, unknownTests bool, preloads []string, logger *logrus.Entry) (*models.ProwJobRun, error) {
+			fetchJobRun: func(dbc *db.DB, jobRunID int64, onlyNewTests bool, preloads []string, logger *logrus.Entry) (*models.ProwJobRun, error) {
 				return nil, errors.New("fetch error")
 			},
 			expectedTests: nil,
@@ -285,58 +294,15 @@ func TestUnit_getNewTestsForJobRun(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ntw := &NewTestsWorker{
-				dbc:           nil,
-				newTestFilter: tt.testFilter,
-				fetchJobRun:   tt.fetchJobRun,
-				jobRunFilter:  &jobRunUnfiltered{},
+				dbc:          nil,
+				fetchJobRun:  tt.fetchJobRun,
+				jobRunFilter: &jobRunUnfiltered{},
 			}
 			newTests, err := ntw.getNewTestsForJobRun(logger, jobRun)
 			assert.Equal(t, tt.expectedTests, newTests)
 			assert.Equal(t, tt.expectedError, err)
 		})
 	}
-}
-
-type oneNewTestFilter struct{}
-type errorNewTestFilter struct{}
-type skippingNewTestFilter struct { // alternate skipping or including actual new tests
-	newTestFilter NewTestFilter
-	sawPrevious   map[string]bool
-}
-type oneJobNewTestFilter struct { // only return new tests against one job
-	newTestFilter NewTestFilter
-	jobName       string
-}
-
-func (m *oneNewTestFilter) IsNewTest(_ *logrus.Entry, test models.ProwJobRunTest) (bool, error) {
-	if test.Test.Name == "test2" {
-		return true, nil
-	}
-	return false, nil
-}
-func (m *errorNewTestFilter) IsNewTest(_ *logrus.Entry, _ models.ProwJobRunTest) (bool, error) {
-	return false, errors.New("filter error")
-}
-
-func (ntf *skippingNewTestFilter) IsNewTest(logger *logrus.Entry, test models.ProwJobRunTest) (bool, error) {
-	if isNew, err := ntf.newTestFilter.IsNewTest(logger, test); err != nil {
-		return false, err
-	} else if isNew {
-		ntf.sawPrevious[test.Test.Name] = !ntf.sawPrevious[test.Test.Name] // alternate skipping or including actual new tests
-		if ntf.sawPrevious[test.Test.Name] {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-func (ntf *oneJobNewTestFilter) IsNewTest(logger *logrus.Entry, test models.ProwJobRunTest) (bool, error) {
-
-	if isNew, err := ntf.newTestFilter.IsNewTest(logger, test); err != nil {
-		return false, err
-	} else if isNew && ntf.jobName == test.ProwJobRun.ProwJob.Name {
-		return true, nil
-	}
-	return false, nil
 }
 
 type jobRunUnfiltered struct{}
@@ -350,7 +316,7 @@ func (n *jobRunUnfiltered) JobFailedEarly(_ *logrus.Entry, _ *models.ProwJobRun)
 }
 
 func TestFunc_getNewTestsForJobRun(t *testing.T) {
-	ntf, ntw := internalNewTestsWorker(util.GetDbHandle(t))
+	ntw := StandardNewTestsWorker(util.GetDbHandle(t))
 
 	// try with a known job run
 	jobRun := &prow.ProwJob{
@@ -364,40 +330,4 @@ func TestFunc_getNewTestsForJobRun(t *testing.T) {
 	fmt.Printf("new tests: %v\n", newTests)
 	assert.NoError(t, err, "Failed to get new tests")
 	assert.Equal(t, 2, len(newTests), "Unexpected number of new tests")
-	assert.True(t, ntf.notNewTests.Has(522), "Test 522 should be considered not new")
-	assert.False(t, ntf.notNewTests.Has(160471), "Test 160471 should be left out to be considered new")
-	assert.False(t, ntf.notNewTests.Has(160472), "Test 160472 should be left out to be considered new")
-}
-
-func TestIsNewTest(t *testing.T) {
-	dbc := util.GetDbHandle(t)
-
-	ntf := &pgNewTestFilter{
-		dbc:         dbc,
-		notNewTests: sets.Set[uint]{},
-		nnTmutex:    &sync.Mutex{},
-	}
-	logrus.SetLevel(logrus.DebugLevel)
-	logger := logrus.WithContext(context.TODO())
-
-	test := models.Test{Name: "[sig-sippy] openshift-tests should work"}
-	test.ID = 522
-	testRun := models.ProwJobRunTest{
-		Test:      test,
-		TestID:    test.ID,
-		CreatedAt: time.Now(),
-	}
-	isNew, err := ntf.IsNewTest(logger, testRun)
-
-	assert.Nil(t, err, "Failed to check if test is new")
-	assert.Equal(t, false, isNew, "Test should not be new")
-
-	test.Name = "a failed test that has never been seen before"
-	test.ID = 160471
-	testRun.Test = test
-	testRun.TestID = test.ID
-	isNew, err = ntf.IsNewTest(logger, testRun)
-
-	assert.Nil(t, err, "Failed to check if test is new")
-	assert.Equal(t, true, isNew, "Test should be new")
 }


### PR DESCRIPTION
## Summary
Queries against the heavily partitioned `prow_job_run_tests` table (~3,500 partitions) were scanning all partitions due to missing partition pruning keys. Two changes address this:

- **Both paths**: Load tests separately from the job run with explicit `prow_job_run_release` and `prow_job_run_timestamp` in the WHERE clause, enabling PostgreSQL to target a single partition instead of scanning ~3,500. Benchmarked against staging with `enable_partitionwise_join = on`:
  - Failed-tests path (`unknownTests=false`): **~432ms → ~0.1ms** per call
  - New-tests path (`unknownTests=true`): **~3,300ms → ~0.2ms** per call
- **New-tests path**: Use `NOT EXISTS` instead of `NOT IN` for the `test_ownerships` anti-join and combine it with a merged-PR check in a single SQL query. This eliminates the N+1 per-test `IsNewTest` queries, the `NewTestFilter` interface, `pgNewTestFilter` struct, and `notNewTests` cache — Postgres handles all filtering in one pass.

## Test plan
- [x] Unit tests pass (`TestUnit_getNewTestsForJobRun`, `TestRiskScenarios`)
- [x] Full project compiles with `go build ./...`
- [x] `go vet` clean
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved job run data retrieval by splitting test-related preloads and loading job run tests via a dedicated, partition-pruned query path.
  * Simplified “new tests” processing by removing the novelty-checking filter/caching layer; results are now generated directly from the fetched job run tests.
* **Tests**
  * Added unit coverage for preload-splitting behavior and updated worker tests to align with the new, unfiltered test result generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->