### PR TITLE
TRT-2782: provide test_details links for all tests

### DIFF
--- a/docs/plans/trt-2782-all-tests-links.md
+++ b/docs/plans/trt-2782-all-tests-links.md
@@ -1,0 +1,103 @@
+# TRT-2782: Provide test_details HATEOAS links for all tests (Phase 1)
+
+## Context
+
+The component_readiness API only includes test_details HATEOAS links for regressed tests. Two code paths enforce this restriction:
+
+1. `getNewCellStatus` only adds tests to `regressedTests` when `ReportStatus < MissingSample` (-100). The `PostAnalysis` middleware loop only iterates over `RegressedTests`.
+2. `LinkInjector.PostAnalysis` has an early return for `ReportStatus > FixedRegression` (-150).
+
+This means non-regressed cells (green/grey/blue) have no test_details links, preventing navigation to individual test results.
+
+## Approach
+
+Add a new `AllTests` field alongside the existing `RegressedTests`. This preserves backward compatibility while exposing all analyzed tests with HATEOAS links. Remove the LinkInjector status guard so links are generated for every test status.
+
+All other middleware PostAnalysis methods already handle non-regressed tests safely:
+- `RegressionTracker.PostAnalysis` returns early at line 124 (`ReportStatus > SignificantTriagedRegression`)
+- `RegressionAllowances.PostAnalysis` is a no-op (returns nil)
+
+Regressed tests appear in both lists and get middleware-processed twice. This is safe because all middleware operations are idempotent (map key assignment, DB lookup with early return).
+
+## Changes
+
+### 1. Add `AllTests` to response type
+**File:** `pkg/apis/api/componentreport/types.go`
+
+Add `AllTests []ReportTestSummary` field to `ReportColumn`:
+```go
+type ReportColumn struct {
+    crtest.ColumnIdentification
+    Status         crtest.Status       `json:"status"`
+    RegressedTests []ReportTestSummary `json:"regressed_tests,omitempty"`
+    AllTests       []ReportTestSummary `json:"all_tests,omitempty"`
+}
+```
+
+### 2. Add `allTests` to internal `cellStatus` struct
+**File:** `pkg/api/componentreadiness/component_report.go` (line 506)
+
+```go
+type cellStatus struct {
+    status         crtest.Status
+    regressedTests []crtype.ReportTestSummary
+    allTests       []crtype.ReportTestSummary
+}
+```
+
+### 3. Populate `allTests` unconditionally in `getNewCellStatus`
+**File:** `pkg/api/componentreadiness/component_report.go` (line 511)
+
+- Carry forward `existingCellStatus.allTests` (like we do for `regressedTests`)
+- Always create a `ReportTestSummary` and append to `allTests`
+- Keep the existing conditional append to `regressedTests` unchanged
+
+### 4. Assign `AllTests` in `buildReport`
+**File:** `pkg/api/componentreadiness/component_report.go` (line 726)
+
+After the existing `reportColumn.RegressedTests = status.regressedTests`, add:
+```go
+reportColumn.AllTests = status.allTests
+sort.Slice(reportColumn.AllTests, func(i, j int) bool {
+    return reportColumn.AllTests[i].ReportStatus < reportColumn.AllTests[j].ReportStatus
+})
+```
+
+### 5. Run PostAnalysis middleware over `AllTests`
+**File:** `pkg/api/componentreadiness/component_report.go` (line 125)
+
+After the existing `RegressedTests` loop (which handles cell status recomputation), add a second loop over `AllTests`:
+```go
+for ati := range col.AllTests {
+    testKey := crtest.Identification{
+        RowIdentification:    col.AllTests[ati].RowIdentification,
+        ColumnIdentification: col.AllTests[ati].ColumnIdentification,
+    }
+    if err := c.middlewares.PostAnalysis(testKey,
+        &report.Rows[ri].Columns[ci].AllTests[ati].TestComparison); err != nil {
+        return err
+    }
+}
+```
+
+Cell status recomputation stays based on `RegressedTests` only (unchanged).
+
+### 6. Remove LinkInjector status guard
+**File:** `pkg/api/componentreadiness/middleware/linkinjector/linkinjector.go` (lines 50-53)
+
+Remove:
+```go
+if testStats.ReportStatus > crtest.FixedRegression {
+    return nil
+}
+```
+
+## Verification
+
+1. `go vet ./pkg/...` and `make lint`
+2. `go test ./pkg/api/componentreadiness/...` and `go test ./pkg/apis/...`
+3. Start sippy serve, hit the `/api/component_readiness` endpoint with test-level parameters, confirm:
+   - `all_tests` field is present on each cell
+   - Every entry in `all_tests` has a `links.test_details` URL regardless of status
+   - `regressed_tests` continues to contain only regressed tests (backward compat)
+   - Cell-level `status` is unchanged (still computed from regressed tests only)

