### PR TITLE
add daily summary table to accelerate matview refreshes

### DIFF
--- a/cmd/sippy/load.go
+++ b/cmd/sippy/load.go
@@ -40,6 +40,7 @@ import (
 	"github.com/openshift/sippy/pkg/dataloader/releaseloader"
 	"github.com/openshift/sippy/pkg/dataloader/testownershiploader"
 	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/dailysummary"
 	"github.com/openshift/sippy/pkg/flags"
 	"github.com/openshift/sippy/pkg/github/commenter"
 )
@@ -347,7 +348,7 @@ func NewLoadCommand() *cobra.Command {
 			log.WithField("elapsed", elapsed).Info("database load complete")
 
 			if refreshMatviews && !f.SkipMatviewRefresh {
-				sippyserver.RefreshData(dbc, cacheClient, false)
+				sippyserver.RefreshData(dbc, cacheClient, false, dailysummary.Options{})
 			}
 
 			elapsed = time.Since(start)

--- a/cmd/sippy/refresh.go
+++ b/cmd/sippy/refresh.go
@@ -1,18 +1,25 @@
 package main
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/openshift/sippy/pkg/db/dailysummary"
 	"github.com/openshift/sippy/pkg/flags"
 	"github.com/openshift/sippy/pkg/sippyserver"
 )
 
 type RefreshFlags struct {
-	DBFlags            *flags.PostgresFlags
-	CacheFlags         *flags.CacheFlags
-	RefreshOnlyIfEmpty bool
+	DBFlags                 *flags.PostgresFlags
+	CacheFlags              *flags.CacheFlags
+	RefreshOnlyIfEmpty      bool
+	RebuildDailySummaries   bool
+	DailySummariesStartDate string
+	DailySummariesEndDate   string
 }
 
 func NewRefreshFlags() *RefreshFlags {
@@ -26,6 +33,32 @@ func (f *RefreshFlags) BindFlags(fs *pflag.FlagSet) {
 	f.DBFlags.BindFlags(fs)
 	f.CacheFlags.BindFlags(fs)
 	fs.BoolVar(&f.RefreshOnlyIfEmpty, "refresh-only-if-empty", f.RefreshOnlyIfEmpty, "only refresh matviews if they're empty")
+	fs.BoolVar(&f.RebuildDailySummaries, "rebuild-daily-summaries", false, "Truncate and rebuild the daily summaries table for the default lookback period (use --daily-summaries-start for older data)")
+	fs.StringVar(&f.DailySummariesStartDate, "daily-summaries-start", "", "Override start date for daily summaries (YYYY-MM-DD)")
+	fs.StringVar(&f.DailySummariesEndDate, "daily-summaries-end", "", "Override end date for daily summaries (YYYY-MM-DD)")
+}
+
+func (f *RefreshFlags) dailySummaryOptions() (dailysummary.Options, error) {
+	opts := dailysummary.Options{Rebuild: f.RebuildDailySummaries}
+	if f.DailySummariesStartDate != "" {
+		t, err := time.Parse("2006-01-02", f.DailySummariesStartDate)
+		if err != nil {
+			return opts, fmt.Errorf("invalid --daily-summaries-start %q: %w", f.DailySummariesStartDate, err)
+		}
+		opts.StartOverride = &t
+	}
+	if f.DailySummariesEndDate != "" {
+		t, err := time.Parse("2006-01-02", f.DailySummariesEndDate)
+		if err != nil {
+			return opts, fmt.Errorf("invalid --daily-summaries-end %q: %w", f.DailySummariesEndDate, err)
+		}
+		opts.EndOverride = &t
+	}
+	if opts.StartOverride != nil && opts.EndOverride != nil && opts.StartOverride.After(*opts.EndOverride) {
+		return opts, fmt.Errorf("--daily-summaries-start (%s) is after --daily-summaries-end (%s)",
+			f.DailySummariesStartDate, f.DailySummariesEndDate)
+	}
+	return opts, nil
 }
 
 func NewRefreshCommand() *cobra.Command {
@@ -46,7 +79,11 @@ func NewRefreshCommand() *cobra.Command {
 			} else if cacheClient == nil {
 				logrus.Warn("no cache provided; refresh will not update cached timestamps, so cached data may not be properly invalidated")
 			}
-			sippyserver.RefreshData(dbc, cacheClient, f.RefreshOnlyIfEmpty)
+			dailySummaryOpts, err := f.dailySummaryOptions()
+			if err != nil {
+				return err
+			}
+			sippyserver.RefreshData(dbc, cacheClient, f.RefreshOnlyIfEmpty, dailySummaryOpts)
 			return nil
 		},
 	}

