### PR TITLE
Remove unused columns from CR BigQuery queries

### DIFF
--- a/pkg/api/componentreadiness/dataprovider/bigquery/querygenerators.go
+++ b/pkg/api/componentreadiness/dataprovider/bigquery/querygenerators.go
@@ -411,7 +411,6 @@ func BuildComponentReportQuery(
 	}
 
 	// WARNING: returning additional columns from this query will require explicit parsing in deserializeRowToTestStatus
-	// TODO: jira_component and jira_component_id appear to not be used? Could save bigquery costs if we remove them.
 	// TODO: last_failure here explicitly uses success_val not adjusted_success_val, this ensures we
 	// show the last time the test failed, not flaked. if you enable the flakes as failures feature (which is
 	// non default today), the last failure time will be wrong which can impact things like failed fix detection.
@@ -538,8 +537,6 @@ func BuildComponentReportQuery(
 // If key test names are configured in the view's advanced options, when any of these tests fail in a job,
 // all other test failures in that job are excluded from regression analysis. Only the highest priority
 // (earliest in the list) key test will be included for each affected job.
-// TODO: I think we're querying more than we need here, there are a lot of long columns returned in this query that are
-// never used, test name, component, file path, url, etc.
 func buildTestDetailsQuery(
 	client *bqcachedclient.Client,
 	testIDOpts []reqopts.TestIdentification,
@@ -597,9 +594,7 @@ func buildTestDetailsQuery(
 					SELECT
 						cm.id AS test_id,
 						ANY_VALUE(test_name) AS test_name,
-						ANY_VALUE(testsuite) AS test_suite,
 						%s
-						file_path,
 						ANY_VALUE(variant_registry_job_name) AS prowjob_name,
 						ANY_VALUE(cm.jira_component) AS jira_component,
 						ANY_VALUE(cm.jira_component_id) AS jira_component_id,
@@ -607,7 +602,6 @@ func buildTestDetailsQuery(
 						ANY_VALUE(junit.prowjob_url) AS prowjob_url,
 						ANY_VALUE(junit.prowjob_build_id) AS prowjob_run_id,
 						ANY_VALUE(junit.prowjob_start) AS prowjob_start,
-						ANY_VALUE(cm.capabilities) as capabilities,
 						SUM(adjusted_success_val) AS success_count,
 						SUM(adjusted_flake_count) AS flake_count,
 						ANY_VALUE(agg_labels.job_labels) AS job_labels,
@@ -794,8 +788,6 @@ func deserializeRowToTestStatus(row []bigquery.Value, schema bigquery.Schema) (s
 	// INFO[2024-04-22T13:31:23.123-03:00] flake_count = %!s(int64=0)
 	// INFO[2024-04-22T13:31:23.124-03:00] component = Cluster Version Operator
 	// INFO[2024-04-22T13:31:23.124-03:00] capabilities = [Other]
-	// INFO[2024-04-22T13:31:23.124-03:00] jira_component = Cluster Version Operator
-	// INFO[2024-04-22T13:31:23.124-03:00] jira_component_id = 12367602000000000/1000000000
 	// INFO[2024-04-22T13:31:23.124-03:00] test_name = [sig-storage] [Serial] Volume metrics Ephemeral should create volume metrics in Volume Manager [Suite:openshift/conformance/serial] [Suite:k8s]
 	// INFO[2024-04-22T13:31:23.124-03:00] test_suite = openshift-tests
 	tid := crtest.KeyWithVariants{

--- a/pkg/api/componentreadiness/dataprovider/postgres/provider.go
+++ b/pkg/api/componentreadiness/dataprovider/postgres/provider.go
@@ -486,17 +486,16 @@ func (p *PostgresProvider) QuerySampleTestStatus(ctx context.Context, reqOptions
 // --- TestDetailsQuerier ---
 
 type testDetailRow struct {
-	TestID          string         `gorm:"column:test_id"`
-	TestName        string         `gorm:"column:test_name"`
-	ProwJobName     string         `gorm:"column:prowjob_name"`
-	ProwJobRunID    string         `gorm:"column:prowjob_run_id"`
-	ProwJobURL      string         `gorm:"column:prowjob_url"`
-	ProwJobStart    time.Time      `gorm:"column:prowjob_start"`
-	ProwJobID       uint           `gorm:"column:prow_job_id"`
-	Status          int            `gorm:"column:status"`
-	JiraComponent   string         `gorm:"column:jira_component"`
-	JiraComponentID *uint          `gorm:"column:jira_component_id"`
-	Capabilities    pq.StringArray `gorm:"column:capabilities;type:text[]"`
+	TestID          string    `gorm:"column:test_id"`
+	TestName        string    `gorm:"column:test_name"`
+	ProwJobName     string    `gorm:"column:prowjob_name"`
+	ProwJobRunID    string    `gorm:"column:prowjob_run_id"`
+	ProwJobURL      string    `gorm:"column:prowjob_url"`
+	ProwJobStart    time.Time `gorm:"column:prowjob_start"`
+	ProwJobID       uint      `gorm:"column:prow_job_id"`
+	Status          int       `gorm:"column:status"`
+	JiraComponent   string    `gorm:"column:jira_component"`
+	JiraComponentID *uint     `gorm:"column:jira_component_id"`
 }
 
 const testDetailQuery = `
@@ -510,8 +509,7 @@ SELECT
     pj.id AS prow_job_id,
     pjrt.status,
     COALESCE(tow.jira_component, '') AS jira_component,
-    tow.jira_component_id,
-    tow.capabilities
+    tow.jira_component_id
 FROM prow_job_run_tests pjrt
 JOIN prow_job_runs pjr ON pjr.id = pjrt.prow_job_run_id
 JOIN prow_jobs pj ON pj.id = pjr.prow_job_id


### PR DESCRIPTION
## Summary

- Remove 3 unused columns from the Component Readiness test details BigQuery query (`test_suite`, `file_path`, `capabilities`) that are selected but never consumed in deserialization
- Remove `capabilities` from the PostgreSQL test details query for parity
- Clean up stale TODOs and debug comments referencing `jira_component`/`jira_component_id` in the component report query (they were never in the SELECT clause)

Reduces bytes scanned per CR query, directly lowering BigQuery cost. The `capabilities` removal is the most impactful since it eliminates reading that column from the `latest_component_mapping` table. `file_path` is kept in the GROUP BY to preserve correct aggregation semantics.

Closes: https://issues.redhat.com/browse/TRT-2746

## Test plan

- [x] `gofmt` clean
- [x] `go vet ./pkg/api/componentreadiness/...` passes
- [x] `go test ./pkg/api/componentreadiness/...` passes
- [x] `make test` passes
- [x] `golangci-lint run ./...` reports 0 issues
- [x] e2e tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component readiness and test detail reporting so the returned data matches what the app now expects.
  * Removed a few unnecessary fields from test detail results, helping prevent mismatches and parsing issues.
  * Clarified internal guidance around report columns to reduce the risk of future display or data-loading errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->