### PR TITLE
TRT-2772: Skip Claude Code install in agentic CI to fix MCP venv setup

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -12,8 +12,12 @@ go mod download
 echo "==> Installing frontend dependencies..."
 make npm
 
-echo "==> Installing Claude Code..."
-curl -fsSL https://claude.ai/install.sh | sh
+if [[ "${SKIP_CLAUDE_INSTALL:-}" != "true" ]]; then
+  echo "==> Installing Claude Code..."
+  curl -fsSL https://claude.ai/install.sh | sh
+else
+  echo "==> Skipping Claude Code install (SKIP_CLAUDE_INSTALL=true)."
+fi
 
 echo "==> Setting up MCP server venv..."
 uv venv --clear mcp/.venv

--- a/hack/agentic_setup.sh
+++ b/hack/agentic_setup.sh
@@ -16,4 +16,4 @@ echo "Starting services..."
 "${REPO_ROOT}/.devcontainer/init-services.sh"
 
 echo "Running post-create setup..."
-"${REPO_ROOT}/.devcontainer/post-create.sh"
+SKIP_CLAUDE_INSTALL=true "${REPO_ROOT}/.devcontainer/post-create.sh"


### PR DESCRIPTION
post-create.sh aborts before setting up the MCP Python venv when the Claude Code install step fails in CI. Add SKIP_CLAUDE_INSTALL env var check so agentic_setup.sh can skip it — the agentic workflow installs Claude Code via its own step.

This allows the agentic-solve workflow to properly run the mcp tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to skip Claude Code installation during setup, making container initialization faster when the tool is not needed.
* **Chores**
  * Updated the setup flow to use the new skip option by default in one of the environment setup paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->