--- a/cmd/sippy/seed_data.go
+++ b/cmd/sippy/seed_data.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
 	v1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/dailysummary"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/models/jobrunscan"
 	"github.com/openshift/sippy/pkg/flags"
@@ -433,7 +434,8 @@ func seedSyntheticData(dbc *db.DB) error {
 	}
 
 	log.Info("Refreshing materialized views...")
-	sippyserver.RefreshData(dbc, nil, false)
+	seedStart := time.Now().Add(-190 * 24 * time.Hour)
+	sippyserver.RefreshData(dbc, nil, false, dailysummary.Options{StartOverride: &seedStart})
 
 	log.Info("Syncing regressions...")
 	if err := syncRegressions(dbc); err != nil {

--- a/pkg/db/dailysummary/dailysummary.go
+++ b/pkg/db/dailysummary/dailysummary.go
@@ -1,0 +1,233 @@
+package dailysummary
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/openshift/sippy/pkg/db"
+)
+
+const (
+	defaultLookbackDays = 14
+	parallelWorkers     = 4
+)
+
+var valueColumns = []string{"successes", "failures", "flakes", "runs"}
+
+var (
+	insertSQL        = buildInsertSQL()
+	onConflictClause = buildOnConflictClause()
+)
+
+func buildInsertSQL() string {
+	return fmt.Sprintf(`
+		INSERT INTO test_daily_summaries (test_id, prow_job_id, suite_id, release, summary_date, %s)
+		SELECT
+			test_id,
+			prow_job_id,
+			COALESCE(suite_id, 0),
+			prow_job_run_release,
+			date(prow_job_run_timestamp),
+			COUNT(*) FILTER (WHERE status = 1),
+			COUNT(*) FILTER (WHERE status = 12),
+			COUNT(*) FILTER (WHERE status = 13),
+			COUNT(*)
+		FROM prow_job_run_tests
+		WHERE prow_job_run_timestamp >= ?::date
+		  AND prow_job_run_timestamp < (?::date + INTERVAL '1 day')
+		  AND prow_job_run_release = ?
+		GROUP BY test_id, prow_job_id, COALESCE(suite_id, 0), prow_job_run_release, date(prow_job_run_timestamp)`,
+		strings.Join(valueColumns, ", "))
+}
+
+func buildOnConflictClause() string {
+	var setClauses, oldCols, newCols []string
+	for _, col := range valueColumns {
+		setClauses = append(setClauses, fmt.Sprintf("%s = EXCLUDED.%s", col, col))
+		oldCols = append(oldCols, "test_daily_summaries."+col)
+		newCols = append(newCols, "EXCLUDED."+col)
+	}
+
+	return fmt.Sprintf(`
+		ON CONFLICT (test_id, prow_job_id, suite_id, release, summary_date)
+		DO UPDATE SET %s
+		WHERE (%s) IS DISTINCT FROM (%s)`,
+		strings.Join(setClauses, ", "),
+		strings.Join(oldCols, ", "),
+		strings.Join(newCols, ", "))
+}
+
+type summaryStore interface {
+	MaxSummaryDate() (*time.Time, error)
+	Truncate() error
+	Releases() ([]string, error)
+	AggregateRangeForRelease(start, end time.Time, release string, skipConflictDetection bool) error
+}
+
+// Options configures the daily summary refresh.
+type Options struct {
+	Rebuild       bool
+	StartOverride *time.Time
+	EndOverride   *time.Time
+}
+
+// Refresh aggregates prow_job_run_tests into the test_daily_summaries
+// table. It runs before matview refreshes so the matviews read from
+// pre-aggregated data instead of scanning raw rows.
+func Refresh(dbc *db.DB, opts Options) error {
+	return refreshSummaries(&pgStore{dbc: dbc}, opts)
+}
+
+func refreshSummaries(store summaryStore, opts Options) error {
+	loadStart := time.Now()
+	log.Info("refreshing daily summaries")
+
+	if opts.Rebuild {
+		log.Info("rebuild requested, truncating test_daily_summaries")
+		if err := store.Truncate(); err != nil {
+			return fmt.Errorf("truncating table: %w", err)
+		}
+	}
+
+	now := time.Now()
+
+	startDate, endDate, err := dateRange(store, opts, now)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("aggregating daily summaries from %s to %s",
+		startDate.Format("2006-01-02"), endDate.Format("2006-01-02"))
+
+	releases, err := store.Releases()
+	if err != nil {
+		return fmt.Errorf("querying releases: %w", err)
+	}
+
+	skipConflictDetection := opts.Rebuild
+	if !skipConflictDetection {
+		maxDate, err := store.MaxSummaryDate()
+		if err != nil {
+			return fmt.Errorf("checking if table is empty: %w", err)
+		}
+		skipConflictDetection = maxDate == nil
+	}
+
+	if err := aggregateReleases(store, releases, startDate, endDate, skipConflictDetection); err != nil {
+		return err
+	}
+
+	log.WithField("elapsed", time.Since(loadStart)).Info("daily summary refresh complete")
+	return nil
+}
+
+func aggregateReleases(store summaryStore, releases []string, startDate, endDate time.Time, skipConflictDetection bool) error {
+	errs := make(chan error, len(releases))
+	work := make(chan string, len(releases))
+
+	var wg sync.WaitGroup
+	for range parallelWorkers {
+		wg.Go(func() {
+			for release := range work {
+				if err := store.AggregateRangeForRelease(startDate, endDate, release, skipConflictDetection); err != nil {
+					errs <- fmt.Errorf("aggregating release %s: %w", release, err)
+					return
+				}
+				log.WithField("release", release).Debug("aggregated daily summary for release")
+			}
+		})
+	}
+
+	for _, release := range releases {
+		work <- release
+	}
+	close(work)
+	wg.Wait()
+	close(errs)
+
+	var combined []error
+	for err := range errs {
+		combined = append(combined, err)
+	}
+	return errors.Join(combined...)
+}
+
+// dateRange computes the aggregation window. If explicit overrides were
+// provided, those are used directly. Otherwise the start is the last
+// summarized date (capped at yesterday) or the default lookback,
+// and the end is now.
+func dateRange(store summaryStore, opts Options, now time.Time) (time.Time, time.Time, error) {
+	if opts.StartOverride != nil && opts.EndOverride != nil {
+		return *opts.StartOverride, *opts.EndOverride, nil
+	}
+
+	endDate := now
+	if opts.EndOverride != nil {
+		endDate = *opts.EndOverride
+	}
+
+	if opts.StartOverride != nil {
+		return *opts.StartOverride, endDate, nil
+	}
+
+	startDate, err := resolveStartDate(store, now)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("querying max summary date: %w", err)
+	}
+
+	return startDate, endDate, nil
+}
+
+// resolveStartDate returns the last summarized date capped at yesterday,
+// or the default lookback if no summaries exist.
+func resolveStartDate(store summaryStore, now time.Time) (time.Time, error) {
+	yesterday := now.AddDate(0, 0, -1)
+
+	maxSummary, err := store.MaxSummaryDate()
+	if err != nil {
+		return time.Time{}, err
+	}
+	if maxSummary != nil {
+		if maxSummary.Before(yesterday) {
+			return *maxSummary, nil
+		}
+		return yesterday, nil
+	}
+
+	return now.AddDate(0, 0, -defaultLookbackDays), nil
+}
+
+// pgStore implements summaryStore against PostgreSQL.
+type pgStore struct {
+	dbc *db.DB
+}
+
+func (s *pgStore) MaxSummaryDate() (*time.Time, error) {
+	var maxDate *time.Time
+	err := s.dbc.DB.Table("test_daily_summaries").
+		Select("MAX(summary_date)").Row().Scan(&maxDate)
+	return maxDate, err
+}
+
+func (s *pgStore) Truncate() error {
+	return s.dbc.DB.Exec("TRUNCATE test_daily_summaries").Error
+}
+
+func (s *pgStore) Releases() ([]string, error) {
+	var releases []string
+	err := s.dbc.DB.Table("prow_jobs").Distinct("release").Pluck("release", &releases).Error
+	return releases, err
+}
+
+func (s *pgStore) AggregateRangeForRelease(startDate, endDate time.Time, release string, skipConflictDetection bool) error {
+	sql := insertSQL
+	if !skipConflictDetection {
+		sql += onConflictClause
+	}
+	return s.dbc.DB.Exec(sql, startDate, endDate, release).Error
+}

