### PR TITLE
NO-JIRA: Move python3 check from global deps to test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export PATH := ${HOME}/go/bin:/go/bin:${PATH}
 DOCKER := $(or $(DOCKER),podman)
 NO_DEP_CHECK_TARGETS := devcontainer-up devcontainer-claude
 ifeq ($(filter $(NO_DEP_CHECK_TARGETS),$(MAKECMDGOALS)),)
-DEPS = npm go python3
+DEPS = npm go
 CHECK := $(foreach dep,$(DEPS),\
         $(if $(shell which $(dep)),"$(dep) found",$(error "Missing $(dep) in PATH")))
 endif
@@ -42,6 +42,7 @@ else
 	gotestsum --junitfile $(ARTIFACT_DIR)/junit.xml ./pkg/...
 endif
 	LANG=en_US.utf-8 LC_ALL=en_US.utf-8 cd sippy-ng; CI=true npm test -- --coverage --passWithNoTests
+	@which python3 > /dev/null 2>&1 || { echo "ERROR: python3 not found in PATH"; exit 1; }
 	cd mcp && \
 		if [ ! -x .venv/bin/python ]; then \
 			python3 -m venv .venv && .venv/bin/pip install --upgrade pip -q; \


### PR DESCRIPTION
The python3 dependency was added to the global DEPS list which runs for all Make targets. This broke the auto-sippy-config-generator CI job which runs `make update-variants` in a container without Python.

Move the check into the test target where MCP tests actually need it.

Fixes: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-prow-auto-sippy-config-generator/2069903480402743296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test setup checks so required tools are validated at the right time.
  * The main dependency check no longer requires Python for every workflow, reducing unnecessary failures.
  * Test runs now fail early with a clear message if Python is not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->