### PR TITLE
replace per-row test ownership upserts with COPY + temp table

### DIFF
--- a/pkg/dataloader/testownershiploader/testownershiploader.go
+++ b/pkg/dataloader/testownershiploader/testownershiploader.go
@@ -3,25 +3,24 @@ package testownershiploader
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/stdlib"
+	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/bigquery"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 
 	"github.com/openshift/sippy/pkg/db"
-	"github.com/openshift/sippy/pkg/db/models"
 )
 
 // TestOwnershipLoader loads test ownership information from BigQuery. This data is generated and
 // pushed to BigQuery from https://github.com/openshift-eng/ci-test-mapping
 type TestOwnershipLoader struct {
-	dbc              *db.DB
-	mappingTableMgr  *bigquery.MappingTableManager
-	errors           []error
-	jiraComponentIDs map[string]uint
-	suiteIDs         map[string]uint
+	ctx             context.Context
+	dbc             *db.DB
+	mappingTableMgr *bigquery.MappingTableManager
+	errors          []error
 }
 
 func New(ctx context.Context, dbc *db.DB, googleServiceAccountCredentialFile, googleOAuthClientCredentialFile string) (*TestOwnershipLoader, error) {
@@ -32,10 +31,9 @@ func New(ctx context.Context, dbc *db.DB, googleServiceAccountCredentialFile, go
 	mappingTableMgr := bigquery.NewMappingTableManager(ctx, client)
 
 	return &TestOwnershipLoader{
-		dbc:              dbc,
-		mappingTableMgr:  mappingTableMgr,
-		jiraComponentIDs: make(map[string]uint),
-		suiteIDs:         make(map[string]uint),
+		ctx:             ctx,
+		dbc:             dbc,
+		mappingTableMgr: mappingTableMgr,
 	}, nil
 }
 
@@ -43,111 +41,180 @@ func (tol *TestOwnershipLoader) Name() string {
 	return "test ownership"
 }
 
+var tmpTestOwnershipColumns = []string{
+	"api_version",
+	"unique_id",
+	"name",
+	"suite",
+	"product",
+	"priority",
+	"staff_approved_obsolete",
+	"component",
+	"capabilities",
+	"jira_component",
+}
+
 func (tol *TestOwnershipLoader) Load() {
+	st := time.Now()
 	mappings, err := tol.mappingTableMgr.ListMappings()
 	if err != nil {
 		tol.errors = append(tol.errors, err)
 		return
 	}
+	log.WithFields(log.Fields{
+		"mappings": len(mappings),
+		"elapsed":  time.Since(st),
+	}).Info("fetched test ownership mappings from BigQuery")
 
-	// Link up the ci-test-mapping records to Sippy's test_ids
-	unknown := 0
-	known := 0
-	var ids []uint
-	for _, m := range mappings {
-		// Find the test in Sippy DB:
-		var test models.Test
-		res := tol.dbc.DB.Table("tests").First(&test, "name = ?", m.Name)
-		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
-			log.WithFields(log.Fields{
-				"testname": m.Name,
-			}).Debugf("sippy doesn't know about this test")
-			unknown++
-			continue
-		}
-		if res.Error != nil {
-			tol.errors = append(tol.errors, res.Error)
-			return
-		}
-		if test.ID == 0 {
-			log.Warningf("test %q has id 0", m.Name)
-			continue
-		}
+	if err := tol.loadMappings(mappings); err != nil {
+		tol.errors = append(tol.errors, err)
+	}
+}
 
-		var suiteID *uint
-		if id, ok := tol.suiteIDs[m.Suite]; ok {
-			suiteID = &id
-		} else {
-			var suite models.Suite
-			res = tol.dbc.DB.Model(&models.Suite{}).First(&suite, "name = ?", m.Suite)
-			if res.Error != nil && !errors.Is(res.Error, gorm.ErrRecordNotFound) {
-				tol.errors = append(tol.errors, errors.Wrap(res.Error, "couldn't find suite "+m.Suite))
-				continue
-			}
-			if res.Error == nil {
-				suiteIDVal := suite.ID
-				suiteID = &suiteIDVal
-				tol.suiteIDs[m.Suite] = suiteIDVal
-			}
+// loadMappings runs all database operations on a single pgx connection so the
+// temp table remains visible across CREATE, COPY, upsert, and delete steps.
+func (tol *TestOwnershipLoader) loadMappings(mappings []v1.TestOwnership) error {
+	sqlDB, err := tol.dbc.DB.DB()
+	if err != nil {
+		return fmt.Errorf("getting sql.DB: %w", err)
+	}
+	conn, err := stdlib.AcquireConn(sqlDB)
+	if err != nil {
+		return fmt.Errorf("acquiring pgx conn: %w", err)
+	}
+	defer func() {
+		if err := stdlib.ReleaseConn(sqlDB, conn); err != nil {
+			log.WithError(err).Error("failed to release pgx conn")
 		}
+	}()
 
-		var jiraComponentID *uint
-		if id, ok := tol.jiraComponentIDs[m.JIRAComponent]; ok {
-			jiraComponentID = &id
-		} else {
-			var jiraComponent models.JiraComponent
-			res = tol.dbc.DB.Model(models.JiraComponent{}).First(&jiraComponent, "name = ?", m.JIRAComponent)
-			if res.Error != nil {
-				msg := fmt.Sprintf("error with jira component %q", m.JIRAComponent)
-				tol.errors = append(tol.errors, errors.WithMessage(res.Error, msg))
-				log.WithError(res.Error).Warning(msg)
-				continue
-			}
-			id := jiraComponent.ID
-			jiraComponentID = &id
-			tol.jiraComponentIDs[m.JIRAComponent] = id
+	if _, err := conn.Exec(tol.ctx, `CREATE TEMP TABLE tmp_test_ownerships (
+		api_version             text NOT NULL DEFAULT '',
+		unique_id               text NOT NULL DEFAULT '',
+		name                    text NOT NULL DEFAULT '',
+		suite                   text NOT NULL DEFAULT '',
+		product                 text NOT NULL DEFAULT '',
+		priority                integer NOT NULL DEFAULT 0,
+		staff_approved_obsolete boolean NOT NULL DEFAULT false,
+		component               text NOT NULL DEFAULT '',
+		capabilities            text[],
+		jira_component          text NOT NULL DEFAULT ''
+	)`); err != nil {
+		return fmt.Errorf("creating temp table: %w", err)
+	}
+	defer func() {
+		if _, err := conn.Exec(tol.ctx, "DROP TABLE IF EXISTS tmp_test_ownerships"); err != nil {
+			log.WithError(err).Error("failed to drop temp table tmp_test_ownerships")
 		}
+	}()
 
-		tom := &models.TestOwnership{
-			APIVersion:            m.APIVersion,
-			Name:                  m.Name,
-			Suite:                 m.Suite,
-			UniqueID:              m.ID,
-			Product:               m.Product,
-			Component:             m.Component,
-			JiraComponent:         m.JIRAComponent,
-			Capabilities:          m.Capabilities,
-			Priority:              m.Priority,
-			StaffApprovedObsolete: m.StaffApprovedObsolete,
-			TestID:                test.ID,
-			SuiteID:               suiteID,
-			JiraComponentID:       jiraComponentID,
-		}
-		known++
-		res = tol.dbc.DB.Model(&models.TestOwnership{}).Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "name"}, {Name: "suite"}},
-			UpdateAll: true,
-		}).Save(tom)
-		if res.Error != nil {
-			tol.errors = append(tol.errors, res.Error)
-			log.WithError(res.Error).Warningf("error saving test ownership record for %q", m.Name)
-			return
-		}
-		ids = append(ids, tom.ID)
+	st := time.Now()
+	copied, err := conn.CopyFrom(tol.ctx,
+		pgx.Identifier{"tmp_test_ownerships"},
+		tmpTestOwnershipColumns,
+		pgx.CopyFromSlice(len(mappings), func(i int) ([]any, error) {
+			m := &mappings[i]
+			return []any{
+				m.APIVersion,
+				m.ID,
+				m.Name,
+				m.Suite,
+				m.Product,
+				m.Priority,
+				m.StaffApprovedObsolete,
+				m.Component,
+				m.Capabilities,
+				m.JIRAComponent,
+			}, nil
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("COPY tmp_test_ownerships: %w", err)
+	}
+	log.WithFields(log.Fields{
+		"rows":    copied,
+		"elapsed": time.Since(st),
+	}).Info("COPY into temp table complete")
+
+	st = time.Now()
+	upsertTag, err := conn.Exec(tol.ctx, `
+		INSERT INTO test_ownerships (
+			api_version, unique_id, name, test_id, suite, suite_id,
+			product, priority, staff_approved_obsolete, component,
+			capabilities, jira_component, jira_component_id,
+			created_at, updated_at
+		)
+		SELECT DISTINCT ON (tmp.name, tmp.suite)
+			tmp.api_version, tmp.unique_id, tmp.name, t.id, tmp.suite, s.id,
+			tmp.product, tmp.priority, tmp.staff_approved_obsolete, tmp.component,
+			tmp.capabilities, tmp.jira_component, jc.id,
+			NOW(), NOW()
+		FROM tmp_test_ownerships tmp
+		INNER JOIN tests t ON t.name = tmp.name AND t.deleted_at IS NULL
+		LEFT JOIN suites s ON s.name = tmp.suite AND s.deleted_at IS NULL
+		LEFT JOIN jira_components jc ON jc.name = tmp.jira_component
+		ORDER BY tmp.name, tmp.suite, tmp.priority DESC
+		ON CONFLICT (name, suite) DO UPDATE SET
+			api_version             = EXCLUDED.api_version,
+			unique_id               = EXCLUDED.unique_id,
+			test_id                 = EXCLUDED.test_id,
+			suite_id                = EXCLUDED.suite_id,
+			product                 = EXCLUDED.product,
+			priority                = EXCLUDED.priority,
+			staff_approved_obsolete = EXCLUDED.staff_approved_obsolete,
+			component               = EXCLUDED.component,
+			capabilities            = EXCLUDED.capabilities,
+			jira_component          = EXCLUDED.jira_component,
+			jira_component_id       = EXCLUDED.jira_component_id,
+			updated_at              = NOW()
+	`)
+	if err != nil {
+		return fmt.Errorf("upserting test_ownerships: %w", err)
+	}
+	known := upsertTag.RowsAffected()
+	log.WithFields(log.Fields{
+		"rows":    known,
+		"elapsed": time.Since(st),
+	}).Info("upsert into test_ownerships complete")
+
+	st = time.Now()
+	deleteTag, err := conn.Exec(tol.ctx, `
+		DELETE FROM test_ownerships
+		WHERE NOT EXISTS (
+			SELECT 1 FROM tmp_test_ownerships tmp
+			WHERE tmp.name = test_ownerships.name AND tmp.suite = test_ownerships.suite
+		)
+		AND EXISTS (
+			SELECT 1 FROM tests t
+			WHERE t.id = test_ownerships.test_id AND t.deleted_at IS NULL
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("deleting obsolete test_ownerships: %w", err)
 	}
 
-	log.Infof("deleting old records...")
-	oldRecords := tol.dbc.DB.Where("id NOT IN ?", ids).Unscoped().Delete(&models.TestOwnership{})
-	if oldRecords.Error != nil {
-		log.WithError(oldRecords.Error).Warningf("couldn't delete old records")
-		tol.errors = append(tol.errors, oldRecords.Error)
+	unknown := int64(len(mappings)) - known
+	if unknown > 0 {
+		log.WithField("unknown", unknown).Warn("some test ownership mappings had no matching test in sippy")
+	}
+
+	var nullComponents []string
+	tol.dbc.DB.Raw(`
+		SELECT DISTINCT jira_component FROM test_ownerships
+		WHERE jira_component_id IS NULL AND jira_component != ''
+	`).Scan(&nullComponents)
+	if len(nullComponents) > 0 {
+		log.WithField("components", nullComponents).Warn("test ownership rows have unresolved jira_component_id")
 	}
 
 	log.WithFields(log.Fields{
 		"known":    known,
 		"unknown":  unknown,
-		"obsolete": oldRecords.RowsAffected,
-	}).Infof("component loading complete")
+		"obsolete": deleteTag.RowsAffected(),
+		"elapsed":  time.Since(st),
+	}).Info("component loading complete")
+
+	return nil
 }
 
 func (tol *TestOwnershipLoader) Errors() []error {


### PR DESCRIPTION
## Summary

- Rewrites the test ownership loader to use COPY + temp table + single upsert SQL instead of ~60,000 individual PostgreSQL round-trips
- COPY raw BigQuery mappings into a temp table, then JOIN against `tests`, `suites`, and `jira_components` to resolve foreign keys server-side in a single `INSERT ... ON CONFLICT` statement
- Stale row deletion uses a single `DELETE ... NOT EXISTS` query instead of collecting IDs and doing `WHERE id NOT IN (huge list)`

## Benchmarks (staging, Go app local, PostgreSQL in AWS RDS)

| Metric | Before | After |
|---|---|---|
| BigQuery mappings | 63,723 | 63,723 |
| Ownership rows upserted | 38,429 | 38,429 |
| PostgreSQL round-trips | ~60,000 | ~5 |
| **Load time** | **3.44 min** | **14 sec** |

## Test plan

- [x] `gofmt`, `go vet`, `golangci-lint` pass
- [x] `make test` passes
- [x] Benchmarked against staging database
- [x] Row count matches prod (difference explained by staging having fewer tests)
- [x] Independent code review found no correctness issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test ownership syncing by switching to a bulk database loading approach for more reliable updates with large datasets.
  * Reduced stale ownership records by ensuring obsolete entries are removed based on the latest mappings.
  * Enhanced error reporting and logging to better surface loading issues and incomplete ownership data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->