### PR TITLE
Upgrade golangci-lint to v2.12.2

### DIFF
--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -25,6 +25,6 @@ else
   $DOCKER run --rm \
     --volume "${PWD}:/go/src/github.com/openshift/sippy${VOLUME_OPTION}" \
     --workdir /go/src/github.com/openshift/sippy \
-    docker.io/golangci/golangci-lint:v2.10.1 \
+    docker.io/golangci/golangci-lint:v2.12.2 \
     golangci-lint --timeout 10m "${@}"
 fi

--- a/pkg/dataloader/prowloader/gcs/gcs_authentication.go
+++ b/pkg/dataloader/prowloader/gcs/gcs_authentication.go
@@ -95,7 +95,7 @@ func saveToken(path string, token *oauth2.Token) {
 		return
 	}
 	defer f.Close()
-	if err := json.NewEncoder(f).Encode(token); err != nil {
+	if err := json.NewEncoder(f).Encode(token); err != nil { //nolint:gosec // G117: intentionally writing OAuth token to local cache file
 		log.Error(err.Error())
 	}
 }

--- a/pkg/sippyserver/daemon_server.go
+++ b/pkg/sippyserver/daemon_server.go
@@ -51,7 +51,7 @@ func (da *DaemonServer) Serve() {
 
 	for _, process := range da.processes {
 		ctx := context.Background()
-		ctx, cancel := context.WithCancel(ctx)
+		ctx, cancel := context.WithCancel(ctx) //nolint:gosec // G118: cancel is stored in pendingContexts and called on shutdown
 
 		pendingContexts = append(pendingContexts, cancel)
 		wg.Add(1)


### PR DESCRIPTION
## Summary
- Bump the golangci-lint container image in `hack/go-lint.sh` from v2.10.1 to v2.12.2
- Suppress two new gosec false positives introduced by the upgrade:
  - **G117** in `gcs_authentication.go`: intentional OAuth token cache write to a local file
  - **G118** in `daemon_server.go`: `cancel` func is stored in `pendingContexts` and called on shutdown, but gosec cannot trace it through the slice

## Test plan
- [x] Ran `gofmt -w` on both modified Go files (no changes needed)
- [x] Ran `golangci-lint --timeout 10m run ./pkg/dataloader/prowloader/gcs/... ./pkg/sippyserver/...` with 0 issues
- [x] CI lint job passes with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)