### PR TITLE
ROSAENG-60465: Add ROSA CLI and Terraform Provider jobs to rosa-stage

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -83,6 +83,10 @@ releases:
       - "^periodic-ci-openshift-release-main-nightly-.*-e2e-rosa-sts-ovn$"
       # SRE operator e2e tests via Prow (staging)
       - "^periodic-ci-openshift-.*-master-rosa-sts-e2e-promotion-stage$"
+      # ROSA CLI e2e tests
+      - "^periodic-ci-openshift-rosa-master-e2e-rosa-.*"
+      # Terraform provider RHCS e2e tests
+      - "^periodic-ci-terraform-redhat-terraform-provider-rhcs-main-e2e-rosa-.*"
   rosa-integration:
     synthetic: true
     regexp:


### PR DESCRIPTION
Add ROSA CLI e2e tests (openshift/rosa) and Terraform Provider RHCS e2e tests to the rosa-stage Sippy release view.

Patterns:
- `^periodic-ci-openshift-rosa-master-e2e-rosa-.*` (ROSA CLI)
- `^periodic-ci-terraform-redhat-terraform-provider-rhcs-main-e2e-rosa-.*` (Terraform RHCS)

These are tracked in rosa-e2e ci-status-jobs.yaml with scope=component mapping to rosa-cli and terraform-provider-rhcs respectively.

Jira: https://redhat.atlassian.net/browse/ROSAENG-60465

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded ROSA stage presubmit coverage to include additional ROSA CLI end-to-end test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->