### PR TITLE
Add capi-tests suite to JUnit import allowlist

### DIFF
--- a/pkg/db/suites.go
+++ b/pkg/db/suites.go
@@ -31,6 +31,7 @@ var testSuites = []string{
 	"stage/parallel",
 	"prod/parallel",
 	"aro-hcp-tests",
+	"github.com/stolostron/capi-tests/test",
 
 	// ROSA
 	"OSD e2e suite",


### PR DESCRIPTION
## Summary
- Add `github.com/stolostron/capi-tests/test` to the test suites allowlist so Sippy can import JUnit test results from the `capi-qe` release

The `capi-qe` release is already configured in `openshift-customizations.yaml` with the job `periodic-ci-stolostron-capi-tests-configure-prow-mgmt-periodics-capz-e2e`, but test results are silently skipped because the suite name is not in the `testSuites` allowlist in `pkg/db/suites.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for importing an additional test suite during database setup, so it can now be recognized and loaded automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->