### PR TITLE
TRT-2737: Rewrite test analysis queries to use test_daily_totals and test_cumulative_summaries

### DIFF
--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -492,7 +492,7 @@ func jobNamesTestResultFunc(dbc *db.DB, release string) testResultsByJobNameFunc
 
 		analyzeSince := time.Now().Add(-14 * 24 * time.Hour)
 
-		q := dbc.DB.Raw(query.QueryTestAnalysis, analyzeSince, testName, jobNames, release)
+		q := dbc.DB.Raw(query.QueryTestAnalysis, analyzeSince, release, release, testName, jobNames)
 		if q.Error != nil {
 			return nil, q.Error
 		}

--- a/pkg/api/test_analysis.go
+++ b/pkg/api/test_analysis.go
@@ -1,71 +1,104 @@
 package api
 
 import (
+	"strings"
 	"time"
 
+	"cloud.google.com/go/civil"
 	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/filter"
 )
 
+const testAnalysisLookbackDays = 14
+
 type CountByDate struct {
-	Date            string  `json:"date"`
-	Group           string  `json:"group"`
-	PassPercentage  float64 `json:"pass_percentage"`
-	FlakePercentage float64 `json:"flake_percentage"`
-	FailPercentage  float64 `json:"fail_percentage"`
-	Runs            int     `json:"runs"`
-	Passes          int     `json:"passes"`
-	Flakes          int     `json:"flakes"`
-	Failures        int     `json:"failures"`
+	Date            civil.Date `json:"date"`
+	Group           string     `json:"group"`
+	PassPercentage  float64    `json:"pass_percentage"`
+	FlakePercentage float64    `json:"flake_percentage"`
+	FailPercentage  float64    `json:"fail_percentage"`
+	Runs            int        `json:"runs"`
+	Passes          int        `json:"passes"`
+	Flakes          int        `json:"flakes"`
+	Failures        int        `json:"failures"`
 }
 