--- a/pkg/db/dailysummary/dailysummary.go
+++ b/pkg/db/dailysummary/dailysummary.go
@@ -87,13 +87,6 @@ func refreshSummaries(store summaryStore, opts Options) error {
 	loadStart := time.Now()
 	log.Info("refreshing daily summaries")
 
-	if opts.Rebuild {
-		log.Info("rebuild requested, truncating test_daily_summaries")
-		if err := store.Truncate(); err != nil {
-			return fmt.Errorf("truncating table: %w", err)
-		}
-	}
-
 	now := time.Now()
 
 	startDate, endDate, err := dateRange(store, opts, now)
@@ -101,22 +94,27 @@ func refreshSummaries(store summaryStore, opts Options) error {
 		return err
 	}
 
-	log.Infof("aggregating daily summaries from %s to %s",
-		startDate.Format("2006-01-02"), endDate.Format("2006-01-02"))
-
 	releases, err := store.Releases()
 	if err != nil {
 		return fmt.Errorf("querying releases: %w", err)
 	}
 
 	skipConflictDetection := opts.Rebuild
-	if !skipConflictDetection {
+	if skipConflictDetection {
+		log.Info("rebuild requested, truncating test_daily_summaries")
+		if err := store.Truncate(); err != nil {
+			return fmt.Errorf("truncating table: %w", err)
+		}
+	} else {
 		maxDate, err := store.MaxSummaryDate()
 		if err != nil {
 			return fmt.Errorf("checking if table is empty: %w", err)
 		}
 		skipConflictDetection = maxDate == nil
 	}
+
+	log.Infof("aggregating daily summaries from %s to %s",
+		startDate.Format("2006-01-02"), endDate.Format("2006-01-02"))
 
 	if err := aggregateReleases(store, releases, startDate, endDate, skipConflictDetection); err != nil {
 		return err
@@ -136,7 +134,7 @@ func aggregateReleases(store summaryStore, releases []string, startDate, endDate
 			for release := range work {
 				if err := store.AggregateRangeForRelease(startDate, endDate, release, skipConflictDetection); err != nil {
 					errs <- fmt.Errorf("aggregating release %s: %w", release, err)
-					return
+					continue
 				}
 				log.WithField("release", release).Debug("aggregated daily summary for release")
 			}
@@ -173,6 +171,10 @@ func dateRange(store summaryStore, opts Options, now time.Time) (time.Time, time
 
 	if opts.StartOverride != nil {
 		return *opts.StartOverride, endDate, nil
+	}
+
+	if opts.Rebuild {
+		return now.AddDate(0, 0, -defaultLookbackDays), endDate, nil
 	}
 
 	startDate, err := resolveStartDate(store, now)

--- a/pkg/db/dailysummary/dailysummary_test.go
+++ b/pkg/db/dailysummary/dailysummary_test.go
@@ -1,0 +1,238 @@
+package dailysummary
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeStore struct {
+	maxSummary    *time.Time
+	maxSummaryErr error
+	truncated     bool
+	truncateErr   error
+	releases      []string
+	releasesErr   error
+	aggregateErr  error
+
+	mu    sync.Mutex
+	calls []aggregateCall
+}
+
+type aggregateCall struct {
+	start, end            time.Time
+	release               string
+	skipConflictDetection bool
+}
+
+func (f *fakeStore) MaxSummaryDate() (*time.Time, error) {
+	return f.maxSummary, f.maxSummaryErr
+}
+
+func (f *fakeStore) Truncate() error {
+	f.truncated = true
+	return f.truncateErr
+}
+
+func (f *fakeStore) Releases() ([]string, error) {
+	if f.releases != nil {
+		return f.releases, f.releasesErr
+	}
+	return []string{"4.22", "5.0"}, f.releasesErr
+}
+
+func (f *fakeStore) AggregateRangeForRelease(start, end time.Time, release string, skipConflictDetection bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, aggregateCall{start: start, end: end, release: release, skipConflictDetection: skipConflictDetection})
+	return f.aggregateErr
+}
+
+func (f *fakeStore) getCalls() []aggregateCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	result := make([]aggregateCall, len(f.calls))
+	copy(result, f.calls)
+	return result
+}
+
+func (f *fakeStore) allSkippedConflictDetection() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, c := range f.calls {
+		if !c.skipConflictDetection {
+			return false
+		}
+	}
+	return true
+}
+
+func (f *fakeStore) noneSkippedConflictDetection() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, c := range f.calls {
+		if c.skipConflictDetection {
+			return false
+		}
+	}
+	return true
+}
+
+func TestRefresh_Incremental(t *testing.T) {
+	maxDate := time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC)
+	store := &fakeStore{maxSummary: &maxDate}
+
+	err := refreshSummaries(store, Options{})
+
+	require.NoError(t, err)
+	assert.Len(t, store.getCalls(), 2)
+	assert.True(t, store.noneSkippedConflictDetection())
+	assert.False(t, store.truncated)
+}
+
+func TestRefresh_IncrementalCapsAtYesterday(t *testing.T) {
+	future := time.Now().AddDate(0, 0, 1)
+	store := &fakeStore{maxSummary: &future}
+
+	err := refreshSummaries(store, Options{})
+
+	require.NoError(t, err)
+	calls := store.getCalls()
+	require.NotEmpty(t, calls)
+	assert.True(t, calls[0].start.Before(future))
+}
+
+func TestRefresh_EmptyTableUsesDefaultLookbackAndSkipsConflictDetection(t *testing.T) {
+	store := &fakeStore{}
+
+	err := refreshSummaries(store, Options{})
+
+	require.NoError(t, err)
+	calls := store.getCalls()
+	require.NotEmpty(t, calls)
+	daysBefore := time.Since(calls[0].start).Hours() / 24
+	assert.InDelta(t, defaultLookbackDays, daysBefore, 1)
+	assert.True(t, store.allSkippedConflictDetection())
+}
+
+func TestRefresh_RebuildUsesInsert(t *testing.T) {
+	store := &fakeStore{}
+
+	err := refreshSummaries(store, Options{Rebuild: true})
+
+	require.NoError(t, err)
+	assert.True(t, store.truncated)
+	assert.Len(t, store.getCalls(), 2)
+	assert.True(t, store.allSkippedConflictDetection())
+}
+
+func TestRefresh_IncrementalUsesUpsert(t *testing.T) {
+	maxDate := time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC)
+	store := &fakeStore{maxSummary: &maxDate}
+
+	err := refreshSummaries(store, Options{})
+
+	require.NoError(t, err)
+	assert.Len(t, store.getCalls(), 2)
+	assert.True(t, store.noneSkippedConflictDetection())
+}
+
+func TestRefresh_DateOverrides(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	maxDate := time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC)
+	store := &fakeStore{maxSummary: &maxDate}
+
+	err := refreshSummaries(store, Options{StartOverride: &start, EndOverride: &end})
+
+	require.NoError(t, err)
+	calls := store.getCalls()
+	require.Len(t, calls, 2)
+	assert.Equal(t, start, calls[0].start)
+	assert.Equal(t, end, calls[0].end)
+}
+
+func TestRefresh_StartOverrideOnly(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	maxDate := time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC)
+	store := &fakeStore{maxSummary: &maxDate}
+
+	err := refreshSummaries(store, Options{StartOverride: &start})
+
+	require.NoError(t, err)
+	calls := store.getCalls()
+	require.Len(t, calls, 2)
+	assert.Equal(t, start, calls[0].start)
+}
+
+func TestRefresh_TruncateError(t *testing.T) {
+	store := &fakeStore{truncateErr: fmt.Errorf("permission denied")}
+
+	err := refreshSummaries(store, Options{Rebuild: true})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "truncating table")
+	assert.Empty(t, store.getCalls())
+}
+
+func TestRefresh_MaxSummaryDateError(t *testing.T) {
+	store := &fakeStore{maxSummaryErr: fmt.Errorf("connection refused")}
+
+	err := refreshSummaries(store, Options{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max summary date")
+	assert.Empty(t, store.getCalls())
+}
+
+func TestRefresh_ReleasesError(t *testing.T) {
+	store := &fakeStore{releasesErr: fmt.Errorf("connection refused")}
+
+	err := refreshSummaries(store, Options{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "querying releases")
+	assert.Empty(t, store.getCalls())
+}
+
+func TestRefresh_AggregateError(t *testing.T) {
+	maxDate := time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC)
+	store := &fakeStore{maxSummary: &maxDate, aggregateErr: fmt.Errorf("disk full")}
+
+	err := refreshSummaries(store, Options{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aggregating release")
+}
+
+func TestRefresh_NoReleases(t *testing.T) {
+	store := &fakeStore{releases: []string{}}
+
+	err := refreshSummaries(store, Options{})
+
+	require.NoError(t, err)
+	assert.Empty(t, store.getCalls())
+}
+
+func TestRefresh_ParallelProcessesAllReleases(t *testing.T) {
+	releases := []string{"4.18", "4.19", "4.20", "4.21", "4.22", "5.0"}
+	maxDate := time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC)
+	store := &fakeStore{maxSummary: &maxDate, releases: releases}
+
+	err := refreshSummaries(store, Options{})
+
+	require.NoError(t, err)
+	calls := store.getCalls()
+	assert.Len(t, calls, len(releases))
+	seen := make(map[string]bool)
+	for _, call := range calls {
+		seen[call.release] = true
+	}
+	for _, rel := range releases {
+		assert.True(t, seen[rel], "release %s not processed", rel)
+	}
+}

--- a/pkg/db/migrations/000002_create_test_daily_summaries.down.sql
+++ b/pkg/db/migrations/000002_create_test_daily_summaries.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS test_daily_summaries CASCADE;

--- a/pkg/db/migrations/000002_create_test_daily_summaries.up.sql
+++ b/pkg/db/migrations/000002_create_test_daily_summaries.up.sql
@@ -1,0 +1,27 @@
+-- TRT-2676: Create test_daily_summaries table
+--
+-- Pre-aggregates prow_job_run_tests data into daily buckets per
+-- (test_id, prow_job_id, suite_id, release, date). The test report
+-- matviews read from this table instead of scanning 100M+ raw rows,
+-- reducing refresh time from ~30 minutes to ~5.5 minutes.
+--
+-- Flat (non-partitioned) — benchmarks showed this is faster than
+-- release-partitioned for the all-release matview query.
+
+CREATE TABLE IF NOT EXISTS test_daily_summaries (
+    test_id BIGINT NOT NULL,
+    prow_job_id BIGINT NOT NULL,
+    suite_id BIGINT NOT NULL DEFAULT 0,
+    release TEXT NOT NULL,
+    summary_date DATE NOT NULL,
+    successes INT NOT NULL DEFAULT 0,
+    failures INT NOT NULL DEFAULT 0,
+    flakes INT NOT NULL DEFAULT 0,
+    runs INT NOT NULL DEFAULT 0
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_test_daily_summaries_unique
+    ON test_daily_summaries (test_id, prow_job_id, suite_id, release, summary_date);
+
+CREATE INDEX IF NOT EXISTS idx_test_daily_summaries_date
+    ON test_daily_summaries (summary_date);

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -158,6 +158,20 @@ type TestAnalysisByJobByDate struct {
 	Failures int
 }
 
+// TestDailySummary stores pre-aggregated daily test results used to
+// accelerate matview refreshes. Table managed by migration 000002.
+type TestDailySummary struct {
+	TestID      uint      `gorm:"column:test_id;not null"`
+	ProwJobID   uint      `gorm:"column:prow_job_id;not null"`
+	SuiteID     uint      `gorm:"column:suite_id;not null;default:0"`
+	Release     string    `gorm:"column:release;not null"`
+	SummaryDate time.Time `gorm:"column:summary_date;type:date;not null"`
+	Successes   int       `gorm:"column:successes;not null;default:0"`
+	Failures    int       `gorm:"column:failures;not null;default:0"`
+	Flakes      int       `gorm:"column:flakes;not null;default:0"`
+	Runs        int       `gorm:"column:runs;not null;default:0"`
+}
+
 // Bug represents a Jira bug.
 type Bug struct {
 	ID              uint           `json:"id" gorm:"primaryKey"`

--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -306,21 +306,21 @@ FROM (
         prow_job_id,
         test_id,
         suite_id,
-        prow_job_run_release,
-        COUNT(*) FILTER (WHERE status = 1  AND prow_job_run_timestamp BETWEEN |||START||| AND |||BOUNDARY|||) AS previous_successes,
-        COUNT(*) FILTER (WHERE status = 13 AND prow_job_run_timestamp BETWEEN |||START||| AND |||BOUNDARY|||) AS previous_flakes,
-        COUNT(*) FILTER (WHERE status = 12 AND prow_job_run_timestamp BETWEEN |||START||| AND |||BOUNDARY|||) AS previous_failures,
-        COUNT(*) FILTER (WHERE prow_job_run_timestamp BETWEEN |||START||| AND |||BOUNDARY|||) AS previous_runs,
-        COUNT(*) FILTER (WHERE status = 1  AND prow_job_run_timestamp BETWEEN |||BOUNDARY||| AND |||END|||) AS current_successes,
-        COUNT(*) FILTER (WHERE status = 13 AND prow_job_run_timestamp BETWEEN |||BOUNDARY||| AND |||END|||) AS current_flakes,
-        COUNT(*) FILTER (WHERE status = 12 AND prow_job_run_timestamp BETWEEN |||BOUNDARY||| AND |||END|||) AS current_failures,
-        COUNT(*) FILTER (WHERE prow_job_run_timestamp BETWEEN |||BOUNDARY||| AND |||END|||) AS current_runs
+        release AS prow_job_run_release,
+        COALESCE(SUM(successes) FILTER (WHERE summary_date >= |||START||| AND summary_date < |||BOUNDARY|||), 0) AS previous_successes,
+        COALESCE(SUM(flakes)    FILTER (WHERE summary_date >= |||START||| AND summary_date < |||BOUNDARY|||), 0) AS previous_flakes,
+        COALESCE(SUM(failures)  FILTER (WHERE summary_date >= |||START||| AND summary_date < |||BOUNDARY|||), 0) AS previous_failures,
+        COALESCE(SUM(runs)      FILTER (WHERE summary_date >= |||START||| AND summary_date < |||BOUNDARY|||), 0) AS previous_runs,
+        COALESCE(SUM(successes) FILTER (WHERE summary_date >= |||BOUNDARY||| AND summary_date <= |||END|||), 0) AS current_successes,
+        COALESCE(SUM(flakes)    FILTER (WHERE summary_date >= |||BOUNDARY||| AND summary_date <= |||END|||), 0) AS current_flakes,
+        COALESCE(SUM(failures)  FILTER (WHERE summary_date >= |||BOUNDARY||| AND summary_date <= |||END|||), 0) AS current_failures,
+        COALESCE(SUM(runs)      FILTER (WHERE summary_date >= |||BOUNDARY||| AND summary_date <= |||END|||), 0) AS current_runs
       FROM
-        prow_job_run_tests
+        test_daily_summaries
       WHERE
-        prow_job_run_timestamp >= |||START||| AND prow_job_run_timestamp <= |||END|||
+        summary_date >= |||START||| AND summary_date <= |||END|||
       GROUP BY
-        prow_job_id, test_id, suite_id, prow_job_run_release
+        prow_job_id, test_id, suite_id, release
     )
     SELECT
         tests.id,

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -13,6 +13,7 @@ import (
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	v1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/dailysummary"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/filter"
@@ -1230,7 +1231,7 @@ func Test_BenchmarkRefreshData(t *testing.T) {
 	r := runBenchmarkCase(t, dbc, benchmarkCase{
 		name: "RefreshData",
 		fn: func(dbc *db.DB) error {
-			sippyserver.RefreshData(dbc, nil, false)
+			sippyserver.RefreshData(dbc, nil, false, dailysummary.Options{})
 			return nil
 		},
 	}, 1)

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -391,9 +391,10 @@ func RefreshData(dbc *db.DB, cacheClient cache.Cache, refreshMatviewsOnlyIfEmpty
 	log.Infof("Refreshing data")
 	summaryStart := time.Now()
 	if err := dailysummary.Refresh(dbc, dailySummaryOpts); err != nil {
-		log.WithError(err).Error("failed to refresh daily summaries, matview refresh will use stale summary data")
+		log.WithError(err).Error("failed to refresh daily summaries")
+	} else {
+		dailySummaryRefreshMetric.Observe(float64(time.Since(summaryStart).Milliseconds()))
 	}
-	dailySummaryRefreshMetric.Observe(float64(time.Since(summaryStart).Milliseconds()))
 	refreshMaterializedViews(dbc, cacheClient, refreshMatviewsOnlyIfEmpty)
 	log.Info("Refresh complete")
 }

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -54,6 +54,7 @@ import (
 	sippyv1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 	sippybq "github.com/openshift/sippy/pkg/bigquery"
 	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/dailysummary"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/filter"
@@ -142,6 +143,12 @@ var allMatViewsRefreshMetric = promauto.NewHistogram(prometheus.HistogramOpts{
 	Name:    "sippy_all_matviews_refresh_millis",
 	Help:    "Milliseconds to refresh our postgresql materialized views",
 	Buckets: []float64{5000, 10000, 30000, 60000, 300000, 600000, 1200000, 1800000, 2400000, 3000000, 3600000},
+})
+
+var dailySummaryRefreshMetric = promauto.NewHistogram(prometheus.HistogramOpts{
+	Name:    "sippy_daily_summary_refresh_millis",
+	Help:    "Milliseconds to refresh the daily summary table",
+	Buckets: []float64{1000, 5000, 10000, 30000, 60000, 300000, 600000, 1200000},
 })
 
 var matViewUniqueNumberOfTests = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -380,8 +387,13 @@ func recordMatviewRefreshTime(cacheClient cache.Cache, matView string, tmpLog *l
 	}
 }
 
-func RefreshData(dbc *db.DB, cacheClient cache.Cache, refreshMatviewsOnlyIfEmpty bool) {
+func RefreshData(dbc *db.DB, cacheClient cache.Cache, refreshMatviewsOnlyIfEmpty bool, dailySummaryOpts dailysummary.Options) {
 	log.Infof("Refreshing data")
+	summaryStart := time.Now()
+	if err := dailysummary.Refresh(dbc, dailySummaryOpts); err != nil {
+		log.WithError(err).Error("failed to refresh daily summaries, matview refresh will use stale summary data")
+	}
+	dailySummaryRefreshMetric.Observe(float64(time.Since(summaryStart).Milliseconds()))
 	refreshMaterializedViews(dbc, cacheClient, refreshMatviewsOnlyIfEmpty)
 	log.Info("Refresh complete")
 }

--- a/scripts/updatesuites.go
+++ b/scripts/updatesuites.go
@@ -12,6 +12,7 @@ import (
 	gormlogger "gorm.io/gorm/logger"
 
 	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/dailysummary"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/sippyserver"
 )
@@ -153,7 +154,7 @@ func testNameWithoutSuite(dbc *gorm.DB) error {
 	// NOTE: does not update timestamps to invalidate cached matview data; not clear if the use case for this script requires that.
 	sippyserver.RefreshData(&db.DB{
 		DB: dbc,
-	}, nil, false)
+	}, nil, false, dailysummary.Options{Rebuild: true})
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- Adds a `test_daily_summaries` table that pre-aggregates `prow_job_run_tests` data into daily buckets per (test_id, prow_job_id, suite_id, release, date)
- Changes the test report matview definitions to read from this summary table instead of scanning ~100M+ raw rows
- Daily summary refresh runs automatically before matview refreshes as part of `RefreshData()`

**Depends on:** #3658 (CASCADE drop for matviews)

## Benchmark results (staging)

| Step | Before | After |
|---|---|---|
| Daily summary update (2 days, incremental) | — | ~1-2 min |
| 7d matview CONCURRENT refresh | ~30 min | ~12 min |
| 2d matview CONCURRENT refresh | ~25 min | ~8 min |

## Boundary precision change

The original matviews used exact timestamp boundaries (e.g., `NOW() - INTERVAL '7 DAY'` = 7×24 hours ago). The daily summary quantizes to calendar day boundaries. This means:
- The boundary between "current" and "previous" windows aligns to midnight UTC instead of the exact refresh timestamp
- For the 7-day window: up to ±1 day of data shifts between windows at the boundary (~14% of one day's counts)
- For the 2-day window: up to ±1 day shift (~50% of one boundary day's counts)

This is acceptable because the matview already uses `NOW()` which shifts continuously — each refresh produces slightly different results. The daily summary quantizes this shift to midnight UTC boundaries.

## Key design decisions

- **Flat table (not partitioned)**: Benchmarks showed non-partitioned is faster for the all-release matview query
- **Per-release aggregation loop**: Each release is aggregated separately so PostgreSQL can prune to that release's partitions in `prow_job_run_tests`, avoiding the 51s planning overhead of evaluating all 3553 sub-partitions
- **Upsert with IS DISTINCT FROM**: Skips updating rows where values haven't changed (12x faster for unchanged data). SET and WHERE columns generated from a shared slice to prevent drift.
- **suite_id NOT NULL DEFAULT 0**: Enables a plain unique index instead of an expression index with COALESCE, which benchmarked 3x faster for upsert conflict resolution
- **No data pruning**: Daily summaries accumulate indefinitely. The `summary_date` index ensures the matview's 14-day filter remains selective as the table grows.
- **Refresh runs in `RefreshData()`**: Not in the load pipeline — this is matview pre-processing, not data loading from an external source

## New CLI flags (on `sippy refresh`)

- `--rebuild-daily-summaries` — Truncate and rebuild for the default lookback period
- `--daily-summaries-start YYYY-MM-DD` — Override start date (for loading historical data)
- `--daily-summaries-end YYYY-MM-DD` — Override end date

## Test plan
- [x] 11 unit tests covering all code paths via fake store
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] End-to-end test on staging with `sippy migrate` + `sippy refresh`
- [x] `make lint`
- [x] `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TRT-2676](https://redhat.atlassian.net/browse/TRT-2676)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daily test summary regeneration controls: `--rebuild-daily-summaries`, `--daily-summaries-start` (YYYY-MM-DD), and `--daily-summaries-end` (YYYY-MM-DD).
  * Introduced pre-aggregated daily test summaries (`test_daily_summaries`) and updated reporting/materialized views to use them.
* **Chores**
  * Daily summaries now refresh during the overall data refresh flow (including seeding and suite refresh), with optional rebuild support.
  * Added tracking for daily summary refresh latency.
  * If daily summary refresh fails, subsequent materialized view refresh is skipped.
* **Tests**
  * Added unit tests for incremental refresh, rebuild mode, date overrides, empty-table behavior, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->