### PR TITLE
Fix an old bug now being hit due to variant registry changes

### DIFF
--- a/pkg/testidentification/ocp_variants.go
+++ b/pkg/testidentification/ocp_variants.go
@@ -107,7 +107,7 @@ func NewOpenshiftVariantManager(ctx context.Context, bqc *bqcachedclient.Client)
 		}
 		for _, v := range row.Variants {
 			jobVariants[row.JobName] = append(jobVariants[row.JobName], fmt.Sprintf("%s:%s", v.VariantName, v.VariantValue))
-			if _, ok := variantKeyValues[v.VariantValue]; ok {
+			if _, ok := variantKeyValues[v.VariantName]; ok {
 				variantKeyValues[v.VariantName].Insert(v.VariantValue)
 			} else {
 				variantKeyValues[v.VariantName] = sets.NewString(v.VariantValue)


### PR DESCRIPTION
Recently our first variants were introduced that are not present on all jobs. This exposed a glaring bug from two years ago per the patch. 

I'm not 100% sure this sparsely populated variants won't cause more issues, if it does, I can change it to populare the variant for all jobs. Doing so however keeps cardinality high, so this new approach would be better if possible. A lot of variants are "default" or "unknown" or "none"