### PR TITLE
use CASCADE when dropping materialized views during schema sync

### DIFF
--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -150,7 +150,10 @@ func syncPostgresMaterializedViews(db *gorm.DB, reportEnd *time.Time) error {
 		// This has to occur after the replaceAll above as they might contain the REPLACE_TIME_NOW constant as well
 		viewDef = strings.ReplaceAll(viewDef, replaceTimeNow, reportEndFmt)
 
-		dropSQL := fmt.Sprintf("DROP MATERIALIZED VIEW IF EXISTS %s", pmv.Name)
+		// CASCADE is safe here: dependent matviews (e.g. collapsed matviews) are
+		// all in PostgresMatViews and will be detected as missing and recreated
+		// by this same sync loop.
+		dropSQL := fmt.Sprintf("DROP MATERIALIZED VIEW IF EXISTS %s CASCADE", pmv.Name)
 		schema := fmt.Sprintf("CREATE MATERIALIZED VIEW %s AS %s WITH NO DATA", pmv.Name, viewDef)
 		matViewUpdated, err := syncSchema(db, hashTypeMatView, pmv.Name, schema, dropSQL, false)
 		if err != nil {

--- a/pkg/db/views_test.go
+++ b/pkg/db/views_test.go
@@ -24,6 +24,26 @@ func TestMatviewSourcesRefreshBeforeDependents(t *testing.T) {
 	}
 }
 
+func TestMatviewSourcesCreatedBeforeDependents(t *testing.T) {
+	indexByName := make(map[string]int)
+	for i, mv := range PostgresMatViews {
+		indexByName[mv.Name] = i
+	}
+
+	for i, mv := range PostgresMatViews {
+		for _, v := range mv.ReplaceStrings {
+			sourceIndex, ok := indexByName[v]
+			if !ok {
+				continue
+			}
+			if sourceIndex >= i {
+				t.Errorf("%s (index %d) depends on %s (index %d), but source must appear earlier in PostgresMatViews for creation order",
+					mv.Name, i, v, sourceIndex)
+			}
+		}
+	}
+}
+
 func TestRefreshByPhase(t *testing.T) {
 	matviews := []PostgresView{
 		{Name: "c", RefreshPhase: 2},


### PR DESCRIPTION
## Summary
- `syncPostgresMaterializedViews` drops and recreates matviews when their SQL definition changes (detected via schema hash). Without CASCADE, this fails if other matviews depend on the one being dropped — e.g., the collapsed matviews (`prow_test_report_7d_collapsed_matview`) depend on the base test report matviews.
- The dependent matviews are detected as missing and recreated by the same sync loop, so CASCADE is safe here.

## Test plan
- [x] `go test ./pkg/db/...` passes (including `TestMatviewSourcesRefreshBeforeDependents`)
- [x] Verify on staging: `go run ./cmd/sippy migrate --database-dsn "$DSN"` completes without "cannot drop materialized view" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved materialized view recreation by adding automatic cascading when dropping views, ensuring dependent objects are handled consistently during updates.
* **Tests**
  * Added coverage to verify materialized view creation order: dependent views now must reference source views that appear earlier, preventing invalid dependency sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->