### PR TITLE
ROSAENG-326: Add operator e2e jobs and separate rosa-integration from rosa-stage

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -64,17 +64,27 @@ releases:
     jobs:
       periodic-ci-openshift-release-main-osd-conformance-aws-k8s-conformance: true
     regexp:
-      # rosa-e2e managed service validation + OCM FVT (current and future versioned jobs)
-      - "^periodic-ci-openshift-online-rosa-e2e-main-.*"
+      # rosa-e2e managed service validation nightlies (all run against staging OCM)
+      - "^periodic-ci-openshift-online-rosa-e2e-main-periodics-.*"
+      # rosa-e2e upgrade tests
+      - "^periodic-ci-openshift-online-rosa-e2e-main-upgrade-.*"
+      # OCM FVT staging
+      - "^periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-.*-staging-.*"
       # ROSA Gap Analysis (all versions)
       - "^periodic-ci-openshift-online-rosa-gap-analysis-main-.*"
       # ROSA HCP conformance (all versions)
       - "^periodic-ci-openshift-release-main-nightly-.*-e2e-rosa-hcp-ovn$"
       # ROSA Classic/STS conformance (all versions)
       - "^periodic-ci-openshift-release-main-nightly-.*-e2e-rosa-sts-ovn$"
+      # SRE operator e2e tests via Prow (staging)
+      - "^periodic-ci-openshift-.*-master-rosa-sts-e2e-promotion-stage$"
   rosa-integration:
     synthetic: true
-    jobs: {}
+    regexp:
+      # OCM FVT integration
+      - "^periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-.*-integration-.*"
+      # SRE operator e2e tests via Prow (integration)
+      - "^periodic-ci-openshift-.*-master-rosa-sts-e2e-promotion-int$"
   rosa-production:
     synthetic: true
     jobs: {}


### PR DESCRIPTION
Add SRE operator e2e Prow jobs to rosa-stage and separate integration jobs into rosa-integration.

## Changes

**rosa-stage**: Replace the catch-all `^periodic-ci-openshift-online-rosa-e2e-main-.*` regexp with specific patterns that only match staging-targeted jobs:
- rosa-e2e nightlies (`periodics-*`)
- rosa-e2e upgrade tests (`upgrade-*`)
- OCM FVT staging (`ocm-fvt-*-staging-*`)
- Daily CI status bot
- Gap analysis, conformance, operator e2e (staging)

**rosa-integration**: Populate with integration-targeted jobs (previously empty):
- OCM FVT integration (`ocm-fvt-*-integration-*`)
- Operator e2e integration (`rosa-sts-e2e-promotion-int`)

The old catch-all pattern incorrectly placed 9 integration FVT jobs into the rosa-stage view.

Jira: https://redhat.atlassian.net/browse/ROSAENG-326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined continuous integration test job selection by replacing broad matching with targeted rules for the ROSA staging and integration environments.
  * Expanded coverage to include additional promotion and end-to-end checks for the SRE operator, along with selectors for OCM FVT integration and related validation/staging scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->