### PR TITLE
NO-JIRA: Add uv to buildroot so that verify-apm can be used in CI

### DIFF
--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -22,3 +22,6 @@ RUN curl -Lso /tmp/golangci-lint.rpm \
       alternatives --install /usr/bin/python3 python3 /usr/bin/python3.14 1 && \
       alternatives --set python3 /usr/bin/python3.14
 RUN go install gotest.tools/gotestsum@latest && mv /root/go/bin/gotestsum /usr/bin
+RUN curl -LsSf https://astral.sh/uv/0.11.28/install.sh | sh && \
+      mv /root/.local/bin/uv /usr/bin/uv && \
+      mv /root/.local/bin/uvx /usr/bin/uvx

--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,10 @@ clean:
 	rm -rf sippy-ng/build
 	rm -rf sippy-ng/node_modules
 
-_uvx_flags = $(if $(filter true,$(CI)),--no-cache)
+_uvx_env = $(if $(filter true,$(CI)),UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools)
 apm:
-	uvx $(_uvx_flags) --from apm-cli@0.13.0 apm install
-	uvx $(_uvx_flags) --from apm-cli@0.13.0 apm compile
+	$(_uvx_env) uvx --from apm-cli@0.13.0 apm install
+	$(_uvx_env) uvx --from apm-cli@0.13.0 apm compile
 
 verify-migrations:
 	./hack/verify-migrations.sh

--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,10 @@ clean:
 	rm -rf sippy-ng/build
 	rm -rf sippy-ng/node_modules
 
+_uvx_flags = $(if $(filter true,$(CI)),--no-cache)
 apm:
-	uvx --from apm-cli@0.13.0 apm install
-	uvx --from apm-cli@0.13.0 apm compile
+	uvx $(_uvx_flags) --from apm-cli@0.13.0 apm install
+	uvx $(_uvx_flags) --from apm-cli@0.13.0 apm compile
 
 verify-migrations:
 	./hack/verify-migrations.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `uv` and `uvx` availability to the build environment.
  * Updated CI build steps to disable package caching for more consistent installs and compilation.
  * Preserved existing caching behavior outside CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->