### PR TITLE
config: add CAPZ e2e stage job to aro-stage

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -24,6 +24,7 @@ releases:
     jobs:
       periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel: true
       periodic-ci-Azure-ARO-HCP-main-periodic-stage-e2e-parallel-ocp-nightly: true
+      periodic-ci-Azure-ARO-HCP-main-capz-e2e-stage: true
       branch-ci-Azure-ARO-HCP-main-e2e-stage-e2e-parallel: true
   aro-production:
     synthetic: true


### PR DESCRIPTION
## Summary
- Add `periodic-ci-Azure-ARO-HCP-main-capz-e2e-stage` to the `aro-stage` release in `openshift-customizations.yaml`
- This makes the new ARO-HCP CAPZ e2e stage workflow visible in Sippy's stage dashboard
- The job was added in [openshift/release#81016](https://github.com/openshift/release/pull/81016) and runs weekdays at 20:00 UTC

Jira: [ARO-27715](https://redhat.atlassian.net/browse/ARO-27715)

## Test plan
- [ ] Verify job appears in the aro-stage dashboard after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)