### PR TITLE
Whitelist Component and Capability for import, drop Procedure

### DIFF
--- a/pkg/testidentification/ocp_variants.go
+++ b/pkg/testidentification/ocp_variants.go
@@ -36,7 +36,8 @@ var importantVariants = []string{
 	"SecurityMode",
 	"Installer",
 	"JobTier",
-	"Procedure",
+	"Component",
+	"Capability",
 	"OS",
 }
 


### PR DESCRIPTION
Should be a net reduction in cardinality as Procedure had 10 distinct values and all jobs had it, whereas Component and Capability are only used on a couple jobs so far

Procedure should be fine to remove, I've never filtered jobs on it and I don't think anyone else would have. It should likely be replaced by Capability long term.