### PR TITLE
Updating rosa-regional-platform to rosa-hyperfleet

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -96,8 +96,8 @@ releases:
   rrp-integration:
     synthetic: true
     jobs:
-      periodic-ci-openshift-online-rosa-regional-platform-main-nightly-ephemeral: true
-      periodic-ci-openshift-online-rosa-regional-platform-main-nightly-integration: true
+      periodic-ci-openshift-online-rosa-hyperfleet-main-nightly-ephemeral: true
+      periodic-ci-openshift-online-rosa-hyperfleet-main-nightly-integration: true
   automation:
     synthetic: true
     jobs:


### PR DESCRIPTION
This is a small PR to rename cluster profile from rosa-regional-platform to rosa-hyperfleet.

Related PR - https://github.com/openshift/release/pull/81072 

cc @cdoan1 