### PR TITLE
TRT-2741: Expand variant keys and decouple daily summaries from variant_combination_id

### DIFF
--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -315,24 +315,25 @@ FROM (
     ),
     pre_agg AS (
       SELECT
-        variant_combination_id,
-        test_id,
-        suite_id,
-        release AS prow_job_run_release,
-        COALESCE(SUM(successes) FILTER (WHERE summary_date >= |||START||| AND summary_date < |||BOUNDARY|||), 0) AS previous_successes,
-        COALESCE(SUM(flakes)    FILTER (WHERE summary_date >= |||START||| AND summary_date < |||BOUNDARY|||), 0) AS previous_flakes,
-        COALESCE(SUM(failures)  FILTER (WHERE summary_date >= |||START||| AND summary_date < |||BOUNDARY|||), 0) AS previous_failures,
-        COALESCE(SUM(runs)      FILTER (WHERE summary_date >= |||START||| AND summary_date < |||BOUNDARY|||), 0) AS previous_runs,
-        COALESCE(SUM(successes) FILTER (WHERE summary_date >= |||BOUNDARY||| AND summary_date <= |||END|||), 0) AS current_successes,
-        COALESCE(SUM(flakes)    FILTER (WHERE summary_date >= |||BOUNDARY||| AND summary_date <= |||END|||), 0) AS current_flakes,
-        COALESCE(SUM(failures)  FILTER (WHERE summary_date >= |||BOUNDARY||| AND summary_date <= |||END|||), 0) AS current_failures,
-        COALESCE(SUM(runs)      FILTER (WHERE summary_date >= |||BOUNDARY||| AND summary_date <= |||END|||), 0) AS current_runs
+        pj.variant_combination_id,
+        tds.test_id,
+        tds.suite_id,
+        tds.release AS prow_job_run_release,
+        COALESCE(SUM(tds.successes) FILTER (WHERE tds.summary_date >= |||START||| AND tds.summary_date < |||BOUNDARY|||), 0) AS previous_successes,
+        COALESCE(SUM(tds.flakes)    FILTER (WHERE tds.summary_date >= |||START||| AND tds.summary_date < |||BOUNDARY|||), 0) AS previous_flakes,
+        COALESCE(SUM(tds.failures)  FILTER (WHERE tds.summary_date >= |||START||| AND tds.summary_date < |||BOUNDARY|||), 0) AS previous_failures,
+        COALESCE(SUM(tds.runs)      FILTER (WHERE tds.summary_date >= |||START||| AND tds.summary_date < |||BOUNDARY|||), 0) AS previous_runs,
+        COALESCE(SUM(tds.successes) FILTER (WHERE tds.summary_date >= |||BOUNDARY||| AND tds.summary_date <= |||END|||), 0) AS current_successes,
+        COALESCE(SUM(tds.flakes)    FILTER (WHERE tds.summary_date >= |||BOUNDARY||| AND tds.summary_date <= |||END|||), 0) AS current_flakes,
+        COALESCE(SUM(tds.failures)  FILTER (WHERE tds.summary_date >= |||BOUNDARY||| AND tds.summary_date <= |||END|||), 0) AS current_failures,
+        COALESCE(SUM(tds.runs)      FILTER (WHERE tds.summary_date >= |||BOUNDARY||| AND tds.summary_date <= |||END|||), 0) AS current_runs
       FROM
-        test_daily_summaries
+        test_daily_summaries tds
+        JOIN prow_jobs pj ON tds.prow_job_id = pj.id
       WHERE
-        summary_date >= |||START||| AND summary_date <= |||END|||
+        tds.summary_date >= |||START||| AND tds.summary_date <= |||END|||
       GROUP BY
-        variant_combination_id, test_id, suite_id, release
+        pj.variant_combination_id, tds.test_id, tds.suite_id, tds.release
     )
     SELECT
         tests.id,

--- a/pkg/testidentification/ocp_variants.go
+++ b/pkg/testidentification/ocp_variants.go
@@ -24,6 +24,11 @@ import (
 var openshiftJobsNeverStableRaw string
 var openshiftJobsNeverStable = strings.Split(openshiftJobsNeverStableRaw, "\n")
 
+// importantVariants controls which BigQuery variant keys are stored in
+// prow_jobs.variants in PostgreSQL. Release-family keys (Release,
+// ReleaseMinor, ReleaseMajor, FromRelease, FromReleaseMinor,
+// FromReleaseMajor) are excluded because they are redundant with
+// prow_jobs.release and the Upgrade variant.
 var importantVariants = []string{
 	"Platform",
 	"Architecture",
@@ -39,6 +44,14 @@ var importantVariants = []string{
 	"Component",
 	"Capability",
 	"OS",
+	"Procedure",
+	"Aggregation",
+	"NetworkAccess",
+	"Scheduler",
+	"Suite",
+	"ContainerRuntime",
+	"CGroupMode",
+	"LayeredProduct",
 }
 
 const (
@@ -133,9 +146,6 @@ func (v *openshiftVariants) IdentifyVariants(jobName string) []string {
 		allVariants = append(allVariants, NeverStable)
 	}
 
-	// Ensure filtered by important variants; including them all
-	// significantly increases cardinality and slows matview refreshes
-	// to a crawl.
 	return filterVariants(allVariants, importantVariants)
 }
 


### PR DESCRIPTION
## Summary
- Adds 8 variant keys to `importantVariants` (Procedure, Aggregation, NetworkAccess, Scheduler, Suite, ContainerRuntime, CGroupMode, LayeredProduct). Release-family keys remain excluded as they are redundant with `prow_jobs.release` and the Upgrade variant.
- Changes the matview `pre_agg` CTE to resolve `variant_combination_id` by joining `prow_jobs` instead of reading it from `test_daily_summaries`. This decouples the matviews from the denormalized column, preparing for its removal in #3749.

The daily summary aggregation and GORM model are unchanged in this PR. The column continues to be written (harmlessly) until the follow-up PR drops it.

Benchmarking against staging-2 showed <1% matview refresh overhead from the added join (`prow_jobs` fits in a 1.1MB in-memory hash table). Aggregate totals are identical; per-variant grouping improves because ~49% of stored `variant_combination_id` values were stale.

## Test plan
- [x] `go vet ./pkg/...` passes
- [x] `make lint` passes (0 issues)
- [x] `make test` passes (Go, JS, Python)
- [x] Benchmarked old vs new `pre_agg` CTE against staging-2 (92.4s vs 93.5s)
- [x] Verified aggregate totals match (22,849 test/suite pairs, 0 mismatches)

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)