### PR TITLE
Add pgx helpers: PgxSession interface and CopyToTempTable generic

### DIFF
--- a/pkg/dataloader/testownershiploader/testownershiploader.go
+++ b/pkg/dataloader/testownershiploader/testownershiploader.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/stdlib"
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/bigquery"
@@ -39,19 +38,6 @@ func New(ctx context.Context, dbc *db.DB, googleServiceAccountCredentialFile, go
 
 func (tol *TestOwnershipLoader) Name() string {
 	return "test ownership"
-}
-
-var tmpTestOwnershipColumns = []string{
-	"api_version",
-	"unique_id",
-	"name",
-	"suite",
-	"product",
-	"priority",
-	"staff_approved_obsolete",
-	"component",
-	"capabilities",
-	"jira_component",
 }
 
 func (tol *TestOwnershipLoader) Load() {
@@ -88,53 +74,26 @@ func (tol *TestOwnershipLoader) loadMappings(mappings []v1.TestOwnership) error 
 		}
 	}()
 
-	if _, err := conn.Exec(tol.ctx, `CREATE TEMP TABLE tmp_test_ownerships (
-		api_version             text NOT NULL DEFAULT '',
-		unique_id               text NOT NULL DEFAULT '',
-		name                    text NOT NULL DEFAULT '',
-		suite                   text NOT NULL DEFAULT '',
-		product                 text NOT NULL DEFAULT '',
-		priority                integer NOT NULL DEFAULT 0,
-		staff_approved_obsolete boolean NOT NULL DEFAULT false,
-		component               text NOT NULL DEFAULT '',
-		capabilities            text[],
-		jira_component          text NOT NULL DEFAULT ''
-	)`); err != nil {
-		return fmt.Errorf("creating temp table: %w", err)
-	}
-	defer func() {
-		if _, err := conn.Exec(tol.ctx, "DROP TABLE IF EXISTS tmp_test_ownerships"); err != nil {
-			log.WithError(err).Error("failed to drop temp table tmp_test_ownerships")
-		}
-	}()
-
 	st := time.Now()
