### PR TITLE
Fix NULL NOT IN bug in variant exclusion filters

### DIFF
--- a/pkg/api/test_analysis.go
+++ b/pkg/api/test_analysis.go
@@ -56,7 +56,7 @@ func GetTestAnalysisOverallFromDB(dbc *db.DB, filters *filter.Filter, release, t
 	}
 
 	for _, bv := range blockedVariants {
-		jq = jq.Where("prow_jobs.variant_combination_id NOT IN (SELECT id FROM variant_combinations WHERE ? = any(variants))", bv)
+		jq = jq.Where("NOT EXISTS (SELECT 1 FROM variant_combinations WHERE ? = any(variants) AND id = prow_jobs.variant_combination_id)", bv)
 	}
 
 	for _, av := range allowedVariants {
@@ -122,7 +122,7 @@ func GetTestAnalysisByJobFromDB(dbc *db.DB, filters *filter.Filter, release, tes
 	}
 
 	for _, bv := range blockedVariants {
-		jq = jq.Where("prow_jobs.variant_combination_id NOT IN (SELECT id FROM variant_combinations WHERE ? = any(variants))", bv)
+		jq = jq.Where("NOT EXISTS (SELECT 1 FROM variant_combinations WHERE ? = any(variants) AND id = prow_jobs.variant_combination_id)", bv)
 	}
 
 	for _, av := range allowedVariants {

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -113,10 +113,7 @@ func TestReportsByVariant(
 	// Query and group by variant:
 	var testReports []api.Test
 	q := `
-WITH excluded_vc AS (
-    SELECT id FROM variant_combinations WHERE @excluded && variants
-),
-results AS (
+WITH results AS (
     SELECT name,
            release,
            sum(current_runs)       AS current_runs,
@@ -130,7 +127,7 @@ results AS (
            unnest(variants)        AS variant
     FROM prow_test_report_7d_matview
 	WHERE release = @release AND name ~* @testsubstrings
-          AND variant_combination_id NOT IN (SELECT id FROM excluded_vc)
+          AND NOT EXISTS (SELECT 1 FROM variant_combinations WHERE @excluded && variants AND id = variant_combination_id)
     GROUP BY name, release, variant
 )
 SELECT *,
@@ -172,10 +169,7 @@ func TestReportExcludeVariants(dbc *db.DB, release, testName string, excludeVari
 
 	// Query and group by variant:
 	var testReport api.Test
-	q := `WITH excluded_vc AS (
-    SELECT id FROM variant_combinations WHERE @excluded && variants
-),
-results AS (
+	q := `WITH results AS (
     SELECT name,
            release,
            sum(current_runs)       AS current_runs,
@@ -188,7 +182,7 @@ results AS (
            sum(previous_flakes)    AS previous_flakes
     FROM prow_test_report_7d_matview
     WHERE release = @release AND name = @testname
-          AND variant_combination_id NOT IN (SELECT id FROM excluded_vc)
+          AND NOT EXISTS (SELECT 1 FROM variant_combinations WHERE @excluded && variants AND id = variant_combination_id)
     GROUP BY name, release
 ) SELECT *, %s FROM results;`
 
@@ -249,7 +243,7 @@ func TestsByNURPAndStandardDeviation(dbc *db.DB, release, table string) *gorm.DB
 			(current_pass_percentage - passing_average) AS delta_from_passing_average,
 			(current_flake_percentage - flake_average) AS delta_from_flake_average`).
 		Where(`release = ?`, release).
-		Where("variant_combination_id NOT IN (SELECT id FROM variant_combinations WHERE 'never-stable' = any(variants))")
+		Where("NOT EXISTS (SELECT 1 FROM variant_combinations WHERE 'never-stable' = any(variants) AND id = variant_combination_id)")
 }
 
 func TestOutputs(dbc *db.DB, release, test string, includedVariants, excludedVariants []string, quantity int) ([]api.TestOutput, error) {
@@ -272,7 +266,7 @@ func TestOutputs(dbc *db.DB, release, test string, includedVariants, excludedVar
 	}
 
 	for _, variant := range excludedVariants {
-		q = q.Where("prow_jobs.variant_combination_id NOT IN (SELECT id FROM variant_combinations WHERE ? = any(variants))", variant)
+		q = q.Where("NOT EXISTS (SELECT 1 FROM variant_combinations WHERE ? = any(variants) AND id = prow_jobs.variant_combination_id)", variant)
 	}
 
 	res := q.
@@ -305,7 +299,7 @@ func TestDurations(dbc *db.DB, release, test string, includedVariants, excludedV
 	}
 
 	for _, variant := range excludedVariants {
-		q = q.Where("prow_jobs.variant_combination_id NOT IN (SELECT id FROM variant_combinations WHERE ? = any(variants))", variant)
+		q = q.Where("NOT EXISTS (SELECT 1 FROM variant_combinations WHERE ? = any(variants) AND id = prow_jobs.variant_combination_id)", variant)
 	}
 
 	res := q.

--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -390,8 +390,8 @@ SELECT suite_name, name, id, jira_component, jira_component_id, release,
     SUM(previous_flakes)::bigint AS previous_flakes,
     (array_agg(open_bugs))[1] AS open_bugs
 FROM |||SOURCE|||
-WHERE variant_combination_id NOT IN (
-    SELECT id FROM variant_combinations WHERE ` + excludedArray + ` && variants
+WHERE NOT EXISTS (
+    SELECT 1 FROM variant_combinations WHERE ` + excludedArray + ` && variants AND id = variant_combination_id
 )
 GROUP BY suite_name, name, id, jira_component, jira_component_id, release
 `


### PR DESCRIPTION
## Summary

- Rows with NULL `variant_combination_id` were silently dropped by `NOT IN` subqueries due to SQL three-valued logic (`NULL NOT IN (...)` evaluates to NULL, treated as FALSE by WHERE).
- Switched all variant exclusion filters from `NOT IN` to `NOT EXISTS`, which is NULL-safe by default: the inner `WHERE (id = NULL)` never matches, so `NOT EXISTS` returns TRUE and the row passes through.
- Removed now-unnecessary `excluded_vc` CTEs from `TestReportsByVariant` and `TestReportExcludeVariants`.

### Fixed locations (8 total across 3 files)
- `TestReportsByVariant` (test_queries.go)
- `TestReportExcludeVariants` (test_queries.go)
- `TestsByNURPAndStandardDeviation` (test_queries.go)
- `TestOutputs` excluded variant filter (test_queries.go)
- `TestDurations` excluded variant filter (test_queries.go)
- Collapsed matview definition (views.go)
- `TestAnalysisByJob` blocked variants (test_analysis.go, 2 locations)

## Test plan
- [x] `go vet ./pkg/db/query/... ./pkg/db/... ./pkg/api/...` passes
- [x] `make test` passes (Go unit tests, Jest, Python)
- [x] Verified no other `NOT IN` patterns against `variant_combinations` remain
- [x] Verified against staging DB that NULL variant_combination_id rows are now included in query results

### Staging verification

Confirmed the bug and fix against the staging database:

```sql
-- NULL NOT IN (non-empty set) returns NULL (dropped by WHERE):
SELECT (NULL::int NOT IN (
    SELECT id FROM variant_combinations WHERE 'Platform:alibaba' = any(variants)
)) AS old_not_in_result;
 old_not_in_result
-------------------
                        -- NULL (treated as FALSE)

-- NOT EXISTS with NULL returns TRUE (row kept):
SELECT (NOT EXISTS (
    SELECT 1 FROM variant_combinations WHERE 'Platform:alibaba' = any(variants) AND id = NULL
)) AS new_not_exists_result;
 new_not_exists_result
-----------------------
 t
```

Real impact on staging data for test `[Jira:"Test Framework"] monitor test e2e-test-analyzer setup` (release 4.14):

| Query | Row count |
|-------|-----------|
| Old `NOT IN` | 68 |
| New `NOT EXISTS` | 70 |

The 2 missing rows are those with NULL `variant_combination_id`, silently dropped by the old query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of excluded and blocked test variants across test analysis, reporting, output, and duration views.
  * Corrected handling of variant combinations with matching or overlapping variants, improving the accuracy of displayed test results and summaries.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->