### PR TITLE
Check GORM query errors instead of silently returning empty results

### DIFF
--- a/pkg/api/job_analysis.go
+++ b/pkg/api/job_analysis.go
@@ -66,7 +66,9 @@ func PrintJobAnalysisJSONFromDB(
 		Where("prow_job_runs.timestamp BETWEEN ? AND ?", start, end).
 		Group("period")
 
-	sumResults.Scan(&sums)
+	if err := sumResults.Scan(&sums).Error; err != nil {
+		return result, err
+	}
 
 	// collect the results
 	results := apitype.JobAnalysisResult{
@@ -114,8 +116,10 @@ func PrintJobAnalysisJSONFromDB(
 		jr = dbc.DB.Table("prow_job_failed_tests_by_hour_matview")
 	}
 
-	jr.Select("period, test_name, count").
-		Where("prow_job_id IN ?", jobs).Scan(&tr)
+	if err := jr.Select("period, test_name, count").
+		Where("prow_job_id IN ?", jobs).Scan(&tr).Error; err != nil {
+		return results, err
+	}
 
 	for _, t := range tr {
 		dateKey := t.Period.UTC().Format(formatter)

--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/apis/cache"
@@ -120,7 +121,9 @@ func JobsRunsReportFromDB(dbc *db.DB, filterOpts *filter.FilterOptions, release 
 
 	// Get the row count before pagination
 	var rowCount int64
-	q.Count(&rowCount)
+	if err := q.Count(&rowCount).Error; err != nil {
+		return nil, err
+	}
 
 	// Paginate the results:
 	if pagination == nil {
@@ -456,7 +459,12 @@ func jobNamesTestResultFunc(dbc *db.DB, release string) testResultsByJobNameFunc
 		}
 
 		testReport := apitype.Test{}
-		q.First(&testReport)
+		if err := q.First(&testReport).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, nil
+			}
+			return nil, err
+		}
 		testReport.Name = testName
 		return &testReport, nil
 	}

--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -9,7 +10,7 @@ import (
 	"time"
 
 	"github.com/lib/pq"
-	"github.com/pkg/errors"
+	pkgerrors "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
 	"gorm.io/gorm"
@@ -47,7 +48,10 @@ func PrintPullRequestsReport(w http.ResponseWriter, req *http.Request, dbClient 
 	}
 
 	prs := make([]models.ReleasePullRequest, 0)
-	q.Find(&prs)
+	if err := q.Find(&prs).Error; err != nil {
+		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": err.Error()})
+		return
+	}
 	RespondWithJSON(http.StatusOK, w, prs)
 }
 
@@ -132,7 +136,9 @@ func GetPayloadStreamTestFailures(dbc *db.DB, release, stream, arch string, filt
 	if err != nil {
 		return nil, err
 	}
-	q.Find(&failedTests)
+	if err := q.Find(&failedTests).Error; err != nil {
+		return nil, err
+	}
 	logger.WithField("failedTestCount", len(failedTests)).Debug("found failed tests")
 
 	// Iterate all failed tests, build structs showing what payloads and jobs it failed in.
@@ -208,11 +214,13 @@ func GetPayloadTestFailures(dbc *db.DB, payloadTag string, logger log.FieldLogge
 	}
 
 	payload := &models.ReleaseTag{}
-	dbc.DB.Where("release_tag = ?", payloadTag).First(payload)
-	logger.Infof("got payload: %+v", payload)
-	if payload.ID == 0 {
-		return result.TestFailures, fmt.Errorf("no payload release tag found for: %s", payloadTag)
+	if err := dbc.DB.Where("release_tag = ?", payloadTag).First(payload).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return result.TestFailures, fmt.Errorf("no payload release tag found for: %s", payloadTag)
+		}
+		return nil, fmt.Errorf("error looking up payload release tag %s: %w", payloadTag, err)
 	}
+	logger.Infof("got payload: %+v", payload)
 
 	result.PayloadsAnalyzed = 1
 
@@ -304,7 +312,9 @@ func GetPayloadEvents(dbClient *db.DB, release string, filterOpts *filter.Filter
 		q = q.Where("release_time <= ?", end)
 	}
 
-	q.Scan(&releases)
+	if err := q.Scan(&releases).Error; err != nil {
+		return nil, err
+	}
 
 	return releases, nil
 }
