### PR TITLE
Improve Component Readiness UI with tabbed views and sorting

### DIFF
--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -1,3 +1,4 @@
+import { AccessibilityModeContext } from '../components/AccessibilityModeProvider'
 import { alpha, InputBase, Typography } from '@mui/material'
 import { formatInTimeZone } from 'date-fns-tz'
 import { safeEncodeURIComponent } from '../helpers'
@@ -18,7 +19,7 @@ import orange from './orange.svg'
 import orange_3d from './extreme-orange.svg'
 import orange_3d_triaged from './extreme-orange-triaged.svg'
 import orange_triaged from './orange-triaged.svg'
-import React from 'react'
+import React, { useContext } from 'react'
 import red from './regressed.svg'
 import red_3d from './extreme.svg'
 import red_3d_triaged from './extreme-triaged.svg'
@@ -264,22 +265,48 @@ export function getStatusAndIcon(
 }
 
 export function StatusLegend() {
+  const { accessibilityModeOn } = useContext(AccessibilityModeContext)
+  const a11y = accessibilityModeOn
   const items = [
-    { src: green, label: 'No Significant Difference' },
-    { src: heart, label: 'Significant Improvement' },
-    { src: green_half_data, label: 'Missing Basis' },
-    { src: green_missing_data, label: 'Missing Basis & Sample' },
-    { src: fixed_waiting, label: 'Fixed (Hopefully)' },
-    { src: red_triaged, label: 'Triaged Regression' },
-    { src: red_3d_triaged, label: 'Extreme Triaged Regression (>15%)' },
-    { src: red, label: 'Significant Regression' },
-    { src: red_3d, label: 'Extreme Regression (>15%)' },
-    { src: fix_failed, label: 'Failed Fix' },
+    { src: a11y ? blue : green, label: 'No Significant Difference' },
+    { src: a11y ? half_blue : green_half_data, label: 'Missing Basis' },
+    {
+      src: a11y ? blue_missing_data : green_missing_data,
+      label: 'Missing Basis & Sample',
+    },
+    {
+      src: a11y ? half_blue : green_half_data,
+      label: 'Missing Sample',
+      style: { transform: 'rotate(180deg)' },
+    },
+    {
+      src: a11y ? fixed_waiting_accessible : fixed_waiting,
+      label: 'Believed Fixed',
+    },
+    { src: a11y ? orange_triaged : red_triaged, label: 'Triaged Regression' },
+    {
+      src: a11y ? orange_3d_triaged : red_3d_triaged,
+      label: 'Extreme Triaged Regression (>15%)',
+    },
+    { src: a11y ? orange : red, label: 'Significant Regression' },
+    { src: a11y ? orange_3d : red_3d, label: 'Extreme Regression (>15%)' },
+    { src: a11y ? fix_failed_accessible : fix_failed, label: 'Failed Fix' },
   ]
 
   return (
-    <div style={{ padding: '8px 0', marginBottom: '12px' }}>
-      <Typography variant="subtitle1" style={{ fontWeight: 'bold' }}>
+    <div
+      style={{
+        padding: '12px 16px',
+        marginBottom: '12px',
+        border: '1px solid #e0e0e0',
+        borderRadius: '4px',
+        textAlign: 'center',
+      }}
+    >
+      <Typography
+        variant="subtitle1"
+        style={{ fontWeight: 'bold', marginBottom: '4px' }}
+      >
         Status Key
       </Typography>
       <div
@@ -289,6 +316,7 @@ export function StatusLegend() {
           gap: '12px 24px',
           padding: '4px 0',
           alignItems: 'center',
+          justifyContent: 'center',
         }}
       >
         {items.map((item) => (
@@ -296,7 +324,13 @@ export function StatusLegend() {
             key={item.label}
             style={{ display: 'flex', alignItems: 'center', gap: '6px' }}
           >
-            <img src={item.src} width="20px" height="20px" alt={item.label} />
+            <img
+              src={item.src}
+              width="20px"
+              height="20px"
+              alt={item.label}
+              style={item.style}
+            />
             <Typography variant="body2">{item.label}</Typography>
           </div>
         ))}

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -155,8 +155,8 @@ export function getStatusAndIcon(
       <img
         alt="SignificantImprovement"
         src={heart}
-        width="15px"
-        height="15px"
+        width="24px"
+        height="24px"
         style={{ filter: `grayscale(${grayFactor}%)` }}
       />
     )
@@ -168,8 +168,8 @@ export function getStatusAndIcon(
       <img
         src={src}
         alt="MissingBasisAndSample"
-        width="15px"
-        height="15px"
+        width="24px"
+        height="24px"
         style={{ filter: `grayscale(${grayFactor}%)` }}
       />
     )
@@ -180,8 +180,8 @@ export function getStatusAndIcon(
       <img
         src={src}
         alt="MissingBasis"
-        width="15px"
-        height="15px"
+        width="24px"
+        height="24px"
         style={{
           filter: `grayscale(${grayFactor}%)`,
         }}
@@ -193,8 +193,8 @@ export function getStatusAndIcon(
     icon = (
       <img
         src={src}
-        width="15px"
-        height="15px"
+        width="24px"
+        height="24px"
         alt="NotSignificant"
         style={{ filter: `grayscale(${grayFactor}%)` }}
       />
@@ -206,8 +206,8 @@ export function getStatusAndIcon(
       <img
         src={src}
         alt="MissingSample"
-        width="15px"
-        height="15px"
+        width="24px"
+        height="24px"
         style={{
           transform: `rotate(180deg)`,
           filter: `grayscale(${grayFactor}%)`,
@@ -217,14 +217,14 @@ export function getStatusAndIcon(
   } else if (status === -150) {
     statusStr = statusStr + 'Fixed (hopefully) regression detected'
     let src = accessibilityMode ? fixed_waiting_accessible : fixed_waiting
-    icon = <img width="15px" height="15px" src={src} alt="Fixed regression" />
+    icon = <img width="24px" height="24px" src={src} alt="Fixed regression" />
   } else if (status === -200) {
     statusStr = statusStr + 'SignificantTriagedRegression detected'
     let src = accessibilityMode ? orange_triaged : red_triaged
     icon = (
       <img
-        width="15px"
-        height="15px"
+        width="24px"
+        height="24px"
         src={src}
         alt="SignificantTriagedRegression"
       />
@@ -235,8 +235,8 @@ export function getStatusAndIcon(
     let src = accessibilityMode ? orange_3d_triaged : red_3d_triaged
     icon = (
       <img
-        width="15px"
-        height="15px"
+        width="24px"
+        height="24px"
         src={src}
         alt="ExtremeTriagedRegression >15%"
       />
@@ -245,22 +245,64 @@ export function getStatusAndIcon(
     statusStr = statusStr + 'SignificantRegression detected'
     let src = accessibilityMode ? orange : red
     icon = (
-      <img width="15px" height="15px" src={src} alt="SignificantRegression" />
+      <img width="24px" height="24px" src={src} alt="SignificantRegression" />
     )
   } else if (status === -500) {
     statusStr =
       statusStr + 'ExtremeRegression detected ( >15% pass rate change)'
     let src = accessibilityMode ? orange_3d : red_3d
     icon = (
-      <img width="15px" height="15px" src={src} alt="ExtremeRegression >15%" />
+      <img width="24px" height="24px" src={src} alt="ExtremeRegression >15%" />
     )
   } else if (status === -1000) {
     statusStr = statusStr + 'Failed fix detected'
     let src = accessibilityMode ? fix_failed_accessible : fix_failed
-    icon = <img width="15px" height="15px" src={src} alt="Fixed regression" />
+    icon = <img width="24px" height="24px" src={src} alt="Fixed regression" />
   }
 
   return [statusStr, icon]
+}
+
+export function StatusLegend() {
+  const items = [
+    { src: green, label: 'No Significant Difference' },
+    { src: heart, label: 'Significant Improvement' },
+    { src: green_half_data, label: 'Missing Basis' },
+    { src: green_missing_data, label: 'Missing Basis & Sample' },
+    { src: fixed_waiting, label: 'Fixed (Hopefully)' },
+    { src: red_triaged, label: 'Triaged Regression' },
+    { src: red_3d_triaged, label: 'Extreme Triaged Regression (>15%)' },
+    { src: red, label: 'Significant Regression' },
+    { src: red_3d, label: 'Extreme Regression (>15%)' },
+    { src: fix_failed, label: 'Failed Fix' },
+  ]
+
+  return (
+    <div style={{ padding: '8px 0', marginBottom: '12px' }}>
+      <Typography variant="subtitle1" style={{ fontWeight: 'bold' }}>
+        Status Key
+      </Typography>
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '12px 24px',
+          padding: '4px 0',
+          alignItems: 'center',
+        }}
+      >
+        {items.map((item) => (
+          <div
+            key={item.label}
+            style={{ display: 'flex', alignItems: 'center', gap: '6px' }}
+          >
+            <img src={item.src} width="20px" height="20px" alt={item.label} />
+            <Typography variant="body2">{item.label}</Typography>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
 }
 
 // The values of a column's key/value pairs (except status) are

--- a/sippy-ng/src/component_readiness/ComponentReadiness.css
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.css
@@ -20,10 +20,9 @@
 }
 
 .cr-comp-read-table {
-  width: auto !important;
+  width: 100% !important;
   margin-top: 0.5em;
   border: 1px solid #eee;
-  table-layout: fixed;
 }
 
 .cr-col-name {

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -710,21 +710,27 @@ export default function ComponentReadiness(props) {
                               new RegExp(escapeRegex(searchRowRegex), 'i')
                             )
 
-                          const rowHasRegression = (componentIndex) =>
-                            data.rows[componentIndex].columns.some(
-                              (column) => column.status <= -200
-                            )
-
-                          const rowMatchesRedOnly = (componentIndex) =>
-                            data.rows[componentIndex].columns.some(
-                              (column) =>
-                                column.status <= -2 &&
+                          const rowVisibleColumns = (componentIndex) =>
+                            data.rows[componentIndex].columns.filter(
+                              (column, idx) =>
                                 formColumnName(column).match(
                                   new RegExp(
                                     escapeRegex(searchColumnRegex),
                                     'i'
                                   )
-                                )
+                                ) &&
+                                keepColumnsList &&
+                                keepColumnsList[idx]
+                            )
+
+                          const rowHasRegression = (componentIndex) =>
+                            rowVisibleColumns(componentIndex).some(
+                              (column) => column.status <= -200
+                            )
+
+                          const rowMatchesRedOnly = (componentIndex) =>
+                            rowVisibleColumns(componentIndex).some(
+                              (column) => column.status <= -2
                             )
 
                           const searchFilteredRows = data.rows
@@ -771,7 +777,7 @@ export default function ComponentReadiness(props) {
                                 sx={{ marginBottom: 1 }}
                               >
                                 <Tab
-                                  label={`🔴 Regressions (${regressionRows.length})`}
+                                  label={`🔴 Regressed Components (${regressionRows.length})`}
                                   value={0}
                                 />
                                 <Tab

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -1,6 +1,15 @@
 import './ComponentReadiness.css'
 import { BooleanParam, StringParam, useQueryParam } from 'use-query-params'
 import {
+  Box,
+  Grid,
+  Tab,
+  TableContainer,
+  Tabs,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import {
   cancelledDataTable,
   formColumnName,
   getColumns,
@@ -12,11 +21,11 @@ import {
   makePageTitle,
   makeRFC3339Time,
   noDataTable,
+  StatusLegend,
 } from './CompReadyUtils'
 import { CompReadyVarsContext } from './CompReadyVars'
 import { escapeRegex } from '../helpers'
 import { grey } from '@mui/material/colors'
-import { Grid, TableContainer, Tooltip, Typography } from '@mui/material'
 import { makeStyles, useTheme } from '@mui/styles'
 import {
   Navigate,
@@ -145,15 +154,16 @@ const useStyles = makeStyles((theme) => ({
     top: 0,
     left: 0,
     zIndex: 1,
+    wordBreak: 'break-word',
   },
   crColJobName: {
     verticalAlign: 'top',
     backgroundColor: theme.palette.mode === 'dark' ? grey[900] : grey['A200'],
   },
   componentName: {
-    width: 175,
-    minWidth: 175,
-    maxWidth: 175,
+    width: 220,
+    minWidth: 220,
+    maxWidth: 220,
     backgroundColor: theme.palette.mode === 'dark' ? grey[800] : 'whitesmoke',
     fontWeight: 'bold',
     position: 'sticky',
@@ -162,17 +172,17 @@ const useStyles = makeStyles((theme) => ({
   },
   crCellResult: {
     backgroundColor: theme.palette.mode === 'dark' ? grey[100] : 'white',
-    height: 50,
-    width: 50,
-    padding: '5px !important',
-    lineHeight: '13px !important',
+    minHeight: 60,
+    padding: '8px !important',
+    lineHeight: '16px !important',
     border: '1px solid #EEE',
+    textAlign: 'center',
   },
   crCellName: {
-    fontSize: '11px !important',
+    fontSize: '14px !important',
   },
   crCellCapabCol: {
-    fontSize: '11px !important',
+    fontSize: '13px !important',
     width: '300px',
   },
 }))
@@ -242,6 +252,7 @@ export default function ComponentReadiness(props) {
   const [warnings, setWarnings] = React.useState([])
 
   const [triageActionTaken, setTriageActionTaken] = React.useState(false)
+  const [componentTab, setComponentTab] = React.useState(0)
 
   const [copyPopoverEl, setCopyPopoverEl] = React.useState(null)
   const copyPopoverOpen = Boolean(copyPopoverEl)
@@ -628,11 +639,15 @@ export default function ComponentReadiness(props) {
                           filterVals={getUpdatedUrlParts(varsContext)}
                           setTriageActionTaken={setTriageActionTaken}
                         />
-                        <TableContainer
-                          component="div"
-                          className="cr-table-wrapper"
-                        >
-                          <Table className="cr-comp-read-table">
+                        {(() => {
+                          const filteredColumns = columnNames.filter(
+                            (column, idx) =>
+                              column.match(
+                                new RegExp(escapeRegex(searchColumnRegex), 'i')
+                              ) && keepColumnsList[idx]
+                          )
+
+                          const renderColumnHeaders = (keyPrefix) => (
                             <TableHead>
                               <TableRow>
                                 <TableCell className={classes.crColResultFull}>
@@ -640,111 +655,151 @@ export default function ComponentReadiness(props) {
                                     Name
                                   </Typography>
                                 </TableCell>
-                                {columnNames
-                                  .filter(
-                                    (column, idx) =>
-                                      column.match(
-                                        new RegExp(
-                                          escapeRegex(searchColumnRegex),
-                                          'i'
-                                        )
-                                      ) && keepColumnsList[idx]
-                                  )
-                                  .map((column, idx) => {
-                                    if (column !== 'Name') {
-                                      return (
-                                        <TableCell
-                                          className={classes.crColResult}
-                                          key={'column' + '-' + idx}
+                                {filteredColumns.map((column, idx) => {
+                                  if (column !== 'Name') {
+                                    return (
+                                      <TableCell
+                                        className={classes.crColResult}
+                                        key={keyPrefix + '-column' + '-' + idx}
+                                      >
+                                        <Tooltip
+                                          title={
+                                            'Single row report for ' + column
+                                          }
                                         >
-                                          <Tooltip
-                                            title={
-                                              'Single row report for ' + column
-                                            }
+                                          <Typography
+                                            className={classes.crCellName}
                                           >
-                                            <Typography
-                                              className={classes.crCellName}
-                                            >
-                                              {' '}
-                                              {column}
-                                            </Typography>
-                                          </Tooltip>
-                                        </TableCell>
-                                      )
-                                    }
-                                  })}
+                                            {' '}
+                                            {column}
+                                          </Typography>
+                                        </Tooltip>
+                                      </TableCell>
+                                    )
+                                  }
+                                })}
                               </TableRow>
                             </TableHead>
-                            <TableBody>
-                              {data.rows
-                                ? Object.keys(data.rows)
-                                    .filter((componentIndex) =>
-                                      data.rows[componentIndex].component.match(
-                                        new RegExp(
-                                          escapeRegex(searchRowRegex),
-                                          'i'
-                                        )
-                                      )
+                          )
+
+                          const renderRow = (componentIndex, keyPrefix) => (
+                            <CompReadyRow
+                              key={keyPrefix + '-' + componentIndex}
+                              componentName={
+                                data.rows[componentIndex].component
+                              }
+                              results={data.rows[componentIndex].columns.filter(
+                                (column, idx) =>
+                                  formColumnName(column).match(
+                                    new RegExp(
+                                      escapeRegex(searchColumnRegex),
+                                      'i'
                                     )
-                                    .filter((componentIndex) =>
-                                      redOnlyChecked
-                                        ? data.rows[
-                                            componentIndex
-                                          ].columns.some(
-                                            // Filter for rows where any of their columns have status <= -2 and accepted by the regex.
-                                            (column) =>
-                                              column.status <= -2 &&
-                                              formColumnName(column).match(
-                                                new RegExp(
-                                                  escapeRegex(
-                                                    searchColumnRegex
-                                                  ),
-                                                  'i'
-                                                )
-                                              )
-                                          )
-                                        : true
-                                    )
-                                    .map((componentIndex) => (
-                                      <CompReadyRow
-                                        key={componentIndex}
-                                        componentName={
-                                          data.rows[componentIndex].component
-                                        }
-                                        results={data.rows[
-                                          componentIndex
-                                        ].columns.filter(
-                                          (column, idx) =>
-                                            formColumnName(column).match(
-                                              new RegExp(
-                                                escapeRegex(searchColumnRegex),
-                                                'i'
-                                              )
-                                            ) &&
-                                            keepColumnsList &&
-                                            keepColumnsList[idx]
-                                        )}
-                                        columnNames={columnNames.filter(
-                                          (column, idx) =>
-                                            column.match(
-                                              new RegExp(
-                                                escapeRegex(searchColumnRegex),
-                                                'i'
-                                              )
-                                            ) &&
-                                            keepColumnsList &&
-                                            keepColumnsList[idx]
-                                        )}
-                                        grayFactor={redOnlyChecked ? 100 : 0}
-                                        filterVals={getUpdatedUrlParts(
-                                          varsContext
-                                        )}
-                                      />
-                                    ))
-                                : null}
-                            </TableBody>
-                          </Table>
-                        </TableContainer>
+                                  ) &&
+                                  keepColumnsList &&
+                                  keepColumnsList[idx]
+                              )}
+                              columnNames={filteredColumns}
+                              grayFactor={redOnlyChecked ? 100 : 0}
+                              filterVals={getUpdatedUrlParts(varsContext)}
+                            />
+                          )
+
+                          const rowMatchesSearch = (componentIndex) =>
+                            data.rows[componentIndex].component.match(
+                              new RegExp(escapeRegex(searchRowRegex), 'i')
+                            )
+
+                          const rowHasRegression = (componentIndex) =>
+                            data.rows[componentIndex].columns.some(
+                              (column) => column.status <= -200
+                            )
+
+                          const rowMatchesRedOnly = (componentIndex) =>
+                            data.rows[componentIndex].columns.some(
+                              (column) =>
+                                column.status <= -2 &&
+                                formColumnName(column).match(
+                                  new RegExp(
+                                    escapeRegex(searchColumnRegex),
+                                    'i'
+                                  )
+                                )
+                            )
+
+                          const searchFilteredRows = data.rows
+                            ? Object.keys(data.rows).filter(rowMatchesSearch)
+                            : []
+
+                          const caseInsensitiveSort = (a, b) =>
+                            data.rows[a].component
+                              .toLowerCase()
+                              .localeCompare(
+                                data.rows[b].component.toLowerCase()
+                              )
+
+                          const regressionRows = searchFilteredRows
+                            .filter(rowHasRegression)
+                            .sort(caseInsensitiveSort)
+
+                          const allRowsSorted = [...searchFilteredRows].sort(
+                            caseInsensitiveSort
+                          )
+
+                          const renderTable = (rows, keyPrefix) => (
+                            <TableContainer
+                              component="div"
+                              className="cr-table-wrapper"
+                            >
+                              <Table className="cr-comp-read-table">
+                                {renderColumnHeaders(keyPrefix)}
+                                <TableBody>
+                                  {rows.map((componentIndex) =>
+                                    renderRow(componentIndex, keyPrefix)
+                                  )}
+                                </TableBody>
+                              </Table>
+                            </TableContainer>
+                          )
+
+                          return (
+                            <Box>
+                              <StatusLegend />
+                              <Tabs
+                                value={componentTab}
+                                onChange={(e, val) => setComponentTab(val)}
+                                sx={{ marginBottom: 1 }}
+                              >
+                                <Tab
+                                  label={`🔴 Regressions (${regressionRows.length})`}
+                                  value={0}
+                                />
+                                <Tab
+                                  label={`📋 All Components (${allRowsSorted.length})`}
+                                  value={1}
+                                />
+                              </Tabs>
+                              {componentTab === 0 &&
+                                (regressionRows.length > 0 ? (
+                                  renderTable(regressionRows, 'reg')
+                                ) : (
+                                  <Typography
+                                    variant="body1"
+                                    sx={{ padding: 2 }}
+                                  >
+                                    No regressions detected.
+                                  </Typography>
+                                ))}
+                              {componentTab === 1 &&
+                                renderTable(
+                                  redOnlyChecked
+                                    ? allRowsSorted.filter(rowMatchesRedOnly)
+                                    : allRowsSorted,
+                                  'all'
+                                )}
+                            </Box>
+                          )
+                        })()}
                         <GeneratedAt time={data.generated_at} />
                         <CopyPageURL apiCallStr={showValuesForReport()} />
                       </div>


### PR DESCRIPTION
## Summary
- Add a tabbed interface separating **Regressions** and **All Components** views with counts, replacing the single mixed table
- Sort all component rows alphabetically (case-insensitive) in both tabs
- Add a **Status Key** legend explaining all status icons
- Increase icon sizes (15px → 24px), font sizes, and cell sizes for modern displays
- Make the table responsive to window resizing by removing fixed table layout

## Test plan
- [ ] Verify the Regressions tab shows only rows with status ≤ -200 (matching backend threshold)
- [ ] Verify the All Components tab shows all rows sorted alphabetically (case-insensitive)
- [ ] Verify the "Show Red Only" checkbox still works on the All Components tab
- [ ] Verify the Status Key displays all icon types with labels
- [ ] Verify the table resizes responsively when the browser window is resized
- [ ] Verify search filters work correctly on both tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added **Regressions** and **All Components** tabs to the component readiness view for quicker filtering.
  * Introduced a **Status Legend** that updates to match the current accessibility mode.

* **UI Improvements**
  * Increased status icon size for improved readability and consistency.
  * Enhanced table usability with better wrapping in the results column and updated column/cell sizing for clearer alignment.

* **Styling**
  * Refined component readiness table layout to better utilize available width and adjusted table layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->