### PR TITLE
[WIP] TRT-2741: Add cumulative summary tables for matview refresh optimization

### DIFF
--- a/cmd/sippy/backfill.go
+++ b/cmd/sippy/backfill.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/civil"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/openshift/sippy/pkg/flags"
+	"github.com/openshift/sippy/pkg/sippyserver"
+)
+
+type BackfillFlags struct {
+	DBFlags   *flags.PostgresFlags
+	Table     string
+	StartDate string
+	EndDate   string
+}
+
+func NewBackfillFlags() *BackfillFlags {
+	return &BackfillFlags{
+		DBFlags: flags.NewPostgresDatabaseFlags(),
+	}
+}
+
+func (f *BackfillFlags) BindFlags(fs *pflag.FlagSet) {
+	f.DBFlags.BindFlags(fs)
+	fs.StringVar(&f.Table, "table", "", "Table to backfill (daily-summaries, daily-totals, cumulative-summaries, variant-cumulative-summaries)")
+	fs.StringVar(&f.StartDate, "start-date", "", "Start date (YYYY-MM-DD)")
+	fs.StringVar(&f.EndDate, "end-date", "", "End date (YYYY-MM-DD)")
+}
+
+func NewBackfillCommand() *cobra.Command {
+	f := NewBackfillFlags()
+
+	cmd := &cobra.Command{
+		Use:   "backfill",
+		Short: "Backfill a specific summary table for a date range",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if f.Table == "" {
+				return fmt.Errorf("--table is required")
+			}
+			if f.StartDate == "" {
+				return fmt.Errorf("--start-date is required")
+			}
+
+			startDate, err := civil.ParseDate(f.StartDate)
+			if err != nil {
+				return fmt.Errorf("invalid --start-date %q: %w", f.StartDate, err)
+			}
+
+			endDate := civil.DateOf(time.Now().UTC())
+			if f.EndDate != "" {
+				endDate, err = civil.ParseDate(f.EndDate)
+				if err != nil {
+					return fmt.Errorf("invalid --end-date %q: %w", f.EndDate, err)
+				}
+			}
+
+			if startDate.After(endDate) {
+				return fmt.Errorf("--start-date (%s) is after --end-date (%s)", startDate, endDate)
+			}
+
+			dbc, err := f.DBFlags.GetDBClient()
+			if err != nil {
+				return err
+			}
+
+			log.WithFields(log.Fields{
+				"table": f.Table,
+				"start": startDate,
+				"end":   endDate,
+			}).Info("starting backfill")
+
+			var releases []string
+			if err := dbc.DB.Table("release_definitions").
+				Order("major DESC, minor DESC").
+				Pluck("release", &releases).Error; err != nil {
+				return fmt.Errorf("querying releases: %w", err)
+			}
+			startTime := time.Date(startDate.Year, time.Month(startDate.Month), startDate.Day, 0, 0, 0, 0, time.UTC)
+			endTime := time.Date(endDate.Year, time.Month(endDate.Month), endDate.Day, 0, 0, 0, 0, time.UTC).AddDate(0, 0, 1)
+			if _, err := dbc.EnsurePartitions(releases, startTime, endTime, false); err != nil {
+				return fmt.Errorf("ensuring partitions: %w", err)
+			}
+
+			return sippyserver.BackfillData(dbc, f.Table, startDate, endDate)
+		},
+	}
+
+	f.BindFlags(cmd.Flags())
+
+	return cmd
+}

--- a/cmd/sippy/load.go
+++ b/cmd/sippy/load.go
@@ -41,7 +41,6 @@ import (
 	"github.com/openshift/sippy/pkg/dataloader/releaseloader"
 	"github.com/openshift/sippy/pkg/dataloader/testownershiploader"
 	"github.com/openshift/sippy/pkg/db"
-	"github.com/openshift/sippy/pkg/db/dailysummary"
 	"github.com/openshift/sippy/pkg/flags"
 	"github.com/openshift/sippy/pkg/github/commenter"
 )
