### PR TITLE
TRT-2695: retroactively re-evaluate symptoms (API)

### DIFF
--- a/docs/features/job-analysis-symptoms.md
+++ b/docs/features/job-analysis-symptoms.md
@@ -112,6 +112,24 @@ Labels are relevant in several Sippy pages:
 They are also displayed in Spyglass (the Deck display of a Prow job) - an HTML summary added to the
 job's bucket entry is included by the html lens.
 
+### 6. Retroactive Re-evaluation
+
+The `POST /api/jobs/runs/reevaluate` endpoint re-runs symptom detection for specified job runs.
+Unlike the cloud function (which processes files as they arrive), the re-evaluator scans all
+artifacts at once for completed job runs.
+
+Flow:
+
+1. Load all active symptom definitions from PostgreSQL (excluding unimplemented matcher types).
+2. For each job run, run one `JobArtifactQuery` per symptom against GCS artifacts.
+3. Delete existing symptom-originated labels (BQ rows with non-empty `symptom_id`, GCS label files).
+4. Write new results to BQ (`job_labels` table), GCS (label JSON files + HTML summary), and
+   PostgreSQL (`prow_job_runs.labels` and `release_job_runs.labels`).
+
+The delete-then-insert strategy makes re-evaluation idempotent: if a symptom is modified, added, or
+removed, re-evaluating produces the correct result. Manually-applied labels (those with empty
+`symptom_id`) are preserved through re-evaluation.
+
 ## Key Code Locations
 
 ### Sippy (`openshift/sippy`)
@@ -122,7 +140,8 @@ job's bucket entry is included by the html lens.
 | `pkg/db/models/job_labels.go` | `JobRunLabel` - BigQuery row schema for the `job_labels` table. |
 | `pkg/db/models/prow.go` | `ProwJobRun.Labels` - the label array stored in Postgres. |
 | `pkg/db/models/triage.go` | `TriageSymptom` - junction table linking symptoms to triage records. |
-| `pkg/api/jobrunscan/` | API handlers for symptom/label CRUD, with validation logic. |
+| `pkg/api/jobrunscan/` | API handlers for symptom/label CRUD and re-evaluation, with validation logic. |
+| `pkg/api/jobrunscan/reevaluate.go` | Re-evaluation service: symptom scanning, BQ/GCS/PostgreSQL write logic. |
 | `pkg/sippyserver/job_run_scan.go` | HTTP route handlers delegating to the jobrunscan API package. |
 | `pkg/sippyclient/jobrunscan/` | Go client library for symptom/label APIs (used by cloud function). |
 | `pkg/componentreadiness/jobrunannotator/jobrunannotator.go` | `JobRunAnnotator` - the `annotate-job-runs` tool which can add labels but doesn't (yet) know about symptoms. |
@@ -148,6 +167,7 @@ All endpoints are under `/api/jobs/` and support standard CRUD:
 - `GET/PUT/DELETE /api/jobs/labels/{id}` - read / update / delete
 - `GET/POST /api/jobs/symptoms` - list / create symptoms
 - `GET/PUT/DELETE /api/jobs/symptoms/{id}` - read / update / delete
+- `POST /api/jobs/runs/reevaluate` - re-evaluate symptoms for specified job runs
 
 See `pkg/api/jobrunscan/` for validation rules and `pkg/api/README.md` for broader API
 documentation.