@@ -337,9 +347,9 @@ func PrintReleasesReport(w http.ResponseWriter, req *http.Request, dbClient *db.
 
 	// This join looks up the names of failed jobs, if any, and returns them as
 	// a JSON aggregation (i.e. failedJobNames will contain a JSON array).
-	q.Table("release_tags").
+	result := q.Table("release_tags").
 		Select(`release_tags.*, release_job_runs.failed_job_names`).
-		Joins(`LEFT OUTER JOIN 
+		Joins(`LEFT OUTER JOIN
    			(
 				SELECT
 					release_tags.release_tag, array_agg(release_job_runs.job_name ORDER BY release_job_runs.job_name asc) AS failed_job_names
@@ -353,6 +363,10 @@ func PrintReleasesReport(w http.ResponseWriter, req *http.Request, dbClient *db.
 					release_tags.release_tag
 			) release_job_runs using (release_tag)`).
 		Scan(&releases)
+	if result.Error != nil {
+		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": result.Error.Error()})
+		return
+	}
 
 	RespondWithJSON(http.StatusOK, w, releases)
 }
@@ -373,30 +387,30 @@ func ReleaseHealthReports(dbClient *db.DB, release string, reportEnd time.Time) 
 	for _, archStream := range results {
 		phase, count, err := query.GetLastPayloadStatus(dbClient.DB, archStream.Architecture, archStream.Stream, release, reportEnd)
 		if err != nil {
-			return apiResults, errors.Wrapf(err, "error finding last %s payload status for %s %s",
+			return apiResults, pkgerrors.Wrapf(err, "error finding last %s payload status for %s %s",
 				release, archStream.Architecture, archStream.Stream)
 		}
 
 		totalPhaseCountsDB, err := query.GetPayloadStreamPhaseCounts(dbClient.DB, release, archStream.Architecture, archStream.Stream, nil, reportEnd)
 		if err != nil {
-			return apiResults, errors.Wrapf(err, "error finding %s payload status counts for %s %s",
+			return apiResults, pkgerrors.Wrapf(err, "error finding %s payload status counts for %s %s",
 				release, archStream.Architecture, archStream.Stream)
 		}
 		totalAcceptanceStatistics, err := query.GetPayloadAcceptanceStatistics(dbClient.DB, release, archStream.Architecture, archStream.Stream, nil, reportEnd)
 		if err != nil {
-			return apiResults, errors.Wrapf(err, "error finding %s payload acceptance statistics for %s %s",
+			return apiResults, pkgerrors.Wrapf(err, "error finding %s payload acceptance statistics for %s %s",
 				release, archStream.Architecture, archStream.Stream)
 		}
 
 		weekAgo := reportEnd.Add(-7 * 24 * time.Hour)
 		currentWeekPhaseCountsDB, err := query.GetPayloadStreamPhaseCounts(dbClient.DB, release, archStream.Architecture, archStream.Stream, &weekAgo, reportEnd)
 		if err != nil {
-			return apiResults, errors.Wrapf(err, "error finding %s payload status counts for %s %s",
+			return apiResults, pkgerrors.Wrapf(err, "error finding %s payload status counts for %s %s",
 				release, archStream.Architecture, archStream.Stream)
 		}
 		currentWeekAcceptanceStatistics, err := query.GetPayloadAcceptanceStatistics(dbClient.DB, release, archStream.Architecture, archStream.Stream, &weekAgo, reportEnd)
 		if err != nil {
-			return apiResults, errors.Wrapf(err, "error finding %s payload acceptance statistics for %s %s",
+			return apiResults, pkgerrors.Wrapf(err, "error finding %s payload acceptance statistics for %s %s",
 				release, archStream.Architecture, archStream.Stream)
 		}
 

--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -576,7 +576,9 @@ func (spec *TestResultsSpec) buildTestsResultsPGGenerator(ctx context.Context, d
 			Name: "Overall",
 		}
 		// TODO: column open_bugs does not exist here?
-		summaryResult.Scan(overallTest)
+		if err := summaryResult.Scan(overallTest).Error; err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	elapsed := time.Since(now)

--- a/pkg/db/query/job_queries.go
+++ b/pkg/db/query/job_queries.go
@@ -2,9 +2,11 @@ package query
 
 import (
 	"database/sql"
+	"errors"
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/db"
@@ -54,7 +56,9 @@ func ProwJobSimilarName(dbc *db.DB, rootName, release string) ([]models.ProwJob,
 	if q.Error != nil {
 		return nil, q.Error
 	}
-	q.Scan(&jobs)
+	if err := q.Scan(&jobs).Error; err != nil {
+		return nil, err
+	}
 
 	return jobs, nil
 }
@@ -66,7 +70,9 @@ func ProwJobRunIDs(dbc *db.DB, prowJobID uint) ([]uint, error) {
 	if q.Error != nil {
 		return nil, q.Error
 	}
-	q.Scan(&jobIDs)
+	if err := q.Scan(&jobIDs).Error; err != nil {
+		return nil, err
+	}
 
 	return jobIDs, nil
 }
@@ -86,7 +92,12 @@ func ProwJobHistoricalTestCounts(dbc *db.DB, prowJobID uint, release string) (in
 		return 0, q.Error
 	}
 
-	q.First(&historicalProwJobRunTestCount)
+	if err := q.First(&historicalProwJobRunTestCount).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return 0, nil
+		}
+		return 0, err
+	}
 
 	return int(historicalProwJobRunTestCount), nil
 }
@@ -105,7 +116,9 @@ func JobReports(dbc *db.DB, filterOpts *filter.FilterOptions, release string, st
 		return jobReports, err
 	}
 
-	q.Scan(&jobReports)
+	if err := q.Scan(&jobReports).Error; err != nil {
+		return nil, err
+	}
 	elapsed := time.Since(now)
 	log.Infof("JobReports completed in %s with %d results from db", elapsed, len(jobReports))
 
@@ -149,7 +162,9 @@ ORDER BY current_pass_percentage ASC;
 	if q.Error != nil {
 		return nil, q.Error
 	}
-	q.Scan(&variantResults)
+	if err := q.Scan(&variantResults).Error; err != nil {
+		return nil, err
+	}
 	return variantResults, nil
 }
 
@@ -162,7 +177,9 @@ func ListFilteredJobIDs(dbc *db.DB, release string, fil *filter.Filter, start, b
 	}
 
 	jobs := make([]int, 0)
-	q.Pluck("id", &jobs)
+	if err := q.Pluck("id", &jobs).Error; err != nil {
+		return nil, err
+	}
 	log.WithField("jobIDs", jobs).Debug("found job IDs after filtering")
 	return jobs, nil
 }

--- a/pkg/db/query/pull_request_queries.go
+++ b/pkg/db/query/pull_request_queries.go
@@ -37,7 +37,9 @@ func PullRequestReport(dbc *db.DB, filterOpts *filter.FilterOptions, release str
 	if err != nil {
 		return results, err
 	}
-	q.Scan(&results)
+	if err := q.Scan(&results).Error; err != nil {
+		return nil, err
+	}
 	return results, nil
 }
 

--- a/pkg/db/query/repository_queries.go
+++ b/pkg/db/query/repository_queries.go
@@ -36,7 +36,9 @@ func RepositoryReport(dbc *db.DB, filterOpts *filter.FilterOptions, release stri
 	if err != nil {
 		return results, err
 	}
-	q.Scan(&results)
+	if err := q.Scan(&results).Error; err != nil {
+		return nil, err
+	}
 	return results, nil
 }
 


### PR DESCRIPTION
## Summary
- 19 GORM query operations (`.Scan`, `.Find`, `.First`, `.Count`, `.Pluck`) were not checking `.Error`, causing database errors to be silently swallowed. Missing tables, connection issues, or query timeouts would return empty results with no indication of failure.
- This was discovered when three materialized views went missing from prod ([TRT-2716](https://redhat.atlassian.net/browse/TRT-2716)) — queries against them silently returned empty data instead of surfacing the error.

### Files changed
- `pkg/api/job_analysis.go` — 2 instances
- `pkg/api/releases.go` — 5 instances
- `pkg/api/tests.go` — 1 instance
- `pkg/api/job_runs.go` — 2 instances
- `pkg/db/query/job_queries.go` — 6 instances
- `pkg/db/query/repository_queries.go` — 1 instance
- `pkg/db/query/pull_request_queries.go` — 1 instance

## Test plan
- [x] Full project compiles with `go build ./...`
- [x] `go vet` clean
- [x] `go test ./pkg/api/...` passes
- [ ] CI passes

Related: https://issues.redhat.com/browse/TRT-2716

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Database error handling improvements** – Database operations in job analysis, test results, releases, and repository reports now properly detect and report failures instead of silently ignoring them, improving system reliability and error visibility across reporting features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->