@@ -371,7 +370,10 @@ func NewLoadCommand() *cobra.Command {
 			log.WithField("elapsed", elapsed).Info("database load complete")
 
 			if refreshMatviews && !f.SkipMatviewRefresh {
-				sippyserver.RefreshData(dbc, cacheClient, false, dailysummary.Options{})
+				if err := sippyserver.RefreshData(dbc, cacheClient, sippyserver.RefreshOptions{}); err != nil {
+					log.WithError(err).Error("refresh failed")
+					allErrs = append(allErrs, err)
+				}
 			}
 
 			elapsed = time.Since(start)

--- a/cmd/sippy/main.go
+++ b/cmd/sippy/main.go
@@ -39,6 +39,7 @@ func main() {
 		NewLoadCommand(),
 		NewSnapshotCommand(),
 		NewRefreshCommand(),
+		NewBackfillCommand(),
 		NewComponentReadinessCommand(),
 		NewAutomateJiraCommand(),
 		NewVariantsCommand(),

--- a/cmd/sippy/refresh.go
+++ b/cmd/sippy/refresh.go
@@ -1,25 +1,18 @@
 package main
 
 import (
-	"fmt"
-	"time"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/openshift/sippy/pkg/db/dailysummary"
 	"github.com/openshift/sippy/pkg/flags"
 	"github.com/openshift/sippy/pkg/sippyserver"
 )
 
 type RefreshFlags struct {
-	DBFlags                 *flags.PostgresFlags
-	CacheFlags              *flags.CacheFlags
-	RefreshOnlyIfEmpty      bool
-	RebuildDailySummaries   bool
-	DailySummariesStartDate string
-	DailySummariesEndDate   string
+	DBFlags            *flags.PostgresFlags
+	CacheFlags         *flags.CacheFlags
+	RefreshOnlyIfEmpty bool
 }
 
 func NewRefreshFlags() *RefreshFlags {
@@ -33,32 +26,6 @@ func (f *RefreshFlags) BindFlags(fs *pflag.FlagSet) {
 	f.DBFlags.BindFlags(fs)
 	f.CacheFlags.BindFlags(fs)
 	fs.BoolVar(&f.RefreshOnlyIfEmpty, "refresh-only-if-empty", f.RefreshOnlyIfEmpty, "only refresh matviews if they're empty")
-	fs.BoolVar(&f.RebuildDailySummaries, "rebuild-daily-summaries", false, "Truncate and rebuild the daily summaries table for the default lookback period (use --daily-summaries-start for older data)")
-	fs.StringVar(&f.DailySummariesStartDate, "daily-summaries-start", "", "Override start date for daily summaries (YYYY-MM-DD)")
-	fs.StringVar(&f.DailySummariesEndDate, "daily-summaries-end", "", "Override end date for daily summaries (YYYY-MM-DD)")
-}
-
-func (f *RefreshFlags) dailySummaryOptions() (dailysummary.Options, error) {
-	opts := dailysummary.Options{Rebuild: f.RebuildDailySummaries}
-	if f.DailySummariesStartDate != "" {
-		t, err := time.Parse("2006-01-02", f.DailySummariesStartDate)
-		if err != nil {
-			return opts, fmt.Errorf("invalid --daily-summaries-start %q: %w", f.DailySummariesStartDate, err)
-		}
-		opts.StartOverride = &t
-	}
-	if f.DailySummariesEndDate != "" {
-		t, err := time.Parse("2006-01-02", f.DailySummariesEndDate)
-		if err != nil {
-			return opts, fmt.Errorf("invalid --daily-summaries-end %q: %w", f.DailySummariesEndDate, err)
-		}
-		opts.EndOverride = &t
-	}
-	if opts.StartOverride != nil && opts.EndOverride != nil && opts.StartOverride.After(*opts.EndOverride) {
-		return opts, fmt.Errorf("--daily-summaries-start (%s) is after --daily-summaries-end (%s)",
-			f.DailySummariesStartDate, f.DailySummariesEndDate)
-	}
-	return opts, nil
 }
 
 func NewRefreshCommand() *cobra.Command {
@@ -79,12 +46,9 @@ func NewRefreshCommand() *cobra.Command {
 			} else if cacheClient == nil {
 				logrus.Warn("no cache provided; refresh will not update cached timestamps, so cached data may not be properly invalidated")
 			}
-			dailySummaryOpts, err := f.dailySummaryOptions()
-			if err != nil {
-				return err
-			}
-			sippyserver.RefreshData(dbc, cacheClient, f.RefreshOnlyIfEmpty, dailySummaryOpts)
-			return nil
+			return sippyserver.RefreshData(dbc, cacheClient, sippyserver.RefreshOptions{
+				RefreshOnlyIfEmpty: f.RefreshOnlyIfEmpty,
+			})
 		},
 	}
 

--- a/cmd/sippy/seed_data.go
+++ b/cmd/sippy/seed_data.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"cloud.google.com/go/civil"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -23,7 +24,6 @@ import (
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
 	v1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 	"github.com/openshift/sippy/pkg/db"
-	"github.com/openshift/sippy/pkg/db/dailysummary"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/models/jobrunscan"
 	"github.com/openshift/sippy/pkg/flags"
@@ -439,8 +439,17 @@ func seedSyntheticData(dbc *db.DB) error {
 	}
 
 	log.Info("Refreshing materialized views...")
-	seedStart := time.Now().Add(-190 * 24 * time.Hour)
-	sippyserver.RefreshData(dbc, nil, false, dailysummary.Options{StartOverride: &seedStart})
+	seedToday := civil.DateOf(time.Now().UTC())
+	seedStart := seedToday.AddDays(-91)
+	seedEnd := seedToday
+	for _, table := range []string{"daily-summaries", "daily-totals", "cumulative-summaries", "variant-cumulative-summaries"} {
+		if err := sippyserver.BackfillData(dbc, table, seedStart, seedEnd); err != nil {
+			return fmt.Errorf("failed to backfill %s: %w", table, err)
+		}
+	}
+	if err := sippyserver.RefreshData(dbc, nil, sippyserver.RefreshOptions{}); err != nil {
+		return fmt.Errorf("failed to refresh data: %w", err)
+	}
 
 	log.Info("Syncing regressions...")
 	if err := syncRegressions(dbc); err != nil {

--- a/pkg/db/cumulativesummary/cumulative_summary.go
+++ b/pkg/db/cumulativesummary/cumulative_summary.go
@@ -1,0 +1,161 @@
+package cumulativesummary
+
+import (
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/civil"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/openshift/sippy/pkg/db"
+)
+
+type summaryStore interface {
+	MaxCumulativeSummaryDate() (*civil.Date, error)
+	MaxDailySummaryDate() (*civil.Date, error)
+	Releases() ([]string, error)
+	UpdateDateForRelease(date civil.Date, release string) error
+}
+
+// Refresh computes cumulative summaries from test_daily_totals.
+// earliestChanged is the earliest date that test_daily_totals was
+// updated; cumulative summaries from that date forward will be recomputed.
+// Returns the earliest date that was updated so downstream consumers
+// (variant cumulative summaries) know where to start.
+func Refresh(dbc *db.DB, earliestChanged civil.Date) (civil.Date, error) {
+	return doRefresh(&pgStore{dbc: dbc}, earliestChanged)
+}
+
+// Backfill processes an explicit date range without automatic date detection.
+func Backfill(dbc *db.DB, startDate, endDate civil.Date) error {
+	store := &pgStore{dbc: dbc}
+	_, err := refreshDateRange(store, startDate, endDate)
+	return err
+}
+
+func doRefresh(store summaryStore, earliestChanged civil.Date) (civil.Date, error) {
+	return doRefreshWithToday(store, earliestChanged, civil.DateOf(time.Now().UTC()))
+}
+
+func doRefreshWithToday(store summaryStore, earliestChanged, today civil.Date) (civil.Date, error) {
+	log.Info("refreshing cumulative summaries")
+
+	maxCumulativeSummaryDate, err := store.MaxCumulativeSummaryDate()
+	if err != nil {
+		return civil.Date{}, fmt.Errorf("checking max cumulative summary date: %w", err)
+	}
+
+	maxDailySummaryDate, err := store.MaxDailySummaryDate()
+	if err != nil {
+		return civil.Date{}, fmt.Errorf("checking max daily summary date: %w", err)
+	}
+	if maxDailySummaryDate == nil {
+		log.Info("no daily summaries found, nothing to update")
+		return earliestChanged, nil
+	}
+	endDate := *maxDailySummaryDate
+
+	startDate := resolveStartDate(earliestChanged, maxCumulativeSummaryDate, today)
+
+	return refreshDateRange(store, startDate, endDate)
+}
+
+func refreshDateRange(store summaryStore, startDate, endDate civil.Date) (civil.Date, error) {
+	loadStart := time.Now()
+	days := endDate.DaysSince(startDate) + 1
+
+	releases, err := store.Releases()
+	if err != nil {
+		return civil.Date{}, fmt.Errorf("querying releases: %w", err)
+	}
+
+	log.WithFields(log.Fields{
+		"start":    startDate,
+		"end":      endDate,
+		"days":     days,
+		"releases": len(releases),
+	}).Info("updating cumulative summaries")
+
+	for date := startDate; !date.After(endDate); date = date.AddDays(1) {
+		updateStart := time.Now()
+		for _, release := range releases {
+			if err := store.UpdateDateForRelease(date, release); err != nil {
+				return civil.Date{}, fmt.Errorf("updating cumulative summaries for %s release %s: %w", date, release, err)
+			}
+		}
+		log.WithFields(log.Fields{
+			"date":    date,
+			"elapsed": time.Since(updateStart),
+		}).Info("updated cumulative summaries for date")
+	}
+
+	log.WithField("elapsed", time.Since(loadStart)).Info("cumulative summary refresh complete")
+	return startDate, nil
+}
+
+type pgStore struct {
+	dbc *db.DB
+}
+
+func (s *pgStore) MaxCumulativeSummaryDate() (*civil.Date, error) {
+	var d *civil.Date
+	err := s.dbc.DB.Table("test_cumulative_summaries").
+		Select("MAX(date)").Row().Scan(&d)
+	if err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}
+
+func (s *pgStore) MaxDailySummaryDate() (*civil.Date, error) {
+	var d *civil.Date
+	err := s.dbc.DB.Table("test_daily_totals").
+		Select("MAX(date)").Row().Scan(&d)
+	if err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}
+
+func (s *pgStore) Releases() ([]string, error) {
+	var releases []string
+	err := s.dbc.DB.Table("release_definitions").
+		Order("major DESC, minor DESC").
+		Pluck("release", &releases).Error
+	return releases, err
+}
+
+func (s *pgStore) UpdateDateForRelease(date civil.Date, release string) error {
+	return s.dbc.DB.Exec(`
+		INSERT INTO test_cumulative_summaries (date, test_id, prow_job_id, suite_id, release,
+		                         prefix_sum_successes, prefix_sum_failures, prefix_sum_flakes, prefix_sum_runs)
+		SELECT
+			?,
+			COALESCE(prev.test_id, tds.test_id),
+			COALESCE(prev.prow_job_id, tds.prow_job_id),
+			COALESCE(prev.suite_id, tds.suite_id),
+			COALESCE(prev.release, tds.release),
+			COALESCE(prev.prefix_sum_successes, 0) + COALESCE(tds.successes, 0),
+			COALESCE(prev.prefix_sum_failures, 0) + COALESCE(tds.failures, 0),
+			COALESCE(prev.prefix_sum_flakes, 0) + COALESCE(tds.flakes, 0),
+			COALESCE(prev.prefix_sum_runs, 0) + COALESCE(tds.runs, 0)
+		FROM (SELECT * FROM test_cumulative_summaries WHERE date = ?::date - 1 AND release = ?) prev
+		FULL OUTER JOIN (SELECT * FROM test_daily_totals WHERE date = ? AND release = ?) tds
+			ON prev.test_id = tds.test_id
+			AND prev.prow_job_id = tds.prow_job_id
+			AND prev.suite_id = tds.suite_id
+		ON CONFLICT (date, release, test_id, prow_job_id, suite_id)
+		DO UPDATE SET
+			prefix_sum_successes = EXCLUDED.prefix_sum_successes,
+			prefix_sum_failures = EXCLUDED.prefix_sum_failures,
+			prefix_sum_flakes = EXCLUDED.prefix_sum_flakes,
+			prefix_sum_runs = EXCLUDED.prefix_sum_runs
+		WHERE (test_cumulative_summaries.prefix_sum_successes, test_cumulative_summaries.prefix_sum_failures,
+		       test_cumulative_summaries.prefix_sum_flakes, test_cumulative_summaries.prefix_sum_runs)
+		   IS DISTINCT FROM
+		      (EXCLUDED.prefix_sum_successes, EXCLUDED.prefix_sum_failures,
+		       EXCLUDED.prefix_sum_flakes, EXCLUDED.prefix_sum_runs)
+	`, date, date, release, date, release).Error
+}

--- a/pkg/db/cumulativesummary/cumulative_summary_test.go
+++ b/pkg/db/cumulativesummary/cumulative_summary_test.go
@@ -1,0 +1,150 @@
+package cumulativesummary
+
+import (
+	"fmt"
+	"testing"
+
+	"cloud.google.com/go/civil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeStore struct {
+	maxCumulativeSummary    *civil.Date
+	maxCumulativeSummaryErr error
+	maxDailySummaryDate     *civil.Date
+	maxDailySummaryDateErr  error
+	updatedDates            []civil.Date
+	updateDateErr           error
+}
+
+func (f *fakeStore) MaxCumulativeSummaryDate() (*civil.Date, error) {
+	return f.maxCumulativeSummary, f.maxCumulativeSummaryErr
+}
+
+func (f *fakeStore) MaxDailySummaryDate() (*civil.Date, error) {
+	return f.maxDailySummaryDate, f.maxDailySummaryDateErr
+}
+
+func (f *fakeStore) Releases() ([]string, error) {
+	return []string{"4.22", "5.0"}, nil
+}
+
+func (f *fakeStore) UpdateDateForRelease(date civil.Date, _ string) error {
+	f.updatedDates = append(f.updatedDates, date)
+	return f.updateDateErr
+}
+
+var today = civil.Date{Year: 2026, Month: 7, Day: 9}
+
+const numReleases = 2
+
+func TestRefresh_NoCumulativeDataUsesEarliestChanged(t *testing.T) {
+	maxDailySummaryDate := today
+	earliestChanged := today.AddDays(-1)
+	store := &fakeStore{maxDailySummaryDate: &maxDailySummaryDate}
+
+	_, err := doRefreshWithToday(store, earliestChanged, today)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, store.updatedDates)
+	assert.Equal(t, earliestChanged, store.updatedDates[0])
+}
+
+func TestRefresh_FillsGapFromMaxCumulative(t *testing.T) {
+	maxCum := today.AddDays(-4)
+	maxDailySummaryDate := today.AddDays(-2)
+	earliestChanged := today.AddDays(-2)
+	store := &fakeStore{maxCumulativeSummary: &maxCum, maxDailySummaryDate: &maxDailySummaryDate}
+
+	_, err := doRefreshWithToday(store, earliestChanged, today)
+
+	require.NoError(t, err)
+	assert.Len(t, store.updatedDates, 2*numReleases)
+	assert.Equal(t, today.AddDays(-3), store.updatedDates[0])
+}
+
+func TestRefresh_StartsFromEarliestChanged(t *testing.T) {
+	maxDailySummaryDate := today.AddDays(-2)
+	earliestChanged := today.AddDays(-3)
+	store := &fakeStore{maxDailySummaryDate: &maxDailySummaryDate}
+
+	_, err := doRefreshWithToday(store, earliestChanged, today)
+
+	require.NoError(t, err)
+	assert.Len(t, store.updatedDates, 2*numReleases)
+	assert.Equal(t, today.AddDays(-3), store.updatedDates[0])
+}
+
+func TestRefresh_FillsSmallGap(t *testing.T) {
+	maxCum := today.AddDays(-6)
+	maxDailySummaryDate := today.AddDays(-2)
+	earliestChanged := today.AddDays(-3)
+	store := &fakeStore{maxCumulativeSummary: &maxCum, maxDailySummaryDate: &maxDailySummaryDate}
+
+	_, err := doRefreshWithToday(store, earliestChanged, today)
+
+	require.NoError(t, err)
+	assert.Equal(t, today.AddDays(-5), store.updatedDates[0])
+	assert.Equal(t, today.AddDays(-2), store.updatedDates[len(store.updatedDates)-1])
+}
+
+func TestRefresh_CapsGapAt14Days(t *testing.T) {
+	maxCum := today.AddDays(-30)
+	maxDailySummaryDate := today
+	earliestChanged := today.AddDays(-1)
+	store := &fakeStore{maxCumulativeSummary: &maxCum, maxDailySummaryDate: &maxDailySummaryDate}
+
+	_, err := doRefreshWithToday(store, earliestChanged, today)
+
+	require.NoError(t, err)
+	assert.Equal(t, today.AddDays(-14), store.updatedDates[0])
+}
+
+func TestRefresh_IncrementalFromMaxPlusOne(t *testing.T) {
+	maxCum := today.AddDays(-3)
+	maxDailySummaryDate := today.AddDays(-2)
+	earliestChanged := today.AddDays(-3)
+	store := &fakeStore{maxCumulativeSummary: &maxCum, maxDailySummaryDate: &maxDailySummaryDate}
+
+	_, err := doRefreshWithToday(store, earliestChanged, today)
+
+	require.NoError(t, err)
+	assert.Len(t, store.updatedDates, 2*numReleases)
+	assert.Equal(t, today.AddDays(-3), store.updatedDates[0])
+}
+
+func TestRefresh_AlreadyUpToDate(t *testing.T) {
+	maxCum := today.AddDays(-2)
+	maxDailySummaryDate := today.AddDays(-2)
+	earliestChanged := today.AddDays(-2)
+	store := &fakeStore{maxCumulativeSummary: &maxCum, maxDailySummaryDate: &maxDailySummaryDate}
+
+	_, err := doRefreshWithToday(store, earliestChanged, today)
+
+	require.NoError(t, err)
+	assert.Len(t, store.updatedDates, 1*numReleases)
+	assert.Equal(t, today.AddDays(-2), store.updatedDates[0])
+}
+
+func TestRefresh_MaxCumulativeSummaryDateError(t *testing.T) {
+	earliestChanged := today.AddDays(-3)
+	store := &fakeStore{maxCumulativeSummaryErr: fmt.Errorf("connection refused")}
+
+	_, err := doRefreshWithToday(store, earliestChanged, today)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max cumulative summary date")
+}
+
+func TestRefresh_UpdateDateError(t *testing.T) {
+	maxCum := today.AddDays(-4)
+	maxDailySummaryDate := today.AddDays(-2)
+	earliestChanged := today.AddDays(-3)
+	store := &fakeStore{maxCumulativeSummary: &maxCum, maxDailySummaryDate: &maxDailySummaryDate, updateDateErr: fmt.Errorf("disk full")}
+
+	_, err := doRefreshWithToday(store, earliestChanged, today)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "updating cumulative summaries")
+}

--- a/pkg/db/cumulativesummary/date_range.go
+++ b/pkg/db/cumulativesummary/date_range.go
@@ -1,0 +1,33 @@
+package cumulativesummary
+
+import (
+	"cloud.google.com/go/civil"
+	log "github.com/sirupsen/logrus"
+)
+
+const maxAutoFillDays = 14
+
+// resolveStartDate determines the start date for an incremental refresh.
+// It picks the earliest of earliestChanged and maxExistingDate+1, then
+// clamps to today-maxAutoFillDays to prevent unbounded backfills during
+// normal refresh cycles.
+func resolveStartDate(earliestChanged civil.Date, maxExistingDate *civil.Date, today civil.Date) civil.Date {
+	startDate := earliestChanged
+	if maxExistingDate != nil {
+		nextDate := maxExistingDate.AddDays(1)
+		if nextDate.Before(startDate) {
+			startDate = nextDate
+		}
+	}
+
+	floor := today.AddDays(-maxAutoFillDays)
+	if startDate.Before(floor) {
+		log.WithFields(log.Fields{
+			"desiredStart": startDate,
+			"clampedStart": floor,
+		}).Warn("cumulative summaries need data older than the auto-fill limit, use backfill command to fill")
+		startDate = floor
+	}
+
+	return startDate
+}

--- a/pkg/db/cumulativesummary/date_range_test.go
+++ b/pkg/db/cumulativesummary/date_range_test.go
@@ -1,0 +1,61 @@
+package cumulativesummary
+
+import (
+	"testing"
+
+	"cloud.google.com/go/civil"
+	"github.com/stretchr/testify/assert"
+)
+
+var testToday = civil.Date{Year: 2026, Month: 7, Day: 9}
+
+func TestResolveStartDate_UsesEarliestChanged(t *testing.T) {
+	earliestChanged := testToday.AddDays(-3)
+
+	result := resolveStartDate(earliestChanged, nil, testToday)
+
+	assert.Equal(t, earliestChanged, result)
+}
+
+func TestResolveStartDate_UsesMaxPlusOneWhenEarlier(t *testing.T) {
+	earliestChanged := testToday.AddDays(-1)
+	maxExisting := testToday.AddDays(-5)
+
+	result := resolveStartDate(earliestChanged, &maxExisting, testToday)
+
+	assert.Equal(t, maxExisting.AddDays(1), result)
+}
+
+func TestResolveStartDate_UsesEarliestChangedWhenEarlierThanMax(t *testing.T) {
+	earliestChanged := testToday.AddDays(-5)
+	maxExisting := testToday.AddDays(-2)
+
+	result := resolveStartDate(earliestChanged, &maxExisting, testToday)
+
+	assert.Equal(t, earliestChanged, result)
+}
+
+func TestResolveStartDate_ClampsToFloor(t *testing.T) {
+	earliestChanged := testToday.AddDays(-30)
+
+	result := resolveStartDate(earliestChanged, nil, testToday)
+
+	assert.Equal(t, testToday.AddDays(-maxAutoFillDays), result)
+}
+
+func TestResolveStartDate_ClampsMaxPlusOneToFloor(t *testing.T) {
+	earliestChanged := testToday.AddDays(-1)
+	maxExisting := testToday.AddDays(-30)
+
+	result := resolveStartDate(earliestChanged, &maxExisting, testToday)
+
+	assert.Equal(t, testToday.AddDays(-maxAutoFillDays), result)
+}
+
+func TestResolveStartDate_DoesNotClampWhenWithinFloor(t *testing.T) {
+	earliestChanged := testToday.AddDays(-7)
+
+	result := resolveStartDate(earliestChanged, nil, testToday)
+
+	assert.Equal(t, earliestChanged, result)
+}

--- a/pkg/db/cumulativesummary/variant_cumulative_summary.go
+++ b/pkg/db/cumulativesummary/variant_cumulative_summary.go
@@ -1,0 +1,243 @@
+package cumulativesummary
+
+import (
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/civil"
+	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+
+	"github.com/openshift/sippy/pkg/db"
+)
+
+type variantStore interface {
+	MaxVariantCumulativeSummaryDate() (*civil.Date, error)
+	MaxCumulativeSummaryDate() (*civil.Date, error)
+	Releases() ([]string, error)
+	UpdateVariantDateForRelease(date civil.Date, release string) error
+	DetectVariantChanges() ([]uint, error)
+	ScopedRebuildVariants(changedProwJobIDs []uint) error
+	UpdateVCIDMapping() error
+	VCIDMappingPopulated() (bool, error)
+}
+
+// RefreshVariantCumulativeSummaries groups test_cumulative_summaries by variant_combination_id
+// into the variant_cumulative_summaries table. Each date's update groups one
+// date's test_cumulative_summaries and inserts. Variant changes are detected via
+// vcid_mappings and trigger scoped rebuilds.
+func RefreshVariantCumulativeSummaries(dbc *db.DB, earliestChanged civil.Date) error {
+	return doVariantRefresh(&pgVariantStore{dbc: dbc}, earliestChanged)
+}
+
+// BackfillVariant processes an explicit date range without automatic date detection.
+func BackfillVariant(dbc *db.DB, startDate, endDate civil.Date) error {
+	store := &pgVariantStore{dbc: dbc}
+	return updateVariantDates(store, startDate, endDate)
+}
+
+func doVariantRefresh(store variantStore, earliestChanged civil.Date) error {
+	loadStart := time.Now()
+	log.Info("refreshing variant cumulative summaries")
+
+	populated, err := store.VCIDMappingPopulated()
+	if err != nil {
+		return fmt.Errorf("checking VCID mapping: %w", err)
+	}
+	if populated {
+		changes, err := store.DetectVariantChanges()
+		if err != nil {
+			return fmt.Errorf("detecting variant changes: %w", err)
+		}
+		if len(changes) > 0 {
+			log.WithField("count", len(changes)).Info("variant changes detected, doing scoped rebuild")
+			if err := store.ScopedRebuildVariants(changes); err != nil {
+				return fmt.Errorf("scoped rebuild for variant changes: %w", err)
+			}
+		}
+	} else {
+		log.Info("VCID mapping empty (first run), skipping variant detection")
+	}
+
+	maxVariantCumulativeSummaryDate, err := store.MaxVariantCumulativeSummaryDate()
+	if err != nil {
+		return fmt.Errorf("checking max variant cumulative summary date: %w", err)
+	}
+
+	maxCumulativeSummaryDate, err := store.MaxCumulativeSummaryDate()
+	if err != nil {
+		return fmt.Errorf("checking max cumulative summary date: %w", err)
+	}
+	if maxCumulativeSummaryDate == nil {
+		log.Info("no cumulative summaries found, nothing to group")
+		return nil
+	}
+
+	startDate := resolveStartDate(earliestChanged, maxVariantCumulativeSummaryDate, civil.DateOf(time.Now().UTC()))
+
+	endDate := *maxCumulativeSummaryDate
+
+	if err := updateVariantDates(store, startDate, endDate); err != nil {
+		return err
+	}
+
+	if err := store.UpdateVCIDMapping(); err != nil {
+		return fmt.Errorf("updating VCID mapping: %w", err)
+	}
+
+	log.WithField("elapsed", time.Since(loadStart)).Info("variant cumulative summary refresh complete")
+	return nil
+}
+
+func updateVariantDates(store variantStore, startDate, endDate civil.Date) error {
+	loadStart := time.Now()
+	days := endDate.DaysSince(startDate) + 1
+
+	releases, err := store.Releases()
+	if err != nil {
+		return fmt.Errorf("querying releases: %w", err)
+	}
+
+	log.WithFields(log.Fields{
+		"start":    startDate,
+		"end":      endDate,
+		"days":     days,
+		"releases": len(releases),
+	}).Info("updating variant cumulative summaries")
+
+	for date := startDate; !date.After(endDate); date = date.AddDays(1) {
+		updateStart := time.Now()
+		for _, release := range releases {
+			if err := store.UpdateVariantDateForRelease(date, release); err != nil {
+				return fmt.Errorf("updating variant cumulative summaries for %s release %s: %w", date, release, err)
+			}
+		}
+		log.WithFields(log.Fields{
+			"date":    date,
+			"elapsed": time.Since(updateStart),
+		}).Info("updated variant cumulative summaries for date")
+	}
+
+	log.WithField("elapsed", time.Since(loadStart)).Info("variant cumulative summary update complete")
+	return nil
+}
+
+type pgVariantStore struct {
+	dbc *db.DB
+}
+
+func (s *pgVariantStore) MaxVariantCumulativeSummaryDate() (*civil.Date, error) {
+	var d *civil.Date
+	err := s.dbc.DB.Table("variant_cumulative_summaries").
+		Select("MAX(date)").Row().Scan(&d)
+	if err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}
+
+func (s *pgVariantStore) MaxCumulativeSummaryDate() (*civil.Date, error) {
+	var d *civil.Date
+	err := s.dbc.DB.Table("test_cumulative_summaries").
+		Select("MAX(date)").Row().Scan(&d)
+	if err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}
+
+func (s *pgVariantStore) Releases() ([]string, error) {
+	var releases []string
+	err := s.dbc.DB.Table("release_definitions").
+		Order("major DESC, minor DESC").
+		Pluck("release", &releases).Error
+	return releases, err
+}
+
+func (s *pgVariantStore) UpdateVariantDateForRelease(date civil.Date, release string) error {
+	return s.dbc.DB.Exec(`
+		INSERT INTO variant_cumulative_summaries (date, test_id, suite_id, variant_combination_id, release,
+		                                 prefix_sum_successes, prefix_sum_failures, prefix_sum_flakes, prefix_sum_runs)
+		SELECT ps.date, ps.test_id, ps.suite_id, pj.variant_combination_id, ps.release,
+			SUM(ps.prefix_sum_successes)::bigint,
+			SUM(ps.prefix_sum_failures)::bigint,
+			SUM(ps.prefix_sum_flakes)::bigint,
+			SUM(ps.prefix_sum_runs)::bigint
+		FROM test_cumulative_summaries ps
+		JOIN prow_jobs pj ON ps.prow_job_id = pj.id
+		WHERE ps.date = ? AND ps.release = ?
+		  AND pj.variant_combination_id IS NOT NULL
+		GROUP BY ps.date, ps.test_id, ps.suite_id, pj.variant_combination_id, ps.release
+		ON CONFLICT (date, release, test_id, suite_id, variant_combination_id)
+		DO UPDATE SET
+			prefix_sum_successes = EXCLUDED.prefix_sum_successes,
+			prefix_sum_failures = EXCLUDED.prefix_sum_failures,
+			prefix_sum_flakes = EXCLUDED.prefix_sum_flakes,
+			prefix_sum_runs = EXCLUDED.prefix_sum_runs
+		WHERE (variant_cumulative_summaries.prefix_sum_successes, variant_cumulative_summaries.prefix_sum_failures,
+		       variant_cumulative_summaries.prefix_sum_flakes, variant_cumulative_summaries.prefix_sum_runs)
+		   IS DISTINCT FROM
+		      (EXCLUDED.prefix_sum_successes, EXCLUDED.prefix_sum_failures,
+		       EXCLUDED.prefix_sum_flakes, EXCLUDED.prefix_sum_runs)
+	`, date, release).Error
+}
+
+func (s *pgVariantStore) VCIDMappingPopulated() (bool, error) {
+	var exists bool
+	err := s.dbc.DB.Raw("SELECT EXISTS(SELECT 1 FROM vcid_mappings LIMIT 1)").Scan(&exists).Error
+	return exists, err
+}
+
+func (s *pgVariantStore) DetectVariantChanges() ([]uint, error) {
+	var changedIDs []uint
+	err := s.dbc.DB.Raw(`
+		SELECT pj.id FROM prow_jobs pj
+		LEFT JOIN vcid_mappings m ON pj.id = m.prow_job_id
+		WHERE m.prow_job_id IS NULL
+		   OR m.variant_combination_id IS DISTINCT FROM pj.variant_combination_id
+	`).Pluck("id", &changedIDs).Error
+	return changedIDs, err
+}
+
+func (s *pgVariantStore) ScopedRebuildVariants(changedProwJobIDs []uint) error {
+	return s.dbc.DB.Exec(`
+		WITH affected_entities AS (
+			SELECT DISTINCT ps.test_id, ps.suite_id, ps.release
+			FROM test_cumulative_summaries ps
+			WHERE ps.prow_job_id IN (?)
+		),
+		deleted AS (
+			DELETE FROM variant_cumulative_summaries vps
+			USING affected_entities ae
+			WHERE vps.test_id = ae.test_id
+			  AND vps.suite_id = ae.suite_id
+			  AND vps.release = ae.release
+		)
+		INSERT INTO variant_cumulative_summaries (date, test_id, suite_id, variant_combination_id, release,
+		                                 prefix_sum_successes, prefix_sum_failures, prefix_sum_flakes, prefix_sum_runs)
+		SELECT ps.date, ps.test_id, ps.suite_id, pj.variant_combination_id, ps.release,
+			SUM(ps.prefix_sum_successes)::bigint, SUM(ps.prefix_sum_failures)::bigint,
+			SUM(ps.prefix_sum_flakes)::bigint, SUM(ps.prefix_sum_runs)::bigint
+		FROM test_cumulative_summaries ps
+		JOIN prow_jobs pj ON ps.prow_job_id = pj.id
+		JOIN affected_entities ae ON ps.test_id = ae.test_id
+			AND ps.suite_id = ae.suite_id AND ps.release = ae.release
+		WHERE pj.variant_combination_id IS NOT NULL
+		  AND ps.date >= CURRENT_DATE - 90
+		GROUP BY ps.date, ps.test_id, ps.suite_id, pj.variant_combination_id, ps.release
+	`, changedProwJobIDs).Error
+}
+
+func (s *pgVariantStore) UpdateVCIDMapping() error {
+	return s.dbc.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("TRUNCATE vcid_mappings").Error; err != nil {
+			return err
+		}
+		return tx.Exec(`
+			INSERT INTO vcid_mappings (prow_job_id, variant_combination_id)
+			SELECT id, variant_combination_id FROM prow_jobs
+		`).Error
+	})
+}