@@ -171,7 +191,7 @@ The symptoms pipeline (definition → detection → labeling → display) is ful
 Active/planned work includes:
 
 - **Retroactive re-evaluation** ([TRT-2695](https://redhat.atlassian.net/browse/TRT-2695))
-  - API and UI to re-run symptom matching for past job runs.
+  - Backend API complete (`POST /api/jobs/runs/reevaluate`). Frontend UI is pending.
 - **Compound symptoms** ([TRT-2466](https://redhat.atlassian.net/browse/TRT-2466))
   - richer CEL-based label composition.
 - **Full management UI** ([TRT-2479](https://redhat.atlassian.net/browse/TRT-2479))

--- a/docs/features/job-analysis-symptoms.md
+++ b/docs/features/job-analysis-symptoms.md
@@ -127,7 +127,7 @@ job's bucket entry is included by the html lens.
 | `pkg/sippyclient/jobrunscan/` | Go client library for symptom/label APIs (used by cloud function). |
 | `pkg/componentreadiness/jobrunannotator/jobrunannotator.go` | `JobRunAnnotator` - the `annotate-job-runs` tool which can add labels but doesn't (yet) know about symptoms. |
 | `pkg/componentreadiness/jobrunannotator/prow_bucket.go` | `JobRunBucketLabel`, `WriteHTMLSummaryToBucket` - writes label files and HTML summaries to GCS. Shared with cloud function. |
-| `pkg/api/jobartifacts/` | `JobArtifactQuery`, `ContentMatcher` - the artifact querying and matching engine used by JAQ and symptom evaluation. |
+| `pkg/api/jobartifacts/` | `JobArtifactQuery`, `ContentMatcher` - the artifact querying and matching engine used by JAQ and symptom evaluation. Results (matched lines per file) are cached by `(jobRunID, pathGlob, matcherKey)` to avoid re-scanning the same job run for the same query; this does **not** cache raw GCS file contents. |
 | `pkg/dataloader/prowloader/prow.go` | `GatherLabelsFromBQ` - reads labels from BQ during fetchdata. |
 | `pkg/api/componentreadiness/regressiontracker.go` | `SyncTriageSymptoms` - links symptoms to triage records. |
 | `cmd/sippy/seed_data.go` | Bootstrap definitions of symptoms and labels for use in manual testing. |

--- a/docs/plans/trt-2695-retroactive-symptoms-backend-plan.md
+++ b/docs/plans/trt-2695-retroactive-symptoms-backend-plan.md
@@ -1,0 +1,475 @@
+# TRT-2695: Backend Implementation Plan - Retroactive Symptom Re-evaluation API
+
+## Overview
+
+Add an authenticated API endpoint to Sippy that re-evaluates all symptom matches for specified job
+runs. The endpoint re-runs symptom detection against job artifacts and updates all three storage
+backends (BigQuery, GCS, PostgreSQL).
+
+**Jira:** [TRT-2695](https://redhat.atlassian.net/browse/TRT-2695)
+**Context doc:** `docs/features/job-analysis-symptoms.md` - update this doc when
+implementation is complete (see Step 8).
+
+## Prerequisites: Orientation
+
+Before writing code, read and understand these files:
+
+| File | What to learn |
+|------|---------------|
+| `pkg/db/models/jobrunscan/symptom.go` | `Symptom` model composed of `SymptomContent` (ID, Summary, MatcherType, FilePattern, MatchString, LabelIDs), `ApplicabilityFilters` (`valid_from`/`valid_until` - **fields exist but not yet used**), and `Metadata`. Implemented MatcherType values: `string`, `regex`, `none`. **`cel` is defined but NOT implemented** (TRT-2466). |
+| `pkg/db/models/jobrunscan/label.go` | `Label` model: `ID`, `label_title`, `explanation`, `hide_display_contexts`. |
+| `pkg/db/models/job_labels.go` | `JobRunLabel` - BigQuery row schema for `ci_analysis_us.job_labels`. Fields: `ID` (prowjob_build_id), `StartTime`, `Label`, `SymptomID`, `SourceTool`, timestamps. Note: no `ProwJobName`, `MatchedFile`, or `MatchedText` fields - see Design Note 3. |
+| `pkg/componentreadiness/jobrunannotator/jobrunannotator.go` | `JobRunAnnotator` - orchestrates BQ reads via `getJobRunsFromBigQuery`, artifact content matching via `filterJobRunByArtifact`, and BQ writes via `bulkInsertJobRunAnnotations` (batches of 500, dry-run support). **Important:** this tool adds labels with *empty* `SymptomID`; it does NOT evaluate symptoms. Reuse its BQ batch-write logic (extracted to standalone function), not its matching logic. |
+| `pkg/componentreadiness/jobrunannotator/prow_bucket.go` | `JobRunBucketLabel` struct + `WriteJSONToBucket()` - writes individual label JSON files to GCS. `WriteHTMLSummaryToBucket()` - reads all label JSONs from `artifacts/job_labels/` and generates `label-summary.html` for Spyglass. `JobRunBucketLabelContainer` provides versioned schema wrapping (`symptom_label_v1`). These are the same functions the cloud function uses. |
+| `pkg/api/jobartifacts/` | The artifact query and content matching engine: `ContentMatcher` interface, `lineMatcher` struct, `Manager` for concurrent artifact scanning, `getJobRunFiles` with `PathGlob` for GCS file discovery. `query.go` implements the GCS interaction with `maxJobFilesToScan` limits. |
+| `pkg/api/jobrunscan/` | Symptom/label CRUD API handlers with validation logic. Follow these patterns for the new handler. |
+| `pkg/sippyserver/job_run_scan.go` | HTTP route registration using gorilla/mux. Handlers: `jsonListSymptoms`, `jsonCreateSymptom`, `jsonGetSymptom`, `jsonUpdateSymptom`, `jsonDeleteSymptom` (and same pattern for labels). |
+| `pkg/sippyclient/jobrunscan/symptoms.go` | `SymptomsClient` - Go client for symptom CRUD. Used by the cloud function. |
+| `pkg/dataloader/prowloader/prow.go` | `GatherLabelsFromBQ()` - queries BQ for labels by build IDs and start time, returns `map[string]pq.StringArray`. Called during fetchdata to populate `prow_job_runs.labels`. |
+| `pkg/dataloader/releaseloader/releasesync.go` | Release sync does the same for `release_job_runs.labels`. |
+| `pkg/api/componentreadiness/regressiontracker.go` | `SyncTriageSymptoms()` and `MergeJobRuns()` - these are called by the regression cache loader, which re-queries BQ on each run and will automatically pick up re-evaluation changes. No direct calls needed from the re-evaluator. |
+
+## Step 1: Create the Re-evaluation Service
+
+Create `pkg/api/jobrunscan/reevaluate.go` (alongside the existing CRUD handlers).
+
+### 1.1: ReEvaluator struct
+
+```go
+type ReEvaluator struct {
+    bqClient    *bigquery.Client       // for BQ reads/writes
+    gcsClient   *storage.Client        // for artifact reads and label file writes
+    gcsBucket   string                 // GCS bucket name for label writes
+    db          *gorm.DB               // Sippy PostgreSQL
+    dryRun      bool                   // if true, log what would happen without writing
+}
+
+type ReEvalStatus string  // one of "missing_error", "eval_error", "rewrite_error", "success"
+type ReEvaluationResult struct{
+    ProwJobBuildID     string
+    Status             ReEvalStatus
+    SymptomsEvaluated  int
+    SymptomsMatched    []string
+    LabelsApplied      []string
+    BQEntriesWritten   int
+    GCSArtifactsWritten int
+    PostgresUpdated    bool
+    Error              string            // human-readable error message, empty on success
+    Links              map[string]string  // HATEOAS links (job_run URL, matched symptom endpoints)
+}
+type ReEvaluationResponse struct {
+    Results []ReEvaluationResult
+    Links   map[string]string    // top-level HATEOAS links (e.g. "self")
+}
+```
+
+Per-result HATEOAS links include the job run's Prow URL and an endpoint for each matched symptom
+(`symptom:{id}` -> `/api/jobs/symptoms/{id}`). Top-level links include a `self` link to the
+reevaluate endpoint. See `InjectReEvalHATEOASLinks` for the implementation.
+
+### 1.2: Core method: `ReEvaluateJobRuns`
+
+```go
+func (r *ReEvaluator) ReEvaluateJobRuns(ctx context.Context, prowJobBuildIDs []string) ([]ReEvaluationResult, error) {
+    // Each of the following is a discrete enough concept that it probably requires its own method,
+    // and perhaps even its own struct with methods.
+
+    // 1. Load all active symptom definitions from PostgreSQL (job_run_symptoms table)
+    //    - Only include implemented matcher types: string, regex, none (file exists)
+    //    - Future: apply applicability filters (valid_from/valid_until) when implemented
+
+    // 2. For each job run, for each symptom, create and run a JobArtifactQuery
+    //    - The query only needs a single file match, a single match in the file, and no context lines
+    //    - Collect all (symptom, job run, file_match, text_match) tuples
+    //    - No retries on timeout - return per-run status to the client for retry decisions
+    //    - Actual query failures are final and populate the per-run error status
+
+    // 3. For each job run that succeeded evaluation:
+    //    a. Clear existing symptom-originated data (Step 2 below)
+    //    b. Write results to BQ, GCS, and PostgreSQL (Steps 3-5 below)
+    //    c. Populate the per-run result
+
+    // 4. Return results for all runs (mix of successes and errors)
+}
+```
+
+### 1.3: Reuse patterns, don't duplicate
+
+The cloud function's flow is: fetch symptoms → for each arriving artifact file, check if it matches
+any symptom → write labels. The re-evaluator does the same thing but for a completed job run: fetch
+symptoms → list all artifacts → evaluate each symptom against matching artifacts → write labels. The
+matching logic in `pkg/api/jobartifacts/` is the same engine. The key difference is the re-evaluator
+processes all artifacts at once (not file-by-file as they arrive).
+
+**Artifact scanning approach:** Run one `JobArtifactQuery` per symptom per job run. This reuses the
+existing `Manager.Query()` pipeline and its `ContentMatcher` implementations with no modifications.
+This means reading the same GCS file multiple times for different symptoms (the JAQ cache stores
+match results keyed by `(jobRunID, pathGlob, matcherKey)`, not raw file contents, so different
+symptoms with different matchers each read from GCS independently). This is acceptable because
+re-evaluation is a rare operation, GCS reads are fairly fast, and trying to optimize with
+multi-symptom-per-file matching would complicate the code significantly.
+
+### 1.4: Extract BQ batch insert helper
+
+Extract the core batch-insert logic from `JobRunAnnotator.bulkInsertJobRunAnnotations` into a
+standalone function in `jobrunannotator.go`:
+
+```go
+func BulkInsertJobRunLabels(ctx context.Context, bqClient *bigquery.Client, dataset, table string,
+    labels []models.JobRunLabel, batchSize int, dryRun bool) error
+```
+
+Both `JobRunAnnotator` and `ReEvaluator` call this function. The existing method becomes a thin
+wrapper.
+
+## Step 2: Clear Existing Symptom-Originated Labels
+
+Before re-inserting, remove existing symptom-originated data. This makes re-evaluation idempotent
+across symptom definition changes (added, modified, or removed symptoms).
+
+### 2.1: BigQuery cleanup
+
+Delete existing rows from `ci_analysis_us.job_labels` where:
+- `prowjob_build_id` matches the target
+- `symptom_id IS NOT NULL AND symptom_id != ''`
+- timestamp matches the job runs evaluated (respecting partitioning)
+
+This preserves manually-applied labels from the `annotate-job-runs` CLI tool (which
+writes labels with empty `symptom_id`).
+
+Use a DML DELETE statement. Note BQ streaming buffer constraints - recently inserted rows may not be
+immediately deletable, so limit by `created_at` at least 90m old. (This could leave some entries
+that should have been deleted; this will be rare and is an acceptable risk.)
+
+### 2.2: GCS cleanup
+
+Delete existing files from `{jobRunPath}/artifacts/job_labels/` in the job's GCS bucket. The JSON
+files all contain symptom information (`symptom_label_v1` schema), so they can be safely removed and
+regenerated. Nothing else writes to this path, so delete all `*.json` files found. Also
+delete `label-summary.html` - it will be regenerated.
+
+### 2.3: PostgreSQL cleanup
+
+The `prow_job_runs.labels` and `release_job_runs.labels` fields are updated via diff
+in Step 5, so they don't require separate cleanup.
+
+## Step 3: Write to BigQuery `job_labels`
+
+For each `(symptom, job run, file_match, text_match)` result:
+
+1. Create a `models.JobRunLabel` struct with:
+   - `ID` = the prow job build ID (this is the `prowjob_build_id` column)
+   - `StartTime` from the job run metadata
+   - `Label` = the label's ID
+   - `SymptomID` = the symptom's ID (non-empty - distinguishes from manual labels)
+   - `SourceTool` = `"sippy-api-reevaluate"` (distinct from `"ci-data-loader"` and
+     `"annotate-job-runs"` for provenance tracking)
+   - Timestamps
+
+2. Use the extracted `BulkInsertJobRunLabels` helper for efficient batched insertion
+   (batches of 500, supports dry-run mode).
+
+**Note:** The `JobRunLabel` model does not have `MatchedFile`/`MatchedText` fields. Provenance of
+what matched is captured in the GCS JSON artifacts (Step 4) but not in the BQ table. If BQ-level
+provenance is needed later, the model would need extending.
+
+## Step 4: Write to GCS
+
+For each result:
+
+1. Create a `JobRunBucketLabel` struct (from `prow_bucket.go`):
+   - `Symptom`: `jobrunscan.SymptomContent` from the matched symptom
+   - `Label`: `jobrunscan.LabelContent` from the applied label
+   - `FileMatch`: relative path of the matched file
+   - `TextMatch`: first matched text (empty for `none` matcher type)
+   - `Bucket`, `JobRunPath`: from the job run metadata
+
+2. Call `WriteJSONToBucket()` - writes to
+   `{jobRunPath}/artifacts/job_labels/{label_id}-{basename}-{sha256}.json`
+
+3. After all labels are written, call `WriteHTMLSummaryToBucket()`:
+   - Reads all JSON files in `artifacts/job_labels/`
+   - Generates and writes `label-summary.html` with `text/html` content type
+   - Spyglass displays this via the html lens
+   - Returns the count of labels included
+
+## Step 5: Update PostgreSQL
+
+### 5.1: Update `prow_job_runs.labels` (diff-based)
+
+The `prow_job_runs.labels` field may contain both symptom-originated labels and manually-applied
+labels. Since newly-written BQ entries are stuck in the streaming buffer and can't be queried,
+we compute the diff locally:
+
+1. Read the current `Labels` array from the `ProwJobRun` record
+2. Query BQ for existing non-symptom-originated labels for evaluated build IDs (not the ones we
+   deleted in Step 2.1 - use the opposite filter: `symptom_id IS NULL OR symptom_id == ''`)
+4. Add the new symptom labels from re-evaluation results
+5. Deduplicate the labels and update the Postgres job run record
+
+This avoids depending on BQ query-ability of recently-streamed rows while preserving
+manually-applied labels.
+
+### 5.2: Update `release_job_runs.labels`
+
+Check if the job run is also present in `release_job_runs` (payload job runs) and update that
+record's `Labels` field with the same results from `prow_job_runs`. See
+`pkg/dataloader/releaseloader/releasesync.go` for the pattern.
+
+### 5.3: Regression data: no action needed
+
+`RegressionJobRun` records store `JobSymptoms` populated from BigQuery during regression cache
+loading. The regression cache loader runs multiple times per day and re-queries BQ fresh each time,
+calling `MergeJobRuns()` (which updates `job_symptoms` via upsert) and `SyncTriageSymptoms()` (which
+recounts triage associations). It processes open regressions and those closed within the last 5 days.
+
+Since re-evaluation updates BQ's `job_labels` table, the next regression cache loader run will
+automatically pick up the changes. No direct update from the re-evaluator is needed.
+
+## Step 6: Register the API Endpoint
+
+### 6.1: Add the route in `server.go`
+
+Follow the existing endpoint registration pattern in `Serve()` which uses a slice of `apiEndpoints`
+structs. Add the endpoint alongside the existing symptom/label routes:
+
+```go
+{
+    HandlerFunc:  s.jsonReEvaluateJobRunSymptoms,
+    EndpointPath: "/api/jobs/runs/reevaluate",
+    Methods:      []string{"POST"},
+    Capabilities: []string{LocalDBCapability, WriteEndpointsCapability},
+}
+```
+
+### 6.2: Implement the handler
+
+Add `jsonReEvaluateJobRunSymptoms` on the Server struct:
+
+```go
+func (s *Server) jsonReEvaluateJobRunSymptoms(w http.ResponseWriter, r *http.Request) {
+    ctx := r.Context()
+
+    var req struct {
+        ProwJobBuildIDs []string `json:"prow_job_build_ids"`
+    }
+    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+        http.Error(w, "invalid request body", http.StatusBadRequest)
+        return
+    }
+
+    // Validate: non-empty, cap at 50 IDs
+    if len(req.ProwJobBuildIDs) == 0 {
+        http.Error(w, "prow_job_build_ids is required", http.StatusBadRequest)
+        return
+    }
+    if len(req.ProwJobBuildIDs) > 50 {
+        http.Error(w, "maximum 50 job runs per request", http.StatusBadRequest)
+        return
+    }
+
+    // Create ReEvaluator with server's BQ/GCS/DB clients
+    re := &ReEvaluator{
+        bqClient:  s.bigQueryClient,
+        gcsClient: s.gcsClient,
+        gcsBucket: s.gcsBucket,
+        db:        s.db,
+    }
+
+    results, err := re.ReEvaluateJobRuns(ctx, req.ProwJobBuildIDs)
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+        return
+    }
+    resp := &ReEvaluationResponse{Results: results}
+    InjectReEvalHATEOASLinks(resp, baseURL(r))
+    respondJSON(w, http.StatusOK, resp)
+}
+```
+
+### 6.3: Capability gating
+
+This endpoint mutates BQ, GCS, and PostgreSQL. It requires both `LocalDBCapability` and
+`WriteEndpointsCapability` (enabled via `--enable-write-endpoints` flag). SSO authentication
+is handled at the deployment level by the oauth proxy.
+
+### 6.4: Request/Response schema
+
+**Request (POST):**
+```json
+{
+  "prow_job_build_ids": ["1234567890", "0987654321"]
+}
+```
+
+**Response (200 OK):**
+
+The response includes HATEOAS links at both the top level (self link to the endpoint) and per-result
+(links to the job run URL and each matched symptom's API endpoint).
+
+```json
+{
+  "results": [
+    {
+      "prow_job_build_id": "1234567890",
+      "status": "success",
+      "symptoms_evaluated": 42,
+      "symptoms_matched": ["DNSTimeout", "PodSandboxFailure", "NetworkError"],
+      "labels_applied": ["InfraFailure", "NodeProblem"],
+      "bq_entries_written": 3,
+      "gcs_artifacts_written": 4,
+      "postgres_updated": true,
+      "links": {
+        "job_run": "https://prow.ci.openshift.org/view/gs/test-platform-results/logs/.../1234567890",
+        "symptom:DNSTimeout": "http://localhost:8080/api/jobs/symptoms/DNSTimeout",
+        "symptom:PodSandboxFailure": "http://localhost:8080/api/jobs/symptoms/PodSandboxFailure",
+        "symptom:NetworkError": "http://localhost:8080/api/jobs/symptoms/NetworkError"
+      }
+    },
+    {
+      "prow_job_build_id": "0987654321",
+      "status": "missing_error",
+      "error": "job run 0987654321 not found in database"
+    }
+  ],
+  "links": {
+    "self": "http://localhost:8080/api/jobs/runs/reevaluate"
+  }
+}
+```
+
+## Step 7: Testing
+
+### 7.1: Unit tests (pure logic, no client mocks)
+
+Structure the code if possible with logic separate from storage client calls. Unit test the logic
+functions directly, without mocking BQ, GCS, or DB. Go interfaces are not designed for easy mock
+substitution of concrete SDK clients, and mock-heavy tests tend to test the mock implementation
+rather than real behavior.
+
+Create `pkg/api/jobrunscan/reevaluate_test.go` for pure-logic tests:
+
+- Test request validation: empty IDs, exceeding batch limit, malformed input
+- Test symptom filtering: only implemented matcher types (string, regex, none) are included;
+  `cel` matchers are excluded
+- Test result aggregation: given a set of match results, verify the correct
+  `ReEvaluationResult` structs are produced
+- Test diff-based label merge logic: given existing labels (some manual, some symptom-originated)
+  and new symptom matches, verify the merged label set preserves manual labels, removes old
+  symptom labels, and adds new ones
+- Test `JobRunLabel` construction: given a symptom match and job run metadata, verify the
+  correct `SourceTool`, `SymptomID`, label fields, etc.
+
+### 7.2: Functional / integration tests (real clients, user-supplied credentials)
+
+Follow the pattern in `pkg/dataloader/releaseloader/releasesync_functional_test.go`: tests skip
+unless the user supplies environment variables with real connection credentials.
+
+Create `pkg/api/jobrunscan/reevaluate_functional_test.go`:
+
+Required environment variables:
+- `GOOGLE_APPLICATION_CREDENTIALS` - path to GCP service account JSON key file
+- `BIGQUERY_PROJECT` - GCP project ID
+- `BIGQUERY_DATASET` - BigQuery dataset
+- `GCS_BUCKET` - GCS bucket for artifact reads/writes
+- `SIPPY_DATABASE_DSN` - PostgreSQL connection string
+- `PROW_JOB_BUILD_ID` - a real build ID to re-evaluate
+
+Test cases (each skipped when env vars are missing):
+- End-to-end: API POST with real credentials, verify BQ entries created, GCS artifacts written,
+  PostgreSQL updated
+- Idempotency: calling twice with the same input produces the same result
+- Symptom change: modify a symptom definition, re-evaluate, verify labels change
+- Symptom removal: delete a symptom, re-evaluate, verify its labels are removed
+- Manual label preservation: verify annotator-created labels survive re-evaluation
+
+## Step 8: Update Documentation
+
+### 8.1: Update `docs/features/job-analysis-symptoms.md`
+
+1. **Data Flow section**: Add a new subsection "6. Retroactive Re-evaluation" describing:
+   - The API endpoint and what it does
+   - The three-backend update flow (BQ → GCS → PostgreSQL)
+   - How it differs from the cloud function (all-at-once vs. file-by-file)
+   - The delete-then-insert strategy for idempotency
+
+2. **API Summary section**: Add:
+   - `POST /api/jobs/runs/reevaluate` - re-evaluate symptoms for specified job runs
+
+3. **Key Code Locations table**: Add:
+   - `pkg/api/jobrunscan/reevaluate.go` - Re-evaluation service and API handler
+
+4. **Status section**: Update TRT-2695 entry to reflect completion
+
+### 8.2: Update `pkg/api/README.md`
+
+Add the new `/api/jobs/runs/reevaluate` endpoint with request/response schema.
+
+## Design Notes
+
+1. **Delete-then-insert for idempotency**: Clear existing symptom-originated labels
+   before re-inserting. This handles symptom definition changes cleanly: if a
+   symptom is modified, added, or removed, re-evaluation produces the correct result.
+
+2. **Preserve manual labels**: Only clear entries with non-empty `symptom_id`. Labels
+   applied via the `annotate-job-runs` CLI tool have empty `symptom_id` and must be
+   preserved through re-evaluation.
+
+3. **Source tracking**: Set `SourceTool = "sippy-api-reevaluate"` so re-evaluated
+   labels are distinguishable from cloud function (`"ci-data-loader"`) and CLI
+   (`"annotate-job-runs"`) origins in BQ queries. The `JobRunLabel` model does not have
+   `MatchedFile`/`MatchedText` fields - file/text match provenance lives in the GCS
+   JSON artifacts only.
+
+4. **CEL matchers**: Skip any symptoms with `matcher_type = "cel"`. Log a warning.
+   This matcher type is defined in the model but not yet implemented (TRT-2466).
+
+5. **Applicability filters**: `valid_from`/`valid_until` fields exist on the Symptom
+   model but nothing uses them yet. When implementing the re-evaluator, add a TODO
+   for future integration. When applicability filters are implemented, the
+   re-evaluator should respect them (e.g. only evaluate symptoms whose validity
+   window covers the job run's start time).
+
+6. **Batch limits**: Cap at 50 job runs per API request. This prevents long-running
+   requests, BQ quota issues, and GCS rate limiting.
+
+7. **Synchronous execution**: For the initial implementation, synchronous processing
+   is sufficient. Individual job run re-evaluation should complete in seconds. If
+   larger batch sizes are needed later, consider async with a task ID + polling
+   pattern.
+
+8. **BQ streaming buffer**: Recently streamed rows (< ~90 minutes) may not be
+   deletable via DML. For the delete-then-insert pattern, this is usually not a
+   problem because re-evaluation targets older job runs. Document this limitation.
+
+9. **One query per symptom**: Rather than building a compound multi-symptom matcher,
+   run one `JobArtifactQuery` per symptom per job run. Each query with a different
+   matcher reads from GCS independently (the JAQ cache keys on matcher, so different
+   symptoms don't share cached reads). This is simpler, reuses existing code without
+   modification, and reliability matters more than speed for this rare operation.
+   Optimization to multi-symptom matching can be revisited later.
+
+10. **No retries on artifact scan timeout**: If a scan times out for a job run, return
+    `eval_error` status for that run in the response. The client can retry individual
+    failures. This avoids unbounded retry loops in the API.
+
+11. **Diff-based PostgreSQL label updates**: Because newly-written BQ rows are in the streaming
+    buffer and not queryable, we can't use `GatherLabelsFromBQ()` to refresh `prow_job_runs.labels`.
+    Instead, query BQ for non-symptom labels, augment them with the re-eval results, and update the
+    PostgreSQL label array. This preserves manually-applied labels while avoiding streaming buffer
+    issues.
+
+12. **Regression data left to loader**: `regression_job_runs.job_symptoms` and
+    `triage_symptoms` are populated by the regression cache loader, which re-queries BQ
+    fresh on each run (multiple times/day). Re-evaluation updates BQ, and the loader
+    picks up the changes automatically. No direct regression updates from the API.
+
+13. **Job run lookup**: The prow build ID (string) *is* the GORM primary
+    key on `ProwJobRun` - just parse to `int64` with `strconv.ParseInt`. The
+    `JobArtifactQuery` takes `JobRunIDs []int64` and looks up `ProwJobRun` by primary key,
+    extracting the GCS bucket path from the `URL` field. No additional lookup needed.
+
+14. **Limited file matches**: The cloud function can create labels for each file that matches a
+    symptom; by limiting the matches during re-evaluation, we may actually delete duplicate labels
+    that were generated initially. This is acceptable as duplicates of the same label for a job run
+    have no real purpose at this time (but all are visible in Spyglass).                 

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -396,6 +396,62 @@ A summary of runs for job(s). Results contains of the following values for each 
 | job      | String         | Return only jobs containing only containing this value in their name                                                     | N/A                                      |
 | limit    | Integer        | The maximum amount of results to return                                                                                  | N/A                                      |
 
+## Re-evaluate Job Run Symptoms
+
+Endpoint: `POST /api/jobs/runs/reevaluate`
+
+Re-runs all symptom definitions against the artifacts for specified job runs and updates
+BigQuery, GCS, and PostgreSQL with the results. Requires `--enable-write-endpoints`.
+
+### Request
+
+```json
+{
+  "prow_job_build_ids": ["1234567890", "0987654321"],
+  "dry_run": false
+}
+```
+
+Maximum 50 job run IDs per request. IDs must be numeric strings.
+
+### Response (200 OK)
+
+```json
+{
+  "results": [
+    {
+      "prow_job_build_id": "1234567890",
+      "status": "success",
+      "symptoms_evaluated": 42,
+      "symptoms_matched": ["CreatePodSandboxForPodFailedInJournal"],
+      "labels_applied": ["InfraFailure", "NodeProblem"],
+      "bq_entries_written": 2,
+      "gcs_artifacts_written": 2,
+      "postgres_updated": true,
+      "links": {
+        "job_run": "https://prow.ci.openshift.org/view/gs/test-platform-results/logs/.../1234567890",
+        "symptom:CreatePodSandboxForPodFailedInJournal": "http://localhost:8080/api/jobs/symptoms/SomeSymptom"
+      }
+    },
+    {
+      "prow_job_build_id": "0987654321",
+      "status": "missing_error",
+      "error": "job run 0987654321 not found in database"
+    }
+  ],
+  "links": {
+    "self": "http://localhost:8080/api/jobs/runs/reevaluate"
+  }
+}
+```
+
+### Status Values
+
+- `success` - re-evaluation completed and all backends updated.
+- `missing_error` - the job run ID was not found in the database.
+- `eval_error` - artifact scanning failed (timeout, GCS error, database error).
+- `rewrite_error` - scanning succeeded but writing to BQ/GCS/PostgreSQL failed.
+
 ## Tests
 
 Endpoint: `/api/tests`

--- a/pkg/api/jobrunscan/reevaluate.go
+++ b/pkg/api/jobrunscan/reevaluate.go
@@ -363,7 +363,7 @@ func (r *ReEvaluator) buildOutputs(matches []symptomMatch, buildID string, jobRu
 
 // loadLabelDefinitions fetches label content for the labels referenced by matched symptoms.
 func (r *ReEvaluator) loadLabelDefinitions(matches []symptomMatch) (map[string]jobrunscan.LabelContent, error) {
-	ids := sets.NewString()
+	ids := sets.New[string]()
 	for _, m := range matches {
 		ids.Insert(m.symptom.LabelIDs...)
 	}
@@ -372,8 +372,8 @@ func (r *ReEvaluator) loadLabelDefinitions(matches []symptomMatch) (map[string]j
 	}
 
 	var labels []jobrunscan.Label
-	if err := r.db.DB.Where("id IN ?", ids.List()).Find(&labels).Error; err != nil {
-		return nil, fmt.Errorf("querying label definitions for %v: %w", ids.List(), err)
+	if err := r.db.DB.Where("id IN ?", ids.UnsortedList()).Find(&labels).Error; err != nil {
+		return nil, fmt.Errorf("querying label definitions for %v: %w", ids.UnsortedList(), err)
 	}
 
 	result := make(map[string]jobrunscan.LabelContent, len(labels))
@@ -551,14 +551,14 @@ func (r *ReEvaluator) queryNonSymptomLabels(ctx context.Context, buildID string,
 
 // mergeLabels combines manual labels with newly applied symptom labels, deduplicating.
 func mergeLabels(manualLabels []string, bqLabels []models.JobRunLabel) []string {
-	merged := sets.NewString()
+	merged := sets.New[string]()
 	for _, l := range manualLabels {
 		merged.Insert(l)
 	}
 	for _, bl := range bqLabels {
 		merged.Insert(bl.Label)
 	}
-	return merged.List()
+	return merged.UnsortedList()
 }
 
 // jobRunPathFromURL extracts the GCS path from a ProwJobRun URL.
@@ -577,20 +577,20 @@ func jobRunPathFromURL(url string) string {
 
 // uniqueSymptomsMatched returns the sorted distinct symptom IDs from the matches.
 func uniqueSymptomsMatched(matches []symptomMatch) []string {
-	s := sets.NewString()
+	s := sets.New[string]()
 	for _, m := range matches {
 		s.Insert(m.symptom.ID)
 	}
-	return s.List()
+	return s.UnsortedList()
 }
 
 // uniqueLabels returns the unique label IDs from a set of BQ labels.
 func uniqueLabels(labels []models.JobRunLabel) []string {
-	s := sets.NewString()
+	s := sets.New[string]()
 	for _, l := range labels {
 		s.Insert(l.Label)
 	}
-	return s.List()
+	return s.UnsortedList()
 }
 
 // ValidateReEvalRequest validates the re-evaluation request parameters.

--- a/pkg/api/jobrunscan/reevaluate.go
+++ b/pkg/api/jobrunscan/reevaluate.go
@@ -123,7 +123,7 @@ func (r *ReEvaluator) ReEvaluateJobRuns(ctx context.Context, prowJobBuildIDs []s
 	if err != nil {
 		return nil, fmt.Errorf("loading symptoms: %w", err)
 	}
-	log.Debugf("symptom reEval: loaded %d active symptoms", len(symptoms))
+	log.WithField("activeSymptoms", len(symptoms)).Debug("symptom reEval: loaded active symptoms")
 
 	results := make([]ReEvaluationResult, 0, len(prowJobBuildIDs))
 	for _, buildID := range prowJobBuildIDs {
@@ -154,9 +154,9 @@ func filterRelevantSymptoms(symptoms []jobrunscan.Symptom) []jobrunscan.Symptom 
 		case jobrunscan.MatcherTypeString, jobrunscan.MatcherTypeRegex, jobrunscan.MatcherTypeFile:
 			filtered = append(filtered, s)
 		case jobrunscan.MatcherTypeCEL:
-			log.Warnf("symptom reEval: skipping symptom %q with unimplemented matcher_type %q (TRT-2466)", s.ID, s.MatcherType)
+			log.WithFields(log.Fields{"symptom": s.ID, "matcherType": s.MatcherType}).Warn("symptom reEval: skipping symptom with unimplemented matcher_type (TRT-2466)")
 		default:
-			log.Warnf("symptom reEval: skipping symptom %q with unknown matcher_type %q", s.ID, s.MatcherType)
+			log.WithFields(log.Fields{"symptom": s.ID, "matcherType": s.MatcherType}).Warn("symptom reEval: skipping symptom with unknown matcher_type")
 		}
 	}
 	return filtered
@@ -213,8 +213,12 @@ func (r *ReEvaluator) reEvaluateOne(ctx context.Context, buildID string, symptom
 	result.LabelsApplied = uniqueLabels(bqLabels)
 
 	if r.dryRun {
-		log.Infof("symptom re-evaluation dry run for %s: %d symptoms matched, %d BQ labels, %d GCS artifacts",
-			buildID, len(result.SymptomsMatched), len(bqLabels), len(bucketLabels))
+		log.WithFields(log.Fields{
+			"buildID":      buildID,
+			"matched":      len(result.SymptomsMatched),
+			"bqLabels":     len(bqLabels),
+			"gcsArtifacts": len(bucketLabels),
+		}).Info("symptom re-evaluation dry run")
 		result.Status = ReEvalSuccess
 		return result
 	}
@@ -249,7 +253,7 @@ func (r *ReEvaluator) evaluateSymptoms(ctx context.Context, jobRunID int64, symp
 	for _, symptom := range symptoms {
 		contentMatcher, err := ContentMatcherForSymptom(symptom.SymptomContent)
 		if err != nil {
-			log.WithError(err).Warnf("symptom reEval: skipping symptom %q due to matcher error", symptom.ID)
+			log.WithError(err).WithField("symptom", symptom.ID).Warn("symptom reEval: skipping symptom due to matcher error")
 			continue
 		}
 
@@ -443,12 +447,12 @@ func (r *ReEvaluator) clearBQLabels(ctx context.Context, buildID string, startTi
 	_, err := q.Read(ctx)
 	if err != nil {
 		if strings.Contains(err.Error(), "streaming buffer") {
-			log.Warnf("symptom reEval: BQ delete for %s hit streaming buffer, skipping: %v", buildID, err)
+			log.WithError(err).WithField("buildID", buildID).Warn("symptom reEval: BQ delete hit streaming buffer, skipping")
 			return nil
 		}
 		return fmt.Errorf("BQ delete for %s: %w", buildID, err)
 	}
-	log.Debugf("symptom reEval: cleared BQ symptom labels for build %s", buildID)
+	log.WithField("buildID", buildID).Debug("symptom reEval: cleared BQ symptom labels")
 	return nil
 }
 
@@ -473,7 +477,7 @@ func (r *ReEvaluator) clearGCSLabels(ctx context.Context, jobRunPath string) err
 			return fmt.Errorf("deleting GCS object %s: %w", attrs.Name, err)
 		}
 	}
-	log.Debugf("symptom reEval: cleared GCS label artifacts for %s", jobRunPath)
+	log.WithField("jobRunPath", jobRunPath).Debug("symptom reEval: cleared GCS label artifacts")
 	return nil
 }
 
@@ -482,7 +486,7 @@ func (r *ReEvaluator) updatePostgresLabels(ctx context.Context, buildID string, 
 	// Query BQ for existing non-symptom labels for this build ID
 	manualLabels, err := r.queryNonSymptomLabels(ctx, buildID, jobRun.Timestamp)
 	if err != nil {
-		log.WithError(err).Warnf("symptom reEval: could not query non-symptom labels from BQ for %s, using existing PG labels as fallback", buildID)
+		log.WithError(err).WithField("buildID", buildID).Warn("symptom reEval: could not query non-symptom labels from BQ, using existing PG labels as fallback")
 		// Fallback: keep existing labels that aren't from symptoms
 		// We can't distinguish these in PG alone, so keep all existing labels
 		manualLabels = jobRun.Labels
@@ -509,7 +513,7 @@ func (r *ReEvaluator) updatePostgresLabels(ctx context.Context, buildID string, 
 		}
 	}
 
-	log.Debugf("symptom reEval: updated PostgreSQL labels for build %s: %v", buildID, merged)
+	log.WithFields(log.Fields{"buildID": buildID, "labels": merged}).Debug("symptom reEval: updated PostgreSQL labels")
 	return nil
 }
 

--- a/pkg/api/jobrunscan/reevaluate.go
+++ b/pkg/api/jobrunscan/reevaluate.go
@@ -555,10 +555,7 @@ func (r *ReEvaluator) queryNonSymptomLabels(ctx context.Context, buildID string,
 
 // mergeLabels combines manual labels with newly applied symptom labels, deduplicating.
 func mergeLabels(manualLabels []string, bqLabels []models.JobRunLabel) []string {
-	merged := sets.New[string]()
-	for _, l := range manualLabels {
-		merged.Insert(l)
-	}
+	merged := sets.New[string](manualLabels...)
 	for _, bl := range bqLabels {
 		merged.Insert(bl.Label)
 	}

--- a/pkg/api/jobrunscan/reevaluate.go
+++ b/pkg/api/jobrunscan/reevaluate.go
@@ -88,23 +88,25 @@ func InjectReEvalHATEOASLinks(resp *ReEvaluationResponse, baseURL string) {
 
 // ReEvaluator re-runs symptom detection against job artifacts and updates BQ, GCS, and PostgreSQL.
 type ReEvaluator struct {
-	bqClient  *bqclient.Client
-	gcsClient *storage.Client
-	gcsBucket string
-	db        *db.DB
-	cache     cache.Cache
-	dryRun    bool
+	bqClient    *bqclient.Client
+	gcsClient   *storage.Client
+	gcsBucket   string
+	db          *db.DB
+	cache       cache.Cache
+	artifactMgr *jobartifacts.Manager
+	dryRun      bool
 }
 
 // NewReEvaluator creates a ReEvaluator with the given clients.
-func NewReEvaluator(bqClient *bqclient.Client, gcsClient *storage.Client, gcsBucket string, dbc *db.DB, cacheClient cache.Cache, dryRun bool) *ReEvaluator {
+func NewReEvaluator(bqClient *bqclient.Client, gcsClient *storage.Client, gcsBucket string, dbc *db.DB, cacheClient cache.Cache, artifactMgr *jobartifacts.Manager, dryRun bool) *ReEvaluator {
 	return &ReEvaluator{
-		bqClient:  bqClient,
-		gcsClient: gcsClient,
-		gcsBucket: gcsBucket,
-		db:        dbc,
-		cache:     cacheClient,
-		dryRun:    dryRun,
+		bqClient:    bqClient,
+		gcsClient:   gcsClient,
+		gcsBucket:   gcsBucket,
+		db:          dbc,
+		cache:       cacheClient,
+		artifactMgr: artifactMgr,
+		dryRun:      dryRun,
 	}
 }
 
@@ -242,7 +244,7 @@ func (r *ReEvaluator) reEvaluateOne(ctx context.Context, buildID string, symptom
 // evaluateSymptoms runs one artifact query per symptom for the given job run.
 func (r *ReEvaluator) evaluateSymptoms(ctx context.Context, jobRunID int64, symptoms []jobrunscan.Symptom) ([]symptomMatch, error) {
 	var matches []symptomMatch
-	mgr := jobartifacts.NewManager(ctx)
+	mgr := r.artifactMgr
 
 	for _, symptom := range symptoms {
 		contentMatcher, err := ContentMatcherForSymptom(symptom.SymptomContent)

--- a/pkg/api/jobrunscan/reevaluate.go
+++ b/pkg/api/jobrunscan/reevaluate.go
@@ -524,7 +524,7 @@ func (r *ReEvaluator) queryNonSymptomLabels(ctx context.Context, buildID string,
 		`SELECT DISTINCT label FROM %s
 		WHERE prowjob_build_id = @buildID
 		AND (symptom_id IS NULL OR symptom_id = '')
-		AND DATE(prowjob_start) >= @startDate`,
+		AND DATE(prowjob_start) = @startDate`,
 		table)
 
 	q := r.bqClient.Query(ctx, bqlabel.JobRunLabelsReEvaluate, queryStr)

--- a/pkg/api/jobrunscan/reevaluate.go
+++ b/pkg/api/jobrunscan/reevaluate.go
@@ -1,0 +1,608 @@
+package jobrunscan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
+	"cloud.google.com/go/storage"
+	"github.com/openshift/sippy/pkg/api/jobartifacts"
+	"github.com/openshift/sippy/pkg/apis/cache"
+	bqclient "github.com/openshift/sippy/pkg/bigquery"
+	"github.com/openshift/sippy/pkg/bigquery/bqlabel"
+	jobrunannotator "github.com/openshift/sippy/pkg/componentreadiness/jobrunannotator"
+	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/openshift/sippy/pkg/db/models/jobrunscan"
+	"github.com/openshift/sippy/pkg/util"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/api/iterator"
+	"gorm.io/gorm"
+)
+
+const (
+	reEvalSourceTool = "sippy-api-reevaluate"
+	maxJobRunsPerReq = 50
+)
+
+// ReEvalStatus indicates the outcome of re-evaluating symptoms for a single job run.
+type ReEvalStatus string
+
+const (
+	ReEvalSuccess      ReEvalStatus = "success"
+	ReEvalMissingError ReEvalStatus = "missing_error"
+	ReEvalEvalError    ReEvalStatus = "eval_error"
+	ReEvalRewriteError ReEvalStatus = "rewrite_error"
+)
+
+// ReEvaluationResult reports what happened for a single job run.
+type ReEvaluationResult struct {
+	ProwJobBuildID      string            `json:"prow_job_build_id"`
+	Status              ReEvalStatus      `json:"status"`
+	SymptomsEvaluated   int               `json:"symptoms_evaluated,omitempty"`
+	SymptomsMatched     []string          `json:"symptoms_matched,omitempty"`
+	LabelsApplied       []string          `json:"labels_applied,omitempty"`
+	BQEntriesWritten    int               `json:"bq_entries_written,omitempty"`
+	GCSArtifactsWritten int               `json:"gcs_artifacts_written,omitempty"`
+	PostgresUpdated     bool              `json:"postgres_updated,omitempty"`
+	Error               string            `json:"error,omitempty"`
+	Links               map[string]string `json:"links,omitempty"`
+}
+
+// ReEvaluationResponse wraps the results with HATEOAS links.
+type ReEvaluationResponse struct {
+	Results []ReEvaluationResult `json:"results"`
+	Links   map[string]string    `json:"links"`
+}
+
+// InjectReEvalHATEOASLinks populates HATEOAS links on the response and each result.
+func InjectReEvalHATEOASLinks(resp *ReEvaluationResponse, baseURL string) {
+	resp.Links = map[string]string{
+		"self": baseURL + "/api/jobs/runs/reevaluate",
+	}
+	for i := range resp.Results {
+		r := &resp.Results[i]
+		if r.Links == nil {
+			continue
+		}
+		for k, v := range r.Links {
+			if k == "job_run" {
+				continue // already absolute URL
+			}
+			// symptom links need the base URL prefix
+			if strings.HasPrefix(k, "symptom:") {
+				r.Links[k] = baseURL + v
+			}
+		}
+	}
+}
+
+// ReEvaluator re-runs symptom detection against job artifacts and updates BQ, GCS, and PostgreSQL.
+type ReEvaluator struct {
+	bqClient  *bqclient.Client
+	gcsClient *storage.Client
+	gcsBucket string
+	db        *db.DB
+	cache     cache.Cache
+	dryRun    bool
+}
+
+// NewReEvaluator creates a ReEvaluator with the given clients.
+func NewReEvaluator(bqClient *bqclient.Client, gcsClient *storage.Client, gcsBucket string, dbc *db.DB, cacheClient cache.Cache, dryRun bool) *ReEvaluator {
+	return &ReEvaluator{
+		bqClient:  bqClient,
+		gcsClient: gcsClient,
+		gcsBucket: gcsBucket,
+		db:        dbc,
+		cache:     cacheClient,
+		dryRun:    dryRun,
+	}
+}
+
+// symptomMatch records that a symptom matched a file/text in a job run.
+type symptomMatch struct {
+	symptom   jobrunscan.Symptom
+	fileMatch string // path relative to bucket root
+	textMatch string // first matched line (empty for "none" matcher)
+}
+
+// ReEvaluateJobRuns re-evaluates all symptom matches for the specified job runs.
+func (r *ReEvaluator) ReEvaluateJobRuns(ctx context.Context, prowJobBuildIDs []string) ([]ReEvaluationResult, error) {
+	symptoms, err := r.loadActiveSymptoms()
+	if err != nil {
+		return nil, fmt.Errorf("loading symptoms: %w", err)
+	}
+	log.Debugf("symptom reEval: loaded %d active symptoms", len(symptoms))
+
+	results := make([]ReEvaluationResult, 0, len(prowJobBuildIDs))
+	for _, buildID := range prowJobBuildIDs {
+		result := r.reEvaluateOne(ctx, buildID, symptoms)
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+// loadActiveSymptoms fetches all symptom definitions with implemented matcher types.
+func (r *ReEvaluator) loadActiveSymptoms() ([]jobrunscan.Symptom, error) {
+	var all []jobrunscan.Symptom
+	res := r.db.DB.Order("id").Find(&all)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return filterRelevantSymptoms(all), nil
+}
+
+// filterRelevantSymptoms returns only symptoms with labels and implemented matcher types (string, regex, none).
+func filterRelevantSymptoms(symptoms []jobrunscan.Symptom) []jobrunscan.Symptom {
+	var filtered []jobrunscan.Symptom
+	for _, s := range symptoms {
+		if len(s.LabelIDs) == 0 {
+			continue // no value in matching symptoms that don't apply labels
+		}
+		switch s.MatcherType {
+		case jobrunscan.MatcherTypeString, jobrunscan.MatcherTypeRegex, jobrunscan.MatcherTypeFile:
+			filtered = append(filtered, s)
+		case jobrunscan.MatcherTypeCEL:
+			log.Warnf("symptom reEval: skipping symptom %q with unimplemented matcher_type %q (TRT-2466)", s.ID, s.MatcherType)
+		default:
+			log.Warnf("symptom reEval: skipping symptom %q with unknown matcher_type %q", s.ID, s.MatcherType)
+		}
+	}
+	return filtered
+}
+
+// reEvaluateOne processes a single job run through all symptoms.
+func (r *ReEvaluator) reEvaluateOne(ctx context.Context, buildID string, symptoms []jobrunscan.Symptom) ReEvaluationResult {
+	result := ReEvaluationResult{
+		ProwJobBuildID:    buildID,
+		SymptomsEvaluated: len(symptoms),
+	}
+
+	jobRunID, err := strconv.ParseInt(buildID, 10, 64)
+	if err != nil {
+		result.Status = ReEvalEvalError
+		result.Error = fmt.Sprintf("invalid build ID %q: %v", buildID, err)
+		return result
+	}
+
+	// Look up the job run to get metadata
+	jobRunModel := new(models.ProwJobRun)
+	res := r.db.DB.First(jobRunModel, jobRunID)
+	if res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			result.Status = ReEvalMissingError
+			result.Error = fmt.Sprintf("job run %s not found in database", buildID)
+		} else {
+			result.Status = ReEvalEvalError
+			result.Error = fmt.Sprintf("looking up job run %s: %v", buildID, res.Error)
+		}
+		return result
+	}
+
+	matches, err := r.evaluateSymptoms(ctx, jobRunID, symptoms)
+	if err != nil {
+		result.Status = ReEvalEvalError
+		result.Error = err.Error()
+		return result
+	}
+	result.SymptomsMatched = uniqueSymptomsMatched(matches)
+
+	result.Links = map[string]string{"job_run": jobRunModel.URL}
+	for _, m := range matches {
+		result.Links["symptom:"+m.symptom.ID] = "/api/jobs/symptoms/" + m.symptom.ID
+	}
+
+	// Compute the label set from matches
+	bqLabels, bucketLabels, err := r.buildOutputs(matches, buildID, jobRunModel)
+	if err != nil {
+		result.Status = ReEvalEvalError
+		result.Error = err.Error()
+		return result
+	}
+	result.LabelsApplied = uniqueLabels(bqLabels)
+
+	if r.dryRun {
+		log.Infof("symptom re-evaluation dry run for %s: %d symptoms matched, %d BQ labels, %d GCS artifacts",
+			buildID, len(result.SymptomsMatched), len(bqLabels), len(bucketLabels))
+		result.Status = ReEvalSuccess
+		return result
+	}
+
+	// Clear existing symptom-originated data, then write new results
+	if err := r.clearAndWrite(ctx, buildID, jobRunModel, bqLabels, bucketLabels); err != nil {
+		result.Status = ReEvalRewriteError
+		result.Error = err.Error()
+		return result
+	}
+
+	result.BQEntriesWritten = len(bqLabels)
+	result.GCSArtifactsWritten = len(bucketLabels)
+
+	// Update PostgreSQL labels
+	if err := r.updatePostgresLabels(ctx, buildID, jobRunModel, bqLabels); err != nil {
+		result.Status = ReEvalRewriteError
+		result.Error = fmt.Sprintf("postgres update failed: %v", err)
+		return result
+	}
+	result.PostgresUpdated = true
+
+	result.Status = ReEvalSuccess
+	return result
+}
+
+// evaluateSymptoms runs one artifact query per symptom for the given job run.
+func (r *ReEvaluator) evaluateSymptoms(ctx context.Context, jobRunID int64, symptoms []jobrunscan.Symptom) ([]symptomMatch, error) {
+	var matches []symptomMatch
+	mgr := jobartifacts.NewManager(ctx)
+
+	for _, symptom := range symptoms {
+		contentMatcher, err := ContentMatcherForSymptom(symptom.SymptomContent)
+		if err != nil {
+			log.WithError(err).Warnf("symptom reEval: skipping symptom %q due to matcher error", symptom.ID)
+			continue
+		}
+
+		q := &jobartifacts.JobArtifactQuery{
+			GcsBucket:      r.gcsClient.Bucket(util.GcsBucketRoot),
+			DbClient:       r.db,
+			Cache:          r.cache,
+			JobRunIDs:      []int64{jobRunID},
+			PathGlob:       symptom.FilePattern,
+			ContentMatcher: contentMatcher,
+		}
+
+		queryResult := mgr.Query(ctx, q)
+		for _, jr := range queryResult.JobRuns {
+			for _, a := range jr.Artifacts {
+				if a.Error != "" || a.TimedOut {
+					continue
+				}
+				matched := false
+				textMatch := ""
+				if contentMatcher == nil {
+					// "none" matcher: file existence is a match
+					matched = true
+				} else if text, ok := a.Matched(); ok {
+					matched = true
+					textMatch = strings.TrimRight(text, "\n")
+				}
+				if matched {
+					matches = append(matches, symptomMatch{
+						symptom:   symptom,
+						fileMatch: a.ArtifactPath,
+						textMatch: textMatch,
+					})
+				}
+			}
+		}
+
+		for _, qErr := range queryResult.Errors {
+			if qErr.TimedOut {
+				return nil, fmt.Errorf("artifact scan timed out for symptom %q", symptom.ID)
+			}
+			return nil, fmt.Errorf("artifact scan error for symptom %q: %s", symptom.ID, qErr.Error)
+		}
+	}
+
+	return matches, nil
+}
+
+// ContentMatcherForSymptom creates the appropriate ContentMatcher for a symptom definition.
+// Returns nil for file-existence-only matcher types (no content matching needed).
+func ContentMatcherForSymptom(symptom jobrunscan.SymptomContent) (jobartifacts.ContentMatcher, error) {
+	switch symptom.MatcherType {
+	case jobrunscan.MatcherTypeString:
+		return jobartifacts.NewStringMatcher(symptom.MatchString, 0, 0, 1), nil
+	case jobrunscan.MatcherTypeRegex:
+		re, err := regexp.Compile(symptom.MatchString)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regex for symptom %q: %w", symptom.ID, err)
+		}
+		return jobartifacts.NewRegexMatcher(re, 0, 0, 1), nil
+	case jobrunscan.MatcherTypeFile:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unsupported matcher type %q for symptom %q", symptom.MatcherType, symptom.ID)
+	}
+}
+
+// buildOutputs creates the BQ labels and GCS bucket labels from symptom matches.
+func (r *ReEvaluator) buildOutputs(matches []symptomMatch, buildID string, jobRun *models.ProwJobRun) ([]models.JobRunLabel, []jobrunannotator.JobRunBucketLabel, error) {
+	now := civil.DateTimeOf(time.Now())
+	startTime := civil.DateTimeOf(jobRun.Timestamp)
+	jobRunPath := jobRunPathFromURL(jobRun.URL)
+
+	var bqLabels []models.JobRunLabel
+	var bucketLabels []jobrunannotator.JobRunBucketLabel
+
+	labelDefs, err := r.loadLabelDefinitions(matches)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading label definitions: %w", err)
+	}
+
+	for _, m := range matches {
+		for _, labelID := range m.symptom.LabelIDs {
+			bqLabels = append(bqLabels, models.JobRunLabel{
+				ID:         buildID,
+				StartTime:  startTime,
+				Label:      labelID,
+				SourceTool: reEvalSourceTool,
+				SymptomID:  m.symptom.ID,
+				CreatedAt:  now,
+				UpdatedAt:  now,
+			})
+
+			labelContent := jobrunscan.LabelContent{ID: labelID}
+			if def, ok := labelDefs[labelID]; ok {
+				labelContent = def
+			}
+			bucketLabels = append(bucketLabels, jobrunannotator.JobRunBucketLabel{
+				Symptom:    m.symptom.SymptomContent,
+				Label:      labelContent,
+				FileMatch:  m.fileMatch,
+				TextMatch:  m.textMatch,
+				Bucket:     r.gcsBucket,
+				JobRunPath: jobRunPath,
+			})
+		}
+	}
+
+	return bqLabels, bucketLabels, nil
+}
+
+// loadLabelDefinitions fetches label content for the labels referenced by matched symptoms.
+func (r *ReEvaluator) loadLabelDefinitions(matches []symptomMatch) (map[string]jobrunscan.LabelContent, error) {
+	ids := sets.NewString()
+	for _, m := range matches {
+		ids.Insert(m.symptom.LabelIDs...)
+	}
+	if ids.Len() == 0 || r.db == nil {
+		return nil, nil
+	}
+
+	var labels []jobrunscan.Label
+	if err := r.db.DB.Where("id IN ?", ids.List()).Find(&labels).Error; err != nil {
+		return nil, fmt.Errorf("querying label definitions for %v: %w", ids.List(), err)
+	}
+
+	result := make(map[string]jobrunscan.LabelContent, len(labels))
+	for _, l := range labels {
+		result[l.ID] = l.LabelContent
+	}
+	return result, nil
+}
+
+// clearAndWrite clears existing symptom-originated data in BQ and GCS, then writes new results.
+func (r *ReEvaluator) clearAndWrite(ctx context.Context, buildID string, jobRun *models.ProwJobRun,
+	bqLabels []models.JobRunLabel, bucketLabels []jobrunannotator.JobRunBucketLabel) error {
+
+	// Clear BQ
+	if err := r.clearBQLabels(ctx, buildID, jobRun.Timestamp); err != nil {
+		return fmt.Errorf("clearing BQ labels: %w", err)
+	}
+
+	// Clear GCS
+	jobRunPath := jobRunPathFromURL(jobRun.URL)
+	if jobRunPath != "" {
+		if err := r.clearGCSLabels(ctx, jobRunPath); err != nil {
+			return fmt.Errorf("clearing GCS labels: %w", err)
+		}
+	}
+
+	// Write BQ
+	if len(bqLabels) > 0 {
+		if err := jobrunannotator.BulkInsertJobRunLabels(ctx, r.bqClient.BQ, r.bqClient.Dataset, "job_labels", bqLabels, 500); err != nil {
+			return fmt.Errorf("writing BQ labels: %w", err)
+		}
+	}
+
+	// Write GCS
+	for _, bl := range bucketLabels {
+		if err := bl.WriteJSONToBucket(ctx, r.gcsClient); err != nil {
+			return fmt.Errorf("writing GCS label artifact: %w", err)
+		}
+	}
+
+	// Write HTML summary
+	if len(bucketLabels) > 0 && jobRunPath != "" {
+		bucket := r.gcsClient.Bucket(r.gcsBucket)
+		if _, err := jobrunannotator.WriteHTMLSummaryToBucket(ctx, bucket, jobRunPath); err != nil {
+			return fmt.Errorf("writing GCS HTML summary: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// clearBQLabels deletes existing symptom-originated labels from BQ for the given build ID.
+func (r *ReEvaluator) clearBQLabels(ctx context.Context, buildID string, startTime time.Time) error {
+	table := fmt.Sprintf("`%s.job_labels`", r.bqClient.Dataset)
+	queryStr := fmt.Sprintf(
+		`DELETE FROM %s
+		WHERE prowjob_build_id = @buildID
+		AND symptom_id IS NOT NULL AND symptom_id != ''
+		AND DATE(prowjob_start) = @startDate`,
+		table)
+
+	q := r.bqClient.Query(ctx, bqlabel.JobRunLabelsReEvaluateDelete, queryStr)
+	q.Parameters = []bigquery.QueryParameter{
+		{Name: "buildID", Value: buildID},
+		{Name: "startDate", Value: civil.DateOf(startTime.UTC())},
+	}
+	_, err := q.Read(ctx)
+	if err != nil {
+		if strings.Contains(err.Error(), "streaming buffer") {
+			log.Warnf("symptom reEval: BQ delete for %s hit streaming buffer, skipping: %v", buildID, err)
+			return nil
+		}
+		return fmt.Errorf("BQ delete for %s: %w", buildID, err)
+	}
+	log.Debugf("symptom reEval: cleared BQ symptom labels for build %s", buildID)
+	return nil
+}
+
+// clearGCSLabels removes all existing label JSON files and the HTML summary from GCS.
+func (r *ReEvaluator) clearGCSLabels(ctx context.Context, jobRunPath string) error {
+	bucket := r.gcsClient.Bucket(r.gcsBucket)
+	labelDir := jobRunPath + jobrunannotator.BucketLabelsPrefix
+
+	it := bucket.Objects(ctx, &storage.Query{
+		Prefix: labelDir,
+	})
+
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("listing GCS label objects: %w", err)
+		}
+		if err := bucket.Object(attrs.Name).Delete(ctx); err != nil && err != storage.ErrObjectNotExist {
+			return fmt.Errorf("deleting GCS object %s: %w", attrs.Name, err)
+		}
+	}
+	log.Debugf("symptom reEval: cleared GCS label artifacts for %s", jobRunPath)
+	return nil
+}
+
+// updatePostgresLabels updates the labels array on prow_job_runs (and release_job_runs if applicable).
+func (r *ReEvaluator) updatePostgresLabels(ctx context.Context, buildID string, jobRun *models.ProwJobRun, newBQLabels []models.JobRunLabel) error {
+	// Query BQ for existing non-symptom labels for this build ID
+	manualLabels, err := r.queryNonSymptomLabels(ctx, buildID, jobRun.Timestamp)
+	if err != nil {
+		log.WithError(err).Warnf("symptom reEval: could not query non-symptom labels from BQ for %s, using existing PG labels as fallback", buildID)
+		// Fallback: keep existing labels that aren't from symptoms
+		// We can't distinguish these in PG alone, so keep all existing labels
+		manualLabels = jobRun.Labels
+	}
+
+	// Merge manual labels with new symptom labels
+	merged := pq.StringArray(mergeLabels(manualLabels, newBQLabels))
+
+	// Update prow_job_runs
+	if err := r.db.DB.Model(&models.ProwJobRun{}).Where("id = ?", jobRun.ID).
+		Update("labels", merged).Error; err != nil {
+		return fmt.Errorf("updating prow_job_runs.labels: %w", err)
+	}
+
+	// Check and update release_job_runs if this job run exists there
+	var releaseJobRun models.ReleaseJobRun
+	if err := r.db.DB.Where("prow_job_run_id = ?", jobRun.ID).First(&releaseJobRun).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("looking up release_job_runs for build %s: %w", buildID, err)
+		}
+	} else {
+		if err := r.db.DB.Model(&releaseJobRun).Update("labels", merged).Error; err != nil {
+			return fmt.Errorf("updating release_job_runs.labels: %w", err)
+		}
+	}
+
+	log.Debugf("symptom reEval: updated PostgreSQL labels for build %s: %v", buildID, merged)
+	return nil
+}
+
+// queryNonSymptomLabels queries BQ for labels that were NOT applied by symptom detection.
+func (r *ReEvaluator) queryNonSymptomLabels(ctx context.Context, buildID string, startTime time.Time) ([]string, error) {
+	table := fmt.Sprintf("`%s.job_labels`", r.bqClient.Dataset)
+	queryStr := fmt.Sprintf(
+		`SELECT DISTINCT label FROM %s
+		WHERE prowjob_build_id = @buildID
+		AND (symptom_id IS NULL OR symptom_id = '')
+		AND DATE(prowjob_start) >= @startDate`,
+		table)
+
+	q := r.bqClient.Query(ctx, bqlabel.JobRunLabelsReEvaluate, queryStr)
+	q.Parameters = []bigquery.QueryParameter{
+		{Name: "buildID", Value: buildID},
+		{Name: "startDate", Value: civil.DateOf(startTime.UTC())},
+	}
+	it, err := q.Read(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var labels []string
+	for {
+		var row struct {
+			Label string `bigquery:"label"`
+		}
+		if err := it.Next(&row); err != nil {
+			if err == iterator.Done {
+				break
+			}
+			return labels, err
+		}
+		labels = append(labels, row.Label)
+	}
+	return labels, nil
+}
+
+// mergeLabels combines manual labels with newly applied symptom labels, deduplicating.
+func mergeLabels(manualLabels []string, bqLabels []models.JobRunLabel) []string {
+	merged := sets.NewString()
+	for _, l := range manualLabels {
+		merged.Insert(l)
+	}
+	for _, bl := range bqLabels {
+		merged.Insert(bl.Label)
+	}
+	return merged.List()
+}
+
+// jobRunPathFromURL extracts the GCS path from a ProwJobRun URL.
+func jobRunPathFromURL(url string) string {
+	const marker = "/" + util.GcsBucketRoot + "/"
+	pathStart := strings.Index(url, marker)
+	if pathStart == -1 {
+		return ""
+	}
+	path := url[pathStart+len(marker):]
+	if !strings.HasSuffix(path, "/") {
+		path += "/"
+	}
+	return path
+}
+
+// uniqueSymptomsMatched returns the sorted distinct symptom IDs from the matches.
+func uniqueSymptomsMatched(matches []symptomMatch) []string {
+	s := sets.NewString()
+	for _, m := range matches {
+		s.Insert(m.symptom.ID)
+	}
+	return s.List()
+}
+
+// uniqueLabels returns the unique label IDs from a set of BQ labels.
+func uniqueLabels(labels []models.JobRunLabel) []string {
+	s := sets.NewString()
+	for _, l := range labels {
+		s.Insert(l.Label)
+	}
+	return s.List()
+}
+
+// ValidateReEvalRequest validates the re-evaluation request parameters.
+func ValidateReEvalRequest(prowJobBuildIDs []string) error {
+	if len(prowJobBuildIDs) == 0 {
+		return fmt.Errorf("prow_job_build_ids is required")
+	}
+	if len(prowJobBuildIDs) > maxJobRunsPerReq {
+		return fmt.Errorf("maximum %d job runs per request", maxJobRunsPerReq)
+	}
+	for _, id := range prowJobBuildIDs {
+		if _, err := strconv.ParseInt(id, 10, 64); err != nil {
+			return fmt.Errorf("invalid prow_job_build_id %q: must be a numeric string", id)
+		}
+	}
+	return nil
+}

--- a/pkg/api/jobrunscan/reevaluate_functional_test.go
+++ b/pkg/api/jobrunscan/reevaluate_functional_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
+	"github.com/openshift/sippy/pkg/api/jobartifacts"
 	bqclient "github.com/openshift/sippy/pkg/bigquery"
 	"github.com/openshift/sippy/pkg/bigquery/bqlabel"
 	"github.com/openshift/sippy/pkg/db"
@@ -67,7 +68,7 @@ func functionalTestReEvaluator(t *testing.T) *ReEvaluator {
 	}
 	dbc := &db.DB{DB: gormDB}
 
-	return NewReEvaluator(bqC, gcsC, gcsBucket, dbc, nil, false)
+	return NewReEvaluator(bqC, gcsC, gcsBucket, dbc, nil, jobartifacts.NewManager(ctx), false)
 }
 
 func TestReEvaluateEndToEnd(t *testing.T) {

--- a/pkg/api/jobrunscan/reevaluate_functional_test.go
+++ b/pkg/api/jobrunscan/reevaluate_functional_test.go
@@ -1,0 +1,119 @@
+package jobrunscan
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	bqclient "github.com/openshift/sippy/pkg/bigquery"
+	"github.com/openshift/sippy/pkg/bigquery/bqlabel"
+	"github.com/openshift/sippy/pkg/db"
+	"google.golang.org/api/option"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// These tests require real GCP and database credentials. They are skipped
+// unless the necessary environment variables are set. To run:
+//
+//	GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json \
+//	BIGQUERY_PROJECT=my-project \
+//	BIGQUERY_DATASET=ci_analysis_us \
+//	GCS_BUCKET=test-platform-results \
+//	SIPPY_DATABASE_DSN=postgresql://user:pass@host:5432/dbname \
+//	PROW_JOB_BUILD_ID=1234567890 \
+//	go test -v -run TestReEvaluate ./pkg/api/jobrunscan/
+
+/* Example of invoking the API:
+   curl -X POST http://localhost:8080/api/jobs/runs/reevaluate \
+        -H 'Content-Type: application/json' \
+        -d '{"prow_job_build_ids": ["2061603073523978240"], "dry_run": true}'
+*/
+
+func functionalTestReEvaluator(t *testing.T) *ReEvaluator {
+	t.Helper()
+
+	credFile := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+	bqProject := os.Getenv("BIGQUERY_PROJECT")
+	bqDataset := os.Getenv("BIGQUERY_DATASET")
+	gcsBucket := os.Getenv("GCS_BUCKET")
+	dbDSN := os.Getenv("SIPPY_DATABASE_DSN")
+	buildID := os.Getenv("PROW_JOB_BUILD_ID")
+
+	if credFile == "" || bqProject == "" || bqDataset == "" || gcsBucket == "" || dbDSN == "" || buildID == "" {
+		t.Skip("Set GOOGLE_APPLICATION_CREDENTIALS, BIGQUERY_PROJECT, BIGQUERY_DATASET, GCS_BUCKET, SIPPY_DATABASE_DSN, and PROW_JOB_BUILD_ID to run this test")
+	}
+
+	ctx := context.Background()
+	opCtx := bqlabel.OperationalContext{
+		App:         bqlabel.AppSippy,
+		Command:     "test",
+		Environment: bqlabel.EnvCli,
+	}
+	bqC, err := bqclient.New(ctx, opCtx, nil, credFile, bqProject, bqDataset, "")
+	if err != nil {
+		t.Fatalf("creating BQ client: %v", err)
+	}
+
+	gcsC, err := storage.NewClient(ctx, option.WithCredentialsFile(credFile))
+	if err != nil {
+		t.Fatalf("creating GCS client: %v", err)
+	}
+
+	gormDB, err := gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("connecting to database: %v", err)
+	}
+	dbc := &db.DB{DB: gormDB}
+
+	return NewReEvaluator(bqC, gcsC, gcsBucket, dbc, nil, false)
+}
+
+func TestReEvaluateEndToEnd(t *testing.T) {
+	re := functionalTestReEvaluator(t)
+	buildID := os.Getenv("PROW_JOB_BUILD_ID")
+
+	results, err := re.ReEvaluateJobRuns(context.Background(), []string{buildID})
+	if err != nil {
+		t.Fatalf("re-evaluation failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.ProwJobBuildID != buildID {
+		t.Errorf("result build ID = %q, want %q", r.ProwJobBuildID, buildID)
+	}
+	t.Logf("result: status=%s, symptoms_evaluated=%d, symptoms_matched=%v, labels_applied=%v, bq=%d, gcs=%d, pg=%v",
+		r.Status, r.SymptomsEvaluated, r.SymptomsMatched, r.LabelsApplied, r.BQEntriesWritten, r.GCSArtifactsWritten, r.PostgresUpdated)
+	if r.Status != ReEvalSuccess {
+		t.Errorf("expected success status, got %s: %s", r.Status, r.Error)
+	}
+}
+
+func TestReEvaluateIdempotent(t *testing.T) {
+	re := functionalTestReEvaluator(t)
+	buildID := os.Getenv("PROW_JOB_BUILD_ID")
+
+	// Run twice
+	results1, err := re.ReEvaluateJobRuns(context.Background(), []string{buildID})
+	if err != nil {
+		t.Fatalf("first re-evaluation failed: %v", err)
+	}
+	results2, err := re.ReEvaluateJobRuns(context.Background(), []string{buildID})
+	if err != nil {
+		t.Fatalf("second re-evaluation failed: %v", err)
+	}
+
+	if len(results1) != 1 || len(results2) != 1 {
+		t.Fatal("expected 1 result each")
+	}
+	r1, r2 := results1[0], results2[0]
+	if !stringSliceEqual(r1.SymptomsMatched, r2.SymptomsMatched) {
+		t.Errorf("symptoms matched differ: %v vs %v", r1.SymptomsMatched, r2.SymptomsMatched)
+	}
+	if !stringSliceEqual(r1.LabelsApplied, r2.LabelsApplied) {
+		t.Errorf("labels applied differ: %v vs %v", r1.LabelsApplied, r2.LabelsApplied)
+	}
+}

--- a/pkg/api/jobrunscan/reevaluate_functional_test.go
+++ b/pkg/api/jobrunscan/reevaluate_functional_test.go
@@ -111,10 +111,10 @@ func TestReEvaluateIdempotent(t *testing.T) {
 		t.Fatal("expected 1 result each")
 	}
 	r1, r2 := results1[0], results2[0]
-	if !stringSliceEqual(r1.SymptomsMatched, r2.SymptomsMatched) {
+	if !sameStrings(r1.SymptomsMatched, r2.SymptomsMatched) {
 		t.Errorf("symptoms matched differ: %v vs %v", r1.SymptomsMatched, r2.SymptomsMatched)
 	}
-	if !stringSliceEqual(r1.LabelsApplied, r2.LabelsApplied) {
+	if !sameStrings(r1.LabelsApplied, r2.LabelsApplied) {
 		t.Errorf("labels applied differ: %v vs %v", r1.LabelsApplied, r2.LabelsApplied)
 	}
 }

--- a/pkg/api/jobrunscan/reevaluate_test.go
+++ b/pkg/api/jobrunscan/reevaluate_test.go
@@ -1,0 +1,418 @@
+package jobrunscan
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/lib/pq"
+
+	"cloud.google.com/go/civil"
+	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/openshift/sippy/pkg/db/models/jobrunscan"
+)
+
+func TestValidateReEvalRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		ids     []string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "empty IDs",
+			ids:     []string{},
+			wantErr: true,
+			errMsg:  "prow_job_build_ids is required",
+		},
+		{
+			name:    "nil IDs",
+			ids:     nil,
+			wantErr: true,
+			errMsg:  "prow_job_build_ids is required",
+		},
+		{
+			name:    "valid single ID",
+			ids:     []string{"1234567890"},
+			wantErr: false,
+		},
+		{
+			name:    "valid multiple IDs",
+			ids:     []string{"111", "222", "333"},
+			wantErr: false,
+		},
+		{
+			name:    "non-numeric ID",
+			ids:     []string{"abc"},
+			wantErr: true,
+			errMsg:  "invalid prow_job_build_id",
+		},
+		{
+			name:    "exceeds max batch size",
+			ids:     makeIDs(51),
+			wantErr: true,
+			errMsg:  "maximum 50 job runs per request",
+		},
+		{
+			name:    "at max batch size",
+			ids:     makeIDs(50),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateReEvalRequest(tt.ids)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateReEvalRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && tt.errMsg != "" {
+				if got := err.Error(); !strings.Contains(got, tt.errMsg) {
+					t.Errorf("error %q does not contain %q", got, tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterImplementedSymptoms(t *testing.T) {
+	withLabels := pq.StringArray{"label-a"}
+	symptoms := []jobrunscan.Symptom{
+		{SymptomContent: jobrunscan.SymptomContent{ID: "s1", MatcherType: jobrunscan.MatcherTypeString, LabelIDs: withLabels}},
+		{SymptomContent: jobrunscan.SymptomContent{ID: "s2", MatcherType: jobrunscan.MatcherTypeRegex, LabelIDs: withLabels}},
+		{SymptomContent: jobrunscan.SymptomContent{ID: "s3", MatcherType: jobrunscan.MatcherTypeFile, LabelIDs: withLabels}},
+		{SymptomContent: jobrunscan.SymptomContent{ID: "s4", MatcherType: jobrunscan.MatcherTypeCEL, LabelIDs: withLabels}},
+		{SymptomContent: jobrunscan.SymptomContent{ID: "s5", MatcherType: "unknown", LabelIDs: withLabels}},
+		{SymptomContent: jobrunscan.SymptomContent{ID: "s6", MatcherType: jobrunscan.MatcherTypeString}},
+	}
+
+	filtered := filterRelevantSymptoms(symptoms)
+	if len(filtered) != 3 {
+		t.Fatalf("expected 3 relevant symptoms, got %d", len(filtered))
+	}
+
+	ids := map[string]bool{}
+	for _, s := range filtered {
+		ids[s.ID] = true
+	}
+	for _, id := range []string{"s1", "s2", "s3"} {
+		if !ids[id] {
+			t.Errorf("expected symptom %q to be included", id)
+		}
+	}
+	for _, id := range []string{"s4", "s5", "s6"} {
+		if ids[id] {
+			t.Errorf("expected symptom %q to be excluded", id)
+		}
+	}
+}
+
+func TestMergeLabels(t *testing.T) {
+	tests := []struct {
+		name         string
+		manualLabels []string
+		bqLabels     []models.JobRunLabel
+		wantLabels   []string
+	}{
+		{
+			name:         "empty both",
+			manualLabels: nil,
+			bqLabels:     nil,
+			wantLabels:   nil,
+		},
+		{
+			name:         "manual only",
+			manualLabels: []string{"FlakeDetected", "InfraFailure"},
+			bqLabels:     nil,
+			wantLabels:   []string{"FlakeDetected", "InfraFailure"},
+		},
+		{
+			name:         "symptom only",
+			manualLabels: nil,
+			bqLabels: []models.JobRunLabel{
+				{Label: "DNSTimeout"},
+				{Label: "NetworkError"},
+			},
+			wantLabels: []string{"DNSTimeout", "NetworkError"},
+		},
+		{
+			name:         "mixed with dedup",
+			manualLabels: []string{"InfraFailure", "DNSTimeout"},
+			bqLabels: []models.JobRunLabel{
+				{Label: "DNSTimeout"},
+				{Label: "NetworkError"},
+			},
+			wantLabels: []string{"DNSTimeout", "InfraFailure", "NetworkError"},
+		},
+		{
+			name:         "duplicate symptom labels deduplicated",
+			manualLabels: nil,
+			bqLabels: []models.JobRunLabel{
+				{Label: "SameLabel", SymptomID: "s1"},
+				{Label: "SameLabel", SymptomID: "s2"},
+			},
+			wantLabels: []string{"SameLabel"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeLabels(tt.manualLabels, tt.bqLabels)
+			if !stringSliceEqual(got, tt.wantLabels) {
+				t.Errorf("mergeLabels() = %v, want %v", got, tt.wantLabels)
+			}
+		})
+	}
+}
+
+func TestUniqueSymptomsMatched(t *testing.T) {
+	matches := []symptomMatch{
+		{symptom: jobrunscan.Symptom{SymptomContent: jobrunscan.SymptomContent{ID: "s1"}}},
+		{symptom: jobrunscan.Symptom{SymptomContent: jobrunscan.SymptomContent{ID: "s1"}}},
+		{symptom: jobrunscan.Symptom{SymptomContent: jobrunscan.SymptomContent{ID: "s2"}}},
+	}
+	got := uniqueSymptomsMatched(matches)
+	want := []string{"s1", "s2"}
+	if !stringSliceEqual(got, want) {
+		t.Errorf("uniqueSymptomsMatched() = %v, want %v", got, want)
+	}
+
+	if got := uniqueSymptomsMatched(nil); len(got) != 0 {
+		t.Errorf("uniqueSymptomsMatched(nil) = %v, want empty", got)
+	}
+}
+
+func TestUniqueLabels(t *testing.T) {
+	labels := []models.JobRunLabel{
+		{Label: "A"},
+		{Label: "B"},
+		{Label: "A"},
+		{Label: "C"},
+		{Label: "B"},
+	}
+	got := uniqueLabels(labels)
+	want := []string{"A", "B", "C"}
+	if !stringSliceEqual(got, want) {
+		t.Errorf("uniqueLabels() = %v, want %v", got, want)
+	}
+}
+
+func TestJobRunPathFromURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "standard URL",
+			url:  "https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.17-e2e-aws-ovn/1234567890",
+			want: "logs/periodic-ci-openshift-release-master-nightly-4.17-e2e-aws-ovn/1234567890/",
+		},
+		{
+			name: "URL with trailing slash",
+			url:  "https://prow.ci.openshift.org/view/gs/test-platform-results/logs/some-job/999/",
+			want: "logs/some-job/999/",
+		},
+		{
+			name: "no bucket root in URL",
+			url:  "https://example.com/some/other/path",
+			want: "",
+		},
+		{
+			name: "empty URL",
+			url:  "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := jobRunPathFromURL(tt.url); got != tt.want {
+				t.Errorf("jobRunPathFromURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContentMatcherForSymptom(t *testing.T) {
+	tests := []struct {
+		name    string
+		symptom jobrunscan.SymptomContent
+		wantNil bool
+		wantErr bool
+	}{
+		{
+			name: "string matcher",
+			symptom: jobrunscan.SymptomContent{
+				MatcherType: jobrunscan.MatcherTypeString,
+				MatchString: "error connecting",
+			},
+			wantNil: false,
+		},
+		{
+			name: "regex matcher",
+			symptom: jobrunscan.SymptomContent{
+				MatcherType: jobrunscan.MatcherTypeRegex,
+				MatchString: "timeout.*dns",
+			},
+			wantNil: false,
+		},
+		{
+			name: "invalid regex",
+			symptom: jobrunscan.SymptomContent{
+				ID:          "bad",
+				MatcherType: jobrunscan.MatcherTypeRegex,
+				MatchString: "[invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "file existence matcher",
+			symptom: jobrunscan.SymptomContent{
+				MatcherType: jobrunscan.MatcherTypeFile,
+			},
+			wantNil: true,
+		},
+		{
+			name: "unsupported matcher type",
+			symptom: jobrunscan.SymptomContent{
+				ID:          "test",
+				MatcherType: "jq",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher, err := ContentMatcherForSymptom(tt.symptom)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ContentMatcherForSymptom() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && (matcher == nil) != tt.wantNil {
+				t.Errorf("ContentMatcherForSymptom() matcher nil = %v, wantNil %v", matcher == nil, tt.wantNil)
+			}
+		})
+	}
+}
+
+func TestBuildOutputs(t *testing.T) {
+	re := &ReEvaluator{gcsBucket: "test-bucket"}
+	matches := []symptomMatch{
+		{
+			symptom: jobrunscan.Symptom{SymptomContent: jobrunscan.SymptomContent{
+				ID:          "DNSTimeout",
+				Summary:     "DNS Timeout detected",
+				MatcherType: jobrunscan.MatcherTypeString,
+				FilePattern: "**/build-log.txt",
+				MatchString: "dns timeout",
+				LabelIDs:    []string{"InfraFailure"},
+			}},
+			fileMatch: "artifacts/build-log.txt",
+			textMatch: "dns timeout occurred at 12:34",
+		},
+	}
+
+	jobRun := &models.ProwJobRun{
+		URL: "https://prow.ci.openshift.org/view/gs/test-platform-results/logs/test-job/12345",
+	}
+
+	bqLabels, bucketLabels, err := re.buildOutputs(matches, "12345", jobRun)
+	if err != nil {
+		t.Fatalf("buildOutputs() error = %v", err)
+	}
+
+	if len(bqLabels) != 1 {
+		t.Fatalf("expected 1 BQ label, got %d", len(bqLabels))
+	}
+
+	bl := bqLabels[0]
+	if bl.ID != "12345" {
+		t.Errorf("BQ label ID = %q, want %q", bl.ID, "12345")
+	}
+	if bl.Label != "InfraFailure" {
+		t.Errorf("BQ label Label = %q, want %q", bl.Label, "InfraFailure")
+	}
+	if bl.SourceTool != reEvalSourceTool {
+		t.Errorf("BQ label SourceTool = %q, want %q", bl.SourceTool, reEvalSourceTool)
+	}
+	if bl.SymptomID != "DNSTimeout" {
+		t.Errorf("BQ label SymptomID = %q, want %q", bl.SymptomID, "DNSTimeout")
+	}
+	if bl.StartTime == (civil.DateTime{}) {
+		t.Error("BQ label StartTime should not be zero")
+	}
+
+	if len(bucketLabels) != 1 {
+		t.Fatalf("expected 1 bucket label, got %d", len(bucketLabels))
+	}
+	gcs := bucketLabels[0]
+	if gcs.Symptom.ID != "DNSTimeout" {
+		t.Errorf("bucket label symptom ID = %q, want %q", gcs.Symptom.ID, "DNSTimeout")
+	}
+	if gcs.FileMatch != "artifacts/build-log.txt" {
+		t.Errorf("bucket label FileMatch = %q, want %q", gcs.FileMatch, "artifacts/build-log.txt")
+	}
+	if gcs.TextMatch != "dns timeout occurred at 12:34" {
+		t.Errorf("bucket label TextMatch = %q", gcs.TextMatch)
+	}
+	if gcs.Bucket != "test-bucket" {
+		t.Errorf("bucket label Bucket = %q, want %q", gcs.Bucket, "test-bucket")
+	}
+	expectedPath := "logs/test-job/12345/"
+	if gcs.JobRunPath != expectedPath {
+		t.Errorf("bucket label JobRunPath = %q, want %q", gcs.JobRunPath, expectedPath)
+	}
+}
+
+func TestBuildOutputsMultipleLabels(t *testing.T) {
+	re := &ReEvaluator{gcsBucket: "test-bucket"}
+	matches := []symptomMatch{
+		{
+			symptom: jobrunscan.Symptom{SymptomContent: jobrunscan.SymptomContent{
+				ID:       "MultiLabel",
+				LabelIDs: []string{"Label1", "Label2"},
+			}},
+			fileMatch: "test-file.txt",
+		},
+	}
+	jobRun := &models.ProwJobRun{
+		URL: "https://example.com/gs/test-platform-results/logs/job/1/",
+	}
+
+	bqLabels, bucketLabels, err := re.buildOutputs(matches, "1", jobRun)
+	if err != nil {
+		t.Fatalf("buildOutputs() error = %v", err)
+	}
+	if len(bqLabels) != 2 {
+		t.Fatalf("expected 2 BQ labels, got %d", len(bqLabels))
+	}
+	if len(bucketLabels) != 2 {
+		t.Fatalf("expected 2 bucket labels, got %d", len(bucketLabels))
+	}
+}
+
+// helpers
+
+func makeIDs(n int) []string {
+	ids := make([]string, n)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("%d", 1000000000+i)
+	}
+	return ids
+}
+
+func stringSliceEqual(a, b []string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/api/jobrunscan/reevaluate_test.go
+++ b/pkg/api/jobrunscan/reevaluate_test.go
@@ -2,6 +2,7 @@ package jobrunscan
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 
@@ -158,7 +159,7 @@ func TestMergeLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := mergeLabels(tt.manualLabels, tt.bqLabels)
-			if !stringSliceEqual(got, tt.wantLabels) {
+			if !sameStrings(got, tt.wantLabels) {
 				t.Errorf("mergeLabels() = %v, want %v", got, tt.wantLabels)
 			}
 		})
@@ -173,7 +174,7 @@ func TestUniqueSymptomsMatched(t *testing.T) {
 	}
 	got := uniqueSymptomsMatched(matches)
 	want := []string{"s1", "s2"}
-	if !stringSliceEqual(got, want) {
+	if !sameStrings(got, want) {
 		t.Errorf("uniqueSymptomsMatched() = %v, want %v", got, want)
 	}
 
@@ -192,7 +193,7 @@ func TestUniqueLabels(t *testing.T) {
 	}
 	got := uniqueLabels(labels)
 	want := []string{"A", "B", "C"}
-	if !stringSliceEqual(got, want) {
+	if !sameStrings(got, want) {
 		t.Errorf("uniqueLabels() = %v, want %v", got, want)
 	}
 }
@@ -402,15 +403,21 @@ func makeIDs(n int) []string {
 	return ids
 }
 
-func stringSliceEqual(a, b []string) bool {
+func sameStrings(a, b []string) bool {
 	if len(a) == 0 && len(b) == 0 {
 		return true
 	}
 	if len(a) != len(b) {
 		return false
 	}
-	for i := range a {
-		if a[i] != b[i] {
+	aSorted := make([]string, len(a))
+	copy(aSorted, a)
+	sort.Strings(aSorted)
+	bSorted := make([]string, len(b))
+	copy(bSorted, b)
+	sort.Strings(bSorted)
+	for i := range aSorted {
+		if aSorted[i] != bSorted[i] {
 			return false
 		}
 	}

--- a/pkg/bigquery/bqlabel/labels.go
+++ b/pkg/bigquery/bqlabel/labels.go
@@ -96,6 +96,8 @@ const (
 	TestLifecycles                      QueryValue = "test-lifecycles"
 	JobRunPayload                       QueryValue = "job-run-payload"
 	JobRunLabels                        QueryValue = "job-run-labels"
+	JobRunLabelsReEvaluate              QueryValue = "job-run-labels-reevaluate"
+	JobRunLabelsReEvaluateDelete        QueryValue = "job-run-labels-reevaluate-delete"
 	JobRunHighRisk                      QueryValue = "job-run-high-risk"
 	JobRuns                             QueryValue = "job-runs"
 	JobVariants                         QueryValue = "job-variants"

--- a/pkg/componentreadiness/jobrunannotator/jobrunannotator.go
+++ b/pkg/componentreadiness/jobrunannotator/jobrunannotator.go
@@ -384,10 +384,7 @@ func (j JobRunAnnotator) filterJobRunByArtifact(ctx context.Context, jobRunIDs [
 	return resultIDs, nil
 }
 
-// bulkInsertVariants inserts all new job variants in batches.
 func (j JobRunAnnotator) bulkInsertJobRunAnnotations(ctx context.Context, inserts []models.JobRunLabel) error {
-	var batchSize = 500
-
 	if !j.execute {
 		jobsStr := ""
 		for _, jobRun := range inserts {
@@ -397,15 +394,22 @@ func (j JobRunAnnotator) bulkInsertJobRunAnnotations(ctx context.Context, insert
 		return nil
 	}
 
-	table := j.bqClient.BQ.Dataset(j.bqClient.Dataset).Table(jobAnnotationTable)
-	inserter := table.Inserter()
-	for i := 0; i < len(inserts); i += batchSize {
+	return BulkInsertJobRunLabels(ctx, j.bqClient.BQ, j.bqClient.Dataset, jobAnnotationTable, inserts, 500)
+}
+
+// BulkInsertJobRunLabels inserts job run labels into BigQuery in batches.
+func BulkInsertJobRunLabels(ctx context.Context, bqClient *bigquery.Client, dataset, table string,
+	labels []models.JobRunLabel, batchSize int) error {
+
+	t := bqClient.Dataset(dataset).Table(table)
+	inserter := t.Inserter()
+	for i := 0; i < len(labels); i += batchSize {
 		end := i + batchSize
-		if end > len(inserts) {
-			end = len(inserts)
+		if end > len(labels) {
+			end = len(labels)
 		}
 
-		if err := inserter.Put(ctx, inserts[i:end]); err != nil {
+		if err := inserter.Put(ctx, labels[i:end]); err != nil {
 			return err
 		}
 		log.Infof("added %d new job label rows", end-i)

--- a/pkg/sippyserver/job_run_scan.go
+++ b/pkg/sippyserver/job_run_scan.go
@@ -40,7 +40,7 @@ func (s *Server) jsonGetLabel(w http.ResponseWriter, req *http.Request) {
 
 func (s *Server) jsonCreateLabel(w http.ResponseWriter, req *http.Request) {
 	user := getUserForRequest(req)
-	log.Infof("label POST made by user: %s", user)
+	log.WithField("user", user).Info("label POST")
 	var label jobrunscan.Label
 	if err := json.NewDecoder(req.Body).Decode(&label); err != nil {
 		log.WithError(err).Error("error parsing new label")
@@ -59,7 +59,7 @@ func (s *Server) jsonUpdateLabel(w http.ResponseWriter, req *http.Request) {
 	id := mux.Vars(req)["id"]
 
 	user := getUserForRequest(req)
-	log.Infof("label PUT made by user: %s", user)
+	log.WithField("user", user).Info("label PUT")
 	var label jobrunscan.Label
 	if err := json.NewDecoder(req.Body).Decode(&label); err != nil {
 		log.WithError(err).Error("error parsing label update")
@@ -83,7 +83,7 @@ func (s *Server) jsonDeleteLabel(w http.ResponseWriter, req *http.Request) {
 	id := mux.Vars(req)["id"]
 
 	user := getUserForRequest(req)
-	log.Infof("label DELETE made by user: %s", user)
+	log.WithField("user", user).Info("label DELETE")
 	if err := apijobrunscan.DeleteLabel(s.db.DB, id, user); err != nil {
 		failureResponse(w, http.StatusInternalServerError, err.Error())
 		return
@@ -120,7 +120,7 @@ func (s *Server) jsonGetSymptom(w http.ResponseWriter, req *http.Request) {
 
 func (s *Server) jsonCreateSymptom(w http.ResponseWriter, req *http.Request) {
 	user := getUserForRequest(req)
-	log.Infof("symptom POST made by user: %s", user)
+	log.WithField("user", user).Info("symptom POST")
 	var symptom jobrunscan.Symptom
 	if err := json.NewDecoder(req.Body).Decode(&symptom); err != nil {
 		log.WithError(err).Error("error parsing new symptom")
@@ -139,7 +139,7 @@ func (s *Server) jsonUpdateSymptom(w http.ResponseWriter, req *http.Request) {
 	id := mux.Vars(req)["id"]
 
 	user := getUserForRequest(req)
-	log.Infof("symptom PUT made by user: %s", user)
+	log.WithField("user", user).Info("symptom PUT")
 	var symptom jobrunscan.Symptom
 	if err := json.NewDecoder(req.Body).Decode(&symptom); err != nil {
 		log.WithError(err).Error("error parsing symptom update")
@@ -163,7 +163,7 @@ func (s *Server) jsonDeleteSymptom(w http.ResponseWriter, req *http.Request) {
 	id := mux.Vars(req)["id"]
 
 	user := getUserForRequest(req)
-	log.Infof("symptom DELETE made by user: %s", user)
+	log.WithField("user", user).Info("symptom DELETE")
 	if err := apijobrunscan.DeleteSymptom(s.db.DB, id, user); err != nil {
 		failureResponse(w, http.StatusInternalServerError, err.Error())
 		return
@@ -174,8 +174,7 @@ func (s *Server) jsonDeleteSymptom(w http.ResponseWriter, req *http.Request) {
 // Job run symptom re-evaluation handler
 
 func (s *Server) jsonReEvaluateJobRunSymptoms(w http.ResponseWriter, req *http.Request) {
-	user := getUserForRequest(req)
-	log.Infof("symptom re-evaluation POST made by user: %s", user)
+	log.WithField("user", getUserForRequest(req)).Info("symptom re-evaluation POST")
 
 	var body struct {
 		ProwJobBuildIDs []string `json:"prow_job_build_ids"`

--- a/pkg/sippyserver/job_run_scan.go
+++ b/pkg/sippyserver/job_run_scan.go
@@ -170,3 +170,42 @@ func (s *Server) jsonDeleteSymptom(w http.ResponseWriter, req *http.Request) {
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
+
+// Job run symptom re-evaluation handler
+
+func (s *Server) jsonReEvaluateJobRunSymptoms(w http.ResponseWriter, req *http.Request) {
+	user := getUserForRequest(req)
+	log.Infof("symptom re-evaluation POST made by user: %s", user)
+
+	var body struct {
+		ProwJobBuildIDs []string `json:"prow_job_build_ids"`
+		DryRun          bool     `json:"dry_run"`
+	}
+	req.Body = http.MaxBytesReader(w, req.Body, 1<<20) // 1 MiB limit to prevent DoS
+	dec := json.NewDecoder(req.Body)
+	dec.DisallowUnknownFields() // catch client errors faster
+	if err := dec.Decode(&body); err != nil {
+		failureResponse(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+
+	if err := apijobrunscan.ValidateReEvalRequest(body.ProwJobBuildIDs); err != nil {
+		failureResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if s.bigQueryClient == nil || s.gcsClient == nil || s.gcsBucket == "" {
+		failureResponse(w, http.StatusServiceUnavailable, "symptom re-evaluation requires BigQuery and GCS configuration")
+		return
+	}
+
+	re := apijobrunscan.NewReEvaluator(s.bigQueryClient, s.gcsClient, s.gcsBucket, s.db, s.cache, body.DryRun)
+	results, err := re.ReEvaluateJobRuns(req.Context(), body.ProwJobBuildIDs)
+	if err != nil {
+		failureResponse(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	resp := apijobrunscan.ReEvaluationResponse{Results: results}
+	apijobrunscan.InjectReEvalHATEOASLinks(&resp, api.GetBaseURL(req))
+	api.RespondWithJSON(http.StatusOK, w, resp)
+}

--- a/pkg/sippyserver/job_run_scan.go
+++ b/pkg/sippyserver/job_run_scan.go
@@ -199,7 +199,7 @@ func (s *Server) jsonReEvaluateJobRunSymptoms(w http.ResponseWriter, req *http.R
 		return
 	}
 
-	re := apijobrunscan.NewReEvaluator(s.bigQueryClient, s.gcsClient, s.gcsBucket, s.db, s.cache, body.DryRun)
+	re := apijobrunscan.NewReEvaluator(s.bigQueryClient, s.gcsClient, s.gcsBucket, s.db, s.cache, s.jobartifactsManager, body.DryRun)
 	results, err := re.ReEvaluateJobRuns(req.Context(), body.ProwJobBuildIDs)
 	if err != nil {
 		failureResponse(w, http.StatusInternalServerError, err.Error())

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -2446,6 +2446,13 @@ func (s *Server) Serve() {
 			HandlerFunc:  s.jsonDeleteSymptom,
 		},
 		{
+			EndpointPath: "/api/jobs/runs/reevaluate",
+			Description:  "Re-evaluate symptom matches for specified job runs",
+			Methods:      []string{http.MethodPost},
+			Capabilities: []string{LocalDBCapability, WriteEndpointsCapability},
+			HandlerFunc:  s.jsonReEvaluateJobRunSymptoms,
+		},
+		{
 			EndpointPath: "/api/job_variants",
 			Description:  "Reports all job variants defined in BigQuery",
 			Capabilities: []string{ComponentReadinessCapability},


### PR DESCRIPTION
Currently just the backend API (frontend will come later).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `POST /api/jobs/runs/reevaluate` to retroactively re-evaluate completed job run symptoms, with `dry_run` support, request validation (max 50 job IDs), and updates across BigQuery, GCS, and PostgreSQL while preserving manually applied labels.

* **Documentation**
  * Documented the new endpoint in the API and symptoms feature docs, and published the backend implementation plan.

* **Tests**
  * Added unit tests plus gated end-to-end functional tests (including idempotency checks).

* **Chores**
  * Refreshed local artifact hash references and updated internal guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->