### PR TITLE
TRT-2748: Require minimum failures before marking key tests as pants on fire

### DIFF
--- a/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
+++ b/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/query"
+	sippyutil "github.com/openshift/sippy/pkg/util"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -27,15 +28,28 @@ const (
 	// to adjust this to a smaller value so that, if a rate improvement is smaller than the openRegressionPityAdjustment,
 	// we still consider it regressed.
 	openRegressionPityAdjustment = -2
+	// keyTestMinFailuresForFailedFix is the minimum number of sample failures
+	// required before marking a key test as FailedFixedRegression ("pants on
+	// fire"). Key tests like "install should succeed" are highly sensitive and
+	// a single failure can be noise.
+	keyTestMinFailuresForFailedFix = 2
 )
 
 var _ middleware.Middleware = &RegressionTracker{}
+
+// failureCounterFunc counts post-resolution failures for a regression.
+// It is a field on RegressionTracker so tests can inject a stub without
+// needing a real database.
+type failureCounterFunc func(regressionID uint, after time.Time) (int, error)
 
 func NewRegressionTrackerMiddleware(dbc *db.DB, reqOptions reqopts.RequestOptions) *RegressionTracker {
 	return &RegressionTracker{
 		log:        log.WithField("middleware", "RegressionTracker"),
 		reqOptions: reqOptions,
 		dbc:        dbc,
+		failureCounter: func(regressionID uint, after time.Time) (int, error) {
+			return query.CountRegressionFailuresAfter(dbc, regressionID, after)
+		},
 	}
 }
 
