### PR TITLE
Use PostgreSQL COPY protocol for test_analysis_by_job_by_dates bulk inserts

### DIFF
--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -19,6 +19,7 @@ import (
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/storage"
 	"github.com/jackc/pgtype"
+	"github.com/jackc/pgx/v4"
 	"github.com/lib/pq"
 	"github.com/openshift/sippy/pkg/bigquery/bqlabel"
 	"github.com/pkg/errors"
@@ -571,17 +572,27 @@ ORDER BY
 		}
 		st := time.Now()
 		dLog.Infof("inserting %d rows", len(insertRows))
-		err = pl.dbc.DB.Transaction(func(tx *gorm.DB) error {
-			err = pl.dbc.DB.WithContext(ctx).CreateInBatches(insertRows, 2000).Error
-			if err != nil {
-				log.WithError(err).Error("error inserting rows")
-			}
-			return err
-		})
+		n, err := pl.dbc.CopyFrom(ctx, "test_analysis_by_job_by_dates",
+			[]string{"date", "test_id", "release", "job_name", "test_name", "runs", "passes", "flakes", "failures"},
+			pgx.CopyFromSlice(len(insertRows), func(i int) ([]any, error) {
+				r := &insertRows[i]
+				return []any{
+					r.Date,
+					r.TestID,
+					r.Release,
+					r.JobName,
+					r.TestName,
+					r.Runs,
+					r.Passes,
+					r.Flakes,
+					r.Failures,
+				}, nil
+			}),
+		)
 		if err != nil {
-			return err
+			return fmt.Errorf("COPY test_analysis_by_job_by_dates: %w", err)
 		}
-		dLog.Infof("insert complete after %s", time.Since(st))
+		dLog.Infof("inserted %d rows in %s", n, time.Since(st))
 	}
 	return nil
 }

--- a/pkg/db/copyfrom.go
+++ b/pkg/db/copyfrom.go
@@ -1,0 +1,34 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/stdlib"
+	log "github.com/sirupsen/logrus"
+)
+
+// CopyFrom uses the PostgreSQL COPY protocol to perform bulk data insertion,
+// streaming all rows in a single protocol-level operation. Callers provide a
+// pgx.CopyFromSource (e.g. pgx.CopyFromRows or pgx.CopyFromSlice) so they
+// can choose whether to pre-allocate rows or generate them lazily.
+//
+// Columns not listed receive their DEFAULT (e.g. serial id, deleted_at NULL).
+func (d *DB) CopyFrom(ctx context.Context, table string, columns []string, rowSrc pgx.CopyFromSource) (int64, error) {
+	sqlDB, err := d.DB.DB()
+	if err != nil {
+		return 0, fmt.Errorf("getting sql.DB: %w", err)
+	}
+	conn, err := stdlib.AcquireConn(sqlDB)
+	if err != nil {
+		return 0, fmt.Errorf("acquiring pgx conn: %w", err)
+	}
+	defer func() {
+		if err := stdlib.ReleaseConn(sqlDB, conn); err != nil {
+			log.WithError(err).Error("failed to release pgx conn")
+		}
+	}()
+
+	return conn.CopyFrom(ctx, pgx.Identifier{table}, columns, rowSrc)
+}


### PR DESCRIPTION
## Summary

- Adds a centralized `CopyFrom` helper on `db.DB` (`pkg/db/copyfrom.go`) that wraps pgx's COPY protocol with connection lifecycle management
- Replaces `CreateInBatches(insertRows, 2000)` with `CopyFrom` for `test_analysis_by_job_by_dates` bulk inserts in the prow loader
- The daily test analysis import inserts ~2.76M rows; `CreateInBatches` generated ~1,381 separate INSERT round-trips taking 20m16s; COPY streams all rows in a single operation, completing in 1m16s (16x speedup)

## Benchmarks (staging-2, Go app local, PostgreSQL in AWS RDS)

| Metric | CreateInBatches | COPY |
|---|---|---|
| Insert time (2.76M rows) | 20m16s | 1m16s |
| Total prow load time | ~30m | ~7m |

## Test plan

- [x] `gofmt`, `go vet`, `golangci-lint` pass
- [x] Unit tests pass (`go test ./pkg/db/... ./pkg/dataloader/prowloader/...`)
- [x] Benchmarked against staging-2 database with production-scale data
- [x] Verified row counts match between CreateInBatches and COPY approaches
- [x] Independent code review found no correctness issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved daily test-analysis data loading with a faster bulk import approach.
  * Added support for high-volume PostgreSQL bulk inserts in the database layer.

* **Bug Fixes**
  * Reduced the likelihood of timeouts or slowdowns when processing large test-analysis updates.
  * Improved error reporting for bulk load failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->