### PR TITLE
TRT-2769: WIP: Rework feature gate test filtering to cover component owned jobs

### DIFF
--- a/cmd/sippy/seed_data.go
+++ b/cmd/sippy/seed_data.go
@@ -176,6 +176,15 @@ var syntheticJobs = []syntheticJobDef{
 			"Suite": "unknown", "Upgrade": "micro", "LayeredProduct": "none",
 		},
 	},
+	{
+		nameTemplate: "periodic-ci-openshift-release-master-ci-%s-e2e-aws-ovn-amd64-capability-networksegmentation",
+		variants: map[string]string{
+			"Platform": "aws", "Architecture": "amd64", "Network": "ovn",
+			"Topology": "ha", "Installer": "ipi", "FeatureSet": "default",
+			"Suite": "parallel", "Upgrade": "none", "LayeredProduct": "none",
+			"Capability": "NetworkSegmentation",
+		},
+	},
 }
 
 // Job template constants for referencing specific jobs in test specs.
@@ -331,6 +340,29 @@ var syntheticTests = []syntheticTestSpec{
 		},
 	},
 
+	// --- Feature gate annotated tests ---
+	{
+		testID: "test-fg-network-segmentation", testName: "[sig-network] [FeatureGate:NetworkSegmentation] pods should communicate across segments",
+		component: "Networking / ovn-kubernetes", capabilities: []string{"networking"},
+		jobCounts: map[string]map[string]testCount{
+			awsAmd64Parallel: {"4.21": {100, 95, 0}, "4.22": {100, 93, 0}},
+			gcpAmd64Parallel: {"4.21": {100, 97, 0}, "4.22": {100, 95, 0}},
+		},
+	},
+	{
+		testID: "test-fg-network-segmentation-2", testName: "[sig-network] [FeatureGate:NetworkSegmentation] network policy should enforce segmentation",
+		component: "Networking / ovn-kubernetes", capabilities: []string{"networking"},
+		jobCounts: map[string]map[string]testCount{
+			awsAmd64Parallel: {"4.21": {100, 94, 0}, "4.22": {100, 92, 0}},
+		},
+	},
+	{
+		testID: "test-fg-aws-dual-stack-install", testName: "[sig-installer] [FeatureGate:AWSDualStackInstall] dual stack install should succeed",
+		component: "Installer / openshift-installer", capabilities: []string{"AWSDualStackInstall"},
+		jobCounts: map[string]map[string]testCount{
+			awsAmd64Parallel: {"4.22": {50, 48, 0}},
+		},
+	},
 	// --- Install / health indicator tests: run on every job, every release ---
 	{
 		testID: "test-install-overall", testName: "install should succeed: overall",
@@ -408,6 +440,10 @@ func seedSyntheticData(dbc *db.DB) error {
 	}
 	if count > 0 {
 		log.Infof("Database already contains %d ProwJobs, skipping seed. Drop and recreate the database to re-seed (e.g. docker compose down -v).", count)
+		// Feature gates use FirstOrCreate and are safe to re-run on an existing DB.
+		if err := seedFeatureGates(dbc); err != nil {
+			return errors.WithMessage(err, "failed to seed feature gates")
+		}
 		return nil
 	}
 
@@ -436,6 +472,10 @@ func seedSyntheticData(dbc *db.DB) error {
 
 	if err := createLabelsAndSymptoms(dbc); err != nil {
 		return errors.WithMessage(err, "failed to create labels and symptoms")
+	}
+
+	if err := seedFeatureGates(dbc); err != nil {
+		return errors.WithMessage(err, "failed to seed feature gates")
 	}
 
 	log.Info("Refreshing materialized views...")
@@ -958,5 +998,24 @@ func createLabelsAndSymptoms(dbc *db.DB) error {
 		}
 	}
 
+	return nil
+}
+
+func seedFeatureGates(dbc *db.DB) error {
+	featureGates := []models.FeatureGate{
+		{Release: "4.22", Topology: "SelfManagedHA", FeatureSet: "TechPreviewNoUpgrade", FeatureGate: "NetworkSegmentation", Status: "enabled"},
+		{Release: "4.22", Topology: "SelfManagedHA", FeatureSet: "TechPreviewNoUpgrade", FeatureGate: "AWSDualStackInstall", Status: "enabled"},
+	}
+
+	for _, fg := range featureGates {
+		var existing models.FeatureGate
+		if err := dbc.DB.Where(
+			"release = ? AND topology = ? AND feature_set = ? AND feature_gate = ?",
+			fg.Release, fg.Topology, fg.FeatureSet, fg.FeatureGate,
+		).FirstOrCreate(&existing, fg).Error; err != nil {
+			return fmt.Errorf("failed to create feature gate %s/%s: %w", fg.Release, fg.FeatureGate, err)
+		}
+	}
+	log.Infof("Created %d feature gate records", len(featureGates))
 	return nil
 }

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -1031,14 +1031,15 @@ type SippyViews struct {
 }
 
 type FeatureGate struct {
-	ID               int            `json:"id"`
-	FeatureGate      string         `json:"feature_gate"`
-	Release          string         `json:"release"`
-	UniqueTestCount  int64          `json:"unique_test_count"`
-	FirstSeenIn      string         `json:"first_seen_in"`
-	FirstSeenInMajor int64          `json:"first_seen_in_major"`
-	FirstSeenInMinor int64          `json:"first_seen_in_minor"`
-	Enabled          pq.StringArray `json:"enabled" gorm:"type:text[]"`
+	ID               int               `json:"id"`
+	FeatureGate      string            `json:"feature_gate"`
+	Release          string            `json:"release"`
+	UniqueTestCount  int64             `json:"unique_test_count"`
+	FirstSeenIn      string            `json:"first_seen_in"`
+	FirstSeenInMajor int64             `json:"first_seen_in_major"`
+	FirstSeenInMinor int64             `json:"first_seen_in_minor"`
+	Enabled          pq.StringArray    `json:"enabled" gorm:"type:text[]"`
+	Links            map[string]string `json:"links,omitempty" gorm:"-"`
 }
 
 func (fg FeatureGate) GetFieldType(param string) ColumnType {

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/signal"
 	"regexp"
@@ -677,8 +678,35 @@ func (s *Server) jsonFeatureGates(w http.ResponseWriter, req *http.Request) {
 			failureResponse(w, http.StatusInternalServerError, "couldn't parse filter opts: "+err.Error())
 			return
 		}
+		baseAPIURL := api.GetBaseURL(req)
+		baseFrontendURL := api.GetBaseFrontendURL(req)
+		for i := range gates {
+			injectFeatureGateHATEOASLinks(&gates[i], release, baseAPIURL, baseFrontendURL)
+		}
 		api.RespondWithJSON(http.StatusOK, w, gates)
 	}
