### PR TITLE
ROSAENG-60110: Update ROSA regexps for stg/int job naming

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -65,12 +65,12 @@ releases:
     jobs:
       periodic-ci-openshift-release-main-osd-conformance-aws-k8s-conformance: true
     regexp:
-      # rosa-e2e managed service validation nightlies (all run against staging OCM)
-      - "^periodic-ci-openshift-online-rosa-e2e-main-periodics-.*"
-      # rosa-e2e upgrade tests
-      - "^periodic-ci-openshift-online-rosa-e2e-main-upgrade-.*"
+      # rosa-e2e managed service validation nightlies (stg)
+      - "^periodic-ci-openshift-online-rosa-e2e-main-periodics-.*-stg-.*"
+      # rosa-e2e upgrade tests (stg)
+      - "^periodic-ci-openshift-online-rosa-e2e-main-upgrade-.*-stg-.*"
       # OCM FVT staging
-      - "^periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-.*-staging-.*"
+      - "^periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-.*-stg-.*"
       # ROSA Gap Analysis (all versions)
       - "^periodic-ci-openshift-online-rosa-gap-analysis-main-.*"
       # ROSA HCP conformance (all versions)
@@ -83,7 +83,7 @@ releases:
     synthetic: true
     regexp:
       # OCM FVT integration
-      - "^periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-.*-integration-.*"
+      - "^periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-.*-int-.*"
       # SRE operator e2e tests via Prow (integration)
       - "^periodic-ci-openshift-.*-master-rosa-sts-e2e-promotion-int$"
   rosa-production:


### PR DESCRIPTION
Update rosa-stage and rosa-integration regexp patterns to match the new shorthand environment naming (stg/int/prd) from the openshift/release job rename.

Depends on: https://github.com/openshift/release/pull/80936

Jira: https://redhat.atlassian.net/browse/ROSAENG-60110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test job naming patterns for ROSA e2e staging and integration environments to use standardized naming conventions (`-stg-` for staging, `-int-` for integration), improving consistency across managed service validation, upgrade nightlies, and OCM FVT test patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->