--- a/pkg/db/dailysummary/dailysummary.go
+++ b/pkg/db/dailysummary/dailysummary.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"cloud.google.com/go/civil"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/openshift/sippy/pkg/db"
@@ -19,14 +20,9 @@ const (
 
 var valueColumns = []string{"successes", "failures", "flakes", "runs"}
 
-var (
-	insertSQL        = buildInsertSQL()
-	onConflictClause = buildOnConflictClause()
-)
-
-func buildInsertSQL() string {
+func buildInsertSQL(tableName, dateColumn string) string {
 	return fmt.Sprintf(`
-		INSERT INTO test_daily_summaries (test_id, prow_job_id, suite_id, release, summary_date, %s)
+		INSERT INTO %s (test_id, prow_job_id, suite_id, release, %s, %s)
 		SELECT
 			pjrt.test_id,
 			pjrt.prow_job_id,
@@ -42,89 +38,135 @@ func buildInsertSQL() string {
 		  AND pjrt.prow_job_run_timestamp < (?::date + INTERVAL '1 day')
 		  AND pjrt.prow_job_run_release = ?
 		GROUP BY pjrt.test_id, pjrt.prow_job_id, COALESCE(pjrt.suite_id, 0), pjrt.prow_job_run_release, date(pjrt.prow_job_run_timestamp)`,
-		strings.Join(valueColumns, ", "))
+		tableName, dateColumn, strings.Join(valueColumns, ", "))
 }
 
-func buildOnConflictClause() string {
+func buildOnConflictClause(tableName, dateColumn string) string {
 	var setClauses, oldCols, newCols []string
 	for _, col := range valueColumns {
 		setClauses = append(setClauses, fmt.Sprintf("%s = EXCLUDED.%s", col, col))
-		oldCols = append(oldCols, "test_daily_summaries."+col)
+		oldCols = append(oldCols, tableName+"."+col)
 		newCols = append(newCols, "EXCLUDED."+col)
 	}
 
 	return fmt.Sprintf(`
-		ON CONFLICT (test_id, prow_job_id, suite_id, release, summary_date)
+		ON CONFLICT (test_id, prow_job_id, suite_id, release, %s)
 		DO UPDATE SET %s
 		WHERE (%s) IS DISTINCT FROM (%s)`,
+		dateColumn,
 		strings.Join(setClauses, ", "),
 		strings.Join(oldCols, ", "),
 		strings.Join(newCols, ", "))
 }
 
 type summaryStore interface {
-	MaxSummaryDate() (*time.Time, error)
-	Truncate() error
+	MaxSummaryDate() (*civil.Date, error)
 	Releases() ([]string, error)
-	AggregateRangeForRelease(start, end time.Time, release string, skipConflictDetection bool) error
+	AggregateRangeForRelease(start, end civil.Date, release string, skipConflictDetection bool) error
 }
 
-// Options configures the daily summary refresh.
-type Options struct {
-	Rebuild       bool
-	StartOverride *time.Time
-	EndOverride   *time.Time
+// Refresh aggregates prow_job_run_tests into test_daily_summaries.
+// Returns the earliest date that was refreshed so downstream consumers
+// (cumulative summaries) know which dates may have changed.
+func Refresh(dbc *db.DB) (civil.Date, error) {
+	return refreshSummaries(&pgStore{dbc: dbc, tableName: "test_daily_summaries", dateColumn: "summary_date"})
 }
 
-// Refresh aggregates prow_job_run_tests into the test_daily_summaries
-// table. It runs before matview refreshes so the matviews read from
-// pre-aggregated data instead of scanning raw rows.
-func Refresh(dbc *db.DB, opts Options) error {
-	return refreshSummaries(&pgStore{dbc: dbc}, opts)
-}
-
-func refreshSummaries(store summaryStore, opts Options) error {
+func refreshSummaries(store summaryStore) (civil.Date, error) {
 	loadStart := time.Now()
 	log.Info("refreshing daily summaries")
 
-	now := time.Now()
-
-	startDate, endDate, err := dateRange(store, opts, now)
+	today := civil.DateOf(time.Now().UTC())
+	maxDate, err := store.MaxSummaryDate()
 	if err != nil {
-		return err
+		return civil.Date{}, fmt.Errorf("querying max summary date: %w", err)
 	}
 
+	startDate := startDateFromMax(maxDate, today)
+	skipConflictDetection := maxDate == nil
+
+	if err := doAggregate(store, startDate, today, skipConflictDetection, loadStart); err != nil {
+		return civil.Date{}, err
+	}
+	return startDate, nil
+}
+
+// Backfill processes an explicit date range without automatic date detection.
+func Backfill(dbc *db.DB, startDate, endDate civil.Date) error {
+	return backfillSummaries(&pgStore{dbc: dbc, tableName: "test_daily_summaries", dateColumn: "summary_date"}, startDate, endDate)
+}
+
+// RefreshTotals aggregates prow_job_run_tests into the partitioned
+// test_daily_totals table. Same logic as Refresh but targets the new table.
+func RefreshTotals(dbc *db.DB) (civil.Date, error) {
+	return refreshSummaries(&pgStore{dbc: dbc, tableName: "test_daily_totals", dateColumn: "date"})
+}
+
+// BackfillTotals backfills the partitioned test_daily_totals table.
+func BackfillTotals(dbc *db.DB, startDate, endDate civil.Date) error {
+	return backfillSummaries(&pgStore{dbc: dbc, tableName: "test_daily_totals", dateColumn: "date"}, startDate, endDate)
+}
+
+func backfillSummaries(store summaryStore, startDate, endDate civil.Date) error {
+	loadStart := time.Now()
 	releases, err := store.Releases()
 	if err != nil {
 		return fmt.Errorf("querying releases: %w", err)
 	}
 
-	skipConflictDetection := opts.Rebuild
-	if skipConflictDetection {
-		log.Info("rebuild requested, truncating test_daily_summaries")
-		if err := store.Truncate(); err != nil {
-			return fmt.Errorf("truncating table: %w", err)
+	days := endDate.DaysSince(startDate) + 1
+	log.WithFields(log.Fields{
+		"start":    startDate,
+		"end":      endDate,
+		"days":     days,
+		"releases": len(releases),
+	}).Info("backfilling daily summaries")
+
+	for date := startDate; !date.After(endDate); date = date.AddDays(1) {
+		dayStart := time.Now()
+		if err := aggregateReleases(store, releases, date, date, false); err != nil {
+			return fmt.Errorf("backfilling %s: %w", date, err)
 		}
-	} else {
-		maxDate, err := store.MaxSummaryDate()
-		if err != nil {
-			return fmt.Errorf("checking if table is empty: %w", err)
-		}
-		skipConflictDetection = maxDate == nil
+		log.WithFields(log.Fields{
+			"date":    date,
+			"elapsed": time.Since(dayStart),
+		}).Info("backfilled daily summaries for date")
 	}
 
-	log.Infof("aggregating daily summaries from %s to %s",
-		startDate.Format("2006-01-02"), endDate.Format("2006-01-02"))
+	log.WithField("elapsed", time.Since(loadStart)).Info("daily summary backfill complete")
+	return nil
+}
 
-	if err := aggregateReleases(store, releases, startDate, endDate, skipConflictDetection); err != nil {
-		return err
+func doAggregate(store summaryStore, startDate, endDate civil.Date, skipConflictDetection bool, loadStart time.Time) error {
+	releases, err := store.Releases()
+	if err != nil {
+		return fmt.Errorf("querying releases: %w", err)
+	}
+
+	days := endDate.DaysSince(startDate) + 1
+	log.WithFields(log.Fields{
+		"start":    startDate,
+		"end":      endDate,
+		"days":     days,
+		"releases": len(releases),
+	}).Info("aggregating daily summaries")
+
+	for date := startDate; !date.After(endDate); date = date.AddDays(1) {
+		dayStart := time.Now()
+		if err := aggregateReleases(store, releases, date, date, skipConflictDetection); err != nil {
+			return fmt.Errorf("aggregating %s: %w", date, err)
+		}
+		log.WithFields(log.Fields{
+			"date":    date,
+			"elapsed": time.Since(dayStart),
+		}).Debug("aggregated daily summaries for date")
 	}
 
 	log.WithField("elapsed", time.Since(loadStart)).Info("daily summary refresh complete")
 	return nil
 }
 
-func aggregateReleases(store summaryStore, releases []string, startDate, endDate time.Time, skipConflictDetection bool) error {
+func aggregateReleases(store summaryStore, releases []string, startDate, endDate civil.Date, skipConflictDetection bool) error {
 	errs := make(chan error, len(releases))
 	work := make(chan string, len(releases))
 
@@ -155,81 +197,46 @@ func aggregateReleases(store summaryStore, releases []string, startDate, endDate
 	return errors.Join(combined...)
 }
 
-// dateRange computes the aggregation window. If explicit overrides were
-// provided, those are used directly. Otherwise the start is the last
-// summarized date (capped at yesterday) or the default lookback,
-// and the end is now.
-func dateRange(store summaryStore, opts Options, now time.Time) (time.Time, time.Time, error) {
-	if opts.StartOverride != nil && opts.EndOverride != nil {
-		return *opts.StartOverride, *opts.EndOverride, nil
-	}
-
-	endDate := now
-	if opts.EndOverride != nil {
-		endDate = *opts.EndOverride
-	}
-
-	if opts.StartOverride != nil {
-		return *opts.StartOverride, endDate, nil
-	}
-
-	if opts.Rebuild {
-		return now.AddDate(0, 0, -defaultLookbackDays), endDate, nil
-	}
-
-	startDate, err := resolveStartDate(store, now)
-	if err != nil {
-		return time.Time{}, time.Time{}, fmt.Errorf("querying max summary date: %w", err)
-	}
-
-	return startDate, endDate, nil
-}
-
-// resolveStartDate returns the last summarized date capped at yesterday,
-// or the default lookback if no summaries exist.
-func resolveStartDate(store summaryStore, now time.Time) (time.Time, error) {
-	yesterday := now.AddDate(0, 0, -1)
-
-	maxSummary, err := store.MaxSummaryDate()
-	if err != nil {
-		return time.Time{}, err
-	}
+func startDateFromMax(maxSummary *civil.Date, today civil.Date) civil.Date {
+	yesterday := today.AddDays(-1)
 	if maxSummary != nil {
 		if maxSummary.Before(yesterday) {
-			return *maxSummary, nil
+			return *maxSummary
 		}
-		return yesterday, nil
+		return yesterday
+	}
+	return today.AddDays(-defaultLookbackDays)
+}
+
+type pgStore struct {
+	dbc        *db.DB
+	tableName  string
+	dateColumn string
+}
+
+func (s *pgStore) MaxSummaryDate() (*civil.Date, error) {
+	var d *civil.Date
+	err := s.dbc.DB.Table(s.tableName).
+		Select(fmt.Sprintf("MAX(%s)", s.dateColumn)).Row().Scan(&d)
+	if err != nil {
+		return nil, err
 	}
 
-	return now.AddDate(0, 0, -defaultLookbackDays), nil
-}
-
-// pgStore implements summaryStore against PostgreSQL.
-type pgStore struct {
-	dbc *db.DB
-}
-
-func (s *pgStore) MaxSummaryDate() (*time.Time, error) {
-	var maxDate *time.Time
-	err := s.dbc.DB.Table("test_daily_summaries").
-		Select("MAX(summary_date)").Row().Scan(&maxDate)
-	return maxDate, err
-}
-
-func (s *pgStore) Truncate() error {
-	return s.dbc.DB.Exec("TRUNCATE test_daily_summaries").Error
+	return d, nil
 }
 
 func (s *pgStore) Releases() ([]string, error) {
 	var releases []string
-	err := s.dbc.DB.Table("prow_jobs").Distinct("release").Pluck("release", &releases).Error
+	err := s.dbc.DB.Table("release_definitions").
+		Order("major DESC, minor DESC").
+		Pluck("release", &releases).Error
 	return releases, err
 }
 
-func (s *pgStore) AggregateRangeForRelease(startDate, endDate time.Time, release string, skipConflictDetection bool) error {
-	sql := insertSQL
+func (s *pgStore) AggregateRangeForRelease(startDate, endDate civil.Date, release string, skipConflictDetection bool) error {
+	sql := buildInsertSQL(s.tableName, s.dateColumn)
 	if !skipConflictDetection {
-		sql += onConflictClause
+		sql += buildOnConflictClause(s.tableName, s.dateColumn)
 	}
 	return s.dbc.DB.Exec(sql, startDate, endDate, release).Error
 }

--- a/pkg/db/dailysummary/dailysummary_test.go
+++ b/pkg/db/dailysummary/dailysummary_test.go
@@ -6,15 +6,14 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/civil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type fakeStore struct {
-	maxSummary    *time.Time
+	maxSummary    *civil.Date
 	maxSummaryErr error
-	truncated     bool
-	truncateErr   error
 	releases      []string
 	releasesErr   error
 	aggregateErr  error
@@ -24,18 +23,13 @@ type fakeStore struct {
 }
 
 type aggregateCall struct {
-	start, end            time.Time
+	start, end            civil.Date
 	release               string
 	skipConflictDetection bool
 }
 
-func (f *fakeStore) MaxSummaryDate() (*time.Time, error) {
+func (f *fakeStore) MaxSummaryDate() (*civil.Date, error) {
 	return f.maxSummary, f.maxSummaryErr
-}
-
-func (f *fakeStore) Truncate() error {
-	f.truncated = true
-	return f.truncateErr
 }
 
 func (f *fakeStore) Releases() ([]string, error) {
@@ -45,7 +39,7 @@ func (f *fakeStore) Releases() ([]string, error) {
 	return []string{"4.22", "5.0"}, f.releasesErr
 }
 
-func (f *fakeStore) AggregateRangeForRelease(start, end time.Time, release string, skipConflictDetection bool) error {
+func (f *fakeStore) AggregateRangeForRelease(start, end civil.Date, release string, skipConflictDetection bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.calls = append(f.calls, aggregateCall{start: start, end: end, release: release, skipConflictDetection: skipConflictDetection})
@@ -83,22 +77,23 @@ func (f *fakeStore) noneSkippedConflictDetection() bool {
 }
 
 func TestRefresh_Incremental(t *testing.T) {
-	maxDate := time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC)
+	today := civil.DateOf(time.Now().UTC())
+	maxDate := today.AddDays(-3)
 	store := &fakeStore{maxSummary: &maxDate}
 
-	err := refreshSummaries(store, Options{})
+	_, err := refreshSummaries(store)
 
 	require.NoError(t, err)
-	assert.Len(t, store.getCalls(), 2)
+	// 4 days (maxDate through today) × 2 releases
+	assert.Len(t, store.getCalls(), 4*2)
 	assert.True(t, store.noneSkippedConflictDetection())
-	assert.False(t, store.truncated)
 }
 
 func TestRefresh_IncrementalCapsAtYesterday(t *testing.T) {
-	future := time.Now().AddDate(0, 0, 1)
+	future := civil.Date{Year: 2099, Month: 1, Day: 1}
 	store := &fakeStore{maxSummary: &future}
 
-	err := refreshSummaries(store, Options{})
+	_, err := refreshSummaries(store)
 
 	require.NoError(t, err)
 	calls := store.getCalls()
@@ -109,80 +104,51 @@ func TestRefresh_IncrementalCapsAtYesterday(t *testing.T) {
 func TestRefresh_EmptyTableUsesDefaultLookbackAndSkipsConflictDetection(t *testing.T) {
 	store := &fakeStore{}
 
-	err := refreshSummaries(store, Options{})
+	_, err := refreshSummaries(store)
 
 	require.NoError(t, err)
 	calls := store.getCalls()
 	require.NotEmpty(t, calls)
-	daysBefore := time.Since(calls[0].start).Hours() / 24
+	today := civil.DateOf(time.Now().UTC())
+	daysBefore := today.DaysSince(calls[0].start)
 	assert.InDelta(t, defaultLookbackDays, daysBefore, 1)
 	assert.True(t, store.allSkippedConflictDetection())
 }
 
-func TestRefresh_RebuildUsesInsert(t *testing.T) {
-	store := &fakeStore{}
-
-	err := refreshSummaries(store, Options{Rebuild: true})
-
-	require.NoError(t, err)
-	assert.True(t, store.truncated)
-	assert.Len(t, store.getCalls(), 2)
-	assert.True(t, store.allSkippedConflictDetection())
-}
-
 func TestRefresh_IncrementalUsesUpsert(t *testing.T) {
-	maxDate := time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC)
+	today := civil.DateOf(time.Now().UTC())
+	maxDate := today.AddDays(-2)
 	store := &fakeStore{maxSummary: &maxDate}
 
-	err := refreshSummaries(store, Options{})
+	_, err := refreshSummaries(store)
 
 	require.NoError(t, err)
-	assert.Len(t, store.getCalls(), 2)
+	// 3 days × 2 releases
+	assert.Len(t, store.getCalls(), 3*2)
 	assert.True(t, store.noneSkippedConflictDetection())
 }
 
-func TestRefresh_DateOverrides(t *testing.T) {
-	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	end := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
-	maxDate := time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC)
-	store := &fakeStore{maxSummary: &maxDate}
+func TestBackfill_UsesExplicitDateRange(t *testing.T) {
+	start := civil.Date{Year: 2026, Month: 7, Day: 1}
+	end := civil.Date{Year: 2026, Month: 7, Day: 3}
+	store := &fakeStore{}
 
-	err := refreshSummaries(store, Options{StartOverride: &start, EndOverride: &end})
-
-	require.NoError(t, err)
-	calls := store.getCalls()
-	require.Len(t, calls, 2)
-	assert.Equal(t, start, calls[0].start)
-	assert.Equal(t, end, calls[0].end)
-}
-
-func TestRefresh_StartOverrideOnly(t *testing.T) {
-	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	maxDate := time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC)
-	store := &fakeStore{maxSummary: &maxDate}
-
-	err := refreshSummaries(store, Options{StartOverride: &start})
+	err := backfillSummaries(store, start, end)
 
 	require.NoError(t, err)
 	calls := store.getCalls()
-	require.Len(t, calls, 2)
+	// 3 days × 2 releases = 6 calls, each single-day
+	require.Len(t, calls, 6)
 	assert.Equal(t, start, calls[0].start)
-}
-
-func TestRefresh_TruncateError(t *testing.T) {
-	store := &fakeStore{truncateErr: fmt.Errorf("permission denied")}
-
-	err := refreshSummaries(store, Options{Rebuild: true})
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "truncating table")
-	assert.Empty(t, store.getCalls())
+	assert.Equal(t, start, calls[0].end)
+	assert.Equal(t, end, calls[len(calls)-1].start)
+	assert.Equal(t, end, calls[len(calls)-1].end)
 }
 
 func TestRefresh_MaxSummaryDateError(t *testing.T) {
 	store := &fakeStore{maxSummaryErr: fmt.Errorf("connection refused")}
 
-	err := refreshSummaries(store, Options{})
+	_, err := refreshSummaries(store)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "max summary date")
@@ -192,7 +158,7 @@ func TestRefresh_MaxSummaryDateError(t *testing.T) {
 func TestRefresh_ReleasesError(t *testing.T) {
 	store := &fakeStore{releasesErr: fmt.Errorf("connection refused")}
 
-	err := refreshSummaries(store, Options{})
+	_, err := refreshSummaries(store)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "querying releases")
@@ -200,10 +166,10 @@ func TestRefresh_ReleasesError(t *testing.T) {
 }
 
 func TestRefresh_AggregateError(t *testing.T) {
-	maxDate := time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC)
+	maxDate := civil.Date{Year: 2026, Month: 6, Day: 17}
 	store := &fakeStore{maxSummary: &maxDate, aggregateErr: fmt.Errorf("disk full")}
 
-	err := refreshSummaries(store, Options{})
+	_, err := refreshSummaries(store)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "aggregating release")
@@ -212,25 +178,28 @@ func TestRefresh_AggregateError(t *testing.T) {
 func TestRefresh_NoReleases(t *testing.T) {
 	store := &fakeStore{releases: []string{}}
 
-	err := refreshSummaries(store, Options{})
+	_, err := refreshSummaries(store)
 
 	require.NoError(t, err)
 	assert.Empty(t, store.getCalls())
 }
 
-func TestRefresh_ParallelProcessesAllReleases(t *testing.T) {
+func TestRefresh_ProcessesAllReleasesPerDay(t *testing.T) {
 	releases := []string{"4.18", "4.19", "4.20", "4.21", "4.22", "5.0"}
-	maxDate := time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC)
+	today := civil.DateOf(time.Now().UTC())
+	maxDate := today.AddDays(-3)
 	store := &fakeStore{maxSummary: &maxDate, releases: releases}
 
-	err := refreshSummaries(store, Options{})
+	_, err := refreshSummaries(store)
 
 	require.NoError(t, err)
 	calls := store.getCalls()
-	assert.Len(t, calls, len(releases))
+	// 4 days (maxDate through today) × 6 releases = 24 calls
+	assert.Len(t, calls, 4*len(releases))
 	seen := make(map[string]bool)
 	for _, call := range calls {
 		seen[call.release] = true
+		assert.Equal(t, call.start, call.end, "each call should be a single day")
 	}
 	for _, rel := range releases {
 		assert.True(t, seen[rel], "release %s not processed", rel)

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -22,13 +22,16 @@ import (
 type SchemaHashType string
 
 const (
-	hashTypeMatView                          SchemaHashType = "matview"
-	hashTypeView                             SchemaHashType = "view"
-	hashTypeMatViewIndex                     SchemaHashType = "matview_index"
-	hashTypeFunction                         SchemaHashType = "function"
-	partitionedTableProwJobRunTests                         = "prow_job_run_tests"
-	partitionedTableProwJobRunTestsOutputs                  = "prow_job_run_test_outputs"
-	partitionedTableTestAnalysisByJobByDates                = "test_analysis_by_job_by_dates"
+	hashTypeMatView                            SchemaHashType = "matview"
+	hashTypeView                               SchemaHashType = "view"
+	hashTypeMatViewIndex                       SchemaHashType = "matview_index"
+	hashTypeFunction                           SchemaHashType = "function"
+	partitionedTableProwJobRunTests                           = "prow_job_run_tests"
+	partitionedTableProwJobRunTestsOutputs                    = "prow_job_run_test_outputs"
+	partitionedTableTestAnalysisByJobByDates                  = "test_analysis_by_job_by_dates"
+	partitionedTableTestDailyTotals                           = "test_daily_totals"
+	partitionedTableTestCumulativeSummaries                   = "test_cumulative_summaries"
+	partitionedTableVariantCumulativeSummaries                = "variant_cumulative_summaries"
 )
 
 type DB struct {
@@ -89,6 +92,8 @@ func New(dsn string, logLevel gormlogger.LogLevel, opts ...Option) (*DB, error) 
 	// partitions. Custom plans use actual parameter values for partition pruning.
 	pgxConfig.RuntimeParams["plan_cache_mode"] = "force_custom_plan"
 	pgxConfig.RuntimeParams["work_mem"] = "128MB"
+	pgxConfig.RuntimeParams["idle_in_transaction_session_timeout"] = "60s"
+	pgxConfig.RuntimeParams["random_page_cost"] = "1.1"
 	if cfg.enablePartitionwise {
 		pgxConfig.RuntimeParams["enable_partitionwise_aggregate"] = "on"
 		pgxConfig.RuntimeParams["enable_partitionwise_join"] = "on"
@@ -169,6 +174,7 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 		&jobrunscan.Label{},
 		&jobrunscan.Symptom{},
 		&models.TestDailySummary{},
+		&models.VCIDMapping{},
 	}
 
 	// Currently we need RunMigrations to run prior
@@ -216,6 +222,9 @@ func (d *DB) PartitionedTables() []string {
 		partitionedTableProwJobRunTests,
 		partitionedTableProwJobRunTestsOutputs,
 		partitionedTableTestAnalysisByJobByDates,
+		partitionedTableTestDailyTotals,
+		partitionedTableTestCumulativeSummaries,
+		partitionedTableVariantCumulativeSummaries,
 	}
 }
 
@@ -241,7 +250,7 @@ func (d *DB) EnsurePartitions(releases []string, startDate, endDate time.Time, d
 			dateColumn = "prow_job_run_timestamp"
 		case partitionedTableProwJobRunTestsOutputs:
 			dateColumn = "prow_job_run_test_timestamp"
-		case partitionedTableTestAnalysisByJobByDates:
+		case partitionedTableTestAnalysisByJobByDates, partitionedTableTestDailyTotals, partitionedTableTestCumulativeSummaries, partitionedTableVariantCumulativeSummaries:
 			dateColumn = "date"
 		default:
 			log.Warnf("unknown partitioned table: %s", tableName)

--- a/pkg/db/migrations/000006_partition_cumulative_tables.down.sql
+++ b/pkg/db/migrations/000006_partition_cumulative_tables.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS variant_cumulative_summaries CASCADE;
+DROP TABLE IF EXISTS test_cumulative_summaries CASCADE;
+DROP TABLE IF EXISTS test_daily_totals CASCADE;

--- a/pkg/db/migrations/000006_partition_cumulative_tables.up.sql
+++ b/pkg/db/migrations/000006_partition_cumulative_tables.up.sql
@@ -1,0 +1,74 @@
+-- TRT-2741: Create partitioned summary tables
+--
+-- Creates 3 partitioned tables using nested LIST->RANGE partitioning:
+-- - Level 1: LIST partition by release
+-- - Level 2: RANGE sub-partition by date (daily granularity)
+--
+-- Tables:
+--   - test_daily_totals (partitioned daily aggregates, replaces test_daily_summaries)
+--   - test_cumulative_summaries (prefix sums from test_daily_totals)
+--   - variant_cumulative_summaries (prefix sums grouped by variant_combination_id)
+--
+-- Partition creation (release partitions + daily sub-partitions) is handled
+-- by the partition management system (gopar).
+
+-- ============================================================================
+-- 1. test_daily_totals
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS test_daily_totals (
+    test_id BIGINT NOT NULL,
+    prow_job_id BIGINT NOT NULL,
+    suite_id BIGINT NOT NULL DEFAULT 0,
+    release TEXT NOT NULL,
+    date DATE NOT NULL,
+    successes INT NOT NULL DEFAULT 0,
+    failures INT NOT NULL DEFAULT 0,
+    flakes INT NOT NULL DEFAULT 0,
+    runs INT NOT NULL DEFAULT 0
+) PARTITION BY LIST (release);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_test_daily_totals_unique
+    ON test_daily_totals (test_id, prow_job_id, suite_id, release, date);
+
+CREATE INDEX IF NOT EXISTS idx_test_daily_totals_date
+    ON test_daily_totals (date);
+
+-- ============================================================================
+-- 2. test_cumulative_summaries
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS test_cumulative_summaries (
+    date DATE NOT NULL,
+    release TEXT NOT NULL,
+    test_id BIGINT NOT NULL,
+    prow_job_id BIGINT NOT NULL,
+    suite_id BIGINT NOT NULL DEFAULT 0,
+    prefix_sum_successes BIGINT NOT NULL DEFAULT 0,
+    prefix_sum_failures BIGINT NOT NULL DEFAULT 0,
+    prefix_sum_flakes BIGINT NOT NULL DEFAULT 0,
+    prefix_sum_runs BIGINT NOT NULL DEFAULT 0,
+
+    PRIMARY KEY (date, release, test_id, prow_job_id, suite_id)
+) PARTITION BY LIST (release);
+
+CREATE INDEX IF NOT EXISTS idx_test_cumulative_summaries_prow_job_id
+    ON test_cumulative_summaries (prow_job_id);
+
+-- ============================================================================
+-- 3. variant_cumulative_summaries
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS variant_cumulative_summaries (
+    date DATE NOT NULL,
+    release TEXT NOT NULL,
+    test_id BIGINT NOT NULL,
+    suite_id BIGINT NOT NULL DEFAULT 0,
+    variant_combination_id BIGINT NOT NULL,
+    prefix_sum_successes BIGINT NOT NULL DEFAULT 0,
+    prefix_sum_failures BIGINT NOT NULL DEFAULT 0,
+    prefix_sum_flakes BIGINT NOT NULL DEFAULT 0,
+    prefix_sum_runs BIGINT NOT NULL DEFAULT 0,
+
+    PRIMARY KEY (date, release, test_id, suite_id, variant_combination_id)
+) PARTITION BY LIST (release);

--- a/pkg/db/migrations/MANIFEST
+++ b/pkg/db/migrations/MANIFEST
@@ -12,3 +12,4 @@
 000003_create_variant_combinations
 000004_drop_variants_gin_index
 000005_drop_daily_summary_variant_combination
+000006_partition_cumulative_tables

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -3,6 +3,7 @@ package models
 import (
 	"time"
 
+	"cloud.google.com/go/civil"
 	"github.com/lib/pq"
 	"gorm.io/gorm"
 
@@ -182,6 +183,69 @@ type TestDailySummary struct {
 	Flakes      int32     `gorm:"column:flakes;not null;default:0"`
 	Runs        int32     `gorm:"column:runs;not null;default:0"`
 }
+
+// TestDailyTotal is the partitioned replacement for TestDailySummary.
+// Same schema, but partitioned by LIST(release) then RANGE(date).
+// Table is partitioned (LIST by release, RANGE by date) -
+// schema managed by migration 000006, not AutoMigrate.
+type TestDailyTotal struct {
+	TestID    uint      `gorm:"column:test_id;not null"`
+	ProwJobID uint      `gorm:"column:prow_job_id;not null"`
+	SuiteID   uint      `gorm:"column:suite_id;not null;default:0"`
+	Release   string    `gorm:"column:release;not null"`
+	Date      time.Time `gorm:"column:date;type:date;not null"`
+	Successes int32     `gorm:"column:successes;not null;default:0"`
+	Failures  int32     `gorm:"column:failures;not null;default:0"`
+	Flakes    int32     `gorm:"column:flakes;not null;default:0"`
+	Runs      int32     `gorm:"column:runs;not null;default:0"`
+}
+
+// TestCumulativeSummary stores running totals of test_daily_summaries values,
+// ordered by date. Any date range [start, end] can be computed as
+// cumulative(end) - cumulative(start-1). Keyed by immutable fields only
+// (no variant_combination_id) so variant changes do not invalidate the data.
+// Entities are carried forward on days with no data so the chain is unbroken.
+// Table is partitioned (LIST by release, RANGE by date) -
+// schema managed by migration 000006, not AutoMigrate.
+type TestCumulativeSummary struct {
+	Date               civil.Date `gorm:"column:date;type:date;not null;primaryKey;priority:1"`
+	Release            string     `gorm:"column:release;not null;primaryKey;priority:2"`
+	TestID             uint       `gorm:"column:test_id;not null;primaryKey;priority:3"`
+	ProwJobID          uint       `gorm:"column:prow_job_id;not null;primaryKey;priority:4;index:idx_test_cumulative_summaries_prow_job_id"`
+	SuiteID            uint       `gorm:"column:suite_id;not null;default:0;primaryKey;priority:5"`
+	PrefixSumSuccesses int64      `gorm:"column:prefix_sum_successes;not null;default:0"`
+	PrefixSumFailures  int64      `gorm:"column:prefix_sum_failures;not null;default:0"`
+	PrefixSumFlakes    int64      `gorm:"column:prefix_sum_flakes;not null;default:0"`
+	PrefixSumRuns      int64      `gorm:"column:prefix_sum_runs;not null;default:0"`
+}
+
+// VariantCumulativeSummary stores running totals of test_cumulative_summaries
+// grouped by variant_combination_id. Updated daily by grouping one day's
+// test_cumulative_summaries. Variant changes detected via VCIDMapping trigger
+// a scoped rebuild for affected entities.
+// Table is partitioned (LIST by release, RANGE by date) -
+// schema managed by migration 000006, not AutoMigrate.
+type VariantCumulativeSummary struct {
+	Date                 civil.Date `gorm:"column:date;type:date;not null;primaryKey;priority:1"`
+	Release              string     `gorm:"column:release;not null;primaryKey;priority:2"`
+	TestID               uint       `gorm:"column:test_id;not null;primaryKey;priority:3"`
+	SuiteID              uint       `gorm:"column:suite_id;not null;default:0;primaryKey;priority:4"`
+	VariantCombinationID uint       `gorm:"column:variant_combination_id;not null;primaryKey;priority:5"`
+	PrefixSumSuccesses   int64      `gorm:"column:prefix_sum_successes;not null;default:0"`
+	PrefixSumFailures    int64      `gorm:"column:prefix_sum_failures;not null;default:0"`
+	PrefixSumFlakes      int64      `gorm:"column:prefix_sum_flakes;not null;default:0"`
+	PrefixSumRuns        int64      `gorm:"column:prefix_sum_runs;not null;default:0"`
+}
+
+// VCIDMapping tracks the prow_job_id to variant_combination_id mapping
+// so the variant cumulative summary refresh can detect when variants change and
+// do a scoped rebuild of only the affected rows.
+type VCIDMapping struct {
+	ProwJobID            uint  `gorm:"column:prow_job_id;primaryKey"`
+	VariantCombinationID *uint `gorm:"column:variant_combination_id"`
+}
+
+func (VCIDMapping) TableName() string { return "vcid_mappings" }
 
 // Bug represents a Jira bug.
 type Bug struct {

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -13,7 +13,6 @@ import (
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	v1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 	"github.com/openshift/sippy/pkg/db"
-	"github.com/openshift/sippy/pkg/db/dailysummary"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/filter"
@@ -1231,8 +1230,7 @@ func Test_BenchmarkRefreshData(t *testing.T) {
 	r := runBenchmarkCase(t, dbc, benchmarkCase{
 		name: "RefreshData",
 		fn: func(dbc *db.DB) error {
-			sippyserver.RefreshData(dbc, nil, false, dailysummary.Options{})
-			return nil
+			return sippyserver.RefreshData(dbc, nil, sippyserver.RefreshOptions{})
 		},
 	}, 1)
 	printSummaryTable(t, []benchmarkResult{r}, connName)

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -45,6 +45,7 @@ import (
 
 	"github.com/andygrunwald/go-jira"
 
+	"cloud.google.com/go/civil"
 	"github.com/openshift/sippy/pkg/api"
 	"github.com/openshift/sippy/pkg/api/componentreadiness"
 	"github.com/openshift/sippy/pkg/api/jobrunevents"
@@ -54,6 +55,7 @@ import (
 	sippyv1 "github.com/openshift/sippy/pkg/apis/sippy/v1"
 	sippybq "github.com/openshift/sippy/pkg/bigquery"
 	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/cumulativesummary"
 	"github.com/openshift/sippy/pkg/db/dailysummary"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/query"
@@ -149,6 +151,12 @@ var dailySummaryRefreshMetric = promauto.NewHistogram(prometheus.HistogramOpts{
 	Name:    "sippy_daily_summary_refresh_millis",
 	Help:    "Milliseconds to refresh the daily summary table",
 	Buckets: []float64{1000, 5000, 10000, 30000, 60000, 300000, 600000, 1200000},
+})
+
+var cumulativeSummaryRefreshMetric = promauto.NewHistogram(prometheus.HistogramOpts{
+	Name:    "sippy_cumulative_summary_refresh_millis",
+	Help:    "Milliseconds to refresh the cumulative summary tables",
+	Buckets: []float64{100, 500, 1000, 5000, 10000, 30000, 60000, 300000, 600000},
 })
 
 var matViewUniqueNumberOfTests = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -387,16 +395,65 @@ func recordMatviewRefreshTime(cacheClient cache.Cache, matView string, tmpLog *l
 	}
 }
 
-func RefreshData(dbc *db.DB, cacheClient cache.Cache, refreshMatviewsOnlyIfEmpty bool, dailySummaryOpts dailysummary.Options) {
+// RefreshOptions controls the incremental refresh behavior.
+type RefreshOptions struct {
+	RefreshOnlyIfEmpty bool
+}
+
+// RefreshData runs the normal incremental refresh of all summary tables
+// and materialized views. Used by the load command and the serve loop.
+func RefreshData(dbc *db.DB, cacheClient cache.Cache, opts RefreshOptions) error {
 	log.Infof("Refreshing data")
+
 	summaryStart := time.Now()
-	if err := dailysummary.Refresh(dbc, dailySummaryOpts); err != nil {
-		log.WithError(err).Error("failed to refresh daily summaries")
-	} else {
-		dailySummaryRefreshMetric.Observe(float64(time.Since(summaryStart).Milliseconds()))
+	if _, err := dailysummary.Refresh(dbc); err != nil {
+		return fmt.Errorf("failed to refresh daily summaries: %w", err)
 	}
-	refreshMaterializedViews(dbc, cacheClient, refreshMatviewsOnlyIfEmpty)
+	dailySummaryRefreshMetric.Observe(float64(time.Since(summaryStart).Milliseconds()))
+
+	totalsStart := time.Now()
+	earliestTotalsChanged, err := dailysummary.RefreshTotals(dbc)
+	if err != nil {
+		return fmt.Errorf("failed to refresh daily totals: %w", err)
+	}
+	log.WithField("elapsed", time.Since(totalsStart)).Info("daily totals refresh complete")
+
+	cumulativeStart := time.Now()
+	earliestCumulativeChanged, err := cumulativesummary.Refresh(dbc, earliestTotalsChanged)
+	if err != nil {
+		return fmt.Errorf("failed to refresh cumulative summaries: %w", err)
+	}
+	if err := cumulativesummary.RefreshVariantCumulativeSummaries(dbc, earliestCumulativeChanged); err != nil {
+		return fmt.Errorf("failed to refresh variant cumulative summaries: %w", err)
+	}
+	cumulativeSummaryRefreshMetric.Observe(float64(time.Since(cumulativeStart).Milliseconds()))
+
+	refreshMaterializedViews(dbc, cacheClient, opts.RefreshOnlyIfEmpty)
 	log.Info("Refresh complete")
+	return nil
+}
+
+// BackfillData refreshes a specific table for a given date range,
+// bypassing the normal incremental logic. Used for backfilling.
+func BackfillData(dbc *db.DB, table string, startDate, endDate civil.Date) error {
+	log.WithFields(log.Fields{
+		"table": table,
+		"start": startDate,
+		"end":   endDate,
+	}).Info("Backfilling table")
+
+	switch table {
+	case "daily-summaries":
+		return dailysummary.Backfill(dbc, startDate, endDate)
+	case "daily-totals":
+		return dailysummary.BackfillTotals(dbc, startDate, endDate)
+	case "cumulative-summaries":
+		return cumulativesummary.Backfill(dbc, startDate, endDate)
+	case "variant-cumulative-summaries":
+		return cumulativesummary.BackfillVariant(dbc, startDate, endDate)
+	default:
+		return fmt.Errorf("unknown table: %s", table)
+	}
 }
 
 func (s *Server) hasCapabilities(capabilities []string) bool {

--- a/scripts/backfill-summaries.sh
+++ b/scripts/backfill-summaries.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# Gradually backfill a summary table one day at a time.
+# Each day runs as a separate pod to avoid long-running transactions.
+#
+# Usage:
+#   ./scripts/backfill-summaries.sh --table TABLE [OPTIONS]
+#
+# Options:
+#   --table TABLE     Table to backfill (daily-summaries, cumulative-summaries,
+#                     variant-cumulative-summaries) [required]
+#   --days N          Number of days to backfill (default: 91)
+#   --namespace NS    Kubernetes namespace (default: sippy)
+#   --image IMAGE     Container image (default: auto-detect from sippy DC)
+#   --db-secret NAME  Database secret name [required]
+#   --pause SECONDS   Seconds to wait between days (default: 5)
+#   --batch N         Days per pod (default: 1)
+#   --dry-run         Print commands without executing
+
+set -euo pipefail
+
+DAYS=91
+TABLE=""
+NAMESPACE=sippy
+IMAGE=""
+DB_SECRET=""
+PAUSE=5
+BATCH=1
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --table)      TABLE="$2"; shift 2 ;;
+        --days)       DAYS="$2"; shift 2 ;;
+        --namespace)  NAMESPACE="$2"; shift 2 ;;
+        --image)      IMAGE="$2"; shift 2 ;;
+        --db-secret)  DB_SECRET="$2"; shift 2 ;;
+        --pause)      PAUSE="$2"; shift 2 ;;
+        --batch)      BATCH="$2"; shift 2 ;;
+        --dry-run)    DRY_RUN=true; shift ;;
+        *)            echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+for arg_name in DAYS PAUSE BATCH; do
+    arg_val="${!arg_name}"
+    if ! [[ "$arg_val" =~ ^[1-9][0-9]*$ ]]; then
+        echo "Error: --$(echo "$arg_name" | tr '[:upper:]' '[:lower:]') must be a positive integer, got '$arg_val'" >&2
+        exit 1
+    fi
+done
+
+if [[ -z "$DB_SECRET" ]]; then
+    echo "Error: --db-secret is required" >&2
+    exit 1
+fi
+
+if [[ -z "$TABLE" ]]; then
+    echo "Error: --table is required" >&2
+    echo "Valid tables: daily-summaries, daily-totals, cumulative-summaries, variant-cumulative-summaries" >&2
+    exit 1
+fi
+
+case "$TABLE" in
+    daily-summaries|daily-totals|cumulative-summaries|variant-cumulative-summaries) ;;
+    *)
+        echo "Error: invalid table '$TABLE'" >&2
+        echo "Valid tables: daily-summaries, daily-totals, cumulative-summaries, variant-cumulative-summaries" >&2
+        exit 1
+        ;;
+esac
+
+if [[ -z "$IMAGE" ]]; then
+    IMAGE=$(oc -n "$NAMESPACE" get dc/sippy -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null) || true
+    if [[ -z "$IMAGE" ]]; then
+        echo "Could not auto-detect image. Use --image to specify." >&2
+        exit 1
+    fi
+    echo "Using image: $IMAGE"
+fi
+
+today=$(date -u +%Y-%m-%d)
+completed=0
+failed=0
+
+for ((offset=DAYS; offset>0; offset-=BATCH)); do
+    batch_end_offset=$((offset - BATCH + 1))
+    if (( batch_end_offset < 0 )); then
+        batch_end_offset=0
+    fi
+
+    start_date=$(date -u -v-${offset}d +%Y-%m-%d 2>/dev/null || date -u -d "$today - ${offset} days" +%Y-%m-%d)
+    end_date=$(date -u -v-${batch_end_offset}d +%Y-%m-%d 2>/dev/null || date -u -d "$today - ${batch_end_offset} days" +%Y-%m-%d)
+
+    pod_name="sippy-backfill-$(echo "$start_date" | tr -d '-')"
+    echo "[$(date +%H:%M:%S)] Processing $start_date to $end_date ($((DAYS - offset + BATCH))/$DAYS days)..."
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "  Would create pod $pod_name: sippy backfill --table=$TABLE --start-date=$start_date --end-date=$end_date"
+        completed=$((completed + 1))
+        continue
+    fi
+
+    # Clean up any leftover pod from a previous run
+    oc -n "$NAMESPACE" delete pod "$pod_name" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+    sleep 2
+
+    oc -n "$NAMESPACE" run "$pod_name" --rm -i --restart=Never \
+        --image="$IMAGE" \
+        --overrides="{
+            \"spec\": {
+                \"containers\": [{
+                    \"name\": \"$pod_name\",
+                    \"image\": \"$IMAGE\",
+                    \"command\": [\"sippy\"],
+                    \"args\": [\"backfill\",
+                        \"--table=$TABLE\",
+                        \"--start-date=$start_date\",
+                        \"--end-date=$end_date\"],
+                    \"env\": [{
+                        \"name\": \"SIPPY_DATABASE_DSN\",
+                        \"valueFrom\": {\"secretKeyRef\": {\"name\": \"$DB_SECRET\", \"key\": \"dsn\"}}
+                    }]
+                }]
+            }
+        }" 2>&1 | { grep -iE 'summar|error|elapsed|complete|panic|fatal|fail|timeout|warn' || true; } || true
+    exit_code=${PIPESTATUS[0]}
+    if [[ $exit_code -eq 0 ]]; then
+        completed=$((completed + 1))
+        echo "  Done."
+    else
+        failed=$((failed + 1))
+        echo "  FAILED (exit $exit_code)" >&2
+    fi
+
+    if (( offset - BATCH > 0 )); then
+        sleep "$PAUSE"
+    fi
+done
+
+echo ""
+echo "Backfill complete: $completed succeeded, $failed failed out of $(( (DAYS + BATCH - 1) / BATCH )) batches."

--- a/scripts/updatesuites.go
+++ b/scripts/updatesuites.go
@@ -12,7 +12,6 @@ import (
 	gormlogger "gorm.io/gorm/logger"
 
 	"github.com/openshift/sippy/pkg/db"
-	"github.com/openshift/sippy/pkg/db/dailysummary"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/sippyserver"
 )
@@ -152,9 +151,11 @@ func testNameWithoutSuite(dbc *gorm.DB) error {
 
 	// Refresh materialized views
 	// NOTE: does not update timestamps to invalidate cached matview data; not clear if the use case for this script requires that.
-	sippyserver.RefreshData(&db.DB{
+	if err := sippyserver.RefreshData(&db.DB{
 		DB: dbc,
-	}, nil, false, dailysummary.Options{Rebuild: true})
+	}, nil, sippyserver.RefreshOptions{}); err != nil {
+		return fmt.Errorf("refreshing data: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Add foundation tables for computing arbitrary date range aggregates
without expensive matview refreshes. This is Phase 1 (additive only,
nothing consumes these tables yet).

### New tables
- `test_cumulative_summaries`: running totals from `test_daily_summaries`, keyed by immutable fields (no variant_combination_id). Entities carry forward on gap days via FULL OUTER JOIN.
- `variant_cumulative_summaries`: groups `test_cumulative_summaries` by `variant_combination_id`. Updated daily by grouping one day's cumulative summaries. Variant changes detected via `vcid_mappings` trigger scoped rebuilds.
- `vcid_mappings`: tracks prow_job variant_combination_id mapping for change detection.

### New commands
- `sippy backfill --table TABLE --start-date DATE [--end-date DATE]`: targeted backfill of a specific table for a date range
- `scripts/backfill-summaries.sh`: shell script for gradually backfilling via pods

### Other changes
- Daily summary lookback extended from 14 to 90 days
- Releases queried from `release_definitions` (newest first) for better parallel worker distribution
- Session settings: `idle_in_transaction_session_timeout=60s`, `random_page_cost=1.1`
- `dailysummary.Refresh` returns earliest changed date for downstream consumers
- Separate `Refresh` and `Backfill` entry points in all summary packages

### Notable behavior changes
- `--rebuild-daily-summaries` flag removed from `sippy refresh` to prevent accidental data loss. Use `sippy backfill` instead.
- `scripts/updatesuites.go` previously used `Rebuild: true` to truncate and rebuild daily summaries after renaming tests. It now does an incremental refresh only. If a full rebuild is needed after running updatesuites, use `sippy backfill --table daily-summaries`.

## Test plan
- [ ] Unit tests pass (`go test ./pkg/...`)
- [ ] Build succeeds (`go build ./pkg/...`)
- [ ] Deploy to staging and run backfill script for cumulative summaries
- [ ] Verify cumulative summary correctness against direct SUM of daily summaries
- [ ] Verify incremental refresh processes only new dates


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **`backfill`** CLI command for filling summary tables over a UTC date range.
  * Added cumulative and variant cumulative refresh/backfill support, including table-level dispatch.
  * Added a Kubernetes batch script to run backfills in short-lived pods.
* **Bug Fixes**
  * Refresh operations now **fail fast** and surface errors instead of continuing silently.
  * Materialized view refresh now reports refresh failures.
* **Chores**
  * Expanded partitioned tables and updated DB runtime settings; refreshed seeding to use the new backfill/refresh flow.
* **Tests**
  * Added unit tests covering cumulative refresh/backfill date-window edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->