### PR TITLE
Use variant_combinations for query filtering and drop GIN index

### DIFF
--- a/pkg/api/test_analysis.go
+++ b/pkg/api/test_analysis.go
@@ -56,11 +56,11 @@ func GetTestAnalysisOverallFromDB(dbc *db.DB, filters *filter.Filter, release, t
 	}
 
 	for _, bv := range blockedVariants {
-		jq = jq.Where("? != ANY(prow_jobs.variants)", bv)
+		jq = jq.Where("prow_jobs.variant_combination_id NOT IN (SELECT id FROM variant_combinations WHERE ? = any(variants))", bv)
 	}
 
 	for _, av := range allowedVariants {
-		jq = jq.Where("? = ANY(prow_jobs.variants)", av)
+		jq = jq.Where("prow_jobs.variant_combination_id IN (SELECT id FROM variant_combinations WHERE ? = any(variants))", av)
 	}
 
 	r := jq.Scan(&rows)
@@ -122,11 +122,11 @@ func GetTestAnalysisByJobFromDB(dbc *db.DB, filters *filter.Filter, release, tes
 	}
 
 	for _, bv := range blockedVariants {
-		jq = jq.Where("? != ANY(variants)", bv)
+		jq = jq.Where("prow_jobs.variant_combination_id NOT IN (SELECT id FROM variant_combinations WHERE ? = any(variants))", bv)
 	}
 
 	for _, av := range allowedVariants {
-		jq = jq.Where("? = ANY(variants)", av)
+		jq = jq.Where("prow_jobs.variant_combination_id IN (SELECT id FROM variant_combinations WHERE ? = any(variants))", av)
 	}
 
 	r := jq.Scan(&rows)

--- a/pkg/db/migrations/000004_drop_variants_gin_index.down.sql
+++ b/pkg/db/migrations/000004_drop_variants_gin_index.down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_prow_jobs_variants ON prow_jobs USING gin (variants);

--- a/pkg/db/migrations/000004_drop_variants_gin_index.up.sql
+++ b/pkg/db/migrations/000004_drop_variants_gin_index.up.sql
@@ -1,0 +1,4 @@
+-- Drop the GIN index on prow_jobs.variants. All variant filtering now
+-- goes through variant_combination_id lookups against the small
+-- variant_combinations table, so the GIN index is unused.
+DROP INDEX IF EXISTS idx_prow_jobs_variants;

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -25,7 +25,7 @@ type ProwJob struct {
 	Kind     ProwKind
 	Name     string         `gorm:"unique"`
 	Release  string         `gorm:"index"`
-	Variants pq.StringArray `gorm:"type:text[];index:idx_prow_jobs_variants,type:gin"`
+	Variants pq.StringArray `gorm:"type:text[]"`
 	// VariantCombinationID references variant_combinations.id, maintained by a
 	// BEFORE INSERT/UPDATE trigger. NULL only when Variants is NULL.
 	VariantCombinationID *uint `gorm:"column:variant_combination_id"`

--- a/pkg/db/query/misc_queries.go
+++ b/pkg/db/query/misc_queries.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"database/sql"
 	"fmt"
 	"time"
 
@@ -28,20 +29,25 @@ func PlatformInfraSuccess(dbc *db.DB, platforms sets.Set[string], period string)
 		return nil, fmt.Errorf("unknown period %s", period)
 	}
 
-	raw := dbc.DB.Table(table).
-		Select("*, unnest(variants) as variant").
-		Where("name = ?", testidentification.NewInfrastructureTestName)
-
 	var sqlResults []struct {
 		Variant        string
 		PassPercentage float64
 	}
