### PR TITLE
config: add CAPZ e2e production job to aro-production

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -34,6 +34,7 @@ releases:
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-centralindia-e2e-parallel: true
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-uksouth-e2e-parallel: true
       periodic-ci-Azure-ARO-HCP-main-periodic-prod-e2e-parallel-ocp-nightly: true
+      periodic-ci-Azure-ARO-HCP-main-capz-e2e-production: true
       branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel: true
   aro-classic-integration:
     synthetic: true


### PR DESCRIPTION
## Summary
- Add `periodic-ci-Azure-ARO-HCP-main-capz-e2e-production` to the `aro-production` release in `openshift-customizations.yaml`
- This makes the new ARO-HCP CAPZ e2e production workflow visible in Sippy's production dashboard
- The job was added in [openshift/release#80110](https://github.com/openshift/release/pull/80110) and runs weekdays at 20:00 UTC

## Test plan
- [ ] Verify job appears in the aro-production dashboard after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)