-	copied, err := conn.CopyFrom(tol.ctx,
-		pgx.Identifier{"tmp_test_ownerships"},
-		tmpTestOwnershipColumns,
-		pgx.CopyFromSlice(len(mappings), func(i int) ([]any, error) {
-			m := &mappings[i]
-			return []any{
-				m.APIVersion,
-				m.ID,
-				m.Name,
-				m.Suite,
-				m.Product,
-				m.Priority,
-				m.StaffApprovedObsolete,
-				m.Component,
-				m.Capabilities,
-				m.JIRAComponent,
-			}, nil
-		}),
+	cleanup, err := db.CopyToTempTable(tol.ctx, conn, "tmp_test_ownerships", mappings,
+		[]db.TempColumn[v1.TestOwnership]{
+			{Name: "api_version", Type: "text NOT NULL DEFAULT ''", Value: func(m *v1.TestOwnership) any { return m.APIVersion }},
+			{Name: "unique_id", Type: "text NOT NULL DEFAULT ''", Value: func(m *v1.TestOwnership) any { return m.ID }},
+			{Name: "name", Type: "text NOT NULL DEFAULT ''", Value: func(m *v1.TestOwnership) any { return m.Name }},
+			{Name: "suite", Type: "text NOT NULL DEFAULT ''", Value: func(m *v1.TestOwnership) any { return m.Suite }},
+			{Name: "product", Type: "text NOT NULL DEFAULT ''", Value: func(m *v1.TestOwnership) any { return m.Product }},
+			{Name: "priority", Type: "integer NOT NULL DEFAULT 0", Value: func(m *v1.TestOwnership) any { return m.Priority }},
+			{Name: "staff_approved_obsolete", Type: "boolean NOT NULL DEFAULT false", Value: func(m *v1.TestOwnership) any { return m.StaffApprovedObsolete }},
+			{Name: "component", Type: "text NOT NULL DEFAULT ''", Value: func(m *v1.TestOwnership) any { return m.Component }},
+			{Name: "capabilities", Type: "text[]", Value: func(m *v1.TestOwnership) any { return m.Capabilities }},
+			{Name: "jira_component", Type: "text NOT NULL DEFAULT ''", Value: func(m *v1.TestOwnership) any { return m.JIRAComponent }},
+		},
 	)
+	defer cleanup()
 	if err != nil {
-		return fmt.Errorf("COPY tmp_test_ownerships: %w", err)
+		return err
 	}
-	log.WithFields(log.Fields{
-		"rows":    copied,
-		"elapsed": time.Since(st),
-	}).Info("COPY into temp table complete")
+	log.WithField("elapsed", time.Since(st)).Info("COPY into temp table complete")
 
 	st = time.Now()
 	upsertTag, err := conn.Exec(tol.ctx, `
@@ -199,10 +158,12 @@ func (tol *TestOwnershipLoader) loadMappings(mappings []v1.TestOwnership) error 
 	}
 
 	var nullComponents []string
-	tol.dbc.DB.Raw(`
+	if err := tol.dbc.DB.Raw(`
 		SELECT DISTINCT jira_component FROM test_ownerships
 		WHERE jira_component_id IS NULL AND jira_component != ''
-	`).Scan(&nullComponents)
+	`).Scan(&nullComponents).Error; err != nil {
+		log.WithError(err).Warn("failed to query unresolved jira components")
+	}
 	if len(nullComponents) > 0 {
 		log.WithField("components", nullComponents).Warn("test ownership rows have unresolved jira_component_id")
 	}

--- a/pkg/db/pgx.go
+++ b/pkg/db/pgx.go
@@ -1,0 +1,85 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	log "github.com/sirupsen/logrus"
+)
+
+// PgxSession is satisfied by both *pgx.Conn and pgx.Tx.
+type PgxSession interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error)
+}
+
+type TempColumn[T any] struct {
+	Name  string
+	Type  string
+	Value func(*T) any
+}
+
+func CopyToTempTable[T any](
+	ctx context.Context,
+	conn PgxSession,
+	tempTable string,
+	rows []T,
+	cols []TempColumn[T],
+) (cleanup func(), err error) {
+	if !validIdentifier(tempTable) {
+		return func() {}, fmt.Errorf("CopyToTempTable: invalid table name %q", tempTable)
+	}
+	if len(cols) == 0 {
+		return func() {}, fmt.Errorf("CopyToTempTable: cols must not be empty")
+	}
+	for _, c := range cols {
+		if !validIdentifier(c.Name) {
+			return func() {}, fmt.Errorf("CopyToTempTable: invalid column name %q", c.Name)
+		}
+	}
+
+	drop := func() {
+		if _, err := conn.Exec(context.Background(), "DROP TABLE IF EXISTS "+tempTable); err != nil {
+			log.WithError(err).WithField("table", tempTable).Error("failed to drop temp table")
+		}
+	}
+
+	colDefs := make([]string, len(cols))
+	colNames := make([]string, len(cols))
+	for i, c := range cols {
+		colDefs[i] = fmt.Sprintf("%s %s", c.Name, c.Type)
+		colNames[i] = c.Name
+	}
+
+	createSQL := fmt.Sprintf("CREATE TEMP TABLE %s (%s)", tempTable, strings.Join(colDefs, ", "))
+	if _, err := conn.Exec(ctx, createSQL); err != nil {
+		return func() {}, fmt.Errorf("creating %s: %w", tempTable, err)
+	}
+
+	if _, err := conn.CopyFrom(ctx,
+		pgx.Identifier{tempTable},
+		colNames,
+		pgx.CopyFromSlice(len(rows), func(i int) ([]any, error) {
+			vals := make([]any, len(cols))
+			for j, c := range cols {
+				vals[j] = c.Value(&rows[i])
+			}
+			return vals, nil
+		}),
+	); err != nil {
+		drop()
+		return func() {}, fmt.Errorf("COPY %s: %w", tempTable, err)
+	}
+	return drop, nil
+}
+
+var identifierRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+func validIdentifier(name string) bool {
+	return identifierRe.MatchString(name)
+}


### PR DESCRIPTION
## Summary

- Introduces shared pgx utilities in `pkg/db/pgx.go`:
  - `PgxSession`: interface satisfied by both `*pgx.Conn` and `pgx.Tx`, enabling functions to work with either raw connections or transactions
  - `TempColumn[T]`: typed column definition binding a column name, SQL type, and value extractor so callers cannot have out-of-order columns
  - `CopyToTempTable[T]`: creates a temp table, COPYs rows into it via the COPY protocol, and returns a cleanup function. Cleans up automatically on COPY failure.
- Converts `testownershiploader` to use `CopyToTempTable`, replacing manual CREATE TEMP TABLE + CopyFrom + DROP TABLE boilerplate

## Test plan

- [x] `make lint` passes (0 issues)
- [x] `make test` passes
- [x] `make e2e` passes (108 tests, 0 failures)
- [x] Ran test ownership loader against staging DB: 64,045 mappings fetched, 38,970 upserted, 0 errors
- [x] Independent code review via isolated sub-agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Streamlined bulk-loading of test ownership data into PostgreSQL temporary tables.
  - Added a reusable bulk-insert helper for temporary tables with typed column definitions and automatic cleanup.
  - Strengthened validation and error handling during temporary table creation, data loading, and cleanup.
- **Bug Fixes**
  - Improved detection and warning logs when scanning unresolved component data fails.
- **Refactor**
  - Simplified the database loading workflow while preserving existing upsert/delete behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->