### PR TITLE
config: add CAPZ e2e integration job to aro-integration

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -18,6 +18,7 @@ releases:
     jobs:
       periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel: true
       periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel-ocp-nightly: true
+      periodic-ci-Azure-ARO-HCP-main-capz-e2e-integration: true
       branch-ci-Azure-ARO-HCP-main-e2e-integration-e2e-parallel: true
   aro-stage:
     synthetic: true


### PR DESCRIPTION
## Summary
- Add `periodic-ci-Azure-ARO-HCP-main-capz-e2e-integration` to the `aro-integration` release in `openshift-customizations.yaml`
- This makes the new ARO-HCP CAPZ e2e integration workflow visible in Sippy's integration dashboard
- The job was added in [openshift/release#81015](https://github.com/openshift/release/pull/81015) and runs weekdays at 20:00 UTC

Jira: [ARO-27714](https://redhat.atlassian.net/browse/ARO-27714)

## Test plan
- [ ] Verify job appears in the aro-integration dashboard after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated validation coverage with an additional periodic integration job for OpenShift deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->