### PR TITLE
Add timestamp to JobRunTestCount for partition pruning

### DIFF
--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -203,7 +203,7 @@ func FetchJobRun(dbc *db.DB, jobRunID int64, unknownTests bool, preloads []strin
 		return nil, res.Error
 	}
 
-	jobRunTestCount, err := query.JobRunTestCount(dbc, jobRunID, jobRun.ProwJobRelease)
+	jobRunTestCount, err := query.JobRunTestCount(dbc, jobRunID, jobRun.ProwJobRelease, jobRun.Timestamp)
 	if err != nil { // should be unusual
 		logger.WithError(err).Errorf("Error getting test count for job run %d", jobRunID)
 		jobRunTestCount = -1

--- a/pkg/db/query/job_queries.go
+++ b/pkg/db/query/job_queries.go
@@ -28,12 +28,13 @@ func LoadProwJobCache(dbc *db.DB) (map[string]*models.ProwJob, error) {
 	return prowJobCache, nil
 }
 
-func JobRunTestCount(dbc *db.DB, jobRunID int64, release string) (int, error) {
+func JobRunTestCount(dbc *db.DB, jobRunID int64, release string, timestamp time.Time) (int, error) {
 	var prowJobRunTestCount int64
 
 	res := dbc.DB.Model(&models.ProwJobRunTest{}).
 		Where("prow_job_run_id = ?", jobRunID).
 		Where("prow_job_run_release = ?", release).
+		Where("prow_job_run_timestamp = ?", timestamp).
 		Count(&prowJobRunTestCount)
 	if res.Error != nil {
 		return -1, res.Error

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -415,20 +415,23 @@ func getBenchmarkCases(asOf time.Time) []benchmarkCase {
 		{
 			name: "JobRunTestCount",
 			fn: func(dbc *db.DB) error {
-				var jobRunID int64
+				var result struct {
+					ID        int64
+					Timestamp time.Time
+				}
 				res := dbc.DB.Table("prow_job_runs").
 					Joins("JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id").
 					Where("prow_jobs.name = ? AND prow_jobs.release = ?", benchmarkJobName, benchmarkRelease).
 					Order("prow_job_runs.timestamp DESC").
 					Limit(1).
-					Select("prow_job_runs.id").
-					Scan(&jobRunID)
+					Select("prow_job_runs.id, prow_job_runs.timestamp").
+					Scan(&result)
 				if res.Error != nil {
 					return res.Error
 				}
-				count, err := query.JobRunTestCount(dbc, jobRunID, benchmarkRelease)
+				count, err := query.JobRunTestCount(dbc, result.ID, benchmarkRelease, result.Timestamp)
 				if err == nil {
-					log.Printf("JobRunTestCount for run %d: %d tests", jobRunID, count)
+					log.Printf("JobRunTestCount for run %d: %d tests", result.ID, count)
 				}
 				return err
 			},


### PR DESCRIPTION
## Summary
- `JobRunTestCount` queries the partitioned `prow_job_run_tests` table with `prow_job_run_release` (LIST pruning) but not `prow_job_run_timestamp` (RANGE pruning), causing it to scan all RANGE sub-partitions within a release. Adding the timestamp enables full partition pruning to a single partition.
- Benchmarked against staging with `enable_partitionwise_join = on`: **~5.5ms → ~0.12ms** warm (~45x improvement).

## Test plan
- [x] Full project compiles with `go build ./...`
- [x] `go vet` clean
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)