### PR TITLE
TRT-2736: Move test capabilities and lifecycles endpoints to PostgreSQL

### DIFF
--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -813,7 +813,7 @@ func GetTestCapabilitiesFromDB(ctx context.Context, dbc *db.DB) ([]string, error
 }
 
 // GetTestLifecyclesFromDB returns a sorted list of distinct test lifecycle values
-// derived from the JobTier variant on prow_jobs.
+// derived from the JobTier variant in variant_combinations.
 func GetTestLifecyclesFromDB(ctx context.Context, dbc *db.DB) ([]string, error) {
 	if dbc == nil || dbc.DB == nil {
 		return []string{}, nil

--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -796,64 +796,44 @@ func FetchTestResultsFromBQ(ctx context.Context, q *bigquery.Query) ([]apitype.T
 	return result, errs
 }
 
-// GetTestCapabilitiesFromDB returns a sorted list of capabilities from the BQ component_mapping_latest table
-func GetTestCapabilitiesFromDB(ctx context.Context, bqClient *bq.Client) ([]string, error) {
-	if bqClient == nil || bqClient.BQ == nil {
+// GetTestCapabilitiesFromDB returns a sorted list of distinct capabilities from the test_ownerships table.
+func GetTestCapabilitiesFromDB(ctx context.Context, dbc *db.DB) ([]string, error) {
+	if dbc == nil || dbc.DB == nil {
 		return []string{}, nil
 	}
-
-	qFmt := "SELECT ARRAY_AGG(DISTINCT capability ORDER BY capability) AS capabilities FROM `%s.component_mapping_latest`, UNNEST(capabilities) AS capability"
-	q := bqClient.Query(ctx, bqlabel.TestCapabilities, fmt.Sprintf(qFmt, bqClient.Dataset))
-
-	log.Infof("Fetching test capabilities with:\n%s\n", q.Q)
-
-	it, err := q.Read(ctx)
+	var capabilities []string
+	err := dbc.DB.WithContext(ctx).
+		Raw(`SELECT DISTINCT unnest(capabilities) AS capability FROM test_ownerships WHERE capabilities IS NOT NULL ORDER BY capability`).
+		Pluck("capability", &capabilities).Error
 	if err != nil {
-		log.WithError(err).Error("error querying test capabilities from bigquery")
-		return []string{}, err
+		log.WithError(err).Error("error querying test capabilities from database")
+		return []string{}, errors.Wrap(err, "error querying test capabilities from database")
 	}
-
-	var row struct {
-		Capabilities []string `bigquery:"capabilities"`
-	}
-	err = it.Next(&row)
-	if err != nil {
-		log.WithError(err).Error("error retrieving test capabilities from bigquery")
-		return []string{}, errors.Wrap(err, "error retrieving test capabilities from bigquery")
-	}
-
-	return row.Capabilities, nil
+	return capabilities, nil
 }
 
-// GetTestLifecyclesFromDB returns a sorted list of lifecycles from the BQ junit table
-func GetTestLifecyclesFromDB(ctx context.Context, bqClient *bq.Client) ([]string, error) {
-	if bqClient == nil || bqClient.BQ == nil {
+// GetTestLifecyclesFromDB returns a sorted list of distinct test lifecycle values
+// derived from the JobTier variant on prow_jobs.
+func GetTestLifecyclesFromDB(ctx context.Context, dbc *db.DB) ([]string, error) {
+	if dbc == nil || dbc.DB == nil {
 		return []string{}, nil
 	}
-
-	// Query recent data (last 7 days) to satisfy partition filter requirement on modified_time
-	qFmt := `SELECT ARRAY_AGG(DISTINCT lifecycle ORDER BY lifecycle) AS lifecycles
-		FROM %s.junit
-		WHERE modified_time >= DATETIME_SUB(CURRENT_DATETIME(), INTERVAL 7 DAY)
-		AND lifecycle IS NOT NULL AND lifecycle != ''`
-	q := bqClient.Query(ctx, bqlabel.TestLifecycles, fmt.Sprintf(qFmt, bqClient.Dataset))
-
-	log.Infof("Fetching test lifecycles with:\n%s\n", q.Q)
-
-	it, err := q.Read(ctx)
+	var pairs []string
+	err := dbc.DB.WithContext(ctx).
+		Raw(`SELECT DISTINCT unnest(variants) AS pair FROM variant_combinations`).
+		Pluck("pair", &pairs).Error
 	if err != nil {
-		log.WithError(err).Error("error querying test lifecycles from bigquery")
-		return []string{}, err
+		log.WithError(err).Error("error querying test lifecycles from database")
+		return []string{}, errors.Wrap(err, "error querying test lifecycles from database")
 	}
 
-	var row struct {
-		Lifecycles []string `bigquery:"lifecycles"`
+	var lifecycles []string
+	for _, pair := range pairs {
+		key, val, ok := strings.Cut(pair, ":")
+		if ok && key == "JobTier" && val != "" {
+			lifecycles = append(lifecycles, val)
+		}
 	}
-	err = it.Next(&row)
-	if err != nil {
-		log.WithError(err).Error("error retrieving test lifecycles from bigquery")
-		return []string{}, errors.Wrap(err, "error retrieving test lifecycles from bigquery")
-	}
-
-	return row.Lifecycles, nil
+	gosort.Strings(lifecycles)
+	return lifecycles, nil
 }

--- a/pkg/bigquery/bqlabel/labels.go
+++ b/pkg/bigquery/bqlabel/labels.go
@@ -92,8 +92,6 @@ const (
 	TestOutputs                         QueryValue = "test-outputs"
 	TestResults                         QueryValue = "test-results"
 	TestResultsOverall                  QueryValue = "test-results-overall"
-	TestCapabilities                    QueryValue = "test-capabilities"
-	TestLifecycles                      QueryValue = "test-lifecycles"
 	JobRunPayload                       QueryValue = "job-run-payload"
 	JobRunLabels                        QueryValue = "job-run-labels"
 	JobRunLabelsReEvaluate              QueryValue = "job-run-labels-reevaluate"

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1184,7 +1184,7 @@ func (s *Server) jsonReleasesReportFromDB(w http.ResponseWriter, req *http.Reque
 }
 
 func (s *Server) jsonTestCapabilitiesFromDB(w http.ResponseWriter, req *http.Request) {
-	capabilities, err := api.GetTestCapabilitiesFromDB(req.Context(), s.bigQueryClient)
+	capabilities, err := api.GetTestCapabilitiesFromDB(req.Context(), s.db)
 	if err != nil {
 		log.WithError(err).Error("error querying test capabilities")
 		failureResponse(w, http.StatusInternalServerError, "error querying test capabilities")
@@ -1195,7 +1195,7 @@ func (s *Server) jsonTestCapabilitiesFromDB(w http.ResponseWriter, req *http.Req
 }
 
 func (s *Server) jsonTestLifecyclesFromDB(w http.ResponseWriter, req *http.Request) {
-	lifecycles, err := api.GetTestLifecyclesFromDB(req.Context(), s.bigQueryClient)
+	lifecycles, err := api.GetTestLifecyclesFromDB(req.Context(), s.db)
 	if err != nil {
 		log.WithError(err).Error("error querying test lifecycles")
 		failureResponse(w, http.StatusInternalServerError, "error querying test lifecycles")


### PR DESCRIPTION
## Summary
- Replace BigQuery queries with PostgreSQL equivalents for `/api/tests/capabilities` and `/api/tests/lifecycles`
- Capabilities queried from `test_ownerships.capabilities` (text array, already populated by TestOwnershipLoader)
- Lifecycles derived from `JobTier` variant values on `variant_combinations` table

## Benchmarks (staging: 18K jobs, 34K test ownerships, 2K variant combinations)

| Query | PostgreSQL | BigQuery (uncached) |
|---|---|---|
| Capabilities | 38ms | ~840ms |
| Lifecycles | 8ms | ~840ms |

Both endpoints have a 1-hour HTTP cache, so these are worst-case latencies.

## Test plan
- [x] `go vet` passes
- [x] `go test ./pkg/api/... ./pkg/sippyserver/...` passes
- [x] Benchmarked on staging database

Fixes: https://issues.redhat.com/browse/TRT-2736

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Test capabilities and lifecycle values are now loaded from the primary database, improving consistency and reliability of the returned results.
  * The affected endpoints continue to return the same JSON response format, with unchanged error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->