@@ -46,6 +60,7 @@ type RegressionTracker struct {
 	log             log.FieldLogger
 	reqOptions      reqopts.RequestOptions
 	dbc             *db.DB
+	failureCounter  failureCounterFunc
 	openRegressions []*models.TestRegression
 	// hasLoadedRegressions will be true once we've loaded regression data
 	hasLoadedRegressions bool
@@ -141,9 +156,29 @@ func (r *RegressionTracker) PostAnalysis(testKey crtest.Identification, testStat
 			}
 
 			switch {
+			case allTriagesResolved && testStats.LastFailure != nil && lastResolution.Before(*testStats.LastFailure) &&
+				sippyutil.StrSliceContains(r.reqOptions.AdvancedOption.KeyTestNames, testKey.TestName):
+				failuresAfterFix, err := r.failureCounter(or.ID, lastResolution)
+				if err != nil {
+					r.log.WithError(err).WithField("regression_id", or.ID).Warn("failed to count post-resolution failures for key test, falling back to FailedFixedRegression")
+					testStats.ReportStatus = crtest.FailedFixedRegression
+					testStats.Explanations = append(testStats.Explanations, fmt.Sprintf(
+						"Regression is triaged, and believed fixed as of %s, but failures have been observed as recently as %s.",
+						lastResolution.Format(time.RFC3339), testStats.LastFailure.Format(time.RFC3339)))
+					return nil
+				}
+				if failuresAfterFix < keyTestMinFailuresForFailedFix {
+					testStats.ReportStatus = crtest.FixedRegression
+					testStats.Explanations = append(testStats.Explanations, fmt.Sprintf(
+						"Regression is triaged and believed fixed as of %s. Failures since resolution (%d) are below the key test threshold (%d) for a failed fix.",
+						lastResolution.Format(time.RFC3339), failuresAfterFix, keyTestMinFailuresForFailedFix))
+				} else {
+					testStats.ReportStatus = crtest.FailedFixedRegression
+					testStats.Explanations = append(testStats.Explanations, fmt.Sprintf(
+						"Regression is triaged, and believed fixed as of %s, but failures have been observed as recently as %s.",
+						lastResolution.Format(time.RFC3339), testStats.LastFailure.Format(time.RFC3339)))
+				}
 			case allTriagesResolved && testStats.LastFailure != nil && lastResolution.Before(*testStats.LastFailure):
-				// claimed fixed but does not appear to be
-				// aka liar liar pants on fire
 				testStats.ReportStatus = crtest.FailedFixedRegression
 				testStats.Explanations = append(testStats.Explanations, fmt.Sprintf(
 					"Regression is triaged, and believed fixed as of %s, but failures have been observed as recently as %s.",

--- a/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker_test.go
+++ b/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker_test.go
@@ -2,6 +2,7 @@ package regressiontracker
 
 import (
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
@@ -159,7 +160,7 @@ func TestRegressionTracker_PostAnalysis(t *testing.T) {
 			},
 		},
 		{
-			name: "triage resolved but has failed since",
+			name: "triage resolved but has failed since (non-key test)",
 			testStats: testdetails.TestComparison{
 				ReportStatus: crtest.ExtremeRegression,
 				Explanations: []string{},
@@ -878,6 +879,147 @@ func TestFindOpenRegression_SubsetMatching(t *testing.T) {
 			assert.Equal(t, sampleRelease, got.Release)
 			assert.Equal(t, baseRelease, got.BaseRelease)
 			assert.Equal(t, testID, got.TestID)
+		})
+	}
+}
+
+func TestRegressionTracker_PostAnalysis_KeyTestThreshold(t *testing.T) {
+	baseRelease := "4.19"
+	sampleRelease := "4.18"
+	keyTestName := "install should succeed"
+	keyTestID := "install-should-succeed"
+	regularTestName := "regular test"
+	regularTestID := "regular-test"
+
+	daysAgo5 := time.Now().UTC().Add(-5 * 24 * time.Hour)
+	daysAgo3 := time.Now().UTC().Add(-3 * 24 * time.Hour)
+	daysAgo2 := time.Now().UTC().Add(-2 * 24 * time.Hour)
+
+	resolvedTriage := models.Triage{
+		ID:          42,
+		URL:         "https://example.com/bug-123",
+		Description: "fixed",
+		Type:        "product",
+		Resolved: sql.NullTime{
+			Time:  daysAgo3,
+			Valid: true,
+		},
+	}
+
+	tests := []struct {
+		name              string
+		testName          string
+		testID            string
+		failureCount      int
+		failureCountErr   error
+		expectStatus      crtest.Status
+		expectExplanation string
+	}{
+		{
+			name:              "key test with zero post-resolution failures reports FixedRegression",
+			testName:          keyTestName,
+			testID:            keyTestID,
+			failureCount:      0,
+			expectStatus:      crtest.FixedRegression,
+			expectExplanation: "below the key test threshold",
+		},
+		{
+			name:              "key test with one post-resolution failure reports FixedRegression",
+			testName:          keyTestName,
+			testID:            keyTestID,
+			failureCount:      1,
+			expectStatus:      crtest.FixedRegression,
+			expectExplanation: "below the key test threshold",
+		},
+		{
+			name:              "key test at threshold reports FailedFixedRegression",
+			testName:          keyTestName,
+			testID:            keyTestID,
+			failureCount:      keyTestMinFailuresForFailedFix,
+			expectStatus:      crtest.FailedFixedRegression,
+			expectExplanation: "failures have been observed",
+		},
+		{
+			name:              "key test above threshold reports FailedFixedRegression",
+			testName:          keyTestName,
+			testID:            keyTestID,
+			failureCount:      keyTestMinFailuresForFailedFix + 3,
+			expectStatus:      crtest.FailedFixedRegression,
+			expectExplanation: "failures have been observed",
+		},
+		{
+			name:              "non-key test with one failure still reports FailedFixedRegression",
+			testName:          regularTestName,
+			testID:            regularTestID,
+			failureCount:      0,
+			expectStatus:      crtest.FailedFixedRegression,
+			expectExplanation: "failures have been observed",
+		},
+		{
+			name:              "key test with counter error falls back to FailedFixedRegression",
+			testName:          keyTestName,
+			testID:            keyTestID,
+			failureCountErr:   fmt.Errorf("database error"),
+			expectStatus:      crtest.FailedFixedRegression,
+			expectExplanation: "failures have been observed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testKey := crtest.Identification{
+				RowIdentification: crtest.RowIdentification{
+					Component:  "comp",
+					Capability: "cap",
+					TestName:   tt.testName,
+					TestSuite:  "suite",
+					TestID:     tt.testID,
+				},
+				ColumnIdentification: crtest.ColumnIdentification{
+					Variants: map[string]string{"arch": "amd64"},
+				},
+			}
+			variantsStrSlice := utils.VariantsMapToStringSlice(testKey.Variants)
+
+			openRegression := &models.TestRegression{
+				ID:       1,
+				Release:  sampleRelease,
+				TestID:   tt.testID,
+				TestName: tt.testName,
+				Variants: variantsStrSlice,
+				Opened:   daysAgo5,
+				Triages:  []models.Triage{resolvedTriage},
+			}
+
+			mw := RegressionTracker{
+				reqOptions: reqopts.RequestOptions{
+					BaseRelease:   reqopts.Release{Name: baseRelease},
+					SampleRelease: reqopts.Release{Name: sampleRelease},
+					AdvancedOption: reqopts.Advanced{
+						Confidence:   95,
+						KeyTestNames: []string{keyTestName},
+					},
+				},
+				openRegressions:      []*models.TestRegression{openRegression},
+				hasLoadedRegressions: true,
+				failureCounter: func(_ uint, _ time.Time) (int, error) {
+					return tt.failureCount, tt.failureCountErr
+				},
+				log: logrus.New(),
+			}
+
+			testStats := &testdetails.TestComparison{
+				ReportStatus: crtest.ExtremeRegression,
+				Explanations: []string{},
+				LastFailure:  &daysAgo2,
+				Regression:   openRegression,
+			}
+
+			err := mw.PostAnalysis(testKey, testStats)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectStatus, testStats.ReportStatus)
+			assert.Len(t, testStats.Explanations, 1)
+			assert.Contains(t, testStats.Explanations[0], tt.expectExplanation)
 		})
 	}
 }

