### PR TITLE
add composite index on (release, timestamp) to job runs matview

### DIFF
--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -36,9 +36,10 @@ var PostgresMatViews = []PostgresView{
 		},
 	},
 	{
-		Name:         "prow_job_runs_report_matview",
-		Definition:   jobRunsReportMatView,
-		IndexColumns: []string{"id"},
+		Name:              "prow_job_runs_report_matview",
+		Definition:        jobRunsReportMatView,
+		IndexColumns:      []string{"id"},
+		AdditionalIndexes: []string{"release, timestamp DESC"},
 	},
 	{
 		Name:         "prow_job_failed_tests_by_day_matview",
@@ -103,6 +104,10 @@ type PostgresView struct {
 	// replaced if changes are made to these values. IndexColumns are required as we need them defined to be able to
 	// refresh materialized views concurrently. (avoiding locking reads for several minutes while we update)
 	IndexColumns []string
+	// AdditionalIndexes are non-unique indexes to create on the materialized view for query performance.
+	// Each entry is a raw column expression (e.g. "release, timestamp DESC") and will be named
+	// idx_[Name]_[sequence].
+	AdditionalIndexes []string
 	// RefreshPhase controls the order in which matviews are refreshed. All matviews
 	// in phase 0 refresh first (concurrently), then all in phase 1, and so on.
 	// Use this when a matview reads from another matview and needs it to be up-to-date.
@@ -163,6 +168,15 @@ func syncPostgresMaterializedViews(db *gorm.DB, reportEnd *time.Time) error {
 		dropSQL = fmt.Sprintf("DROP INDEX IF EXISTS %s", indexName)
 		if _, err := syncSchema(db, hashTypeMatViewIndex, indexName, index, dropSQL, matViewUpdated); err != nil {
 			return err
+		}
+
+		for i, cols := range pmv.AdditionalIndexes {
+			idxName := fmt.Sprintf("idx_%s_%d", pmv.Name, i)
+			idxSQL := fmt.Sprintf("CREATE INDEX %s ON %s(%s)", idxName, pmv.Name, cols)
+			dropSQL = fmt.Sprintf("DROP INDEX IF EXISTS %s", idxName)
+			if _, err := syncSchema(db, hashTypeMatViewIndex, idxName, idxSQL, dropSQL, matViewUpdated); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add `AdditionalIndexes` field to `PostgresView` for non-unique indexes alongside the required unique index
- Add a `(release, timestamp DESC)` index on `prow_job_runs_report_matview`

## Problem
Every query against `prow_job_runs_report_matview` filters by `release` and sorts by `timestamp DESC`, but only `id` was indexed. This forced sequential scans across all ~527K rows for every paginated request to `/api/jobs/runs`.

## Benchmarks (staging)

With the matview data warm in shared_buffers, typical `/api/jobs/runs` response times are 350-700ms. With the index, the database portion of the query drops from a sequential scan (~120ms warm for COUNT, longer for the paginated SELECT) to an index scan (15ms for COUNT, sub-millisecond for paginated SELECT). The index also eliminates the sort step since the data is pre-ordered.

The improvement is more pronounced under cold-cache conditions (e.g. after a matview refresh evicts pages): the sequential scan rises to 2+ seconds while the index scan stays sub-millisecond.

**Index build cost**: ~1.2s per matview refresh — negligible against the ~14-minute refresh.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/db/...`
- [x] Verified index is created by `sippy migrate` on staging
- [x] Verified `/api/jobs/runs` response times improve with index present

@coderabbitai pause

🤖 Generated with [Claude Code](https://claude.com/claude-code)