### PR TITLE
UI: show regression/triage ID column in list views

### DIFF
--- a/sippy-ng/src/component_readiness/RegressedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsPanel.js
@@ -144,6 +144,14 @@ export default function RegressedTestsPanel(props) {
         ]
       : []),
     {
+      field: 'regression_id',
+      headerName: 'Regression ID',
+      type: 'number',
+      flex: 6,
+      valueGetter: (params) => params.row.regression?.id,
+      renderCell: (param) => <div>{param.value}</div>,
+    },
+    {
       field: 'component',
       headerName: 'Component',
       flex: 20,

--- a/sippy-ng/src/component_readiness/RegressionPotentialMatchesTab.js
+++ b/sippy-ng/src/component_readiness/RegressionPotentialMatchesTab.js
@@ -159,6 +159,19 @@ export default function RegressionPotentialMatchesTab({
 
   const columns = [
     {
+      field: 'triage_id',
+      headerName: 'Triage ID',
+      type: 'number',
+      flex: 4,
+      align: 'center',
+      valueGetter: (params) => {
+        return params.row.triage.id
+      },
+      renderCell: (param) => (
+        <Typography variant="body2">{param.value}</Typography>
+      ),
+    },
+    {
       field: 'resolution_date',
       valueGetter: (params) => {
         return params.row.triage.resolved?.Valid

--- a/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
@@ -105,6 +105,16 @@ export default function TriagedRegressionTestList(props) {
 
   const columns = [
     {
+      field: 'id',
+      headerName: 'Regression ID',
+      type: 'number',
+      flex: 8,
+      valueGetter: (params) => {
+        return params.row.id
+      },
+      renderCell: (param) => <div>{param.value}</div>,
+    },
+    {
       field: 'test_name',
       headerName: 'Test Name',
       flex: 50,

--- a/sippy-ng/src/component_readiness/TriagedRegressions.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressions.js
@@ -180,6 +180,16 @@ export default function TriagedRegressions({
 
   const columns = [
     {
+      field: 'id',
+      headerName: 'ID',
+      type: 'number',
+      flex: 2,
+      valueGetter: (value) => {
+        return value.row.id
+      },
+      renderCell: (param) => <div>{param.value}</div>,
+    },
+    {
       field: 'resolution_date',
       valueGetter: (value) => {
         return value.row.resolved?.Valid ? 'Resolved' : 'Unresolved'

--- a/sippy-ng/src/component_readiness/TriagedRegressions.test.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressions.test.js
@@ -1,0 +1,63 @@
+import { BrowserRouter } from 'react-router-dom'
+import { createTheme, ThemeProvider } from '@mui/material/styles'
+import { QueryParamProvider } from 'use-query-params'
+import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6'
+import { render, screen, within } from '@testing-library/react'
+import EventEmitter from 'eventemitter3'
+import React from 'react'
+import TriagedRegressions from './TriagedRegressions'
+
+const theme = createTheme()
+
+const renderWithProviders = (ui) =>
+  render(
+    <BrowserRouter>
+      <QueryParamProvider adapter={ReactRouter6Adapter}>
+        <ThemeProvider theme={theme}>{ui}</ThemeProvider>
+      </QueryParamProvider>
+    </BrowserRouter>
+  )
+
+const triageEntries = [
+  {
+    id: 589,
+    description: 'installer failed',
+    type: 'product',
+    url: 'https://issues.redhat.com/browse/OCPBUGS-1',
+    created_at: '2024-09-05T00:00:00Z',
+    updated_at: '2024-09-05T00:00:00Z',
+    resolved: { Valid: false },
+    regressions: [],
+  },
+  {
+    id: 12,
+    description: 'installer failed',
+    type: 'product',
+    url: 'https://issues.redhat.com/browse/OCPBUGS-2',
+    created_at: '2024-09-04T00:00:00Z',
+    updated_at: '2024-09-04T00:00:00Z',
+    resolved: { Valid: false },
+    regressions: [],
+  },
+]
+
+describe('TriagedRegressions ID column', () => {
+  test('renders an ID column header and the triage IDs', () => {
+    renderWithProviders(
+      <TriagedRegressions
+        eventEmitter={new EventEmitter()}
+        triageEntries={triageEntries}
+        allRegressedTests={[]}
+      />
+    )
+
+    // The new ID column header is present.
+    expect(screen.getByRole('columnheader', { name: 'ID' })).toBeInTheDocument()
+
+    // Both triage IDs are shown as visible cell values, which is essential for
+    // distinguishing entries with identical descriptions (e.g. installer failures).
+    const grid = screen.getByRole('grid')
+    expect(within(grid).getByText('589')).toBeInTheDocument()
+    expect(within(grid).getByText('12')).toBeInTheDocument()
+  })
+})

--- a/sippy-ng/src/component_readiness/UpdateTriagePanel.js
+++ b/sippy-ng/src/component_readiness/UpdateTriagePanel.js
@@ -167,6 +167,13 @@ export default function UpdateTriagePanel({
                   ),
                 },
                 {
+                  field: 'id',
+                  headerName: 'Regression ID',
+                  type: 'number',
+                  flex: 8,
+                  renderCell: (param) => <div>{param.value}</div>,
+                },
+                {
                   field: 'test_name',
                   headerName: 'Test Name',
                   flex: 50,

--- a/sippy-ng/src/datagrid/filterUtils.js
+++ b/sippy-ng/src/datagrid/filterUtils.js
@@ -131,6 +131,7 @@ export function evaluateFilter(row, filter, columns = null) {
     case 'contains':
       match = value.includes(filterValue)
       break
+    case '=':
     case 'equals':
       match = value === filterValue
       break

--- a/sippy-ng/src/datagrid/filterUtils.test.js
+++ b/sippy-ng/src/datagrid/filterUtils.test.js
@@ -1,0 +1,113 @@
+import { applyFilterModel, evaluateFilter } from './filterUtils'
+
+describe('evaluateFilter', () => {
+  const row = { id: 589, description: 'installer failed' }
+
+  test('equals matches exact value', () => {
+    const filter = {
+      columnField: 'description',
+      operatorValue: 'equals',
+      value: 'installer failed',
+    }
+    expect(evaluateFilter(row, filter)).toBe(true)
+  })
+
+  test('contains matches substring', () => {
+    const filter = {
+      columnField: 'description',
+      operatorValue: 'contains',
+      value: 'installer',
+    }
+    expect(evaluateFilter(row, filter)).toBe(true)
+  })
+
+  // The numeric column type (used by the ID columns) exposes the '=' operator
+  // in the filter UI. It must behave like an exact match, not a substring match.
+  test("'=' is an exact match for numeric IDs", () => {
+    const filter = { columnField: 'id', operatorValue: '=', value: '589' }
+    expect(evaluateFilter(row, filter)).toBe(true)
+  })
+
+  test("'=' does not match a partial numeric ID", () => {
+    const filter = { columnField: 'id', operatorValue: '=', value: '58' }
+    expect(evaluateFilter(row, filter)).toBe(false)
+
+    const supersetFilter = {
+      columnField: 'id',
+      operatorValue: '=',
+      value: '5890',
+    }
+    expect(evaluateFilter(row, supersetFilter)).toBe(false)
+  })
+
+  test("'!=' negates an exact numeric match", () => {
+    expect(
+      evaluateFilter(row, {
+        columnField: 'id',
+        operatorValue: '!=',
+        value: '589',
+      })
+    ).toBe(false)
+    expect(
+      evaluateFilter(row, {
+        columnField: 'id',
+        operatorValue: '!=',
+        value: '1',
+      })
+    ).toBe(true)
+  })
+
+  test('numeric comparison operators work on IDs', () => {
+    expect(
+      evaluateFilter(row, {
+        columnField: 'id',
+        operatorValue: '>',
+        value: '500',
+      })
+    ).toBe(true)
+    expect(
+      evaluateFilter(row, {
+        columnField: 'id',
+        operatorValue: '<',
+        value: '500',
+      })
+    ).toBe(false)
+  })
+
+  test('uses column valueGetter when provided', () => {
+    const columns = [
+      {
+        field: 'regression_id',
+        valueGetter: (params) => params.row.regression?.id,
+      },
+    ]
+    const regressionRow = { regression: { id: 589 } }
+    const filter = {
+      columnField: 'regression_id',
+      operatorValue: '=',
+      value: '589',
+    }
+    expect(evaluateFilter(regressionRow, filter, columns)).toBe(true)
+  })
+})
+
+describe('applyFilterModel', () => {
+  const rows = [
+    { id: 1, description: 'a' },
+    { id: 22, description: 'b' },
+    { id: 222, description: 'c' },
+  ]
+
+  test('filters numeric IDs by exact match', () => {
+    const filterModel = {
+      items: [{ columnField: 'id', operatorValue: '=', value: '22' }],
+    }
+    const result = applyFilterModel(rows, filterModel)
+    expect(result).toEqual([{ id: 22, description: 'b' }])
+  })
+
+  test('returns all rows when there are no valid filters', () => {
+    expect(applyFilterModel(rows, { items: [] })).toEqual(rows)
+    expect(applyFilterModel(rows, null)).toEqual(rows)
+  })
+})


### PR DESCRIPTION
## Problem

In Sippy's list views (regressions, triages, etc.), each item shows status, description, and other metadata — but not the numeric **ID**. This makes it difficult to refer to specific regressions/triages when discussing them, especially during AI-assisted triage workflows.

The problem is particularly acute for:

- **Untriaged regressions lists**: installer failures often have identical descriptions, making items visually indistinguishable without an ID.
- **Human-AI collaboration**: when the AI agent analyzes 20+ regressions and reports back which ones need manual investigation, IDs are the most unambiguous way to reference specific items (e.g. "regression 589 needs deeper investigation" vs. repeating a long description that may match multiple entries).

## Change

The numeric IDs (`Triage.ID` and `TestRegression.ID`) are already present in the API responses, so this is a **frontend-only** change that surfaces them as a column in the relevant DataGrid list views:

| View | File | Column |
| --- | --- | --- |
| Triages list (`/component_readiness/triages`) | `TriagedRegressions.js` | **ID** |
| Unresolved / Untriaged / All regressions tabs | `RegressedTestsPanel.js` | **Regression ID** |
| Triaged regressions list & triage detail page | `TriagedRegressionTestList.js` | **Regression ID** |
| Potential matching triages grid | `RegressionPotentialMatchesTab.js` | **Triage ID** |
| Remove-regressions grid (Update Triage) | `UpdateTriagePanel.js` | **Regression ID** |

(`TriagePotentialMatches.js` already displayed a Regression ID column.)

Columns use the existing `type: 'number'` idiom (as in `JobTable.js`/`FeatureGates.js`) so they sort numerically, align correctly, and expose numeric filter operators.

## Drive-by fix

While wiring up numeric columns I found a gap in the shared client-side filter (`datagrid/filterUtils.js`): the `=` operator that `type: 'number'` columns expose in the filter UI had no `case` and fell through to the `contains` default — so filtering an ID with `=589` would also match `5890`. Added `=` as an exact-match alias of `equals`. No previous `applyFilterModel`-based grid used a numeric column, so this path was never exercised before.

## Tests

- `datagrid/filterUtils.test.js` — covers the `=` exact-match fix and numeric ID filtering (9 tests).
- `component_readiness/TriagedRegressions.test.js` — renders the grid and asserts the new **ID** column header and ID values appear, using two identical-description entries (the exact disambiguation scenario from the issue).

## Verification

- `npx eslint .` (full project) — clean
- `npx prettier --check` on changed files — clean
- Full Jest suite — 23/23 tests pass
- `react-scripts build` — compiles successfully

Closes #3662

---
🤖 *This PR (description and commits) was generated by AI on behalf of @mkowalski, who has reviewed it.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Regression ID” and “Triage ID” identifier columns across component readiness data grids to improve tracking and visibility.
* **Bug Fixes**
  * Updated client-side filtering to support the `=` equality operator consistently with existing “equals” behavior.
* **Tests**
  * Added/expanded Jest and React Testing Library coverage to verify new grid ID columns render correctly and filtering works for equality, negation, and numeric comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->