### PR TITLE
Temporary fix to keep deprecated QE component readiness functional

### DIFF
--- a/pkg/api/componentreadiness/dataprovider/bigquery/querygenerators.go
+++ b/pkg/api/componentreadiness/dataprovider/bigquery/querygenerators.go
@@ -268,6 +268,14 @@ func buildKeyTestFilterClause(tableAlias string) string {
 func buildCRQueryCTEs(dataset, junitTable, jobNameQueryPortion, jobRunAnnotationToIgnore, releaseFilter string, keyTestNames []string) (string, []bigquery.QueryParameter) {
 	var commonParams []bigquery.QueryParameter
 
+	// The release column clustering optimization only works for ci_analysis_us where the
+	// column is populated by ci-to-bigquery. ci_analysis_qe has a NULL release column,
+	// we're not entirely sure why, but the instance is deprecated and will be deleted soon,
+	// so we do not want to overly invest in fixing it.
+	if strings.HasSuffix(dataset, "ci_analysis_qe") {
+		releaseFilter = ""
+	}
+
 	// Create the deduped_testcases CTE - this is the source of truth for all subsequent CTEs
 	dedupedCTE := fmt.Sprintf(`deduped_testcases_with_rownum AS (
 			SELECT


### PR DESCRIPTION
Since #3563 QE component readiness has been showing no sample, the
release filtering doesn't work because all results are null for the
release column on the table. I was not able to determine why the
ci-to-bigquery cloud function is not populating QE rows properly.

However given QE component readiness is considered deprecated (only
80ish/350 jobs can possibly contribute to it, and we're working hard to
unify CI signal by porting all QE private test suites to component
repos), this is the simplest solution to disable the release filter.

This bypasses the clustering on release column and scans the whole
table, as we were doing prior to a month ago. Cost is not really a
concern here as the QE datasets are orders of magnitude smaller, and
seldom queried at all.

I did some analysis on whether or not it was worth restoring:

Jobs contributing to combos with >= 3 runs: 89
Jobs contributing to combos with >= 6 runs: 82

So about 90 jobs could possibly have caught a full regression (75% of running 5.0 qe jobs appear to not contribute anything that could possibly trigger CR). However 90 jobs is still a moderate signal. Decided this makes it worthwhile to patch the instance up to work for now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated query behavior for a deprecated analytics dataset variant so release-based filtering is no longer applied when not supported.
  * This helps prevent incorrect query parameters from being added in that specific case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->