-func GetTestAnalysisOverallFromDB(dbc *db.DB, filters *filter.Filter, release, testName string, reportEnd time.Time) (map[string][]CountByDate, error) {
-	var rows []CountByDate
-	jq := dbc.DB.Table("test_analysis_by_job_by_dates").
-		Select(`test_id,
-			test_name,
-			to_date((date at time zone 'UTC')::text, 'YYYY-MM-DD'::text)::text as date,
-			'overall' as group,
-			SUM(runs) as runs,
-			SUM(passes) as passes,
-			SUM(flakes) as flakes,
-			SUM(failures) as failures,
-			SUM(passes) * 100.0 / NULLIF(SUM(runs), 0) AS pass_percentage,
-			SUM(flakes) * 100.0 / NULLIF(SUM(runs), 0) AS flake_percentage,
-			SUM(failures) * 100.0 / NULLIF(SUM(runs), 0) AS fail_percentage`).
-		Joins("JOIN prow_jobs on prow_jobs.name = job_name").
-		Where("test_analysis_by_job_by_dates.release = ?", release).
-		Where("test_name = ?", testName).
-		Where("date >= ?", time.Now().Add(-24*14*time.Hour)).
-		Order("date ASC").
-		Group("date, test_id, test_name, test_analysis_by_job_by_dates.release")
-
-	var allowedVariants, blockedVariants []string
-	if filters != nil {
-		for _, f := range filters.Items {
-			if f.Field == "variants" {
-				if f.Not {
-					blockedVariants = append(blockedVariants, f.Value)
-				} else {
-					allowedVariants = append(allowedVariants, f.Value)
-				}
+func extractVariantFilters(filters *filter.Filter) (allowed, blocked []string) {
+	if filters == nil {
+		return nil, nil
+	}
+	for _, f := range filters.Items {
+		if f.Field == "variants" {
+			if f.Not {
+				blocked = append(blocked, f.Value)
+			} else {
+				allowed = append(allowed, f.Value)
 			}
 		}
 	}
+	return allowed, blocked
+}
 
-	for _, bv := range blockedVariants {
-		jq = jq.Where("NOT EXISTS (SELECT 1 FROM variant_combinations WHERE ? = any(variants) AND id = prow_jobs.variant_combination_id)", bv)
+func applyVariantCombinationFilters(q *gorm.DB, allowed, blocked []string) *gorm.DB {
+	for _, bv := range blocked {
+		q = q.Where("NOT EXISTS (SELECT 1 FROM variant_combinations WHERE ? = ANY(variants) AND id = pj.variant_combination_id)", bv)
 	}
+	for _, av := range allowed {
+		q = q.Where("EXISTS (SELECT 1 FROM variant_combinations WHERE ? = ANY(variants) AND id = pj.variant_combination_id)", av)
+	}
+	return q
+}
 
-	for _, av := range allowedVariants {
-		jq = jq.Where("prow_jobs.variant_combination_id IN (SELECT id FROM variant_combinations WHERE ? = any(variants))", av)
-	}
+var testAnalysisAggColumns = []string{
+	"SUM(tds.runs) AS runs",
+	"SUM(tds.successes) AS passes",
+	"SUM(tds.flakes) AS flakes",
+	"SUM(tds.failures) AS failures",
+	"SUM(tds.successes) * 100.0 / NULLIF(SUM(tds.runs), 0) AS pass_percentage",
+	"SUM(tds.flakes) * 100.0 / NULLIF(SUM(tds.runs), 0) AS flake_percentage",
+	"SUM(tds.failures) * 100.0 / NULLIF(SUM(tds.runs), 0) AS fail_percentage",
+}
+
+// withAggColumns appends the shared test analysis aggregation columns
+// to the supplied per-query columns and joins them into a SELECT string.
+func withAggColumns(columns ...string) string {
+	return strings.Join(append(columns, testAnalysisAggColumns...), ", ")
+}
+
+func testAnalysisBaseQuery(dbc *db.DB, filters *filter.Filter, release, testName string, since civil.Date) *gorm.DB {
+	q := dbc.DB.Table("test_daily_totals tds").
+		Joins("JOIN tests t ON t.id = tds.test_id").
+		Joins("JOIN prow_jobs pj ON pj.id = tds.prow_job_id").
+		Where("tds.release = ?", release).
+		Where("t.name = ?", testName).
+		Where("tds.date >= ?", since).
+		Order("tds.date ASC")
+
+	allowed, blocked := extractVariantFilters(filters)
+	return applyVariantCombinationFilters(q, allowed, blocked)
+}
+
+func GetTestAnalysisOverallFromDB(dbc *db.DB, filters *filter.Filter, release, testName string, reportEnd time.Time) (map[string][]CountByDate, error) {
+	endDate := civil.DateOf(reportEnd.UTC())
+	sinceDate := endDate.AddDays(-testAnalysisLookbackDays)
+
+	var rows []CountByDate
+	jq := testAnalysisBaseQuery(dbc, filters, release, testName, sinceDate).
+		Select(withAggColumns(
+			"tds.test_id",
+			`t.name AS test_name`,
+			`tds.date AS date`,
+			`'overall' AS "group"`,
+		)).
+		Where("tds.date <= ?", endDate).
+		Group("tds.date, tds.test_id, t.name, tds.release")
 
 	r := jq.Scan(&rows)
 	if r.Error != nil {
-		log.WithError(r.Error).Error("error querying test analysis by job")
+		log.WithError(r.Error).Error("error querying test analysis overall")
 		return nil, r.Error
 	}
 
@@ -86,48 +119,20 @@ func GetTestAnalysisByJobFromDB(dbc *db.DB, filters *filter.Filter, release, tes
 		results["overall"] = overall
 	}
 
-	jq := dbc.DB.Table("test_analysis_by_job_by_dates").
-		Select(`test_id,
-			test_name,
-			to_date((date at time zone 'UTC')::text, 'YYYY-MM-DD'::text)::text as date,
-			prow_jobs.release,
-			job_name as group,
-			runs,
-			passes,
-			flakes,
-			failures,
-			variants,
-			passes * 100.0 / NULLIF(runs, 0) AS pass_percentage,
-			flakes * 100.0 / NULLIF(runs, 0) AS flake_percentage,
-			failures * 100.0 / NULLIF(runs, 0) AS fail_percentage`).
-		Joins("INNER JOIN prow_jobs on prow_jobs.name = job_name").
-		Where("prow_jobs.release = ?", release).
-		Where("test_analysis_by_job_by_dates.release = ?", release).
-		Where("test_name = ?", testName).
-		Where("date <= ?", reportEnd).
-		Where("date >= ?", reportEnd.Add(-24*14*time.Hour)).
-		Order("date ASC")
+	endDate := civil.DateOf(reportEnd.UTC())
+	sinceDate := endDate.AddDays(-testAnalysisLookbackDays)
 
-	var allowedVariants, blockedVariants []string
-	if filters != nil {
-		for _, f := range filters.Items {
-			if f.Field == "variants" {
-				if f.Not {
-					blockedVariants = append(blockedVariants, f.Value)
-				} else {
-					allowedVariants = append(allowedVariants, f.Value)
-				}
-			}
-		}
-	}
-
-	for _, bv := range blockedVariants {
-		jq = jq.Where("NOT EXISTS (SELECT 1 FROM variant_combinations WHERE ? = any(variants) AND id = prow_jobs.variant_combination_id)", bv)
-	}
-
-	for _, av := range allowedVariants {
-		jq = jq.Where("prow_jobs.variant_combination_id IN (SELECT id FROM variant_combinations WHERE ? = any(variants))", av)
-	}
+	jq := testAnalysisBaseQuery(dbc, filters, release, testName, sinceDate).
+		Select(withAggColumns(
+			"tds.test_id",
+			`t.name AS test_name`,
+			`tds.date AS date`,
+			"pj.release",
+			`pj.name AS "group"`,
+			"pj.variants",
+		)).
+		Where("tds.date <= ?", endDate).
+		Group("tds.date, tds.test_id, t.name, pj.release, pj.name, pj.variants")
 
 	r := jq.Scan(&rows)
 	if r.Error != nil {
@@ -154,40 +159,34 @@ func GetTestAnalysisByVariantFromDB(dbc *db.DB, filters *filter.Filter, release,
 		results["overall"] = overall
 	}
 
-	vq := dbc.DB.Table("prow_test_analysis_by_variant_14d_view").
-		Where("release = ?", release).
-		Where("test_name = ?", testName).
-		Where("date <= ?", reportEnd).
-		Select(`to_date((date at time zone 'UTC')::text, 'YYYY-MM-DD'::text)::text as date,
-			variant as group,
-			runs,
-			passes,
-			flakes,
-			failures,
-			passes * 100.0 / NULLIF(runs, 0) AS pass_percentage,
-			flakes * 100.0 / NULLIF(runs, 0) AS flake_percentage,
-			failures * 100.0 / NULLIF(runs, 0) AS fail_percentage`).
-		Order("date ASC")
+	endDate := civil.DateOf(reportEnd.UTC())
+	sinceDate := endDate.AddDays(-testAnalysisLookbackDays)
 
-	var allowedVariants, blockedVariants []string
-	if filters != nil {
-		for _, f := range filters.Items {
-			if f.Field == "variants" {
-				if f.Not {
-					blockedVariants = append(blockedVariants, f.Value)
-				} else {
-					allowedVariants = append(allowedVariants, f.Value)
-				}
-			}
-		}
+	inner := dbc.DB.Table("test_daily_totals tds").
+		Select(withAggColumns(
+			"tds.test_id",
+			`t.name AS test_name`,
+			`tds.date AS date`,
+			`unnest(vc.variants) AS "group"`,
+			"tds.release",
+		)).
+		Joins("JOIN tests t ON t.id = tds.test_id").
+		Joins("JOIN prow_jobs pj ON pj.id = tds.prow_job_id").
+		Joins("JOIN variant_combinations vc ON vc.id = pj.variant_combination_id").
+		Where("tds.release = ?", release).
+		Where("t.name = ?", testName).
+		Where("tds.date >= ?", sinceDate).
+		Where("tds.date <= ?", endDate).
+		Group("t.name, t.id, tds.test_id, tds.date, unnest(vc.variants), tds.release").
+		Order("tds.date ASC")
 
-		if len(blockedVariants) > 0 {
-			vq = vq.Where("variant NOT IN ?", blockedVariants)
-		}
-
-		if len(allowedVariants) > 0 {
-			vq = vq.Where("variant IN ?", allowedVariants)
-		}
+	vq := dbc.DB.Table("(?) AS analysis", inner).Select("*")
+	allowed, blocked := extractVariantFilters(filters)
+	if len(blocked) > 0 {
+		vq = vq.Where(`"group" NOT IN ?`, blocked)
+	}
+	if len(allowed) > 0 {
+		vq = vq.Where(`"group" IN ?`, allowed)
 	}
 
 	r := vq.Scan(&rows)

--- a/pkg/api/test_analysis_test.go
+++ b/pkg/api/test_analysis_test.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/sippy/pkg/filter"
+)
+
+func TestExtractVariantFilters(t *testing.T) {
+	tests := []struct {
+		name            string
+		filters         *filter.Filter
+		expectedAllowed []string
+		expectedBlocked []string
+	}{
+		{
+			name:            "nil filter",
+			filters:         nil,
+			expectedAllowed: nil,
+			expectedBlocked: nil,
+		},
+		{
+			name:            "no variant filters",
+			filters:         &filter.Filter{Items: []filter.FilterItem{{Field: "name", Value: "test1"}}},
+			expectedAllowed: nil,
+			expectedBlocked: nil,
+		},
+		{
+			name: "allowed variants",
+			filters: &filter.Filter{Items: []filter.FilterItem{
+				{Field: "variants", Value: "Platform:aws"},
+				{Field: "variants", Value: "Network:ovn"},
+			}},
+			expectedAllowed: []string{"Platform:aws", "Network:ovn"},
+			expectedBlocked: nil,
+		},
+		{
+			name: "blocked variants",
+			filters: &filter.Filter{Items: []filter.FilterItem{
+				{Field: "variants", Value: "Platform:aws", Not: true},
+			}},
+			expectedAllowed: nil,
+			expectedBlocked: []string{"Platform:aws"},
+		},
+		{
+			name: "mixed allowed and blocked",
+			filters: &filter.Filter{Items: []filter.FilterItem{
+				{Field: "variants", Value: "Platform:aws"},
+				{Field: "variants", Value: "Topology:single", Not: true},
+				{Field: "name", Value: "ignored"},
+			}},
+			expectedAllowed: []string{"Platform:aws"},
+			expectedBlocked: []string{"Topology:single"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allowed, blocked := extractVariantFilters(tt.filters)
+			assert.Equal(t, tt.expectedAllowed, allowed)
+			assert.Equal(t, tt.expectedBlocked, blocked)
+		})
+	}
+}

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -66,12 +66,27 @@ const (
     GROUP BY bug_tests.test_id`
 
 	QueryTestAnalysis = `
-        select current_successes, current_runs,
+        SELECT current_successes, current_runs,
                current_successes * 100.0 / NULLIF(current_runs, 0) AS current_pass_percentage
-        from (
-            select sum(runs) as current_runs, sum(passes) as current_successes
-            from test_analysis_by_job_by_dates
-            where date >= ? AND test_name = ? AND job_name IN ? AND release = ?
+        FROM (
+            SELECT
+                SUM(e.prefix_sum_successes - COALESCE(s.prefix_sum_successes, 0)) AS current_successes,
+                SUM(e.prefix_sum_runs - COALESCE(s.prefix_sum_runs, 0)) AS current_runs
+            -- e = latest cumulative snapshot for the release
+            FROM test_cumulative_summaries e
+            JOIN tests t ON t.id = e.test_id
+            JOIN prow_jobs pj ON pj.id = e.prow_job_id
+            -- s = prior-day baseline; the difference e - s gives the windowed totals
+            LEFT JOIN test_cumulative_summaries s
+                ON s.test_id = e.test_id
+                AND s.prow_job_id = e.prow_job_id
+                AND s.suite_id = e.suite_id
+                AND s.release = e.release
+                AND s.date = (?::date - INTERVAL '1 day')::date
+            WHERE e.date = (SELECT MAX(date) FROM test_cumulative_summaries WHERE release = ?)
+                AND e.release = ?
+                AND t.name = ?
+                AND pj.name IN ?
         ) t`
 )
 

--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -37,12 +37,7 @@ var PostgresMatViews = []PostgresView{
 }
 
 // PostgresViews are regular, non-materialized views:
-var PostgresViews = []PostgresView{
-	{
-		Name:       "prow_test_analysis_by_variant_14d_view",
-		Definition: testAnalysisByVariantView,
-	},
-}
+var PostgresViews = []PostgresView{}
 
 type PostgresView struct {
 	// Name is the name of the materialized view in postgres.
@@ -233,47 +228,6 @@ FROM prow_job_runs
    LEFT JOIN pull_requests ON pull_requests.id = prow_job_runs.id
    JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id
 WHERE prow_job_runs."timestamp" >= |||TIMENOW||| - interval '90 days'
-`
-const testAnalysisByVariantView = `
-SELECT
-	byjob.test_id AS test_id,
-	byjob.test_name AS test_name,
-	byjob.date AS date,
-	unnest(prow_jobs.variants) AS variant,
-	prow_jobs.release,
-	SUM(runs) as runs,
-	SUM(passes) as passes,
-	SUM(flakes) as flakes,
-	SUM(failures) as failures
-FROM
-	test_analysis_by_job_by_dates byjob
-	JOIN tests ON tests.id = byjob.test_id
-	JOIN prow_jobs ON prow_jobs.name = byjob.job_name
-WHERE
-	byjob.date >= (|||TIMENOW||| - '15 days'::interval)
-GROUP BY
-	tests.name, tests.id, byjob.test_id, byjob.test_name, date, unnest(prow_jobs.variants), prow_jobs.release
-`
-
-const testAnalysisByJobMatView = `
-SELECT
-    tests.id AS test_id,
-    tests.name AS test_name,
-    date(prow_job_run_tests.prow_job_run_timestamp) AS date,
-    prow_job_run_tests.prow_job_run_release AS release,
-    prow_jobs.name AS job_name,
-    COUNT(*) FILTER (WHERE prow_job_run_tests.prow_job_run_timestamp >= (|||TIMENOW||| - '14 days'::interval) AND prow_job_run_tests.prow_job_run_timestamp <= |||TIMENOW|||) AS runs,
-    COUNT(*) FILTER (WHERE prow_job_run_tests.status = 1 AND prow_job_run_tests.prow_job_run_timestamp >= (|||TIMENOW||| - '14 days'::interval) AND prow_job_run_tests.prow_job_run_timestamp <= |||TIMENOW|||) AS passes,
-    COUNT(*) FILTER (WHERE prow_job_run_tests.status = 13 AND prow_job_run_tests.prow_job_run_timestamp >= (|||TIMENOW||| - '14 days'::interval) AND prow_job_run_tests.prow_job_run_timestamp <= |||TIMENOW|||) AS flakes,
-    COUNT(*) FILTER (WHERE prow_job_run_tests.status = 12 AND prow_job_run_tests.prow_job_run_timestamp >= (|||TIMENOW||| - '14 days'::interval) AND prow_job_run_tests.prow_job_run_timestamp <= |||TIMENOW|||) AS failures
-FROM
-    prow_job_run_tests
-    JOIN tests ON tests.id = prow_job_run_tests.test_id
-    JOIN prow_jobs ON prow_jobs.id = prow_job_run_tests.prow_job_id
-WHERE
-    prow_job_run_tests.prow_job_run_timestamp > (|||TIMENOW||| - '14 days'::interval)
-GROUP BY
-    tests.name, tests.id, date(prow_job_run_tests.prow_job_run_timestamp), prow_job_run_tests.prow_job_run_release, prow_jobs.name
 `
 
 // TODO: remove distinct once bug fixed re dupes in release_job_runs

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -246,7 +246,7 @@ func getBenchmarkCases(asOf time.Time) []benchmarkCase {
 					CurrentPassPercent float64
 				}
 				var result testResult
-				res := dbc.DB.Raw(query.QueryTestAnalysis, analyzeSince, benchmarkTestName, []string{benchmarkJobName}, benchmarkRelease)
+				res := dbc.DB.Raw(query.QueryTestAnalysis, analyzeSince, benchmarkRelease, benchmarkRelease, benchmarkTestName, []string{benchmarkJobName})
 				if res.Error != nil {
 					return res.Error
 				}
@@ -481,9 +481,10 @@ func getBenchmarkCases(asOf time.Time) []benchmarkCase {
 				var result passRate
 				res := dbc.DB.Raw(query.QueryTestAnalysis,
 					time.Now().Add(-24*14*time.Hour),
+					benchmarkRelease,
+					benchmarkRelease,
 					benchmarkTestName,
-					[]string{benchmarkJobName},
-					benchmarkRelease).Scan(&result)
+					[]string{benchmarkJobName}).Scan(&result)
 				if res.Error != nil {
 					return res.Error
 				}


### PR DESCRIPTION
## Summary

- Rewrites all 4 test analysis consumers to query the new partitioned tables instead of the legacy `test_analysis_by_job_by_dates` table:
  - `test_daily_totals` for per-day breakdowns (overall, by-job, by-variant endpoints)
  - `test_cumulative_summaries` for range aggregation (`QueryTestAnalysis` pass rate)
- Variant filtering joins through `prow_jobs.variant_combination_id` to the `variant_combinations` table
- Removes the `prow_test_analysis_by_variant_14d_view` (a regular view with a single consumer, inlined into Go code) and the unused `testAnalysisByJobMatView` constant
- The `test_analysis_by_job_by_dates` table and its BQ loader are kept running for now and will be removed in a follow-up PR once the new queries are verified in production

### Benchmark results (staging, warm cache)

| Consumer | Old table | New query | Table used |
|---|---|---|---|
| Overall (C1) | 119ms | 34ms | test_daily_totals |
| By Job (C2) | 23ms | 110ms | test_daily_totals |
| By Variant (C3) | 40+ seconds | 147ms | test_daily_totals |
| Pass Rate (C4) | 19ms | 41ms | test_cumulative_summaries |

The variant endpoint (`/api/tests/analysis/variants`) improves from 40+ seconds to 147ms because it now queries the partitioned `test_daily_totals` table joined to the small `variant_combinations` table via integer FK, instead of scanning the `prow_test_analysis_by_variant_14d_view` which joined `test_analysis_by_job_by_dates` to `prow_jobs` via a text-based `job_name` match.

### Correctness verification (staging)

- **Cumulative query (C4)**: Exact match with equivalent `test_daily_totals` SUM query (332 successes, 365 runs, 90.96% pass rate)
- **Overall/ByJob**: Results match the old table on shared dates. Where differences exist, they are due to different job coverage between the BQ-fed old table and the PG-native `test_daily_totals` (e.g., 264 vs 273 jobs on 2026-07-12). On the single shared job with a count difference (`...upgrade-from-stable-4.19...`: old=1 run, new=2 runs), the difference is a BQ/PG loader timing cutoff, not a logic bug.
- **ByVariant**: 894 rows across 93 distinct variant names, all data validated (positive counts, percentages 0-100)
- **Variant filtering**: Both `EXISTS` (allowed) and `NOT EXISTS` (blocked) patterns verified. Allowed filter correctly restricts to matching variants; blocked filter correctly excludes.

### Behavioral changes

1. **Date boundary filtering** shifts from a sliding timestamp window (`NOW() - '14 days'::interval` against a `TIMESTAMP WITH TIME ZONE` column) to calendar-day boundaries (`date >= ?` against a `DATE` column). This means the 14-day lookback always includes full calendar days rather than depending on time-of-day. In practice, this may include one additional day of data at the boundary.

2. **Overall analysis now respects `reportEnd`**. Previously, `GetTestAnalysisOverallFromDB` ignored the `reportEnd` parameter and always used `time.Now()`, causing the overall series to drift from the job/variant series on historical (pinned-date) reports. It now uses `reportEnd` consistently with the other two endpoints.

3. **Variant analysis window aligned to 14 days**. The old variant view used a 15-day lookback while the other endpoints used 14 days. All three now use 14 days consistently.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (Go + JS)
- [x] `make e2e` passes
- [x] `go vet ./pkg/...` clean
- [x] Benchmarked all 4 consumer queries on staging with and without variant filters
- [x] Verified correctness: cumulative query exact match, daily query parity with old table on shared data
- [x] Deployed to sippy-staging, verified all API response times under 5 seconds
- [x] Independent isolated code review found no bugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Test analysis now consistently enforces allow/block variant filtering across overall, job-level, and variant-level reports.
  - Reporting window tightened with clearer 14-day date bounds.
  - Overall and job-level summaries now use a more unified aggregation approach.
- **Bug Fixes**
  - Pass-rate calculations now derive current runs/successes from cumulative daily snapshots (with prior-day baseline).
  - Corrected SQL parameter binding to ensure accurate results.
  - Variant-level reporting no longer relies on the previously registered view.
- **Tests**
  - Added unit coverage for allowed/blocked/mixed variant filter extraction.
  - Updated result date handling to a calendar-date type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->