### PR TITLE
Batch BigQuery label fetching and skip GCS for cached job runs

### DIFF
--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -269,11 +269,11 @@ func (pl *ProwLoader) Load() {
 	}
 
 	// Pre-fetch labels for all jobs in bulk instead of one BQ query per job.
-	labelsCache, err := pl.prefetchLabels(prowJobs)
-	if err != nil {
+	if lc, err := pl.prefetchLabels(prowJobs); err == nil {
+		pl.labelsCache = lc
+	} else {
 		pl.errors = append(pl.errors, errors.Wrap(err, "error pre-fetching labels from BigQuery"))
 	}
-	pl.labelsCache = labelsCache
 
 	queue := make(chan *prow.ProwJob)
 	errsCh := make(chan error, len(prowJobs))
@@ -312,7 +312,7 @@ func (pl *ProwLoader) Load() {
 
 	// load the test analysis by job data into tables partitioned by day, letting bigquery do the
 	// heavy lifting for us.
-	err = pl.loadDailyTestAnalysisByJob(pl.ctx)
+	err := pl.loadDailyTestAnalysisByJob(pl.ctx)
 	if err != nil {
 		pl.errors = append(pl.errors, errors.Wrap(err, "error updating daily test analysis by job"))
 	}

--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -81,6 +81,7 @@ type ProwLoader struct {
 	gcsClient                    *storage.Client
 	promPusher                   *push.Pusher
 	loadSince                    *time.Time
+	labelsCache                  map[string]pq.StringArray
 }
 
 func New(
@@ -267,6 +268,13 @@ func (pl *ProwLoader) Load() {
 		log.Infof("Partition cleanup complete: detached %d, dropped %d", detached, dropped)
 	}
 
+	// Pre-fetch labels for all jobs in bulk instead of one BQ query per job.
+	labelsCache, err := pl.prefetchLabels(prowJobs)
+	if err != nil {
+		pl.errors = append(pl.errors, errors.Wrap(err, "error pre-fetching labels from BigQuery"))
+	}
+	pl.labelsCache = labelsCache
+
 	queue := make(chan *prow.ProwJob)
 	errsCh := make(chan error, len(prowJobs))
 	total := len(prowJobs)
@@ -304,7 +312,7 @@ func (pl *ProwLoader) Load() {
 
 	// load the test analysis by job data into tables partitioned by day, letting bigquery do the
 	// heavy lifting for us.
-	err := pl.loadDailyTestAnalysisByJob(pl.ctx)
+	err = pl.loadDailyTestAnalysisByJob(pl.ctx)
 	if err != nil {
 		pl.errors = append(pl.errors, errors.Wrap(err, "error updating daily test analysis by job"))
 	}
@@ -890,12 +898,26 @@ func (pl *ProwLoader) prowJobToJobRun(ctx context.Context, pj *prow.ProwJob, rel
 		return nil
 	}
 
+	// Keep the ProwJob definition up to date (variants, release, etc.).
+	pl.prowJobCacheLock.Lock()
+	dbProwJob, err := pl.createOrUpdateProwJob(ctx, pj, release, pjLog)
+	pl.prowJobCacheLock.Unlock()
+	if err != nil {
+		return err
+	}
+
+	// Check the run cache after updating the job definition but before
+	// the expensive GCS listing, to skip I/O for already-processed runs.
+	pl.prowJobRunCacheLock.RLock()
+	_, ok := pl.prowJobRunCache[uint(id)]
+	pl.prowJobRunCacheLock.RUnlock()
+	if ok {
+		pjLog.Debugf("skipping, job run was already processed")
+		return nil
+	}
+
 	pjLog.Infof("starting processing")
 
-	// find all files here then pass to getClusterData
-	// and prowJobRunTestsFromGCS
-	// add more regexes if we require more
-	// results from scanning for file names
 	path, err := GetGCSPathForProwJobURL(pjLog, pj.Status.URL)
 	if err != nil {
 		pjLog.WithError(err).WithField("prowJobURL", pj.Status.URL).Error("error getting GCS path for prow job URL")
@@ -911,23 +933,6 @@ func (pl *ProwLoader) prowJobToJobRun(ctx context.Context, pj *prow.ProwJob, rel
 	var junitMatches []string
 	if len(allMatches) > 0 {
 		junitMatches = allMatches[0]
-	}
-
-	// Lock the whole prow job block to avoid trying to create the pj multiple times concurrently\
-	// (resulting in a DB error)
-	pl.prowJobCacheLock.Lock()
-	dbProwJob, err := pl.createOrUpdateProwJob(ctx, pj, release, pjLog)
-	pl.prowJobCacheLock.Unlock()
-	if err != nil {
-		return err
-	}
-
-	pl.prowJobRunCacheLock.RLock()
-	_, ok := pl.prowJobRunCache[uint(id)]
-	pl.prowJobRunCacheLock.RUnlock()
-	if ok {
-		pjLog.Infof("processing complete; job run was already processed")
-		return nil
 	}
 
 	pjLog.Info("processing GCS bucket")
@@ -991,11 +996,7 @@ func (pl *ProwLoader) processGCSBucketJobRun(ctx context.Context, pj *prow.ProwJ
 
 	pulls := pl.findOrAddPullRequests(pj.Spec.Refs, path)
 
-	labelResult, err := GatherLabelsFromBQ(ctx, pl.bigQueryClient, []string{pj.Status.BuildID}, pj.Status.StartTime)
-	if err != nil {
-		return err
-	}
-	labels := labelResult[pj.Status.BuildID] // result could be empty but nil labels is fine
+	labels := pl.labelsCache[pj.Status.BuildID] // result could be empty; nil labels is fine
 
 	var annotations []models.ProwJobRunAnnotation
 	for k, v := range pj.Annotations {
@@ -1165,6 +1166,26 @@ func (pl *ProwLoader) findOrAddPullRequests(refs *prow.Refs, pjPath string) []mo
 	}
 
 	return pulls
+}
+
+func (pl *ProwLoader) prefetchLabels(prowJobs []prow.ProwJob) (map[string]pq.StringArray, error) {
+	buildIDs := make([]string, 0, len(prowJobs))
+	var earliest time.Time
+	for i := range prowJobs {
+		buildIDs = append(buildIDs, prowJobs[i].Status.BuildID)
+		if earliest.IsZero() || prowJobs[i].Status.StartTime.Before(earliest) {
+			earliest = prowJobs[i].Status.StartTime
+		}
+	}
+
+	log.WithField("count", len(buildIDs)).Info("pre-fetching labels from BigQuery in bulk")
+	start := time.Now()
+	labels, err := GatherLabelsFromBQ(pl.ctx, pl.bigQueryClient, buildIDs, earliest)
+	if err != nil {
+		return nil, fmt.Errorf("pre-fetching %d labels from BigQuery: %w", len(buildIDs), err)
+	}
+	log.WithField("count", len(labels)).WithField("duration", time.Since(start)).Info("pre-fetched labels from BigQuery")
+	return labels, nil
 }
 
 const LabelsDatasetEnv = "JOB_LABELS_DATASET"


### PR DESCRIPTION
## Summary

- Replace per-job BigQuery label queries with a single bulk prefetch before the worker loop, eliminating thousands of individual BQ round-trips per load cycle
- Move the `prowJobRunCache` check before the GCS `FindAllMatches` listing so already-processed runs skip the expensive object listing entirely
- Keep `createOrUpdateProwJob` before the cache check to ensure job definitions (variants, release) stay current

## Evidence from production logs

  Production fetchdata runs (hourly, June 24 2026) show that the prow loader spends 25-29 minutes processing 16-18K jobs from BigQuery, but only 2-3% actually need GCS processing. The rest are duplicates from the
  12-hour lookback overlap.

  The current code flow in `prowJobToJobRun` fetches GCS artifacts (path resolution, bucket client, JUnit file matching) *before* checking the in-memory cache. This means ~3,500 jobs per run go through full GCS
  I/O only to be discarded as already processed.

  | Metric | 14:00 run | 15:03 run | 16:08 run |
  |---|---|---|---|
  | Jobs from BigQuery | 16,368 | 17,292 | 18,644 |
  | Skipped by in-memory cache (before `prowJobToJobRun`) | ~12,604 (77%) | ~13,444 (78%) | ~14,699 (79%) |
  | GCS fetched then found already processed | 3,297 (20%) | 3,327 (19%) | 3,537 (19%) |
  | GCS fetched and actually needed | 467 (3%) | 521 (3%) | 408 (2%) |
  | **Prow loader time** | **24m 31s** | **25m 18s** | **28m 49s** |

  Moving the cache check before the GCS fetch eliminates ~3,500 unnecessary GCS round-trips per run (~19% of total jobs).

## Evidence from staging

  Deployed the PR image to staging and ran two load cycles against the staging database.

  **Run 1 (cold start, empty staging DB):**
  - 205,482 jobs from BigQuery
  - Bulk label prefetch: 205K build IDs returned 4,636 labels in **12.7 seconds** (single BQ query)
  - Processed 29,705 of 205K jobs in ~43 minutes before being stopped (all jobs required full GCS processing since the DB was empty)
  - 7,291 new job runs inserted

  **Run 2 (warm start, 7K runs already cached):**
  - 21,353 jobs from BigQuery
  - Bulk label prefetch: 21K build IDs returned 363 labels in **2.75 seconds**
  - Of 17,041 jobs processed (at time of observation), only 2,977 (17%) needed GCS processing
  - **14,064 jobs (83%) skipped GCS listing entirely** via the early cache check
  - Cache-hit jobs processed at the rate of thousands per second (no I/O)

  **Label verification:**
  - Staging database shows 55,667 of 544,340 job runs have labels applied
  - Most recent labeled runs (June 24) show correct values (e.g., `ImagePullNeverCompletes`, `TestFailureDuringHighCPUEvents`)

## Test plan

- [x] `go vet ./pkg/dataloader/prowloader/...` passes
- [x] `go test ./pkg/dataloader/prowloader/...` passes
- [x] `go build ./cmd/sippy/...` compiles
- [x] Verify in staging that bulk label prefetch logs show a single BQ query with count and duration
- [x] Verify cached job runs skip GCS listing (83% of jobs skipped in warm run)
- [x] Verify newly imported job runs still have correct labels in the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)