### PR TITLE
[WIP] Add 14-day time bound to failed-tests matviews

### DIFF
--- a/pkg/api/job_analysis.go
+++ b/pkg/api/job_analysis.go
@@ -109,6 +109,7 @@ func PrintJobAnalysisJSONFromDB(
 	}
 	tr := make([]testResult, 0)
 
+	// These matviews only contain data for the last ~14 days.
 	jr := dbc.DB.Table("prow_job_failed_tests_by_day_matview")
 	if period == PeriodHour {
 		jr = dbc.DB.Table("prow_job_failed_tests_by_hour_matview")

--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -429,6 +429,7 @@ SELECT date_trunc('|||BY|||'::text, pjrt.prow_job_run_timestamp) AS period,
 FROM prow_job_run_tests pjrt
    JOIN tests tests ON pjrt.test_id = tests.id
 WHERE pjrt.status = 12
+  AND pjrt.prow_job_run_timestamp > (|||TIMENOW||| - '15 days'::interval)
 GROUP BY tests.name, (date_trunc('|||BY|||'::text, pjrt.prow_job_run_timestamp)), pjrt.prow_job_id
 `
 


### PR DESCRIPTION
## Summary
- The `prow_job_failed_tests_by_day` and `prow_job_failed_tests_by_hour` materialized views scanned the entire `prow_job_run_tests` table with no time filter, taking **~3 minutes per refresh**. The only consumer (job analysis page) uses a 14-day window.
- Adding a 15-day time bound (14 days plus 1 day of buffer for refresh timing) enables RANGE partition pruning within each release, reducing refresh time and row count.

## Benchmarks (staging, `enable_partitionwise_join = on`)

| Approach | Refresh time | Row count |
|---|---|---|
| No time bound (current) | **~3 minutes** | 1,280,753 |
| 15-day bound | **~1 minute** | 133,295 |

Matview read performance is unchanged (~46ms).

## Alternative
PR #3647 removes the matviews entirely and queries the partitioned table directly (~249ms warm reads, no refresh needed). This PR is a smaller, lower-risk change that keeps the matview pattern.

## Test plan
- [x] Full project compiles with `go build ./...`
- [x] `go vet` clean
- [x] Benchmarked refresh time on staging
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)