+}
+
+func injectFeatureGateHATEOASLinks(fg *apitype.FeatureGate, release, baseAPIURL, baseFrontendURL string) {
+	fg.Links = make(map[string]string, 3)
+
+	annotationFilter := url.QueryEscape(fmt.Sprintf(
+		`{"items":[{"columnField":"name","operatorValue":"contains","value":"FeatureGate:%s]"}]}`,
+		fg.FeatureGate))
+	fg.Links["tests_by_annotation"] = fmt.Sprintf(
+		"%s/api/tests?release=%s&filter=%s",
+		baseAPIURL, release, annotationFilter)
+
+	capabilityFilter := url.QueryEscape(fmt.Sprintf(
+		`{"items":[{"columnField":"name","operatorValue":"contains","value":"openshift-tests should work"},{"columnField":"variants","operatorValue":"contains","value":"Capability:%s"}],"linkOperator":"and"}`,
+		fg.FeatureGate))
+	fg.Links["tests_by_capability"] = fmt.Sprintf(
+		"%s/api/tests?release=%s&filter=%s",
+		baseAPIURL, release, capabilityFilter)
+
+	fg.Links["ui_detail"] = fmt.Sprintf(
+		"%s/feature_gates/%s/%s",
+		baseFrontendURL, release, url.PathEscape(fg.FeatureGate))
 }
 
 func (s *Server) jsonTestAnalysis(w http.ResponseWriter, req *http.Request, dbFN func(*db.DB, *filter.Filter, string, string, time.Time) (map[string][]api.CountByDate, error)) {

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -690,23 +690,32 @@ func (s *Server) jsonFeatureGates(w http.ResponseWriter, req *http.Request) {
 func injectFeatureGateHATEOASLinks(fg *apitype.FeatureGate, release, baseAPIURL, baseFrontendURL string) {
 	fg.Links = make(map[string]string, 3)
 
-	annotationFilter := url.QueryEscape(fmt.Sprintf(
-		`{"items":[{"columnField":"name","operatorValue":"contains","value":"FeatureGate:%s]"}]}`,
-		fg.FeatureGate))
-	fg.Links["tests_by_annotation"] = fmt.Sprintf(
-		"%s/api/tests?release=%s&filter=%s",
-		baseAPIURL, release, annotationFilter)
+	// Trailing "]" anchors the match so a shorter gate name can't prefix-match a longer one.
+	annotationFilter := filter.Filter{
+		Items: []filter.FilterItem{
+			{Field: "name", Operator: filter.OperatorContains, Value: fmt.Sprintf("FeatureGate:%s]", fg.FeatureGate)},
+		},
+	}
+	fg.Links["tests_by_annotation"] = buildFilteredTestsURL(baseAPIURL, release, annotationFilter)
 
-	capabilityFilter := url.QueryEscape(fmt.Sprintf(
-		`{"items":[{"columnField":"name","operatorValue":"contains","value":"openshift-tests should work"},{"columnField":"variants","operatorValue":"contains","value":"Capability:%s"}],"linkOperator":"and"}`,
-		fg.FeatureGate))
-	fg.Links["tests_by_capability"] = fmt.Sprintf(
-		"%s/api/tests?release=%s&filter=%s",
-		baseAPIURL, release, capabilityFilter)
+	capabilityFilter := filter.Filter{
+		Items: []filter.FilterItem{
+			{Field: "name", Operator: filter.OperatorContains, Value: "openshift-tests should work"},
+			{Field: "variants", Operator: filter.OperatorContains, Value: fmt.Sprintf("Capability:%s", fg.FeatureGate)},
+		},
+		LinkOperator: filter.LinkOperatorAnd,
+	}
+	fg.Links["tests_by_capability"] = buildFilteredTestsURL(baseAPIURL, release, capabilityFilter)
 
 	fg.Links["ui_detail"] = fmt.Sprintf(
 		"%s/feature_gates/%s/%s",
 		baseFrontendURL, release, url.PathEscape(fg.FeatureGate))
+}
+
+func buildFilteredTestsURL(baseAPIURL, release string, f filter.Filter) string {
+	filterJSON, _ := json.Marshal(f)
+	return fmt.Sprintf("%s/api/tests?release=%s&filter=%s",
+		baseAPIURL, url.QueryEscape(release), url.QueryEscape(string(filterJSON)))
 }
 
 func (s *Server) jsonTestAnalysis(w http.ResponseWriter, req *http.Request, dbFN func(*db.DB, *filter.Filter, string, string, time.Time) (map[string][]api.CountByDate, error)) {

--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -261,11 +261,14 @@ const JobsWrapper = () => {
 
 const FeatureGateDetailWrapper = () => {
   let { release, feature_gate } = useParams()
+  const navigate = useNavigate()
+
   if (release === 'latest') {
     release = findFirstNonGARelease(React.useContext(ReleasesContext))
+    navigate(`/feature_gates/${release}/${feature_gate}`, { replace: true })
   }
 
-  return RedirectLatestReleaseWrapper(
+  return (
     <FeatureGateDetail
       key={'fg-detail-' + release + '-' + feature_gate}
       release={release}

--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -15,7 +15,6 @@ import {
   findFirstNonGARelease,
   getReportStartDate,
   getUrlWithoutParams,
-  pathForTestSubstringByVariant,
   relativeTime,
 } from './helpers'
 import { JobAnalysis } from './jobs/JobAnalysis'
@@ -46,6 +45,7 @@ import CollapsibleChatDrawer from './chat/CollapsibleChatDrawer'
 import ComponentReadiness from './component_readiness/ComponentReadiness'
 import Drawer from '@mui/material/Drawer'
 import EventsChart from './prow_job_runs/EventsChart'
+import FeatureGateDetail from './tests/FeatureGateDetail'
 import FeatureGates from './tests/FeatureGates'
 import IconButton from '@mui/material/IconButton'
 import Install from './releases/Install'
@@ -259,16 +259,17 @@ const JobsWrapper = () => {
   )
 }
 
-const FeatureGateRedirectWrapper = () => {
+const FeatureGateDetailWrapper = () => {
   let { release, feature_gate } = useParams()
   if (release === 'latest') {
     release = findFirstNonGARelease(React.useContext(ReleasesContext))
   }
 
-  return (
-    <Navigate
-      to={pathForTestSubstringByVariant(release, 'FeatureGate:' + feature_gate)}
-      replace
+  return RedirectLatestReleaseWrapper(
+    <FeatureGateDetail
+      key={'fg-detail-' + release + '-' + feature_gate}
+      release={release}
+      featureGate={feature_gate}
     />
   )
 }
@@ -713,7 +714,7 @@ function App(props) {
 
                             <Route
                               path="/feature_gates/:release/:feature_gate"
-                              element={<FeatureGateRedirectWrapper />}
+                              element={<FeatureGateDetailWrapper />}
                             />
 
                             <Route

--- a/sippy-ng/src/tests/FeatureGateDetail.js
+++ b/sippy-ng/src/tests/FeatureGateDetail.js
@@ -21,9 +21,16 @@ function TestResultsSection({ title, apiUrl, release }) {
   const [rows, setRows] = React.useState([])
   const [isLoaded, setLoaded] = React.useState(false)
   const [fetchError, setFetchError] = React.useState('')
+  const [sortModel, setSortModel] = React.useState([
+    { field: 'current_pass_percentage', sort: 'asc' },
+  ])
 
   useEffect(() => {
-    if (!apiUrl) return
+    if (!apiUrl) {
+      setRows([])
+      setLoaded(true)
+      return
+    }
     setLoaded(false)
     setFetchError('')
 
@@ -107,7 +114,8 @@ function TestResultsSection({ title, apiUrl, release }) {
         autoHeight={true}
         rowsPerPageOptions={[10, 25, 50]}
         pageSize={25}
-        sortModel={[{ field: 'current_pass_percentage', sort: 'asc' }]}
+        sortModel={sortModel}
+        onSortModelChange={setSortModel}
         disableSelectionOnClick
       />
     </Box>
@@ -204,12 +212,9 @@ export default function FeatureGateDetail(props) {
       <SimpleBreadcrumbs
         release={release}
         currentPage={featureGate}
-        crumbs={[
-          {
-            text: 'Feature Gates',
-            link: `/feature_gates/${release}`,
-          },
-        ]}
+        previousPage={
+          <Link to={`/feature_gates/${release}`}>Feature Gates</Link>
+        }
       />
       <Container size="xl">
         <Typography align="center" variant="h4" sx={{ mb: 2 }}>

--- a/sippy-ng/src/tests/FeatureGateDetail.js
+++ b/sippy-ng/src/tests/FeatureGateDetail.js
@@ -1,0 +1,274 @@
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Container,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material'
+import { DataGrid } from '@mui/x-data-grid'
+import { Link } from 'react-router-dom'
+import { pathForTestByVariant, safeEncodeURIComponent } from '../helpers'
+import Alert from '@mui/material/Alert'
+import PropTypes from 'prop-types'
+import React, { Fragment, useEffect } from 'react'
+import SimpleBreadcrumbs from '../components/SimpleBreadcrumbs'
+
+function TestResultsSection({ title, apiUrl, release }) {
+  const [rows, setRows] = React.useState([])
+  const [isLoaded, setLoaded] = React.useState(false)
+  const [fetchError, setFetchError] = React.useState('')
+
+  useEffect(() => {
+    if (!apiUrl) return
+    setLoaded(false)
+    setFetchError('')
+
+    fetch(apiUrl)
+      .then((response) => {
+        if (response.status !== 200) {
+          throw new Error('server returned ' + response.status)
+        }
+        return response.json()
+      })
+      .then((json) => {
+        setRows(json || [])
+        setLoaded(true)
+      })
+      .catch((error) => {
+        setFetchError('Could not retrieve ' + title + ': ' + error)
+        setLoaded(true)
+      })
+  }, [apiUrl, title])
+
+  const columns = [
+    {
+      field: 'name',
+      headerName: 'Test Name',
+      flex: 4,
+      renderCell: (params) => (
+        <Link to={pathForTestByVariant(release, params.value)}>
+          {params.value}
+        </Link>
+      ),
+    },
+    {
+      field: 'current_successes',
+      headerName: 'Current Successes',
+      type: 'number',
+      flex: 1,
+    },
+    {
+      field: 'current_failures',
+      headerName: 'Current Failures',
+      type: 'number',
+      flex: 1,
+    },
+    {
+      field: 'current_flakes',
+      headerName: 'Current Flakes',
+      type: 'number',
+      flex: 1,
+    },
+    {
+      field: 'current_pass_percentage',
+      headerName: 'Current Pass %',
+      type: 'number',
+      flex: 1,
+      renderCell: (params) =>
+        params.value != null ? params.value.toFixed(2) + '%' : '',
+    },
+    {
+      field: 'current_runs',
+      headerName: 'Current Runs',
+      type: 'number',
+      flex: 1,
+    },
+  ]
+
+  if (fetchError) {
+    return <Alert severity="error">{fetchError}</Alert>
+  }
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Typography variant="h6" sx={{ mb: 1 }}>
+        {title} ({isLoaded ? rows.length : '...'} tests)
+      </Typography>
+      <DataGrid
+        loading={!isLoaded}
+        rows={rows}
+        columns={columns}
+        getRowId={(row) => row.name}
+        getRowHeight={() => 'auto'}
+        autoHeight={true}
+        rowsPerPageOptions={[10, 25, 50]}
+        pageSize={25}
+        sortModel={[{ field: 'current_pass_percentage', sort: 'asc' }]}
+        disableSelectionOnClick
+      />
+    </Box>
+  )
+}
+
+TestResultsSection.propTypes = {
+  title: PropTypes.string.isRequired,
+  apiUrl: PropTypes.string,
+  release: PropTypes.string.isRequired,
+}
+
+export default function FeatureGateDetail(props) {
+  const { release, featureGate } = props
+
+  const [gate, setGate] = React.useState(null)
+  const [isLoaded, setLoaded] = React.useState(false)
+  const [fetchError, setFetchError] = React.useState('')
+  const [activeTab, setActiveTab] = React.useState(0)
+
+  useEffect(() => {
+    document.title = `Sippy > ${release} > Feature Gates > ${featureGate}`
+    setLoaded(false)
+    setFetchError('')
+
+    const filterParam = safeEncodeURIComponent(
+      JSON.stringify({
+        items: [
+          {
+            columnField: 'feature_gate',
+            operatorValue: 'equals',
+            value: featureGate,
+          },
+        ],
+      })
+    )
+
+    fetch(
+      process.env.REACT_APP_API_URL +
+        '/api/feature_gates?release=' +
+        release +
+        '&filter=' +
+        filterParam
+    )
+      .then((response) => {
+        if (response.status !== 200) {
+          throw new Error('server returned ' + response.status)
+        }
+        return response.json()
+      })
+      .then((json) => {
+        if (json && json.length > 0) {
+          setGate(json[0])
+        }
+        setLoaded(true)
+      })
+      .catch((error) => {
+        setFetchError('Could not retrieve feature gate: ' + error)
+        setLoaded(true)
+      })
+  }, [release, featureGate])
+
+  if (fetchError) {
+    return (
+      <Container size="xl">
+        <Alert severity="error">{fetchError}</Alert>
+      </Container>
+    )
+  }
+
+  if (!isLoaded) {
+    return (
+      <Container
+        size="xl"
+        sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}
+      >
+        <CircularProgress />
+      </Container>
+    )
+  }
+
+  if (!gate) {
+    return (
+      <Container size="xl">
+        <Alert severity="warning">
+          Feature gate &quot;{featureGate}&quot; not found in release {release}.
+        </Alert>
+      </Container>
+    )
+  }
+
+  return (
+    <Fragment>
+      <SimpleBreadcrumbs
+        release={release}
+        currentPage={featureGate}
+        crumbs={[
+          {
+            text: 'Feature Gates',
+            link: `/feature_gates/${release}`,
+          },
+        ]}
+      />
+      <Container size="xl">
+        <Typography align="center" variant="h4" sx={{ mb: 2 }}>
+          {featureGate}
+        </Typography>
+
+        <Card sx={{ mb: 3 }}>
+          <CardContent>
+            <Typography variant="body1" sx={{ mb: 1 }}>
+              <strong>Release:</strong> {gate.release}
+            </Typography>
+            <Typography variant="body1" sx={{ mb: 1 }}>
+              <strong>First Seen In:</strong> {gate.first_seen_in}
+            </Typography>
+            <Typography variant="body1" sx={{ mb: 1 }}>
+              <strong>Total Test Count:</strong> {gate.unique_test_count}
+            </Typography>
+            <Typography variant="body1" component="div">
+              <strong>Enabled:</strong>{' '}
+              {gate.enabled &&
+                gate.enabled.map((e) => (
+                  <Chip key={e} label={e} size="small" sx={{ mr: 0.5 }} />
+                ))}
+            </Typography>
+          </CardContent>
+        </Card>
+
+        <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+          <Tabs
+            value={activeTab}
+            onChange={(e, v) => setActiveTab(v)}
+            aria-label="feature gate test sections"
+          >
+            <Tab label="Tests by Annotation" />
+            <Tab label="Tests by Capability" />
+          </Tabs>
+        </Box>
+
+        {activeTab === 0 && gate.links && (
+          <TestResultsSection
+            title="Tests tagged with FeatureGate annotation"
+            apiUrl={gate.links.tests_by_annotation}
+            release={release}
+          />
+        )}
+
+        {activeTab === 1 && gate.links && (
+          <TestResultsSection
+            title="Tests matching capability variant"
+            apiUrl={gate.links.tests_by_capability}
+            release={release}
+          />
+        )}
+      </Container>
+    </Fragment>
+  )
+}
+
+FeatureGateDetail.propTypes = {
+  release: PropTypes.string.isRequired,
+  featureGate: PropTypes.string.isRequired,
+}

--- a/sippy-ng/src/tests/FeatureGates.js
+++ b/sippy-ng/src/tests/FeatureGates.js
@@ -4,7 +4,6 @@ import { Link, useNavigate } from 'react-router-dom'
 import { NumberParam, StringParam, useQueryParam } from 'use-query-params'
 import {
   parseVersion,
-  pathForTestSubstringByVariant,
   safeEncodeURIComponent,
   useStableJSONQueryParam,
 } from '../helpers'
@@ -259,7 +258,7 @@ export default function FeatureGates(props) {
       type: 'number',
       flex: 2,
       renderCell: (params) => {
-        return <Link to={linkForFGTests(params)}>{params.value}</Link>
+        return <Link to={linkForFeatureGateDetail(params)}>{params.value}</Link>
       },
     },
     {
@@ -293,12 +292,18 @@ export default function FeatureGates(props) {
     },
   ]
 
-  const linkForFGTests = (params) => {
-    let fgAnnotation = `FeatureGate:${params.row.feature_gate}]`
-    if (params.row.feature_gate.includes('Install')) {
-      fgAnnotation = 'install should succeed'
+  const linkForFeatureGateDetail = (params) => {
+    if (params.row.links && params.row.links.ui_detail) {
+      try {
+        const url = new URL(params.row.links.ui_detail)
+        return url.pathname
+      } catch (e) {
+        // fall through
+      }
     }
-    return pathForTestSubstringByVariant(props.release, fgAnnotation)
+    return `/feature_gates/${props.release}/${encodeURIComponent(
+      params.row.feature_gate
+    )}`
   }
 
   const fetchData = () => {
@@ -343,7 +348,7 @@ export default function FeatureGates(props) {
 
   const onRowClick = (params) => {
     console.log('clicked')
-    navigate(linkForFGTests(params))
+    navigate(linkForFeatureGateDetail(params))
   }
 
   useEffect(() => {

--- a/test/e2e/feature_gates_test.go
+++ b/test/e2e/feature_gates_test.go
@@ -1,0 +1,125 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/openshift/sippy/pkg/apis/api"
+	"github.com/openshift/sippy/test/e2e/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeatureGatesAPI(t *testing.T) {
+	var gates []api.FeatureGate
+	err := util.SippyGet("/api/feature_gates?release="+util.Release, &gates)
+	require.NoError(t, err, "error fetching feature gates")
+	require.Greater(t, len(gates), 0, "no feature gates returned")
+	t.Logf("found %d feature gates", len(gates))
+
+	gatesByName := make(map[string]api.FeatureGate)
+	for _, g := range gates {
+		gatesByName[g.FeatureGate] = g
+	}
+
+	t.Run("NetworkSegmentation gate exists with correct data", func(t *testing.T) {
+		fg, ok := gatesByName["NetworkSegmentation"]
+		require.True(t, ok, "NetworkSegmentation feature gate not found")
+		assert.Equal(t, util.Release, fg.Release)
+		assert.Greater(t, fg.UniqueTestCount, int64(0), "expected tests for NetworkSegmentation")
+		assert.NotEmpty(t, fg.Enabled, "expected enabled topologies")
+	})
+
+	t.Run("AWSDualStackInstall gate exists", func(t *testing.T) {
+		fg, ok := gatesByName["AWSDualStackInstall"]
+		require.True(t, ok, "AWSDualStackInstall feature gate not found")
+		assert.Equal(t, util.Release, fg.Release)
+	})
+}
+
+func TestFeatureGatesHATEOASLinks(t *testing.T) {
+	var gates []api.FeatureGate
+	err := util.SippyGet("/api/feature_gates?release="+util.Release, &gates)
+	require.NoError(t, err, "error fetching feature gates")
+	require.Greater(t, len(gates), 0, "no feature gates returned")
+
+	for _, fg := range gates {
+		t.Run(fg.FeatureGate+" has HATEOAS links", func(t *testing.T) {
+			require.NotNil(t, fg.Links, "Links map should not be nil")
+
+			testsAnnotation, ok := fg.Links["tests_by_annotation"]
+			assert.True(t, ok, "missing tests_by_annotation link")
+			assert.Contains(t, testsAnnotation, "/api/tests?release="+util.Release)
+			assert.Contains(t, testsAnnotation, "FeatureGate%3A"+fg.FeatureGate)
+
+			testsCapability, ok := fg.Links["tests_by_capability"]
+			assert.True(t, ok, "missing tests_by_capability link")
+			assert.Contains(t, testsCapability, "/api/tests?release="+util.Release)
+			assert.Contains(t, testsCapability, "openshift-tests+should+work")
+			assert.Contains(t, testsCapability, "Capability%3A"+fg.FeatureGate)
+
+			uiDetail, ok := fg.Links["ui_detail"]
+			assert.True(t, ok, "missing ui_detail link")
+			assert.Contains(t, uiDetail, "/feature_gates/"+util.Release+"/"+fg.FeatureGate)
+		})
+	}
+}
+
+func TestFeatureGatesAnnotationLinkFollowable(t *testing.T) {
+	var gates []api.FeatureGate
+	err := util.SippyGet("/api/feature_gates?release="+util.Release, &gates)
+	require.NoError(t, err)
+
+	gatesByName := make(map[string]api.FeatureGate)
+	for _, g := range gates {
+		gatesByName[g.FeatureGate] = g
+	}
+
+	fg, ok := gatesByName["NetworkSegmentation"]
+	require.True(t, ok, "NetworkSegmentation not found")
+
+	link := fg.Links["tests_by_annotation"]
+	require.NotEmpty(t, link)
+
+	var tests []api.Test
+	err = util.SippyGetAbsolute(link, &tests)
+	require.NoError(t, err, "failed to follow tests_by_annotation link")
+	assert.Greater(t, len(tests), 0, "expected tests when following tests_by_annotation link for NetworkSegmentation")
+	for _, test := range tests {
+		assert.Contains(t, test.Name, "FeatureGate:NetworkSegmentation", "test name should contain the feature gate annotation")
+	}
+}
+
+func TestFeatureGatesCapabilityLinkFollowable(t *testing.T) {
+	var gates []api.FeatureGate
+	err := util.SippyGet("/api/feature_gates?release="+util.Release, &gates)
+	require.NoError(t, err)
+
+	gatesByName := make(map[string]api.FeatureGate)
+	for _, g := range gates {
+		gatesByName[g.FeatureGate] = g
+	}
+
+	fg, ok := gatesByName["NetworkSegmentation"]
+	require.True(t, ok, "NetworkSegmentation not found")
+
+	link := fg.Links["tests_by_capability"]
+	require.NotEmpty(t, link)
+
+	var tests []api.Test
+	err = util.SippyGetAbsolute(link, &tests)
+	require.NoError(t, err, "failed to follow tests_by_capability link")
+	assert.Greater(t, len(tests), 0, "expected tests when following tests_by_capability link for NetworkSegmentation")
+	for _, test := range tests {
+		assert.Contains(t, test.Name, "openshift-tests should work", "test name should contain openshift-tests should work")
+	}
+}
+
+func TestFeatureGatesFilterByName(t *testing.T) {
+	var gates []api.FeatureGate
+	filterJSON := `{"items":[{"columnField":"feature_gate","operatorValue":"equals","value":"NetworkSegmentation"}]}`
+	err := util.SippyGet("/api/feature_gates?release="+util.Release+"&filter="+filterJSON, &gates)
+	require.NoError(t, err, "error filtering feature gates")
+	require.Len(t, gates, 1, "expected exactly one feature gate")
+	assert.Equal(t, "NetworkSegmentation", gates[0].FeatureGate)
+	assert.NotNil(t, gates[0].Links)
+}

--- a/test/e2e/util/e2erequest.go
+++ b/test/e2e/util/e2erequest.go
@@ -40,8 +40,12 @@ func BuildE2EURL(apiPath string) string {
 }
 
 func SippyGet(path string, data interface{}) error {
+	return SippyGetAbsolute(BuildE2EURL(path), data)
+}
+
+func SippyGetAbsolute(url string, data interface{}) error {
 	client := &http.Client{Timeout: 30 * time.Second}
-	req, err := client.Get(BuildE2EURL(path)) //nolint:gosec // G704: URL is constructed from test helper's hardcoded localhost base URL
+	req, err := client.Get(url) //nolint:gosec // G704: URL is constructed from test helper's hardcoded localhost base URL
 	if err != nil {
 		return err
 	}

--- a/test/e2e/util/e2erequest.go
+++ b/test/e2e/util/e2erequest.go
@@ -45,7 +45,7 @@ func SippyGet(path string, data interface{}) error {
 
 func SippyGetAbsolute(url string, data interface{}) error {
 	client := &http.Client{Timeout: 30 * time.Second}
-	req, err := client.Get(url) //nolint:gosec // G704: URL is constructed from test helper's hardcoded localhost base URL
+	req, err := client.Get(url) //nolint:gosec // G107: URL is either from BuildE2EURL (hardcoded localhost) or a server-returned HATEOAS link in e2e tests
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Centralizes the logic for how to find test results for a featuregate
  for re-use in the openshift/api verification job.
- Feature Gate API now returns hateoas links clients can follow.
- Includes a link to the tests tagged for the feature gate name.
- Includes a link to the synthetic "openshift-tests should work" as an
  indicator the job fully passed, for any jobs tied to a Capability.
- Replaces the hack for featuregates containing Install to automatically
  route to all install results and exclude actual tests for the FG.
- Adds feature gate seed data and e2e tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Feature Gates detail page with tabs for tests by annotation and by capability variant.
  * Feature gate listings now include navigation links to the related test lists and UI detail.
  * Expanded synthetic feature-gate seeding coverage (including NetworkSegmentation and AWSDualStackInstall scenarios).

* **Bug Fixes**
  * Improved Feature Gates navigation so the correct detail page renders for both specific releases and **latest**.

* **Tests**
  * Added end-to-end coverage for the Feature Gates API, including HATEOAS links, filtering, and link follow-through.

* **Chores**
  * Refined end-to-end request helper for absolute URL GETs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->