### PR TITLE
Add variant_combinations table for efficient matview grouping

### DIFF
--- a/pkg/db/dailysummary/dailysummary.go
+++ b/pkg/db/dailysummary/dailysummary.go
@@ -17,7 +17,7 @@ const (
 	parallelWorkers     = 4
 )
 
-var valueColumns = []string{"successes", "failures", "flakes", "runs"}
+var valueColumns = []string{"variant_combination_id", "successes", "failures", "flakes", "runs"}
 
 var (
 	insertSQL        = buildInsertSQL()
@@ -28,20 +28,22 @@ func buildInsertSQL() string {
 	return fmt.Sprintf(`
 		INSERT INTO test_daily_summaries (test_id, prow_job_id, suite_id, release, summary_date, %s)
 		SELECT
-			test_id,
-			prow_job_id,
-			COALESCE(suite_id, 0),
-			prow_job_run_release,
-			date(prow_job_run_timestamp),
-			COUNT(*) FILTER (WHERE status = 1),
-			COUNT(*) FILTER (WHERE status = 12),
-			COUNT(*) FILTER (WHERE status = 13),
+			pjrt.test_id,
+			pjrt.prow_job_id,
+			COALESCE(pjrt.suite_id, 0),
+			pjrt.prow_job_run_release,
+			date(pjrt.prow_job_run_timestamp),
+			pj.variant_combination_id,
+			COUNT(*) FILTER (WHERE pjrt.status = 1),
+			COUNT(*) FILTER (WHERE pjrt.status = 12),
+			COUNT(*) FILTER (WHERE pjrt.status = 13),
 			COUNT(*)
-		FROM prow_job_run_tests
-		WHERE prow_job_run_timestamp >= ?::date
-		  AND prow_job_run_timestamp < (?::date + INTERVAL '1 day')
-		  AND prow_job_run_release = ?
-		GROUP BY test_id, prow_job_id, COALESCE(suite_id, 0), prow_job_run_release, date(prow_job_run_timestamp)`,
+		FROM prow_job_run_tests pjrt
+		JOIN prow_jobs pj ON pjrt.prow_job_id = pj.id
+		WHERE pjrt.prow_job_run_timestamp >= ?::date
+		  AND pjrt.prow_job_run_timestamp < (?::date + INTERVAL '1 day')
+		  AND pjrt.prow_job_run_release = ?
+		GROUP BY pjrt.test_id, pjrt.prow_job_id, COALESCE(pjrt.suite_id, 0), pjrt.prow_job_run_release, date(pjrt.prow_job_run_timestamp), pj.variant_combination_id`,
 		strings.Join(valueColumns, ", "))
 }
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -141,6 +141,7 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 		&models.ReleasePullRequest{},
 		&models.ReleaseRepository{},
 		&models.ReleaseJobRun{},
+		&models.VariantCombination{},
 		&models.ProwJob{},
 		&models.ProwJobRun{},
 		&models.ProwJobRunAnnotation{},
@@ -166,6 +167,7 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 		&models.ChatConversation{},
 		&jobrunscan.Label{},
 		&jobrunscan.Symptom{},
+		&models.TestDailySummary{},
 	}
 
 	// Currently we need RunMigrations to run prior
@@ -184,6 +186,10 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 	}
 
 	if err := ensureTriageSymptomCascade(d.DB); err != nil {
+		return err
+	}
+
+	if err := ensureVariantCombinationTrigger(d.DB); err != nil {
 		return err
 	}
 
@@ -534,6 +540,49 @@ func ensureTriageSymptomCascade(db *gorm.DB) error {
 		}
 	}
 	return nil
+}
+
+// ensureVariantCombinationTrigger sets up the variant_combination_id
+// infrastructure that depends on tables created by AutoMigrate:
+//   - Attaches the trigger (function created by migration 000003)
+//   - Backfills variant_combination_id on existing prow_jobs rows
+//   - Adds variant_combination_id to test_daily_summaries and truncates
+//     so the next refresh populates it
+func ensureVariantCombinationTrigger(db *gorm.DB) error {
+	return db.Exec(`
+		DO $$
+		BEGIN
+			-- Attach trigger if not already present
+			IF NOT EXISTS (
+				SELECT 1 FROM pg_trigger WHERE tgname = 'trg_prow_jobs_variant_combination'
+			) THEN
+				CREATE TRIGGER trg_prow_jobs_variant_combination
+					BEFORE INSERT OR UPDATE OF variants ON prow_jobs
+					FOR EACH ROW
+					EXECUTE FUNCTION set_variant_combination_id();
+			END IF;
+
+			-- Backfill existing prow_jobs rows that have NULL variant_combination_id
+			INSERT INTO variant_combinations (variants)
+			SELECT DISTINCT variants FROM prow_jobs
+			WHERE variants IS NOT NULL AND variant_combination_id IS NULL
+			ON CONFLICT (variants) DO NOTHING;
+
+			UPDATE prow_jobs
+			SET variant_combination_id = vc.id
+			FROM variant_combinations vc
+			WHERE prow_jobs.variants = vc.variants
+			  AND prow_jobs.variants IS NOT NULL
+			  AND prow_jobs.variant_combination_id IS NULL;
+
+			-- Truncate test_daily_summaries if any rows lack variant_combination_id
+			-- so the next refresh repopulates with it set.
+			IF EXISTS (
+				SELECT 1 FROM test_daily_summaries WHERE variant_combination_id IS NULL LIMIT 1
+			) THEN
+				TRUNCATE test_daily_summaries;
+			END IF;
+		END $$`).Error
 }
 
 func ParseGormLogLevel(logLevel string) (gormlogger.LogLevel, error) {

--- a/pkg/db/migrations/000003_create_variant_combinations.down.sql
+++ b/pkg/db/migrations/000003_create_variant_combinations.down.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER IF EXISTS trg_prow_jobs_variant_combination ON prow_jobs;
+DROP FUNCTION IF EXISTS set_variant_combination_id();

--- a/pkg/db/migrations/000003_create_variant_combinations.up.sql
+++ b/pkg/db/migrations/000003_create_variant_combinations.up.sql
@@ -1,0 +1,26 @@
+-- Trigger function for variant_combinations
+--
+-- Upserts into variant_combinations and sets the FK on prow_jobs.
+-- Only NULL variants produce a NULL variant_combination_id; empty
+-- arrays ('{}') get their own entry.
+--
+-- The variant_combinations table, prow_jobs.variant_combination_id
+-- column, and FK constraint are created by GORM AutoMigrate. The
+-- trigger is attached by ensureVariantCombinationTrigger after
+-- AutoMigrate ensures prow_jobs exists.
+
+CREATE OR REPLACE FUNCTION set_variant_combination_id()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.variants IS NOT NULL THEN
+        INSERT INTO variant_combinations (variants)
+        VALUES (NEW.variants)
+        ON CONFLICT (variants) DO UPDATE SET variants = EXCLUDED.variants
+        RETURNING id
+        INTO NEW.variant_combination_id;
+    ELSE
+        NEW.variant_combination_id := NULL;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -11,15 +11,26 @@ import (
 
 type ProwKind string
 
+// VariantCombination assigns an integer ID to each unique variants array,
+// enabling efficient GROUP BY in matviews. Populated via a trigger on prow_jobs.
+type VariantCombination struct {
+	ID       uint           `gorm:"primaryKey"`
+	Variants pq.StringArray `gorm:"type:text[];uniqueIndex:idx_variant_combinations_variants;not null"`
+}
+
 // ProwJob represents a prow job and stores data about its variants, associated bugs, etc.
 type ProwJob struct {
 	gorm.Model
 
-	Kind        ProwKind
-	Name        string         `gorm:"unique"`
-	Release     string         `gorm:"index"`
-	Variants    pq.StringArray `gorm:"type:text[];index:idx_prow_jobs_variants,type:gin"`
-	TestGridURL string
+	Kind     ProwKind
+	Name     string         `gorm:"unique"`
+	Release  string         `gorm:"index"`
+	Variants pq.StringArray `gorm:"type:text[];index:idx_prow_jobs_variants,type:gin"`
+	// VariantCombinationID references variant_combinations.id, maintained by a
+	// BEFORE INSERT/UPDATE trigger. NULL only when Variants is NULL.
+	VariantCombinationID *uint `gorm:"column:variant_combination_id"`
+	VariantCombination   *VariantCombination
+	TestGridURL          string
 	// Bugs maps to all the bugs we scanned and found this prowjob name mentioned in the description or any comment.
 	Bugs    []Bug        `gorm:"many2many:bug_jobs;"`
 	JobRuns []ProwJobRun `gorm:"constraint:OnDelete:CASCADE;"`
@@ -161,15 +172,16 @@ type TestAnalysisByJobByDate struct {
 // TestDailySummary stores pre-aggregated daily test results used to
 // accelerate matview refreshes. Table managed by migration 000002.
 type TestDailySummary struct {
-	TestID      uint      `gorm:"column:test_id;not null"`
-	ProwJobID   uint      `gorm:"column:prow_job_id;not null"`
-	SuiteID     uint      `gorm:"column:suite_id;not null;default:0"`
-	Release     string    `gorm:"column:release;not null"`
-	SummaryDate time.Time `gorm:"column:summary_date;type:date;not null"`
-	Successes   int       `gorm:"column:successes;not null;default:0"`
-	Failures    int       `gorm:"column:failures;not null;default:0"`
-	Flakes      int       `gorm:"column:flakes;not null;default:0"`
-	Runs        int       `gorm:"column:runs;not null;default:0"`
+	TestID               uint      `gorm:"column:test_id;not null"`
+	ProwJobID            uint      `gorm:"column:prow_job_id;not null"`
+	SuiteID              uint      `gorm:"column:suite_id;not null;default:0"`
+	Release              string    `gorm:"column:release;not null"`
+	SummaryDate          time.Time `gorm:"column:summary_date;type:date;not null"`
+	VariantCombinationID *uint     `gorm:"column:variant_combination_id"`
+	Successes            int       `gorm:"column:successes;not null;default:0"`
+	Failures             int       `gorm:"column:failures;not null;default:0"`
+	Flakes               int       `gorm:"column:flakes;not null;default:0"`
+	Runs                 int       `gorm:"column:runs;not null;default:0"`
 }
 
 // Bug represents a Jira bug.

--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -17,7 +17,7 @@ var PostgresMatViews = []PostgresView{
 	{
 		Name:         "prow_test_report_7d_matview",
 		Definition:   testReportMatView,
-		IndexColumns: []string{"release", "name", "id", "variants", "suite_name"},
+		IndexColumns: []string{"release", "name", "id", "variant_combination_id", "suite_name"},
 		ReplaceStrings: map[string]string{
 			"|||START|||":    "|||TIMENOW||| - INTERVAL '14 DAY'",
 			"|||BOUNDARY|||": "|||TIMENOW||| - INTERVAL '7 DAY'",
@@ -27,7 +27,7 @@ var PostgresMatViews = []PostgresView{
 	{
 		Name:         "prow_test_report_2d_matview",
 		Definition:   testReportMatView,
-		IndexColumns: []string{"release", "name", "id", "variants", "suite_name"},
+		IndexColumns: []string{"release", "name", "id", "variant_combination_id", "suite_name"},
 		RefreshPhase: 1, // avoid CPU overload from refreshing concurrently with the 7d matview
 		ReplaceStrings: map[string]string{
 			"|||START|||":    "|||TIMENOW||| - INTERVAL '9 DAY'",
@@ -315,7 +315,7 @@ FROM (
     ),
     pre_agg AS (
       SELECT
-        prow_job_id,
+        variant_combination_id,
         test_id,
         suite_id,
         release AS prow_job_run_release,
@@ -332,7 +332,7 @@ FROM (
       WHERE
         summary_date >= |||START||| AND summary_date <= |||END|||
       GROUP BY
-        prow_job_id, test_id, suite_id, release
+        variant_combination_id, test_id, suite_id, release
     )
     SELECT
         tests.id,
@@ -340,16 +340,17 @@ FROM (
         suites.name AS suite_name,
         jira_components.name AS jira_component,
         jira_components.id AS jira_component_id,
-        SUM(pre_agg.previous_successes)::bigint AS previous_successes,
-        SUM(pre_agg.previous_flakes)::bigint AS previous_flakes,
-        SUM(pre_agg.previous_failures)::bigint AS previous_failures,
-        SUM(pre_agg.previous_runs)::bigint AS previous_runs,
-        SUM(pre_agg.current_successes)::bigint AS current_successes,
-        SUM(pre_agg.current_flakes)::bigint AS current_flakes,
-        SUM(pre_agg.current_failures)::bigint AS current_failures,
-        SUM(pre_agg.current_runs)::bigint AS current_runs,
+        pre_agg.previous_successes::bigint AS previous_successes,
+        pre_agg.previous_flakes::bigint AS previous_flakes,
+        pre_agg.previous_failures::bigint AS previous_failures,
+        pre_agg.previous_runs::bigint AS previous_runs,
+        pre_agg.current_successes::bigint AS current_successes,
+        pre_agg.current_flakes::bigint AS current_flakes,
+        pre_agg.current_failures::bigint AS current_failures,
+        pre_agg.current_runs::bigint AS current_runs,
         open_bugs.open_bugs AS open_bugs,
-        prow_jobs.variants,
+        vc.variants,
+        pre_agg.variant_combination_id,
         pre_agg.prow_job_run_release AS release
     FROM
         pre_agg
@@ -358,9 +359,7 @@ FROM (
         LEFT JOIN suites ON suites.id = pre_agg.suite_id
         LEFT JOIN test_ownerships ON (tests.id = test_ownerships.test_id AND pre_agg.suite_id = test_ownerships.suite_id)
         LEFT JOIN jira_components ON test_ownerships.jira_component = jira_components.name
-        JOIN prow_jobs ON pre_agg.prow_job_id = prow_jobs.id
-    GROUP BY
-        tests.id, tests.name, jira_components.name, jira_components.id, suites.name, open_bugs.open_bugs, prow_jobs.variants, pre_agg.prow_job_run_release
+        LEFT JOIN variant_combinations vc ON pre_agg.variant_combination_id = vc.id
 ) AS base
 WINDOW w AS (PARTITION BY base.id, base.suite_name, base.release)
 `


### PR DESCRIPTION
## Summary

- Introduces a `variant_combinations` table that assigns a SERIAL integer ID to each unique `prow_jobs.variants` array
- A `BEFORE INSERT OR UPDATE` trigger on `prow_jobs` automatically maintains the FK, requiring no Go loader changes
- Denormalizes `variant_combination_id` into `test_daily_summaries` for single-stage matview aggregation
- Updates the `testReportMatView` definition to GROUP BY `variant_combination_id` (int4) directly from `test_daily_summaries`, eliminating the previous two-stage aggregation (per-job → per-variant-combo collapse)

### Benchmark results (staging, 18K jobs, 45M daily summary rows)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Matview query (7d) | ~158s | ~69s | **56% faster** |
| Pre-agg intermediate rows | 8.7M | 4.8M (direct) | Eliminated collapse step |

### Migration details

- Creates `variant_combinations` table + trigger + backfill (~4.5s on staging)
- Truncates `test_daily_summaries` (repopulated on next refresh with `variant_combination_id` set)
- Matview schema auto-detected as changed and recreated by `syncPostgresMaterializedViews`

## Test plan

- [x] Migration up/down/up cycle verified on seed and staging databases
- [x] `go build ./...` and `go test ./pkg/db/...` pass
- [x] Full refresh on staging completes successfully (daily summaries + all matviews)
- [x] Matview data verified identical to pre-change (zero row count, value, or key differences on staging)
- [x] Verify sippy-ng frontend renders test reports correctly after matview change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@coderabbitai ignore