### PR TITLE
Fix AutoMigrate failure for test_daily_summaries column type conflict

### DIFF
--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -178,10 +178,10 @@ type TestDailySummary struct {
 	Release              string    `gorm:"column:release;not null"`
 	SummaryDate          time.Time `gorm:"column:summary_date;type:date;not null"`
 	VariantCombinationID *uint     `gorm:"column:variant_combination_id"`
-	Successes            int       `gorm:"column:successes;not null;default:0"`
-	Failures             int       `gorm:"column:failures;not null;default:0"`
-	Flakes               int       `gorm:"column:flakes;not null;default:0"`
-	Runs                 int       `gorm:"column:runs;not null;default:0"`
+	Successes            int32     `gorm:"column:successes;not null;default:0"`
+	Failures             int32     `gorm:"column:failures;not null;default:0"`
+	Flakes               int32     `gorm:"column:flakes;not null;default:0"`
+	Runs                 int32     `gorm:"column:runs;not null;default:0"`
 }
 
 // Bug represents a Jira bug.


### PR DESCRIPTION
## Summary

Fixes a production deployment failure introduced by #3678. GORM AutoMigrate tries to alter `test_daily_summaries` columns from `INT` to `BIGINT` (Go `int` maps to `bigint` on 64-bit), but PostgreSQL rejects the ALTER because materialized views depend on the table:

```
ERROR: cannot alter type of a column used by a view or rule (SQLSTATE 0A000)
```

The pre-hook is in CrashLoopBackOff in production (17 restarts). Existing pods are still serving but no new deployments can roll out.

## Fix

Use `int32` for the count fields (`successes`, `failures`, `flakes`, `runs`) on `TestDailySummary` to match the `INT` columns created by migration 000002. This lets GORM manage the table correctly (including adding the `variant_combination_id` column) without triggering type alterations on existing columns.

## Test plan

- [x] `go build ./...` and `go test ./pkg/db/...` pass
- [x] Verified fix resolves the staging deployment failure:
  - Pre-hook completed successfully (`sippy-staging-20-hook-pre`: Completed)
  - Pod running (`sippy-staging-20-qscvj`: Running)
  - Previously failed with the same `cannot alter type` error on staging before the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)