### PR TITLE
Fix nil map panic in variant manager initialization

### DIFF
--- a/pkg/testidentification/ocp_variants.go
+++ b/pkg/testidentification/ocp_variants.go
@@ -107,7 +107,7 @@ func NewOpenshiftVariantManager(ctx context.Context, bqc *bqcachedclient.Client)
 		}
 		for _, v := range row.Variants {
 			jobVariants[row.JobName] = append(jobVariants[row.JobName], fmt.Sprintf("%s:%s", v.VariantName, v.VariantValue))
-			if _, ok := variantKeyValues[v.VariantValue]; ok {
+			if _, ok := variantKeyValues[v.VariantName]; ok {
 				variantKeyValues[v.VariantName].Insert(v.VariantValue)
 			} else {
 				variantKeyValues[v.VariantName] = sets.NewString(v.VariantValue)


### PR DESCRIPTION
Fix a wrong map key in `NewOpenshiftVariantManager` that caused `panic: assignment to entry in nil map` during fetchdata. The lookup checked `variantKeyValues[v.VariantValue]` but the insert targeted `variantKeyValues[v.VariantName]`, so when a variant value string coincided with an existing map key, it tried to insert into a nil entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how variant information is grouped when loading data, ensuring values are now associated with the right variant names.
  * This improves consistency in variant-based results and prevents duplicate or misplaced entries from being created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->