### PR TITLE
TRT-2771: Return HTTP 400 for invalid filter fields instead of 500

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/go-version v1.7.0
+	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pgtype v1.14.0
 	github.com/jackc/pgx/v4 v4.18.2
 	github.com/jferrl/go-githubauth v1.1.0
@@ -98,7 +99,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.14.3 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.3 // indirect

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -2,8 +2,13 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/jackc/pgconn"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/api/googleapi"
 )
 
 func RespondWithJSON(statusCode int, w http.ResponseWriter, data interface{}) {
@@ -19,4 +24,30 @@ func RespondWithJSON(statusCode int, w http.ResponseWriter, data interface{}) {
 	if err := json.NewEncoder(w).Encode(data); err != nil {
 		fmt.Fprintf(w, `{"message": "could not marshal results: %s"}`, err)
 	}
+}
+
+// RespondWithError writes an error JSON response, returning HTTP 400 for
+// database column errors (invalid filter/sort fields) and 500 for everything else.
+func RespondWithError(w http.ResponseWriter, msg string, err error) {
+	code := http.StatusInternalServerError
+	if IsBadRequestError(err) {
+		code = http.StatusBadRequest
+	}
+	log.WithError(err).Error(msg)
+	RespondWithJSON(code, w, map[string]any{"code": code, "message": msg})
+}
+
+const pgUndefinedColumn = "42703"
+
+func IsBadRequestError(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == pgUndefinedColumn {
+		return true
+	}
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) && apiErr.Code == http.StatusBadRequest &&
+		len(apiErr.Errors) > 0 && apiErr.Errors[0].Reason == "invalidQuery" {
+		return true
+	}
+	return false
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -39,6 +39,10 @@ func RespondWithError(w http.ResponseWriter, msg string, err error) {
 
 const pgUndefinedColumn = "42703"
 
+// bqInvalidQuery matches BigQuery's error reason for query-level errors
+// such as unrecognized column names, invalid syntax, and type mismatches.
+const bqInvalidQuery = "invalidQuery"
+
 func IsBadRequestError(err error) bool {
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) && pgErr.Code == pgUndefinedColumn {
@@ -46,7 +50,7 @@ func IsBadRequestError(err error) bool {
 	}
 	var apiErr *googleapi.Error
 	if errors.As(err, &apiErr) && apiErr.Code == http.StatusBadRequest &&
-		len(apiErr.Errors) > 0 && apiErr.Errors[0].Reason == "invalidQuery" {
+		len(apiErr.Errors) > 0 && apiErr.Errors[0].Reason == bqInvalidQuery {
 		return true
 	}
 	return false

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgconn"
+	"google.golang.org/api/googleapi"
+)
+
+func TestIsBadRequestError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "generic error",
+			err:  fmt.Errorf("something went wrong"),
+			want: false,
+		},
+		{
+			name: "pg undefined column",
+			err:  &pgconn.PgError{Code: "42703"},
+			want: true,
+		},
+		{
+			name: "pg other error code",
+			err:  &pgconn.PgError{Code: "23505"},
+			want: false,
+		},
+		{
+			name: "wrapped pg undefined column",
+			err:  fmt.Errorf("query failed: %w", &pgconn.PgError{Code: "42703"}),
+			want: true,
+		},
+		{
+			name: "googleapi 400 with invalidQuery reason",
+			err: &googleapi.Error{
+				Code:   400,
+				Errors: []googleapi.ErrorItem{{Reason: "invalidQuery", Message: "Unrecognized name: bad_col"}},
+			},
+			want: true,
+		},
+		{
+			name: "googleapi 400 without invalidQuery reason",
+			err: &googleapi.Error{
+				Code:   400,
+				Errors: []googleapi.ErrorItem{{Reason: "invalid", Message: "some other error"}},
+			},
+			want: false,
+		},
+		{
+			name: "googleapi 400 with no error items",
+			err:  &googleapi.Error{Code: 400},
+			want: false,
+		},
+		{
+			name: "googleapi 500",
+			err: &googleapi.Error{
+				Code:   500,
+				Errors: []googleapi.ErrorItem{{Reason: "backendError"}},
+			},
+			want: false,
+		},
+		{
+			name: "wrapped googleapi 400 invalidQuery",
+			err: fmt.Errorf("bq failed: %w", &googleapi.Error{
+				Code:   400,
+				Errors: []googleapi.ErrorItem{{Reason: "invalidQuery"}},
+			}),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsBadRequestError(tt.err)
+			if got != tt.want {
+				t.Errorf("IsBadRequestError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -37,6 +38,11 @@ func TestIsBadRequestError(t *testing.T) {
 		{
 			name: "wrapped pg undefined column",
 			err:  fmt.Errorf("query failed: %w", &pgconn.PgError{Code: "42703"}),
+			want: true,
+		},
+		{
+			name: "joined pg undefined column",
+			err:  errors.Join(fmt.Errorf("first error"), &pgconn.PgError{Code: "42703"}),
 			want: true,
 		},
 		{

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -43,7 +43,7 @@ func TestIsBadRequestError(t *testing.T) {
 			name: "googleapi 400 with invalidQuery reason",
 			err: &googleapi.Error{
 				Code:   400,
-				Errors: []googleapi.ErrorItem{{Reason: "invalidQuery", Message: "Unrecognized name: bad_col"}},
+				Errors: []googleapi.ErrorItem{{Reason: bqInvalidQuery, Message: "Unrecognized name: bad_col"}},
 			},
 			want: true,
 		},
@@ -72,7 +72,7 @@ func TestIsBadRequestError(t *testing.T) {
 			name: "wrapped googleapi 400 invalidQuery",
 			err: fmt.Errorf("bq failed: %w", &googleapi.Error{
 				Code:   400,
-				Errors: []googleapi.ErrorItem{{Reason: "invalidQuery"}},
+				Errors: []googleapi.ErrorItem{{Reason: bqInvalidQuery}},
 			}),
 			want: true,
 		},

--- a/pkg/api/jobs.go
+++ b/pkg/api/jobs.go
@@ -177,13 +177,13 @@ func PrintJobsReportFromDB(w http.ResponseWriter, req *http.Request,
 
 	filterOpts, err := filter.FilterOptionsFromRequest(req, currentPassPercentage, apitype.SortDescending)
 	if err != nil {
-		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": "Error building job report:" + err.Error()})
+		RespondWithJSON(http.StatusBadRequest, w, map[string]any{"code": http.StatusBadRequest, "message": "Error building job report: " + err.Error()})
 		return
 	}
 
 	jobsResult, err := JobReportsFromDB(dbc, release, req.URL.Query().Get("period"), filterOpts, start, boundary, end, reportEnd)
 	if err != nil {
-		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": "Error building job report:" + err.Error()})
+		RespondWithError(w, "error building job report", err)
 		return
 	}
 

--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -35,7 +35,7 @@ func PrintPullRequestsReport(w http.ResponseWriter, req *http.Request, dbClient 
 	q = q.Joins(`INNER JOIN release_tag_pull_requests ON release_tag_pull_requests.release_pull_request_id = release_pull_requests.id JOIN release_tags on release_tags.id = release_tag_pull_requests.release_tag_id`)
 	filterOpts, err := filter.FilterOptionsFromRequest(req, "id", apitype.SortDescending)
 	if err != nil {
-		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": err.Error()})
+		RespondWithJSON(http.StatusBadRequest, w, map[string]any{"code": http.StatusBadRequest, "message": err.Error()})
 		return
 	}
 	q, err = filter.FilterableDBResult(q, filterOpts, nil)
@@ -331,7 +331,7 @@ func PrintReleasesReport(w http.ResponseWriter, req *http.Request, dbClient *db.
 
 	filterOpts, err := filter.FilterOptionsFromRequest(req, "release_tag", apitype.SortDescending)
 	if err != nil {
-		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": "Error building job run report:" + err.Error()})
+		RespondWithJSON(http.StatusBadRequest, w, map[string]any{"code": http.StatusBadRequest, "message": "Error building releases report: " + err.Error()})
 		return
 	}
 	q, err := filter.FilterableDBResult(releaseFilter(req, dbClient.DB), filterOpts, nil)

--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -12,7 +13,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/pkg/errors"
+	pkgerrors "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
 
@@ -348,7 +349,7 @@ func PrintTestsJSONFromDB(
 
 	result, err := spec.buildTestsResultsFromPostgres(req.Context(), dbc, cacheClient)
 	if err != nil {
-		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": "Error building job report:" + err.Error()})
+		RespondWithError(w, "error building test report", err)
 		return
 	}
 
@@ -368,7 +369,7 @@ func PrintTestsJSONFromBigQuery(release string, w http.ResponseWriter, req *http
 
 	result, err := spec.buildTestsResultsFromBigQuery(req.Context(), bqc)
 	if err != nil {
-		RespondWithJSON(http.StatusInternalServerError, w, map[string]interface{}{"code": http.StatusInternalServerError, "message": "Error building job report:" + err.Error()})
+		RespondWithError(w, "error building test report", err)
 		return
 	}
 
@@ -382,7 +383,7 @@ func PrintTestsJSONFromBigQuery(release string, w http.ResponseWriter, req *http
 
 func GetJobRunTestsCountByLookback(dbc *db.DB, lookbackDays int) (int64, int64, error) {
 	if lookbackDays < 1 {
-		return -1, -1, errors.New("Lookback Days must be greater than zero")
+		return -1, -1, errors.New("lookback days must be greater than zero")
 	}
 	// Calculate the truncated time
 	now := time.Now().UTC()
@@ -442,7 +443,7 @@ func (spec *TestResultsSpec) buildTestsResultsFromPostgres(ctx context.Context, 
 		testResults{},
 	)
 	if errs != nil {
-		return result, fmt.Errorf("error(s) querying test results: %v", errs)
+		return result, errors.Join(errs...)
 	}
 	return result, nil
 }
@@ -609,7 +610,7 @@ func (spec *TestResultsSpec) buildTestsResultsFromBigQuery(ctx context.Context, 
 		generator,
 		testResultsBQ{})
 	if errs != nil {
-		return result, fmt.Errorf("error(s) querying test results: %v", errs)
+		return result, errors.Join(errs...)
 	}
 	return result, nil
 }
@@ -788,7 +789,7 @@ func FetchTestResultsFromBQ(ctx context.Context, q *bigquery.Query) ([]apitype.T
 		}
 		if err != nil {
 			log.WithError(err).Error("error parsing test result from bigquery")
-			errs = append(errs, errors.Wrap(err, "error parsing test result from bigquery"))
+			errs = append(errs, pkgerrors.Wrap(err, "error parsing test result from bigquery"))
 			continue
 		}
 		result = append(result, row)
@@ -807,7 +808,7 @@ func GetTestCapabilitiesFromDB(ctx context.Context, dbc *db.DB) ([]string, error
 		Pluck("capability", &capabilities).Error
 	if err != nil {
 		log.WithError(err).Error("error querying test capabilities from database")
-		return []string{}, errors.Wrap(err, "error querying test capabilities from database")
+		return []string{}, pkgerrors.Wrap(err, "error querying test capabilities from database")
 	}
 	return capabilities, nil
 }
@@ -824,7 +825,7 @@ func GetTestLifecyclesFromDB(ctx context.Context, dbc *db.DB) ([]string, error) 
 		Pluck("pair", &pairs).Error
 	if err != nil {
 		log.WithError(err).Error("error querying test lifecycles from database")
-		return []string{}, errors.Wrap(err, "error querying test lifecycles from database")
+		return []string{}, pkgerrors.Wrap(err, "error querying test lifecycles from database")
 	}
 
 	var lifecycles []string

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -22,7 +22,6 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
-
 	"github.com/openshift/sippy/pkg/api/componentreadiness/dataprovider"
 	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
 	"github.com/openshift/sippy/pkg/api/jobartifacts"
@@ -452,6 +451,15 @@ func failureResponse(w http.ResponseWriter, code int, message string) {
 	})
 }
 
+func failureResponseWithError(w http.ResponseWriter, message string, err error) {
+	code := http.StatusInternalServerError
+	if api.IsBadRequestError(err) {
+		code = http.StatusBadRequest
+	}
+	log.WithError(err).Error(message)
+	failureResponse(w, code, message)
+}
+
 // some standard error types
 const APIConfigError = "APIConfigError"
 const ParameterMissing = "ParameterMissing"
@@ -484,13 +492,13 @@ func (s *Server) jsonReleaseTagsReport(w http.ResponseWriter, req *http.Request)
 func (s *Server) jsonIncidentEvent(w http.ResponseWriter, req *http.Request) {
 	start, err := getISO8601Date("start", req)
 	if err != nil {
-		failureResponse(w, http.StatusInternalServerError, "couldn't parse start param: "+err.Error())
+		failureResponse(w, http.StatusBadRequest, "couldn't parse start param: "+err.Error())
 		return
 	}
 
 	end, err := getISO8601Date("end", req)
 	if err != nil {
-		failureResponse(w, http.StatusInternalServerError, "couldn't parse end param: "+err.Error())
+		failureResponse(w, http.StatusBadRequest, "couldn't parse end param: "+err.Error())
 		return
 	}
 
@@ -508,25 +516,25 @@ func (s *Server) jsonReleaseTagsEvent(w http.ResponseWriter, req *http.Request) 
 	if release != "" {
 		filterOpts, err := filter.FilterOptionsFromRequest(req, "release_time", apitype.SortDescending)
 		if err != nil {
-			failureResponse(w, http.StatusInternalServerError, "couldn't parse filter opts: "+err.Error())
+			failureResponse(w, http.StatusBadRequest, "couldn't parse filter opts: "+err.Error())
 			return
 		}
 
 		start, err := getISO8601Date("start", req)
 		if err != nil {
-			failureResponse(w, http.StatusInternalServerError, "couldn't parse start param: "+err.Error())
+			failureResponse(w, http.StatusBadRequest, "couldn't parse start param: "+err.Error())
 			return
 		}
 
 		end, err := getISO8601Date("end", req)
 		if err != nil {
-			failureResponse(w, http.StatusInternalServerError, "couldn't parse end param: "+err.Error())
+			failureResponse(w, http.StatusBadRequest, "couldn't parse end param: "+err.Error())
 			return
 		}
 
 		results, err := api.GetPayloadEvents(s.db, release, filterOpts, start, end)
 		if err != nil {
-			failureResponse(w, http.StatusInternalServerError, "couldn't get payload events: "+err.Error())
+			failureResponseWithError(w, "couldn't get payload events", err)
 			return
 		}
 
@@ -546,14 +554,13 @@ func (s *Server) jsonListPayloadJobRuns(w http.ResponseWriter, req *http.Request
 	filterOpts, err := filter.FilterOptionsFromRequest(req, "id", apitype.SortDescending)
 	if err != nil {
 		log.WithError(err).Error("error")
-		failureResponse(w, http.StatusInternalServerError, "Error building job run report: "+err.Error())
+		failureResponse(w, http.StatusBadRequest, "Error building job run report: "+err.Error())
 		return
 	}
 
 	payloadJobRuns, err := api.ListPayloadJobRuns(s.db, filterOpts, param.SafeRead(req, "release"))
 	if err != nil {
-		log.WithError(err).Error("error listing payload job runs")
-		failureResponse(w, http.StatusBadRequest, "error listing payload job runs: "+err.Error())
+		failureResponseWithError(w, "error listing payload job runs", err)
 		return
 	}
 	api.RespondWithJSON(http.StatusOK, w, payloadJobRuns)
@@ -579,7 +586,7 @@ func (s *Server) jsonGetPayloadAnalysis(w http.ResponseWriter, req *http.Request
 
 	filterOpts, err := filter.FilterOptionsFromRequest(req, "id", apitype.SortDescending)
 	if err != nil {
-		failureResponse(w, http.StatusInternalServerError, err.Error())
+		failureResponse(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -591,8 +598,7 @@ func (s *Server) jsonGetPayloadAnalysis(w http.ResponseWriter, req *http.Request
 
 	result, err := api.GetPayloadStreamTestFailures(s.db, release, stream, arch, filterOpts, s.GetReportEnd())
 	if err != nil {
-		log.WithError(err).Error("error")
-		failureResponse(w, http.StatusInternalServerError, "Error analyzing payload: "+err.Error())
+		failureResponseWithError(w, "error analyzing payload", err)
 		return
 	}
 
@@ -669,12 +675,12 @@ func (s *Server) jsonFeatureGates(w http.ResponseWriter, req *http.Request) {
 	if release != "" {
 		filterOpts, err := filter.FilterOptionsFromRequest(req, "unique_test_count", apitype.SortAscending)
 		if err != nil {
-			failureResponse(w, http.StatusInternalServerError, "couldn't parse filter opts: "+err.Error())
+			failureResponse(w, http.StatusBadRequest, "couldn't parse filter opts: "+err.Error())
 			return
 		}
 		gates, err := query.GetFeatureGatesFromDB(s.db.DB, release, filterOpts)
 		if err != nil {
-			failureResponse(w, http.StatusInternalServerError, "couldn't parse filter opts: "+err.Error())
+			failureResponseWithError(w, "couldn't query feature gates", err)
 			return
 		}
 		api.RespondWithJSON(http.StatusOK, w, gates)
@@ -690,12 +696,12 @@ func (s *Server) jsonTestAnalysis(w http.ResponseWriter, req *http.Request, dbFN
 	if release != "" {
 		filters, err := filter.ExtractFilters(req)
 		if err != nil {
-			failureResponse(w, http.StatusInternalServerError, "couldn't parse filter opts: "+err.Error())
+			failureResponse(w, http.StatusBadRequest, "couldn't parse filter opts: "+err.Error())
 			return
 		}
 		results, err := dbFN(s.db, filters, release, testName, s.GetReportEnd())
 		if err != nil {
-			failureResponse(w, http.StatusInternalServerError, err.Error())
+			failureResponseWithError(w, "error querying test analysis", err)
 			return
 		}
 		api.RespondWithJSON(200, w, results)
@@ -746,14 +752,13 @@ func (s *Server) jsonTestDurationsFromDB(w http.ResponseWriter, req *http.Reques
 
 	filters, err := filter.ExtractFilters(req)
 	if err != nil {
-		failureResponse(w, http.StatusInternalServerError, "error processing filter options")
+		failureResponse(w, http.StatusBadRequest, "error processing filter options")
 		return
 	}
 
 	outputs, err := api.GetTestDurationsFromDB(s.db, release, testName, filters)
 	if err != nil {
-		log.WithError(err).Error("error querying test outputs from db")
-		failureResponse(w, http.StatusInternalServerError, "error querying test outputs from db")
+		failureResponseWithError(w, "error querying test durations from db", err)
 		return
 	}
 	api.RespondWithJSON(http.StatusOK, w, outputs)
@@ -772,14 +777,13 @@ func (s *Server) jsonTestOutputsFromDB(w http.ResponseWriter, req *http.Request)
 
 	filters, err := filter.ExtractFilters(req)
 	if err != nil {
-		failureResponse(w, http.StatusInternalServerError, "error processing filter options")
+		failureResponse(w, http.StatusBadRequest, "error processing filter options")
 		return
 	}
 
 	outputs, err := api.GetTestOutputsFromDB(s.db, release, testName, filters, 10)
 	if err != nil {
-		log.WithError(err).Error("error querying test outputs from db")
-		failureResponse(w, http.StatusInternalServerError, "error querying test outputs from db")
+		failureResponseWithError(w, "error querying test outputs from db", err)
 		return
 	}
 	api.RespondWithJSON(http.StatusOK, w, outputs)
@@ -839,7 +843,7 @@ func (s *Server) jsonGetRecentTestFailures(w http.ResponseWriter, req *http.Requ
 
 	result, err := api.GetRecentTestFailures(s.db, release, period, previousPeriod, includeOutputs, filterOpts, pagination, s.GetReportEnd())
 	if err != nil {
-		failureResponse(w, http.StatusInternalServerError, err.Error())
+		failureResponseWithError(w, "error querying recent test failures", err)
 		return
 	}
 
@@ -1110,8 +1114,7 @@ func (s *Server) jsonJobBugsFromDB(w http.ResponseWriter, req *http.Request) {
 
 	jobIDs, err := query.ListFilteredJobIDs(s.db, release, jobFilter, start, boundary, end, limit, sortField, sort)
 	if err != nil {
-		log.WithError(err).Error("error querying jobs")
-		failureResponse(w, http.StatusInternalServerError, "error querying jobs")
+		failureResponseWithError(w, "error querying jobs", err)
 		return
 	}
 
@@ -1286,14 +1289,13 @@ func (s *Server) jsonRepositoriesReportFromDB(w http.ResponseWriter, req *http.R
 	if release != "" {
 		filterOpts, err := filter.FilterOptionsFromRequest(req, "premerge_job_failures", apitype.SortDescending)
 		if err != nil {
-			failureResponse(w, http.StatusInternalServerError, "couldn't parse filter opts: "+err.Error())
+			failureResponse(w, http.StatusBadRequest, "couldn't parse filter opts: "+err.Error())
 			return
 		}
 
 		results, err := api.GetRepositoriesReportFromDB(s.db, release, filterOpts, s.GetReportEnd())
 		if err != nil {
-			log.WithError(err).Error("error")
-			failureResponse(w, http.StatusInternalServerError, "Error fetching repositories: "+err.Error())
+			failureResponseWithError(w, "error fetching repositories", err)
 			return
 		}
 
@@ -1306,14 +1308,13 @@ func (s *Server) jsonPullRequestsReportFromDB(w http.ResponseWriter, req *http.R
 	if release != "" {
 		filterOpts, err := filter.FilterOptionsFromRequest(req, "merged_at", apitype.SortDescending)
 		if err != nil {
-			failureResponse(w, http.StatusInternalServerError, "couldn't parse filter opts: "+err.Error())
+			failureResponse(w, http.StatusBadRequest, "couldn't parse filter opts: "+err.Error())
 			return
 		}
 
 		results, err := api.GetPullRequestsReportFromDB(s.db, release, filterOpts)
 		if err != nil {
-			log.WithError(err).Error("error")
-			failureResponse(w, http.StatusInternalServerError, "Error fetching pull requests: "+err.Error())
+			failureResponseWithError(w, "error fetching pull requests", err)
 			return
 		}
 
@@ -1641,8 +1642,7 @@ func (s *Server) jsonJobsAnalysisFromDB(w http.ResponseWriter, req *http.Request
 	results, err := api.PrintJobAnalysisJSONFromDB(s.db, release, jobFilter, jobRunsFilter,
 		start, boundary, end, limit, sortField, sort, period, s.GetReportEnd())
 	if err != nil {
-		log.WithError(err).Error("error in PrintJobAnalysisJSONFromDB")
-		failureResponse(w, http.StatusInternalServerError, err.Error())
+		failureResponseWithError(w, "error in job analysis", err)
 		return
 	}
 


### PR DESCRIPTION
## Summary

- Catches Postgres SQLSTATE 42703 (undefined column) and BigQuery HTTP 400 errors at the HTTP response boundary, returning 400 instead of 500
- Fixes `FilterOptionsFromRequest` and `ExtractFilters` error responses from 500 to 400 across all handlers
- Error details are logged server-side but not leaked to the client
- Preserves error type chain through `errors.Join` so `pgconn.PgError` is detectable by `errors.As` at the boundary

## Context

API clients sending filter parameters with unrecognized column names (e.g., `columnField: "component"` on `/api/tests`) caused database errors surfaced as HTTP 500 responses. The database already validates column names, so we catch those errors at the boundary layer rather than maintaining a parallel field list.

## Follow-up

Some `pkg/api` functions (e.g., `PrintTestsJSONFromDB`) write HTTP responses directly rather than returning errors to the `sippyserver` handler layer. This creates two parallel error response paths (`RespondWithError` vs `failureResponseWithError`). Unifying this by having all `pkg/api` functions return errors and letting `sippyserver` handle all HTTP responses is left for a follow-up refactor.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (14924 Go tests, 19 JS tests, 54 Python tests)
- [x] Manual: invalid filter field returns 400
- [x] Manual: valid filter field returns 200

### Manual test evidence (against staging DB)

**Invalid filter field (`component`) on `/api/tests` returns 400:**
```
$ curl -s 'localhost:9090/api/tests?release=4.18&filter={"items":[{"columnField":"component","operatorValue":"equals","value":"test"}]}'
{"code":400,"message":"error building test report"}
```

**Valid filter field (`name`) on `/api/tests` returns 200:**
```
$ curl -s 'localhost:9090/api/tests?release=4.18&filter={"items":[{"columnField":"name","operatorValue":"contains","value":"openshift-tests"}]}&limit=1' | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'{len(d)} test(s) returned')"
1 test(s) returned
```

**Invalid filter field (`timestamp`) on `/api/jobs` returns 400:**
```
$ curl -s 'localhost:9090/api/jobs?release=4.18&filter={"items":[{"columnField":"timestamp","operatorValue":"equals","value":"test"}]}'
{"code":400,"message":"error building job report"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error handling so invalid request/filter parameters now return **400 Bad Request** instead of server errors across multiple report and query endpoints.
  * Standardized JSON error responses and messages for job, test, release, and pull request reporting, including clearer “build report” failures.
  * Added consistent bad-request classification for PostgreSQL and BigQuery-style errors.
* **Tests**
  * Added unit tests covering bad-request detection for PostgreSQL and Google API error variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->