-	q := dbc.DB.Table("(?) as results", raw).
-		Select(`
-			variant,
-			SUM(current_successes) * 100.0 / NULLIF(SUM(current_runs), 0) AS pass_percentage`).
-		Where("variant in ?", platforms.UnsortedList()).
-		Group("variant").Scan(&sqlResults)
+	q := dbc.DB.Raw(fmt.Sprintf(`
+		WITH target_variants AS (
+			SELECT vc.id, v.variant
+			FROM variant_combinations vc, unnest(vc.variants) AS v(variant)
+			WHERE v.variant IN @platforms
+		)
+		SELECT tv.variant,
+			SUM(m.current_successes) * 100.0 / NULLIF(SUM(m.current_runs), 0) AS pass_percentage
+		FROM %s m
+		JOIN target_variants tv ON m.variant_combination_id = tv.id
+		WHERE m.name = @testname
+		GROUP BY tv.variant`, table),
+		sql.Named("platforms", platforms.UnsortedList()),
+		sql.Named("testname", testidentification.NewInfrastructureTestName),
+	).Scan(&sqlResults)
 
 	for _, r := range sqlResults {
 		results[r.Variant] = r.PassPercentage

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -268,11 +268,11 @@ func TestOutputs(dbc *db.DB, release, test string, includedVariants, excludedVar
 		Where("prow_job_run_test_outputs.prow_job_run_test_release = ?", release)
 
 	for _, variant := range includedVariants {
-		q = q.Where("? = any(prow_jobs.variants)", variant)
+		q = q.Where("prow_jobs.variant_combination_id IN (SELECT id FROM variant_combinations WHERE ? = any(variants))", variant)
 	}
 
 	for _, variant := range excludedVariants {
-		q = q.Where("NOT ? = any(prow_jobs.variants)", variant)
+		q = q.Where("prow_jobs.variant_combination_id NOT IN (SELECT id FROM variant_combinations WHERE ? = any(variants))", variant)
 	}
 
 	res := q.
@@ -301,11 +301,11 @@ func TestDurations(dbc *db.DB, release, test string, includedVariants, excludedV
 		Where("prow_job_run_tests.prow_job_run_release = ?", release)
 
 	for _, variant := range includedVariants {
-		q = q.Where("? = any(prow_jobs.variants)", variant)
+		q = q.Where("prow_jobs.variant_combination_id IN (SELECT id FROM variant_combinations WHERE ? = any(variants))", variant)
 	}
 
 	for _, variant := range excludedVariants {
-		q = q.Where("NOT ? = any(prow_jobs.variants)", variant)
+		q = q.Where("prow_jobs.variant_combination_id NOT IN (SELECT id FROM variant_combinations WHERE ? = any(variants))", variant)
 	}
 
 	res := q.

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -113,7 +113,10 @@ func TestReportsByVariant(
 	// Query and group by variant:
 	var testReports []api.Test
 	q := `
-WITH results AS (
+WITH excluded_vc AS (
+    SELECT id FROM variant_combinations WHERE @excluded && variants
+),
+results AS (
     SELECT name,
            release,
            sum(current_runs)       AS current_runs,
@@ -127,7 +130,7 @@ WITH results AS (
            unnest(variants)        AS variant
     FROM prow_test_report_7d_matview
 	WHERE release = @release AND name ~* @testsubstrings
-          AND NOT(variants is not null and @excluded && variants)
+          AND variant_combination_id NOT IN (SELECT id FROM excluded_vc)
     GROUP BY name, release, variant
 )
 SELECT *,
@@ -169,7 +172,10 @@ func TestReportExcludeVariants(dbc *db.DB, release, testName string, excludeVari
 
 	// Query and group by variant:
 	var testReport api.Test
-	q := `WITH results AS (
+	q := `WITH excluded_vc AS (
+    SELECT id FROM variant_combinations WHERE @excluded && variants
+),
+results AS (
     SELECT name,
            release,
            sum(current_runs)       AS current_runs,
@@ -182,7 +188,7 @@ func TestReportExcludeVariants(dbc *db.DB, release, testName string, excludeVari
            sum(previous_flakes)    AS previous_flakes
     FROM prow_test_report_7d_matview
     WHERE release = @release AND name = @testname
-          AND NOT(variants is not null and @excluded && variants)
+          AND variant_combination_id NOT IN (SELECT id FROM excluded_vc)
     GROUP BY name, release
 ) SELECT *, %s FROM results;`
 
@@ -243,7 +249,7 @@ func TestsByNURPAndStandardDeviation(dbc *db.DB, release, table string) *gorm.DB
 			(current_pass_percentage - passing_average) AS delta_from_passing_average,
 			(current_flake_percentage - flake_average) AS delta_from_flake_average`).
 		Where(`release = ?`, release).
-		Where(fmt.Sprintf("NOT ('never-stable'=any(%s.variants))", table))
+		Where("variant_combination_id NOT IN (SELECT id FROM variant_combinations WHERE 'never-stable' = any(variants))")
 }
 
 func TestOutputs(dbc *db.DB, release, test string, includedVariants, excludedVariants []string, quantity int) ([]api.TestOutput, error) {

--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -372,10 +372,11 @@ var CollapsedVariantExclusions = []string{"never-stable", "aggregated"}
 var testReportCollapsedMatView = buildCollapsedMatViewSQL()
 
 func buildCollapsedMatViewSQL() string {
-	var clauses []string
-	for _, v := range CollapsedVariantExclusions {
-		clauses = append(clauses, fmt.Sprintf("NOT ('%s' = any(variants))", v))
+	quotedExclusions := make([]string, len(CollapsedVariantExclusions))
+	for i, v := range CollapsedVariantExclusions {
+		quotedExclusions[i] = fmt.Sprintf("'%s'", v)
 	}
+	excludedArray := "ARRAY[" + strings.Join(quotedExclusions, ",") + "]"
 	return `
 SELECT suite_name, name, id, jira_component, jira_component_id, release,
     SUM(current_runs)::bigint AS current_runs,
@@ -388,7 +389,9 @@ SELECT suite_name, name, id, jira_component, jira_component_id, release,
     SUM(previous_flakes)::bigint AS previous_flakes,
     (array_agg(open_bugs))[1] AS open_bugs
 FROM |||SOURCE|||
-WHERE ` + strings.Join(clauses, "\n  AND ") + `
+WHERE variant_combination_id NOT IN (
+    SELECT id FROM variant_combinations WHERE ` + excludedArray + ` && variants
+)
 GROUP BY suite_name, name, id, jira_component, jira_component_id, release
 `
 }


### PR DESCRIPTION
## Summary

- Moves all variant filtering to resolve against the small `variant_combinations` lookup table (2K rows) first, then filter by integer `variant_combination_id`, instead of running array containment checks on large tables
- Drops the GIN index on `prow_jobs.variants` since all filtering now goes through `variant_combination_id`

### Benchmark results (staging)

| Query | Before | After | Speedup |
|-------|--------|-------|---------|
| TestReportExcludeVariants (`@excluded && variants`) | 1,167ms | 55ms | 21x |
| TestsByNURPAndStandardDeviation (`= any(variants)`) | 505ms | 223ms | 2.3x |
| Collapsed matview filter | 1,158ms | 500ms | 2.3x |
| PlatformInfraSuccess (unnest + filter) | 508ms | 346ms | 1.5x |

### Changed functions

- `TestsByNURPAndStandardDeviation` -- `variant_combination_id NOT IN (subquery)`
- `TestReportsByVariant` -- `excluded_vc` CTE + `NOT IN`
- `TestReportExcludeVariants` -- same pattern
- `PlatformInfraSuccess` -- CTE unnests from `variant_combinations`, joins matview by integer ID
- `buildCollapsedMatViewSQL` -- `variant_combination_id NOT IN (subquery)`
- `TestOutputs` / `TestDurations` -- `variant_combination_id IN (subquery)` instead of GIN-indexed array containment
- `GetTestAnalysisOverallFromDB` / `GetTestAnalysisByJobFromDB` -- same pattern

### NULL handling note

The old variant exclusion pattern `NOT(variants is not null and @excluded && variants)` included rows with NULL variants (evaluating to `NOT(false)` = true). The new `variant_combination_id NOT IN (subquery)` pattern excludes NULL rows because `NULL NOT IN (...)` evaluates to NULL (falsy). This is acceptable because:

1. The matview's `variant_combination_id` comes from `test_daily_summaries`, which gets it from `prow_jobs` via the daily summary upsert JOIN
2. The trigger sets `variant_combination_id = NULL` only when `prow_jobs.variants IS NULL`
3. On staging, zero matview rows have NULL `variant_combination_id` -- the variant manager always assigns variants to jobs
4. Rows with truly NULL variants have no meaningful test data to report on

## Test plan

- [x] `go build ./...` and `go test ./pkg/db/... ./pkg/api/...` pass
- [x] Migration 000004 up/down cycle verified
- [x] Deployed to sippy staging and verified all affected API endpoints return correct data:

| # | Endpoint | Function | Result |
|---|----------|----------|--------|
| 1 | `/api/tests` (collapsed) | `TestsByNURPAndStandardDeviation` + collapsed matview | 200, 7MB |
| 2 | `/api/tests` (variant filter) | Uncollapsed matview variant filter | 200, 8,413 rows |
| 3 | `/api/tests/details` | `TestReportsByVariant` | 200, variant breakdown |
| 4 | `/api/tests/outputs` | `TestOutputs` | 200 |
| 5 | `/api/tests/durations` | `TestDurations` | 200 |
| 6 | `/api/variants` | `VariantReports` | 200, 69 variants |
| 7 | `/api/install` | `PlatformInfraSuccess` | 200, 2MB |
| 8 | `/api/tests/analysis/overall` | `GetTestAnalysisOverallFromDB` | 200, 12 daily data points |
| 9 | `/api/tests/analysis/jobs` | `GetTestAnalysisByJobFromDB` | 200, 249 job groups |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variant-based filtering across test analysis, reports, outputs, and duration views for more accurate results.
  * Corrected exclusion handling so selected variants are matched more reliably in queries.
  * Fixed platform infrastructure success calculations to use the updated variant selection logic.
  * Removed reliance on an outdated index and updated database lookups to keep query behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->