### PR TITLE
TRT-2741: Drop variant_combination_id from test_daily_summaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ all: test build
 
 build: builddir clean npm frontend sippy sippy-daemon
 
-.PHONY: verify apm verify-apm
-verify: lint verify-apm
+.PHONY: verify apm verify-apm verify-migrations
+verify: lint verify-apm verify-migrations
 
 builddir:
 	mkdir -p sippy-ng/build
@@ -74,6 +74,9 @@ clean:
 apm:
 	uvx --from apm-cli@0.13.0 apm install
 	uvx --from apm-cli@0.13.0 apm compile
+
+verify-migrations:
+	./hack/verify-migrations.sh
 
 verify-apm: apm
 	@if ! git diff --quiet HEAD -- .claude .cursor .gemini .opencode AGENTS.md CLAUDE.md GEMINI.md sippy-ng/AGENTS.md sippy-ng/CLAUDE.md mcp/AGENTS.md mcp/CLAUDE.md; then \

--- a/hack/verify-migrations.sh
+++ b/hack/verify-migrations.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euo pipefail
+
+MIGRATIONS_DIR="pkg/db/migrations"
+MANIFEST="${MIGRATIONS_DIR}/MANIFEST"
+
+if [ ! -f "$MANIFEST" ]; then
+    echo "ERROR: ${MANIFEST} not found."
+    exit 1
+fi
+
+errors=0
+
+# Check each manifest entry has matching .up.sql and .down.sql files.
+prev_num=0
+while IFS= read -r entry; do
+    [ -z "$entry" ] && continue
+    [[ "$entry" == \#* ]] && continue
+
+    num=$(echo "$entry" | grep -oE '^[0-9]+' | sed 's/^0*//')
+    if [ -z "$num" ]; then
+        echo "ERROR: Invalid manifest entry '${entry}' (must start with a zero-padded number)."
+        errors=$((errors + 1))
+        continue
+    fi
+
+    # Check sequential numbering.
+    expected=$((prev_num + 1))
+    if [ "$num" -ne "$expected" ]; then
+        echo "ERROR: Expected migration $(printf '%06d' "$expected") but found $(printf '%06d' "$num") (gap or duplicate)."
+        errors=$((errors + 1))
+    fi
+    prev_num=$num
+
+    if [ ! -f "${MIGRATIONS_DIR}/${entry}.up.sql" ]; then
+        echo "ERROR: Manifest lists '${entry}' but ${MIGRATIONS_DIR}/${entry}.up.sql does not exist."
+        errors=$((errors + 1))
+    fi
+    if [ ! -f "${MIGRATIONS_DIR}/${entry}.down.sql" ]; then
+        echo "ERROR: Manifest lists '${entry}' but ${MIGRATIONS_DIR}/${entry}.down.sql does not exist."
+        errors=$((errors + 1))
+    fi
+done < "$MANIFEST"
+
+# Check no extra SQL files exist beyond what the manifest lists.
+expected_sql=$((prev_num * 2))
+actual_sql=$(find "$MIGRATIONS_DIR" -maxdepth 1 -name '*.sql' | wc -l | tr -d ' ')
+if [ "$actual_sql" -ne "$expected_sql" ]; then
+    echo "ERROR: Expected ${expected_sql} .sql files (${prev_num} up + ${prev_num} down) but found ${actual_sql}."
+    errors=$((errors + 1))
+fi
+
+if [ "$errors" -gt 0 ]; then
+    echo "FAILED: ${errors} migration verification error(s)."
+    exit 1
+fi
+
+echo "Migrations OK: ${prev_num} migrations verified."

--- a/pkg/db/dailysummary/dailysummary.go
+++ b/pkg/db/dailysummary/dailysummary.go
@@ -17,7 +17,7 @@ const (
 	parallelWorkers     = 4
 )
 
-var valueColumns = []string{"variant_combination_id", "successes", "failures", "flakes", "runs"}
+var valueColumns = []string{"successes", "failures", "flakes", "runs"}
 
 var (
 	insertSQL        = buildInsertSQL()
@@ -33,17 +33,15 @@ func buildInsertSQL() string {
 			COALESCE(pjrt.suite_id, 0),
 			pjrt.prow_job_run_release,
 			date(pjrt.prow_job_run_timestamp),
-			pj.variant_combination_id,
 			COUNT(*) FILTER (WHERE pjrt.status = 1),
 			COUNT(*) FILTER (WHERE pjrt.status = 12),
 			COUNT(*) FILTER (WHERE pjrt.status = 13),
 			COUNT(*)
 		FROM prow_job_run_tests pjrt
-		JOIN prow_jobs pj ON pjrt.prow_job_id = pj.id
 		WHERE pjrt.prow_job_run_timestamp >= ?::date
 		  AND pjrt.prow_job_run_timestamp < (?::date + INTERVAL '1 day')
 		  AND pjrt.prow_job_run_release = ?
-		GROUP BY pjrt.test_id, pjrt.prow_job_id, COALESCE(pjrt.suite_id, 0), pjrt.prow_job_run_release, date(pjrt.prow_job_run_timestamp), pj.variant_combination_id`,
+		GROUP BY pjrt.test_id, pjrt.prow_job_id, COALESCE(pjrt.suite_id, 0), pjrt.prow_job_run_release, date(pjrt.prow_job_run_timestamp)`,
 		strings.Join(valueColumns, ", "))
 }
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -548,10 +548,9 @@ func ensureTriageSymptomCascade(db *gorm.DB) error {
 // function is created by migration 000003; the table is created by
 // AutoMigrate, so this must run after both.
 //
-// When the trigger is first attached, existing rows are backfilled
-// and test_daily_summaries is truncated so the next refresh
-// populates it with variant_combination_id set. In steady state
-// (trigger already exists) this is a single catalog lookup.
+// When the trigger is first attached, existing rows are backfilled.
+// In steady state (trigger already exists) this is a single catalog
+// lookup.
 func ensureVariantCombinationTrigger(db *gorm.DB) error {
 	return db.Exec(`
 		DO $$
@@ -577,8 +576,6 @@ func ensureVariantCombinationTrigger(db *gorm.DB) error {
 				WHERE prow_jobs.variants = vc.variants
 				  AND prow_jobs.variants IS NOT NULL
 				  AND prow_jobs.variant_combination_id IS NULL;
-
-				TRUNCATE test_daily_summaries;
 			END IF;
 		END $$`).Error
 }

--- a/pkg/db/migrations/000005_drop_daily_summary_variant_combination.down.sql
+++ b/pkg/db/migrations/000005_drop_daily_summary_variant_combination.down.sql
@@ -1,0 +1,2 @@
+TRUNCATE test_daily_summaries;
+ALTER TABLE test_daily_summaries ADD COLUMN IF NOT EXISTS variant_combination_id BIGINT;

--- a/pkg/db/migrations/000005_drop_daily_summary_variant_combination.up.sql
+++ b/pkg/db/migrations/000005_drop_daily_summary_variant_combination.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE test_daily_summaries DROP COLUMN IF EXISTS variant_combination_id;

--- a/pkg/db/migrations/MANIFEST
+++ b/pkg/db/migrations/MANIFEST
@@ -1,0 +1,14 @@
+# Migration manifest. Each line is a migration prefix (NNNNNN_name) that
+# must have matching .up.sql and .down.sql files in this directory.
+# Versions must be sequential with no gaps or duplicates.
+#
+# When adding a new migration, append it here. This file forces a git
+# merge conflict if two PRs independently add the same version number.
+#
+# Run `make verify-migrations` to validate.
+
+000001_create_partitioned_tables
+000002_create_test_daily_summaries
+000003_create_variant_combinations
+000004_drop_variants_gin_index
+000005_drop_daily_summary_variant_combination

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -172,16 +172,15 @@ type TestAnalysisByJobByDate struct {
 // TestDailySummary stores pre-aggregated daily test results used to
 // accelerate matview refreshes. Table managed by migration 000002.
 type TestDailySummary struct {
-	TestID               uint      `gorm:"column:test_id;not null"`
-	ProwJobID            uint      `gorm:"column:prow_job_id;not null"`
-	SuiteID              uint      `gorm:"column:suite_id;not null;default:0"`
-	Release              string    `gorm:"column:release;not null"`
-	SummaryDate          time.Time `gorm:"column:summary_date;type:date;not null"`
-	VariantCombinationID *uint     `gorm:"column:variant_combination_id"`
-	Successes            int32     `gorm:"column:successes;not null;default:0"`
-	Failures             int32     `gorm:"column:failures;not null;default:0"`
-	Flakes               int32     `gorm:"column:flakes;not null;default:0"`
-	Runs                 int32     `gorm:"column:runs;not null;default:0"`
+	TestID      uint      `gorm:"column:test_id;not null"`
+	ProwJobID   uint      `gorm:"column:prow_job_id;not null"`
+	SuiteID     uint      `gorm:"column:suite_id;not null;default:0"`
+	Release     string    `gorm:"column:release;not null"`
+	SummaryDate time.Time `gorm:"column:summary_date;type:date;not null"`
+	Successes   int32     `gorm:"column:successes;not null;default:0"`
+	Failures    int32     `gorm:"column:failures;not null;default:0"`
+	Flakes      int32     `gorm:"column:flakes;not null;default:0"`
+	Runs        int32     `gorm:"column:runs;not null;default:0"`
 }
 
 // Bug represents a Jira bug.


### PR DESCRIPTION
> **Deploy after #3722 has been deployed and matviews have refreshed.**

## Summary
- Drops the `variant_combination_id` column from `test_daily_summaries` (migration 000005)
- Removes all remaining references: the GORM struct field, the daily summary INSERT/ON CONFLICT SQL, and the TRUNCATE in `ensureVariantCombinationTrigger`
- Adds a migration manifest (`pkg/db/migrations/MANIFEST`) and `make verify-migrations` target to detect conflicting migration numbers across PRs

## Rollback note
The down migration truncates `test_daily_summaries` before re-adding the column. After rollback, a daily summary refresh is needed.

## Test plan
- [x] `make verify-migrations` passes
- [x] `go vet ./pkg/...` passes
- [x] `go test ./pkg/db/dailysummary/ ./pkg/db/ ./pkg/db/models/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new verification check for database migrations to help catch missing, duplicate, or out-of-order migration files.
* **Bug Fixes**
  * Updated daily summary handling to no longer depend on variant combination details.
  * Adjusted migration behavior to keep summary data consistent when schema changes are applied or rolled back.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->