--- a/pkg/db/query/triage_queries.go
+++ b/pkg/db/query/triage_queries.go
@@ -1,6 +1,10 @@
 package query
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
 	log "github.com/sirupsen/logrus"
@@ -27,6 +31,21 @@ func ListOpenRegressions(dbc *db.DB, release string) ([]*models.TestRegression, 
 		log.WithError(res.Error).Error("error listing all regressions")
 	}
 	return openRegressions, res.Error
+}
+
+// CountRegressionFailuresAfter counts failed job runs for a regression that
+// started after the specified time.
+func CountRegressionFailuresAfter(dbc *db.DB, regressionID uint, after time.Time) (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	var count int64
+	res := dbc.DB.WithContext(ctx).Model(&models.RegressionJobRun{}).
+		Where("regression_id = ? AND start_time > ? AND test_failed", regressionID, after).
+		Count(&count)
+	if res.Error != nil {
+		return 0, fmt.Errorf("error counting post-resolution failures for regression %d: %w", regressionID, res.Error)
+	}
+	return int(count), nil
 }
 
 func ListRegressions(dbc *db.DB, release string) ([]models.TestRegression, error) {


### PR DESCRIPTION
Key tests like "install should succeed" are highly sensitive and a single post-fix failure is often noise. This adds a threshold (2 failures) before escalating key tests to FailedFixedRegression, reducing false positives. Non-key tests retain the existing single-failure behavior.

The failure counting is injected via a function field on RegressionTracker so tests can verify the threshold logic without a database connection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Key tests are now handled with a separate failure threshold, so regressions can be classified more accurately based on how many failures happened after a fix was marked.

* **Bug Fixes**
  * Improved triage results when failures continue after a fix, including safer fallback behavior if failure counting cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->