--- a/docs/plans/trt-2782-all-tests-links.md
+++ b/docs/plans/trt-2782-all-tests-links.md
@@ -92,12 +92,18 @@ if testStats.ReportStatus > crtest.FixedRegression {
 }
 ```
 
+### 7. Restrict `AllTests` to Level 4 only
+
+To avoid response bloat (~1GB at top level), `AllTests` is only populated when `testId` is present in the request (Level 4, the test variant page). This is the only level where the frontend renders `test_details` links from `all_tests`. At Levels 1-3, `AllTests` is omitted from the response.
+
+The `includeAllTests()` helper on `ComponentReportGenerator` controls this, gating accumulation in `getNewCellStatus`, assignment in `buildReport`, and PostAnalysis middleware processing.
+
 ## Verification
 
 1. `go vet ./pkg/...` and `make lint`
 2. `go test ./pkg/api/componentreadiness/...` and `go test ./pkg/apis/...`
-3. Start sippy serve, hit the `/api/component_readiness` endpoint with test-level parameters, confirm:
-   - `all_tests` field is present on each cell
-   - Every entry in `all_tests` has a `links.test_details` URL regardless of status
+3. Start sippy serve, hit the `/api/component_readiness` endpoint and confirm:
+   - Level 1 (`?view=...`): no `all_tests` field in response
+   - Level 4 (`?view=...&component=X&capability=Y&testId=Z`): `all_tests` present with `test_details` links
    - `regressed_tests` continues to contain only regressed tests (backward compat)
    - Cell-level `status` is unchanged (still computed from regressed tests only)

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -146,13 +146,15 @@ func (c *ComponentReportGenerator) PostAnalysis(report *crtype.ComponentReport) 
 				report.Rows[ri].Columns[ci].Status = worstStatus
 			}
 
-			for ati := range col.AllTests {
-				testKey := crtest.Identification{
-					RowIdentification:    col.AllTests[ati].RowIdentification,
-					ColumnIdentification: col.AllTests[ati].ColumnIdentification,
-				}
-				if err := c.middlewares.PostAnalysis(testKey, &report.Rows[ri].Columns[ci].AllTests[ati].TestComparison); err != nil {
-					return err
+			if c.includeAllTests() {
+				for ati := range col.AllTests {
+					testKey := crtest.Identification{
+						RowIdentification:    col.AllTests[ati].RowIdentification,
+						ColumnIdentification: col.AllTests[ati].ColumnIdentification,
+					}
+					if err := c.middlewares.PostAnalysis(testKey, &report.Rows[ri].Columns[ci].AllTests[ati].TestComparison); err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -300,6 +302,12 @@ func (c *ComponentReportGenerator) initializeMiddleware() {
 	// Initialize LinkInjector middleware
 	linkInjector := linkinjector.NewLinkInjectorMiddleware(c.ReqOptions, c.baseURL)
 	c.middlewares = append(c.middlewares, linkInjector)
+}
+
+// includeAllTests returns true when the request is for a specific test (Level 4),
+// which is the only level where the frontend renders test_details links from AllTests.
+func (c *ComponentReportGenerator) includeAllTests() bool {
+	return len(c.ReqOptions.TestIDOptions) > 0 && c.ReqOptions.TestIDOptions[0].TestID != ""
 }
 
 // GenerateReport is the main entry point for generation of a component readiness report.
@@ -519,7 +527,7 @@ type cellStatus struct {
 	allTests       []crtype.ReportTestSummary
 }
 
-func getNewCellStatus(testID crtest.Identification, testStats testdetails.TestComparison, existingCellStatus *cellStatus) cellStatus {
+func getNewCellStatus(testID crtest.Identification, testStats testdetails.TestComparison, existingCellStatus *cellStatus, includeAllTests bool) cellStatus {
 	var newCellStatus cellStatus
 	if existingCellStatus != nil {
 		if (testStats.ReportStatus < crtest.NotSignificant && testStats.ReportStatus < existingCellStatus.status) ||
@@ -530,7 +538,9 @@ func getNewCellStatus(testID crtest.Identification, testStats testdetails.TestCo
 			newCellStatus.status = existingCellStatus.status
 		}
 		newCellStatus.regressedTests = existingCellStatus.regressedTests
-		newCellStatus.allTests = existingCellStatus.allTests
+		if includeAllTests {
+			newCellStatus.allTests = existingCellStatus.allTests
+		}
 	} else {
 		newCellStatus.status = testStats.ReportStatus
 	}
@@ -539,7 +549,9 @@ func getNewCellStatus(testID crtest.Identification, testStats testdetails.TestCo
 		Identification: testID,
 		TestComparison: testStats,
 	}
-	newCellStatus.allTests = append(newCellStatus.allTests, rt)
+	if includeAllTests {
+		newCellStatus.allTests = append(newCellStatus.allTests, rt)
+	}
 
 	if testStats.ReportStatus < crtest.MissingSample {
 		newCellStatus.regressedTests = append(newCellStatus.regressedTests, rt)
@@ -552,6 +564,7 @@ func updateCellStatus(
 	columnIdentifications []crtest.ColumnID,
 	testID crtest.Identification,
 	testStats testdetails.TestComparison,
+	includeAllTests bool,
 	// use the inputs above to update the maps below (golang passes maps by reference)
 	status map[crtest.RowIdentification]map[crtest.ColumnID]cellStatus,
 	allRows map[crtest.RowIdentification]struct{},
@@ -576,16 +589,16 @@ func updateCellStatus(
 		if !ok {
 			row = map[crtest.ColumnID]cellStatus{}
 			for _, columnIdentification := range columnIdentifications {
-				row[columnIdentification] = getNewCellStatus(testID, testStats, nil)
+				row[columnIdentification] = getNewCellStatus(testID, testStats, nil, includeAllTests)
 				status[rowIdentification] = row
 			}
 		} else {
 			for _, columnIdentification := range columnIdentifications {
 				existing, ok := row[columnIdentification]
 				if !ok {
-					row[columnIdentification] = getNewCellStatus(testID, testStats, nil)
+					row[columnIdentification] = getNewCellStatus(testID, testStats, nil, includeAllTests)
 				} else {
-					row[columnIdentification] = getNewCellStatus(testID, testStats, &existing)
+					row[columnIdentification] = getNewCellStatus(testID, testStats, &existing, includeAllTests)
 				}
 			}
 		}
@@ -670,12 +683,12 @@ func (c *ComponentReportGenerator) generateComponentTestReport(basisStatusMap, s
 			return crtype.ComponentReport{}, err
 		}
 		updateCellStatus(
-			rowIdentifications, columnIdentifications, testKey, cellReport, // inputs
+			rowIdentifications, columnIdentifications, testKey, cellReport, c.includeAllTests(), // inputs
 			aggregatedStatus, allRows, allColumns, // these three are maps to be updated
 		)
 	}
 
-	rows, err := buildReport(sortRowIdentifications(allRows), sortColumnIdentifications(allColumns), aggregatedStatus)
+	rows, err := buildReport(sortRowIdentifications(allRows), sortColumnIdentifications(allColumns), aggregatedStatus, c.includeAllTests())
 	if err != nil {
 		return crtype.ComponentReport{}, err
 	}
@@ -714,7 +727,7 @@ func sortColumnIdentifications(allColumns map[crtest.ColumnID]struct{}) []crtest
 	return sortedColumns
 }
 
-func buildReport(sortedRows []crtest.RowIdentification, sortedColumns []crtest.ColumnID, aggregatedStatus map[crtest.RowIdentification]map[crtest.ColumnID]cellStatus) ([]crtype.ReportRow, error) {
+func buildReport(sortedRows []crtest.RowIdentification, sortedColumns []crtest.ColumnID, aggregatedStatus map[crtest.RowIdentification]map[crtest.ColumnID]cellStatus, includeAllTests bool) ([]crtype.ReportRow, error) {
 	// Now build the report
 	var regressionRows, goodRows []crtype.ReportRow
 	for _, rowID := range sortedRows {
@@ -743,10 +756,12 @@ func buildReport(sortedRows []crtest.RowIdentification, sortedColumns []crtest.C
 				sort.Slice(reportColumn.RegressedTests, func(i, j int) bool {
 					return reportColumn.RegressedTests[i].ReportStatus < reportColumn.RegressedTests[j].ReportStatus
 				})
-				reportColumn.AllTests = status.allTests
-				sort.Slice(reportColumn.AllTests, func(i, j int) bool {
-					return reportColumn.AllTests[i].ReportStatus < reportColumn.AllTests[j].ReportStatus
-				})
+				if includeAllTests {
+					reportColumn.AllTests = status.allTests
+					sort.Slice(reportColumn.AllTests, func(i, j int) bool {
+						return reportColumn.AllTests[i].ReportStatus < reportColumn.AllTests[j].ReportStatus
+					})
+				}
 			}
 			reportRow.Columns = append(reportRow.Columns, reportColumn)
 			if reportColumn.Status <= crtest.SignificantTriagedRegression {

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -631,6 +631,7 @@ func initTestAnalysisStruct(
 }
 
 func (c *ComponentReportGenerator) generateComponentTestReport(basisStatusMap, sampleStatusMap map[string]crstatus.TestStatus) (crtype.ComponentReport, error) {
+	includeAllTests := c.includeAllTests()
 	// aggregatedStatus is the aggregated status based on the requested rows and columns
 	aggregatedStatus := map[crtest.RowIdentification]map[crtest.ColumnID]cellStatus{}
 	// allRows and allColumns are used to make sure rows are ordered and all rows have the same columns in the same order
@@ -683,12 +684,12 @@ func (c *ComponentReportGenerator) generateComponentTestReport(basisStatusMap, s
 			return crtype.ComponentReport{}, err
 		}
 		updateCellStatus(
-			rowIdentifications, columnIdentifications, testKey, cellReport, c.includeAllTests(), // inputs
+			rowIdentifications, columnIdentifications, testKey, cellReport, includeAllTests, // inputs
 			aggregatedStatus, allRows, allColumns, // these three are maps to be updated
 		)
 	}
 
-	rows, err := buildReport(sortRowIdentifications(allRows), sortColumnIdentifications(allColumns), aggregatedStatus, c.includeAllTests())
+	rows, err := buildReport(sortRowIdentifications(allRows), sortColumnIdentifications(allColumns), aggregatedStatus, includeAllTests)
 	if err != nil {
 		return crtype.ComponentReport{}, err
 	}

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -145,6 +145,16 @@ func (c *ComponentReportGenerator) PostAnalysis(report *crtype.ComponentReport) 
 			if len(col.RegressedTests) > 0 {
 				report.Rows[ri].Columns[ci].Status = worstStatus
 			}
+
+			for ati := range col.AllTests {
+				testKey := crtest.Identification{
+					RowIdentification:    col.AllTests[ati].RowIdentification,
+					ColumnIdentification: col.AllTests[ati].ColumnIdentification,
+				}
+				if err := c.middlewares.PostAnalysis(testKey, &report.Rows[ri].Columns[ci].AllTests[ati].TestComparison); err != nil {
+					return err
+				}
+			}
 		}
 	}
 
@@ -506,6 +516,7 @@ func (c *ComponentReportGenerator) getRowColumnIdentifications(testIDStr string,
 type cellStatus struct {
 	status         crtest.Status
 	regressedTests []crtype.ReportTestSummary
+	allTests       []crtype.ReportTestSummary
 }
 
 func getNewCellStatus(testID crtest.Identification, testStats testdetails.TestComparison, existingCellStatus *cellStatus) cellStatus {
@@ -519,14 +530,18 @@ func getNewCellStatus(testID crtest.Identification, testStats testdetails.TestCo
 			newCellStatus.status = existingCellStatus.status
 		}
 		newCellStatus.regressedTests = existingCellStatus.regressedTests
+		newCellStatus.allTests = existingCellStatus.allTests
 	} else {
 		newCellStatus.status = testStats.ReportStatus
 	}
+
+	rt := crtype.ReportTestSummary{
+		Identification: testID,
+		TestComparison: testStats,
+	}
+	newCellStatus.allTests = append(newCellStatus.allTests, rt)
+
 	if testStats.ReportStatus < crtest.MissingSample {
-		rt := crtype.ReportTestSummary{
-			Identification: testID,
-			TestComparison: testStats,
-		}
 		newCellStatus.regressedTests = append(newCellStatus.regressedTests, rt)
 	}
 	return newCellStatus
@@ -727,6 +742,10 @@ func buildReport(sortedRows []crtest.RowIdentification, sortedColumns []crtest.C
 				reportColumn.RegressedTests = status.regressedTests
 				sort.Slice(reportColumn.RegressedTests, func(i, j int) bool {
 					return reportColumn.RegressedTests[i].ReportStatus < reportColumn.RegressedTests[j].ReportStatus
+				})
+				reportColumn.AllTests = status.allTests
+				sort.Slice(reportColumn.AllTests, func(i, j int) bool {
+					return reportColumn.AllTests[i].ReportStatus < reportColumn.AllTests[j].ReportStatus
 				})
 			}
 			reportRow.Columns = append(reportRow.Columns, reportColumn)

--- a/pkg/api/componentreadiness/component_report_test.go
+++ b/pkg/api/componentreadiness/component_report_test.go
@@ -1218,12 +1218,16 @@ func TestGenerateComponentReport(t *testing.T) {
 
 					}
 
-					// AllTests should contain at least as many entries as RegressedTests
-					assert.GreaterOrEqual(t, len(report.Rows[ir].Columns[ic].AllTests),
-						len(report.Rows[ir].Columns[ic].RegressedTests),
-						"AllTests should be a superset of RegressedTests for row %d col %d", ir, ic)
-					// Clear AllTests for the deep comparison below; the count check above
-					// validates it is populated.
+					if tc.generator.includeAllTests() {
+						// Level 4 (testId set): AllTests should be a superset of RegressedTests
+						assert.GreaterOrEqual(t, len(report.Rows[ir].Columns[ic].AllTests),
+							len(report.Rows[ir].Columns[ic].RegressedTests),
+							"AllTests should be a superset of RegressedTests for row %d col %d", ir, ic)
+					} else {
+						// Levels 1-3: AllTests is not populated to avoid response bloat
+						assert.Empty(t, report.Rows[ir].Columns[ic].AllTests,
+							"AllTests should be empty at non-test-level for row %d col %d", ir, ic)
+					}
 					report.Rows[ir].Columns[ic].AllTests = nil
 				}
 			}

--- a/pkg/api/componentreadiness/component_report_test.go
+++ b/pkg/api/componentreadiness/component_report_test.go
@@ -1217,6 +1217,14 @@ func TestGenerateComponentReport(t *testing.T) {
 						report.Rows[ir].Columns[ic].RegressedTests[it].FisherExact = nil
 
 					}
+
+					// AllTests should contain at least as many entries as RegressedTests
+					assert.GreaterOrEqual(t, len(report.Rows[ir].Columns[ic].AllTests),
+						len(report.Rows[ir].Columns[ic].RegressedTests),
+						"AllTests should be a superset of RegressedTests for row %d col %d", ir, ic)
+					// Clear AllTests for the deep comparison below; the count check above
+					// validates it is populated.
+					report.Rows[ir].Columns[ic].AllTests = nil
 				}
 			}
 			assert.Equal(t, tc.expectedReport, report, "expected report %+v, got %+v", tc.expectedReport, report)

--- a/pkg/api/componentreadiness/middleware/linkinjector/linkinjector.go
+++ b/pkg/api/componentreadiness/middleware/linkinjector/linkinjector.go
@@ -47,11 +47,6 @@ func (l *LinkInjector) PreAnalysis(testKey crtest.Identification, testStats *tes
 
 // PostAnalysis injects HATEOAS links into test analysis results
 func (l *LinkInjector) PostAnalysis(testKey crtest.Identification, testStats *testdetails.TestComparison) error {
-	// Early return if status is above FixedRegression (i.e. regression has not yet rolled off)
-	if testStats.ReportStatus > crtest.FixedRegression {
-		return nil
-	}
-
 	// Initialize Links map if it doesn't exist
 	if testStats.Links == nil {
 		testStats.Links = make(map[string]string)

--- a/pkg/apis/api/componentreport/types.go
+++ b/pkg/apis/api/componentreport/types.go
@@ -26,6 +26,7 @@ type ReportColumn struct {
 	crtest.ColumnIdentification
 	Status         crtest.Status       `json:"status"`
 	RegressedTests []ReportTestSummary `json:"regressed_tests,omitempty"`
+	AllTests       []ReportTestSummary `json:"all_tests,omitempty"`
 }
 
 type ReportTestSummary struct {

--- a/test/e2e/componentreadiness/alltests_links_test.go
+++ b/test/e2e/componentreadiness/alltests_links_test.go
@@ -1,0 +1,110 @@
+package componentreadiness
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openshift/sippy/pkg/apis/api/componentreport"
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/crtest"
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/crview"
+	"github.com/openshift/sippy/test/e2e/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllTestsLinksPresent(t *testing.T) {
+	var views []crview.View
+	err := util.SippyGet("/api/component_readiness/views", &views)
+	require.NoError(t, err, "error fetching views")
+	require.Greater(t, len(views), 0, "no views returned")
+
+	var report componentreport.ComponentReport
+	err = util.SippyGet(fmt.Sprintf("/api/component_readiness?view=%s", views[0].Name), &report)
+	require.NoError(t, err, "error fetching component report")
+	require.Greater(t, len(report.Rows), 0, "component report has no rows")
+
+	t.Run("regressed tests have test_details links in AllTests", func(t *testing.T) {
+		var foundRegression bool
+		for _, row := range report.Rows {
+			for _, col := range row.Columns {
+				if len(col.RegressedTests) == 0 {
+					continue
+				}
+				foundRegression = true
+
+				// Every regressed test should appear in AllTests with a test_details link
+				for _, rt := range col.RegressedTests {
+					assert.NotNil(t, rt.Links, "regressed test %s should have links", rt.TestName)
+					assert.Contains(t, rt.Links, "test_details",
+						"regressed test %s should have a test_details link", rt.TestName)
+				}
+
+				// AllTests should be a superset of RegressedTests
+				assert.GreaterOrEqual(t, len(col.AllTests), len(col.RegressedTests),
+					"AllTests should contain at least as many entries as RegressedTests")
+
+				// Every entry in AllTests should have a test_details link
+				for _, at := range col.AllTests {
+					assert.NotNil(t, at.Links, "AllTests entry %s should have links", at.TestName)
+					assert.Contains(t, at.Links, "test_details",
+						"AllTests entry %s should have a test_details link", at.TestName)
+				}
+			}
+		}
+		if !foundRegression {
+			t.Skip("no regressed tests in report to verify")
+		}
+	})
+
+	t.Run("non-regressed tests have test_details links in AllTests", func(t *testing.T) {
+		var foundNonRegressed bool
+		for _, row := range report.Rows {
+			for _, col := range row.Columns {
+				if len(col.AllTests) == 0 || len(col.RegressedTests) > 0 {
+					continue
+				}
+				// This cell has tests analyzed but none regressed
+				if col.Status == crtest.NotSignificant ||
+					col.Status == crtest.SignificantImprovement ||
+					col.Status == crtest.MissingBasis {
+					foundNonRegressed = true
+
+					for _, at := range col.AllTests {
+						assert.NotNil(t, at.Links,
+							"non-regressed test %s (status %d) should have links", at.TestName, at.ReportStatus)
+						assert.Contains(t, at.Links, "test_details",
+							"non-regressed test %s (status %d) should have a test_details link", at.TestName, at.ReportStatus)
+						assert.Contains(t, at.Links["test_details"], "testId=",
+							"test_details link for %s should contain testId parameter", at.TestName)
+					}
+				}
+			}
+		}
+		if !foundNonRegressed {
+			t.Skip("no non-regressed cells with tests found in report")
+		}
+	})
+
+	t.Run("AllTests is empty only for cells with no test data", func(t *testing.T) {
+		for _, row := range report.Rows {
+			for _, col := range row.Columns {
+				if col.Status == crtest.MissingBasisAndSample {
+					assert.Empty(t, col.AllTests,
+						"MissingBasisAndSample cell should have no AllTests entries")
+				}
+			}
+		}
+	})
+
+	t.Run("RegressedTests unchanged by AllTests addition", func(t *testing.T) {
+		for _, row := range report.Rows {
+			for _, col := range row.Columns {
+				for _, rt := range col.RegressedTests {
+					assert.Less(t, int(rt.ReportStatus), int(crtest.MissingSample),
+						"RegressedTests should only contain tests with regression status, got %d for %s",
+						rt.ReportStatus, rt.TestName)
+				}
+			}
+		}
+	})
+}

--- a/test/e2e/componentreadiness/alltests_links_test.go
+++ b/test/e2e/componentreadiness/alltests_links_test.go
@@ -110,13 +110,17 @@ func TestAllTestsLinksPresent(t *testing.T) {
 	component := l1Row.Component
 	require.NotEmpty(t, component, "level 1 row has empty component")
 
-	// Level 2: get a capability
+	// Level 2: get a capability, preferring one with mixed statuses
 	var l2Report componentreport.ComponentReport
 	err = util.SippyGet(fmt.Sprintf("/api/component_readiness?view=%s&component=%s",
 		url.QueryEscape(viewName), url.QueryEscape(component)), &l2Report)
 	require.NoError(t, err, "error fetching level 2 report")
 	require.Greater(t, len(l2Report.Rows), 0, "level 2 report has no rows for component=%s", component)
-	capability := l2Report.Rows[0].Capability
+	l2Row := findRowWithMixedStatuses(l2Report.Rows)
+	if l2Row == nil {
+		l2Row = &l2Report.Rows[0]
+	}
+	capability := l2Row.Capability
 	require.NotEmpty(t, capability, "level 2 row has empty capability")
 
 	// Level 3: find a test with mixed variant statuses

--- a/test/e2e/componentreadiness/alltests_links_test.go
+++ b/test/e2e/componentreadiness/alltests_links_test.go
@@ -2,6 +2,7 @@ package componentreadiness
 
 import (
 	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/openshift/sippy/pkg/apis/api/componentreport"
@@ -12,16 +13,132 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAllTestsLinksPresent(t *testing.T) {
+func TestAllTestsExcludedFromTopLevel(t *testing.T) {
 	var views []crview.View
 	err := util.SippyGet("/api/component_readiness/views", &views)
 	require.NoError(t, err, "error fetching views")
 	require.Greater(t, len(views), 0, "no views returned")
 
 	var report componentreport.ComponentReport
-	err = util.SippyGet(fmt.Sprintf("/api/component_readiness?view=%s", views[0].Name), &report)
+	err = util.SippyGet(fmt.Sprintf("/api/component_readiness?view=%s", url.QueryEscape(views[0].Name)), &report)
 	require.NoError(t, err, "error fetching component report")
 	require.Greater(t, len(report.Rows), 0, "component report has no rows")
+
+	t.Run("AllTests is empty at top level", func(t *testing.T) {
+		for _, row := range report.Rows {
+			for _, col := range row.Columns {
+				assert.Empty(t, col.AllTests,
+					"AllTests should not be populated at top level (component=%s)", row.Component)
+			}
+		}
+	})
+
+	t.Run("RegressedTests still has links at top level", func(t *testing.T) {
+		var foundRegression bool
+		for _, row := range report.Rows {
+			for _, col := range row.Columns {
+				for _, rt := range col.RegressedTests {
+					foundRegression = true
+					assert.NotNil(t, rt.Links, "regressed test %s should have links", rt.TestName)
+					assert.Contains(t, rt.Links, "test_details",
+						"regressed test %s should have a test_details link", rt.TestName)
+				}
+			}
+		}
+		if !foundRegression {
+			t.Skip("no regressed tests in report to verify")
+		}
+	})
+
+	t.Run("RegressedTests unchanged by AllTests addition", func(t *testing.T) {
+		for _, row := range report.Rows {
+			for _, col := range row.Columns {
+				for _, rt := range col.RegressedTests {
+					assert.Less(t, int(rt.ReportStatus), int(crtest.MissingSample),
+						"RegressedTests should only contain tests with regression status, got %d for %s",
+						rt.ReportStatus, rt.TestName)
+				}
+			}
+		}
+	})
+}
+
+// findRowWithMixedStatuses returns a row that has at least one regressed column
+// and at least one non-regressed column, so the Level 4 report will contain both
+// regressed and non-regressed cells for subtest coverage.
+func findRowWithMixedStatuses(rows []componentreport.ReportRow) *componentreport.ReportRow {
+	for i, row := range rows {
+		hasRegressed := false
+		hasNonRegressed := false
+		for _, col := range row.Columns {
+			if col.Status <= crtest.SignificantTriagedRegression {
+				hasRegressed = true
+			}
+			if col.Status == crtest.NotSignificant ||
+				col.Status == crtest.SignificantImprovement ||
+				col.Status == crtest.MissingBasis {
+				hasNonRegressed = true
+			}
+		}
+		if hasRegressed && hasNonRegressed {
+			return &rows[i]
+		}
+	}
+	return nil
+}
+
+func TestAllTestsLinksPresent(t *testing.T) {
+	// Drill down from Level 1 to Level 4 to find a report with AllTests populated.
+	// At each level, prefer rows with mixed statuses (both regressed and non-regressed
+	// columns) so the Level 4 report exercises both link subtests.
+	var views []crview.View
+	err := util.SippyGet("/api/component_readiness/views", &views)
+	require.NoError(t, err, "error fetching views")
+	require.Greater(t, len(views), 0, "no views returned")
+	viewName := views[0].Name
+
+	// Level 1: find a component with both regressed and non-regressed columns
+	var l1Report componentreport.ComponentReport
+	err = util.SippyGet(fmt.Sprintf("/api/component_readiness?view=%s", url.QueryEscape(viewName)), &l1Report)
+	require.NoError(t, err, "error fetching level 1 report")
+	require.Greater(t, len(l1Report.Rows), 0, "level 1 report has no rows")
+
+	l1Row := findRowWithMixedStatuses(l1Report.Rows)
+	if l1Row == nil {
+		l1Row = &l1Report.Rows[0]
+	}
+	component := l1Row.Component
+	require.NotEmpty(t, component, "level 1 row has empty component")
+
+	// Level 2: get a capability
+	var l2Report componentreport.ComponentReport
+	err = util.SippyGet(fmt.Sprintf("/api/component_readiness?view=%s&component=%s",
+		url.QueryEscape(viewName), url.QueryEscape(component)), &l2Report)
+	require.NoError(t, err, "error fetching level 2 report")
+	require.Greater(t, len(l2Report.Rows), 0, "level 2 report has no rows for component=%s", component)
+	capability := l2Report.Rows[0].Capability
+	require.NotEmpty(t, capability, "level 2 row has empty capability")
+
+	// Level 3: find a test with mixed variant statuses
+	var l3Report componentreport.ComponentReport
+	err = util.SippyGet(fmt.Sprintf("/api/component_readiness?view=%s&component=%s&capability=%s",
+		url.QueryEscape(viewName), url.QueryEscape(component), url.QueryEscape(capability)), &l3Report)
+	require.NoError(t, err, "error fetching level 3 report")
+	require.Greater(t, len(l3Report.Rows), 0, "level 3 report has no rows for component=%s capability=%s", component, capability)
+
+	l3Row := findRowWithMixedStatuses(l3Report.Rows)
+	if l3Row == nil {
+		l3Row = &l3Report.Rows[0]
+	}
+	testID := l3Row.TestID
+	require.NotEmpty(t, testID, "level 3 row has empty testId")
+
+	// Level 4: fetch the test variant report where AllTests should be populated
+	var report componentreport.ComponentReport
+	err = util.SippyGet(fmt.Sprintf("/api/component_readiness?view=%s&component=%s&capability=%s&testId=%s",
+		url.QueryEscape(viewName), url.QueryEscape(component), url.QueryEscape(capability), url.QueryEscape(testID)), &report)
+	require.NoError(t, err, "error fetching level 4 report")
+	require.Greater(t, len(report.Rows), 0, "level 4 report has no rows")
 
 	t.Run("regressed tests have test_details links in AllTests", func(t *testing.T) {
 		var foundRegression bool
@@ -32,18 +149,15 @@ func TestAllTestsLinksPresent(t *testing.T) {
 				}
 				foundRegression = true
 
-				// Every regressed test should appear in AllTests with a test_details link
 				for _, rt := range col.RegressedTests {
 					assert.NotNil(t, rt.Links, "regressed test %s should have links", rt.TestName)
 					assert.Contains(t, rt.Links, "test_details",
 						"regressed test %s should have a test_details link", rt.TestName)
 				}
 
-				// AllTests should be a superset of RegressedTests
 				assert.GreaterOrEqual(t, len(col.AllTests), len(col.RegressedTests),
 					"AllTests should contain at least as many entries as RegressedTests")
 
-				// Every entry in AllTests should have a test_details link
 				for _, at := range col.AllTests {
 					assert.NotNil(t, at.Links, "AllTests entry %s should have links", at.TestName)
 					assert.Contains(t, at.Links, "test_details",
@@ -63,7 +177,6 @@ func TestAllTestsLinksPresent(t *testing.T) {
 				if len(col.AllTests) == 0 || len(col.RegressedTests) > 0 {
 					continue
 				}
-				// This cell has tests analyzed but none regressed
 				if col.Status == crtest.NotSignificant ||
 					col.Status == crtest.SignificantImprovement ||
 					col.Status == crtest.MissingBasis {

--- a/test/e2e/util/cache_manipulator.go
+++ b/test/e2e/util/cache_manipulator.go
@@ -175,7 +175,7 @@ func (c *E2ECacheManipulator) GetReport() (componentreport.ComponentReport, stri
 			log.Warnf("Failed to unmarshal ComponentReport key JSON '%s' from key '%s': %v", jsonPart, key, err)
 			continue
 		}
-		if gk.SampleRelease.Name == Release {
+		if gk.SampleRelease.Name == Release && len(gk.TestIDOptions) == 0 {
 			cacheKey = key
 			break
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Component readiness reports now include `all_tests` (`all_tests`) in Level 4 `testId` drilldown responses, alongside existing `regressed_tests`.
  * `all_tests` is sorted, populated with test summaries, and includes `test_details` links; Levels 1–3 omit `all_tests`.  
* **Bug Fixes**
  * Improved `test_details` link generation so links are produced more consistently across test statuses.
* **Documentation**
  * Added a rollout plan documenting the phased API change and compatibility behavior.
* **Tests**
  * Added e2e coverage validating `all_tests`/`regressed_tests` link presence and Level 1 vs Level 4 inclusion rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->