### PR TITLE
Trt 2782 all tests details links UI

### DIFF
--- a/docs/plans/trt-2782-all-tests-links.md
+++ b/docs/plans/trt-2782-all-tests-links.md
@@ -1,0 +1,103 @@
+# TRT-2782: Provide test_details HATEOAS links for all tests (Phase 1)
+
+## Context
+
+The component_readiness API only includes test_details HATEOAS links for regressed tests. Two code paths enforce this restriction:
+
+1. `getNewCellStatus` only adds tests to `regressedTests` when `ReportStatus < MissingSample` (-100). The `PostAnalysis` middleware loop only iterates over `RegressedTests`.
+2. `LinkInjector.PostAnalysis` has an early return for `ReportStatus > FixedRegression` (-150).
+
+This means non-regressed cells (green/grey/blue) have no test_details links, preventing navigation to individual test results.
+
+## Approach
+
+Add a new `AllTests` field alongside the existing `RegressedTests`. This preserves backward compatibility while exposing all analyzed tests with HATEOAS links. Remove the LinkInjector status guard so links are generated for every test status.
+
+All other middleware PostAnalysis methods already handle non-regressed tests safely:
+- `RegressionTracker.PostAnalysis` returns early at line 124 (`ReportStatus > SignificantTriagedRegression`)
+- `RegressionAllowances.PostAnalysis` is a no-op (returns nil)
+
+Regressed tests appear in both lists and get middleware-processed twice. This is safe because all middleware operations are idempotent (map key assignment, DB lookup with early return).
+
+## Changes
+
+### 1. Add `AllTests` to response type
+**File:** `pkg/apis/api/componentreport/types.go`
+
+Add `AllTests []ReportTestSummary` field to `ReportColumn`:
+```go
+type ReportColumn struct {
+    crtest.ColumnIdentification
+    Status         crtest.Status       `json:"status"`
+    RegressedTests []ReportTestSummary `json:"regressed_tests,omitempty"`
+    AllTests       []ReportTestSummary `json:"all_tests,omitempty"`
+}
+```
+
+### 2. Add `allTests` to internal `cellStatus` struct
+**File:** `pkg/api/componentreadiness/component_report.go` (line 506)
+
+```go
+type cellStatus struct {
+    status         crtest.Status
+    regressedTests []crtype.ReportTestSummary
+    allTests       []crtype.ReportTestSummary
+}
+```
+
+### 3. Populate `allTests` unconditionally in `getNewCellStatus`
+**File:** `pkg/api/componentreadiness/component_report.go` (line 511)
+
+- Carry forward `existingCellStatus.allTests` (like we do for `regressedTests`)
+- Always create a `ReportTestSummary` and append to `allTests`
+- Keep the existing conditional append to `regressedTests` unchanged
+
+### 4. Assign `AllTests` in `buildReport`
+**File:** `pkg/api/componentreadiness/component_report.go` (line 726)
+
+After the existing `reportColumn.RegressedTests = status.regressedTests`, add:
+```go
+reportColumn.AllTests = status.allTests
+sort.Slice(reportColumn.AllTests, func(i, j int) bool {
+    return reportColumn.AllTests[i].ReportStatus < reportColumn.AllTests[j].ReportStatus
+})
+```
+
+### 5. Run PostAnalysis middleware over `AllTests`
+**File:** `pkg/api/componentreadiness/component_report.go` (line 125)
+
+After the existing `RegressedTests` loop (which handles cell status recomputation), add a second loop over `AllTests`:
+```go
+for ati := range col.AllTests {
+    testKey := crtest.Identification{
+        RowIdentification:    col.AllTests[ati].RowIdentification,
+        ColumnIdentification: col.AllTests[ati].ColumnIdentification,
+    }
+    if err := c.middlewares.PostAnalysis(testKey,
+        &report.Rows[ri].Columns[ci].AllTests[ati].TestComparison); err != nil {
+        return err
+    }
+}
+```
+
+Cell status recomputation stays based on `RegressedTests` only (unchanged).
+
+### 6. Remove LinkInjector status guard
+**File:** `pkg/api/componentreadiness/middleware/linkinjector/linkinjector.go` (lines 50-53)
+
+Remove:
+```go
+if testStats.ReportStatus > crtest.FixedRegression {
+    return nil
+}
+```
+
+## Verification
+
+1. `go vet ./pkg/...` and `make lint`
+2. `go test ./pkg/api/componentreadiness/...` and `go test ./pkg/apis/...`
+3. Start sippy serve, hit the `/api/component_readiness` endpoint with test-level parameters, confirm:
+   - `all_tests` field is present on each cell
+   - Every entry in `all_tests` has a `links.test_details` URL regardless of status
+   - `regressed_tests` continues to contain only regressed tests (backward compat)
+   - Cell-level `status` is unchanged (still computed from regressed tests only)

--- a/docs/plans/trt-2782-all-tests-links.md
+++ b/docs/plans/trt-2782-all-tests-links.md
@@ -92,12 +92,18 @@ if testStats.ReportStatus > crtest.FixedRegression {
 }
 ```
 
+### 7. Restrict `AllTests` to Level 4 only
+
+To avoid response bloat (~1GB at top level), `AllTests` is only populated when `testId` is present in the request (Level 4, the test variant page). This is the only level where the frontend renders `test_details` links from `all_tests`. At Levels 1-3, `AllTests` is omitted from the response.
+
+The `includeAllTests()` helper on `ComponentReportGenerator` controls this, gating accumulation in `getNewCellStatus`, assignment in `buildReport`, and PostAnalysis middleware processing.
+
 ## Verification
 
 1. `go vet ./pkg/...` and `make lint`
 2. `go test ./pkg/api/componentreadiness/...` and `go test ./pkg/apis/...`
-3. Start sippy serve, hit the `/api/component_readiness` endpoint with test-level parameters, confirm:
-   - `all_tests` field is present on each cell
-   - Every entry in `all_tests` has a `links.test_details` URL regardless of status
+3. Start sippy serve, hit the `/api/component_readiness` endpoint and confirm:
+   - Level 1 (`?view=...`): no `all_tests` field in response
+   - Level 4 (`?view=...&component=X&capability=Y&testId=Z`): `all_tests` present with `test_details` links
    - `regressed_tests` continues to contain only regressed tests (backward compat)
    - Cell-level `status` is unchanged (still computed from regressed tests only)

--- a/docs/plans/trt-2782-frontend-hateoas-links.md
+++ b/docs/plans/trt-2782-frontend-hateoas-links.md
@@ -1,0 +1,62 @@
+# TRT-2782 Phase 2: Frontend, use HATEOAS links for all cells
+
+## Context
+
+Phase 1 (complete) added an `all_tests` field to every cell in the component_readiness API response. Every entry in `all_tests` has a `test_details` HATEOAS link regardless of status. Phase 2 uses these links in the frontend so all grid cells are navigable, then removes the now-unnecessary fallback link generation and `filterVals` prop threading.
+
+Currently, only Level 4 cells (`CompReadyTestCell`) gate clickability on regression status. Levels 1-3 are already fully clickable. The problem: `CompCapTestRow` passes `columnVal.regressed_tests?.[0] || null` to `CompReadyTestCell`, so non-regressed cells render as unclickable icons.
+
+## Changes
+
+### 1. Make Level 4 cells use `all_tests` instead of `regressed_tests`
+**File:** `sippy-ng/src/component_readiness/CompCapTestRow.js`
+
+Change line 46 from `regressed_tests?.[0]` to `all_tests?.[0]` with fallback to `regressed_tests?.[0]` for backward compatibility. Remove `filterVals` prop from the `CompReadyTestCell` call and from this component's props/PropTypes.
+
+### 2. Update `CompReadyTestCell` to use simplified link generation
+**File:** `sippy-ng/src/component_readiness/CompReadyTestCell.js`
+
+- Rename prop `regressedTest` to `test`
+- Remove `filterVals` prop
+- Remove `console.log` debug leftover (line 36)
+- Change link generation to `generateTestDetailsReportLink(test)`
+- Update PropTypes
+
+### 3. Simplify `generateTestDetailsReportLink`
+**File:** `sippy-ng/src/component_readiness/CompReadyUtils.js` (lines 834-868)
+
+Remove `filterVals` and `expandEnvironment` parameters. Remove the hand-built fallback URL. The simplified function just uses HATEOAS links via `getTestDetailsLink` + `convertApiUrlToUiUrl`, returning `null` if absent.
+
+Also delete the unused `generateTestReport` function (lines 764-797), which has zero callers.
+
+### 4. Update all callers of `generateTestDetailsReportLink`
+
+- **`ComponentReadinessToolBar.js`** (line 130): Remove `filterVals` and `expandEnvironment` args. Remove `filterVals` from props, useEffect deps, PropTypes. Stop passing `filterVals` to `RegressedTestsModal`.
+- **`RegressedTestsPanel.js`** (line 299): Remove `filterVals` and `expandEnvironment` args. Remove `filterVals` from props and PropTypes.
+- **`TriagePotentialMatches.js`** (line 361): Remove local `filterVals` variable and `expandEnvironment` arg. Keep `viewToUse` as the `viewName` parameter.
+- **`TriagedRegressionTestList.js`** (line 255): Remove `props.filterVals` and `expandEnvironment` args. Keep `viewName` parameter. Remove `filterVals` from PropTypes.
+
+### 5. Remove `filterVals` from intermediate components that only threaded it
+
+- **`RegressedTestsModal.js`**: Remove `filterVals` from props, from the three `RegressedTestsPanel` instances, from `TriagedTestsPanel`, and from PropTypes.
+- **`TriagedTestsPanel.js`**: Remove `filterVals` from `TriagedRegressionTestList` call and PropTypes.
+- **`CompReadyEnvCapabilityTest.js`**: Stop passing `filterVals` to `CompCapTestRow` and `ComponentReadinessToolBar`. Keep `filterVals` in this component (still used for API call construction at line 115).
+
+### Summary of `filterVals` removal chain
+
+Removing `filterVals` from `generateTestDetailsReportLink` cascades through:
+- `CompReadyTestCell` -> `CompCapTestRow` -> `CompReadyEnvCapabilityTest` (row prop only)
+- `RegressedTestsPanel` -> `RegressedTestsModal` -> `ComponentReadinessToolBar`
+- `TriagedRegressionTestList` -> `TriagedTestsPanel` -> `RegressedTestsModal`
+- `TriagePotentialMatches` (local variable, no prop)
+
+`filterVals` continues to exist in parent page components where it is used for API call construction and Level 1-3 drill-down navigation URLs.
+
+## Verification
+
+1. `cd sippy-ng && npx eslint . --fix && npx prettier --write .`
+2. `cd sippy-ng && npm test`
+3. Start sippy serve + sippy-ng dev server
+4. Navigate to Level 4 cells and verify green/grey cells are now clickable
+5. Verify red cells still navigate correctly
+6. Verify regressed tests modal and triage view links still work

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -146,13 +146,15 @@ func (c *ComponentReportGenerator) PostAnalysis(report *crtype.ComponentReport) 
 				report.Rows[ri].Columns[ci].Status = worstStatus
 			}
 
-			for ati := range col.AllTests {
-				testKey := crtest.Identification{
-					RowIdentification:    col.AllTests[ati].RowIdentification,
-					ColumnIdentification: col.AllTests[ati].ColumnIdentification,
-				}
-				if err := c.middlewares.PostAnalysis(testKey, &report.Rows[ri].Columns[ci].AllTests[ati].TestComparison); err != nil {
-					return err
+			if c.includeAllTests() {
+				for ati := range col.AllTests {
+					testKey := crtest.Identification{
+						RowIdentification:    col.AllTests[ati].RowIdentification,
+						ColumnIdentification: col.AllTests[ati].ColumnIdentification,
+					}
+					if err := c.middlewares.PostAnalysis(testKey, &report.Rows[ri].Columns[ci].AllTests[ati].TestComparison); err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -300,6 +302,12 @@ func (c *ComponentReportGenerator) initializeMiddleware() {
 	// Initialize LinkInjector middleware
 	linkInjector := linkinjector.NewLinkInjectorMiddleware(c.ReqOptions, c.baseURL)
 	c.middlewares = append(c.middlewares, linkInjector)
+}
+
+// includeAllTests returns true when the request is for a specific test (Level 4),
+// which is the only level where the frontend renders test_details links from AllTests.
+func (c *ComponentReportGenerator) includeAllTests() bool {
+	return len(c.ReqOptions.TestIDOptions) > 0 && c.ReqOptions.TestIDOptions[0].TestID != ""
 }
 
 // GenerateReport is the main entry point for generation of a component readiness report.
@@ -519,7 +527,7 @@ type cellStatus struct {
 	allTests       []crtype.ReportTestSummary
 }
 
-func getNewCellStatus(testID crtest.Identification, testStats testdetails.TestComparison, existingCellStatus *cellStatus) cellStatus {
+func getNewCellStatus(testID crtest.Identification, testStats testdetails.TestComparison, existingCellStatus *cellStatus, includeAllTests bool) cellStatus {
 	var newCellStatus cellStatus
 	if existingCellStatus != nil {
 		if (testStats.ReportStatus < crtest.NotSignificant && testStats.ReportStatus < existingCellStatus.status) ||
@@ -530,7 +538,9 @@ func getNewCellStatus(testID crtest.Identification, testStats testdetails.TestCo
 			newCellStatus.status = existingCellStatus.status
 		}
 		newCellStatus.regressedTests = existingCellStatus.regressedTests
-		newCellStatus.allTests = existingCellStatus.allTests
+		if includeAllTests {
+			newCellStatus.allTests = existingCellStatus.allTests
+		}
 	} else {
 		newCellStatus.status = testStats.ReportStatus
 	}
@@ -539,7 +549,9 @@ func getNewCellStatus(testID crtest.Identification, testStats testdetails.TestCo
 		Identification: testID,
 		TestComparison: testStats,
 	}
-	newCellStatus.allTests = append(newCellStatus.allTests, rt)
+	if includeAllTests {
+		newCellStatus.allTests = append(newCellStatus.allTests, rt)
+	}
 
 	if testStats.ReportStatus < crtest.MissingSample {
 		newCellStatus.regressedTests = append(newCellStatus.regressedTests, rt)
@@ -552,6 +564,7 @@ func updateCellStatus(
 	columnIdentifications []crtest.ColumnID,
 	testID crtest.Identification,
 	testStats testdetails.TestComparison,
+	includeAllTests bool,
 	// use the inputs above to update the maps below (golang passes maps by reference)
 	status map[crtest.RowIdentification]map[crtest.ColumnID]cellStatus,
 	allRows map[crtest.RowIdentification]struct{},
@@ -576,16 +589,16 @@ func updateCellStatus(
 		if !ok {
 			row = map[crtest.ColumnID]cellStatus{}
 			for _, columnIdentification := range columnIdentifications {
-				row[columnIdentification] = getNewCellStatus(testID, testStats, nil)
+				row[columnIdentification] = getNewCellStatus(testID, testStats, nil, includeAllTests)
 				status[rowIdentification] = row
 			}
 		} else {
 			for _, columnIdentification := range columnIdentifications {
 				existing, ok := row[columnIdentification]
 				if !ok {
-					row[columnIdentification] = getNewCellStatus(testID, testStats, nil)
+					row[columnIdentification] = getNewCellStatus(testID, testStats, nil, includeAllTests)
 				} else {
-					row[columnIdentification] = getNewCellStatus(testID, testStats, &existing)
+					row[columnIdentification] = getNewCellStatus(testID, testStats, &existing, includeAllTests)
 				}
 			}
 		}
@@ -670,12 +683,12 @@ func (c *ComponentReportGenerator) generateComponentTestReport(basisStatusMap, s
 			return crtype.ComponentReport{}, err
 		}
 		updateCellStatus(
-			rowIdentifications, columnIdentifications, testKey, cellReport, // inputs
+			rowIdentifications, columnIdentifications, testKey, cellReport, c.includeAllTests(), // inputs
 			aggregatedStatus, allRows, allColumns, // these three are maps to be updated
 		)
 	}
 
-	rows, err := buildReport(sortRowIdentifications(allRows), sortColumnIdentifications(allColumns), aggregatedStatus)
+	rows, err := buildReport(sortRowIdentifications(allRows), sortColumnIdentifications(allColumns), aggregatedStatus, c.includeAllTests())
 	if err != nil {
 		return crtype.ComponentReport{}, err
 	}
@@ -714,7 +727,7 @@ func sortColumnIdentifications(allColumns map[crtest.ColumnID]struct{}) []crtest
 	return sortedColumns
 }
 
-func buildReport(sortedRows []crtest.RowIdentification, sortedColumns []crtest.ColumnID, aggregatedStatus map[crtest.RowIdentification]map[crtest.ColumnID]cellStatus) ([]crtype.ReportRow, error) {
+func buildReport(sortedRows []crtest.RowIdentification, sortedColumns []crtest.ColumnID, aggregatedStatus map[crtest.RowIdentification]map[crtest.ColumnID]cellStatus, includeAllTests bool) ([]crtype.ReportRow, error) {
 	// Now build the report
 	var regressionRows, goodRows []crtype.ReportRow
 	for _, rowID := range sortedRows {
@@ -743,10 +756,12 @@ func buildReport(sortedRows []crtest.RowIdentification, sortedColumns []crtest.C
 				sort.Slice(reportColumn.RegressedTests, func(i, j int) bool {
 					return reportColumn.RegressedTests[i].ReportStatus < reportColumn.RegressedTests[j].ReportStatus
 				})
-				reportColumn.AllTests = status.allTests
-				sort.Slice(reportColumn.AllTests, func(i, j int) bool {
-					return reportColumn.AllTests[i].ReportStatus < reportColumn.AllTests[j].ReportStatus
-				})
+				if includeAllTests {
+					reportColumn.AllTests = status.allTests
+					sort.Slice(reportColumn.AllTests, func(i, j int) bool {
+						return reportColumn.AllTests[i].ReportStatus < reportColumn.AllTests[j].ReportStatus
+					})
+				}
 			}
 			reportRow.Columns = append(reportRow.Columns, reportColumn)
 			if reportColumn.Status <= crtest.SignificantTriagedRegression {

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -631,6 +631,7 @@ func initTestAnalysisStruct(
 }
 
 func (c *ComponentReportGenerator) generateComponentTestReport(basisStatusMap, sampleStatusMap map[string]crstatus.TestStatus) (crtype.ComponentReport, error) {
+	includeAllTests := c.includeAllTests()
 	// aggregatedStatus is the aggregated status based on the requested rows and columns
 	aggregatedStatus := map[crtest.RowIdentification]map[crtest.ColumnID]cellStatus{}
 	// allRows and allColumns are used to make sure rows are ordered and all rows have the same columns in the same order
@@ -683,12 +684,12 @@ func (c *ComponentReportGenerator) generateComponentTestReport(basisStatusMap, s
 			return crtype.ComponentReport{}, err
 		}
 		updateCellStatus(
-			rowIdentifications, columnIdentifications, testKey, cellReport, c.includeAllTests(), // inputs
+			rowIdentifications, columnIdentifications, testKey, cellReport, includeAllTests, // inputs
 			aggregatedStatus, allRows, allColumns, // these three are maps to be updated
 		)
 	}
 
-	rows, err := buildReport(sortRowIdentifications(allRows), sortColumnIdentifications(allColumns), aggregatedStatus, c.includeAllTests())
+	rows, err := buildReport(sortRowIdentifications(allRows), sortColumnIdentifications(allColumns), aggregatedStatus, includeAllTests)
 	if err != nil {
 		return crtype.ComponentReport{}, err
 	}

--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -145,6 +145,16 @@ func (c *ComponentReportGenerator) PostAnalysis(report *crtype.ComponentReport) 
 			if len(col.RegressedTests) > 0 {
 				report.Rows[ri].Columns[ci].Status = worstStatus
 			}
+
+			for ati := range col.AllTests {
+				testKey := crtest.Identification{
+					RowIdentification:    col.AllTests[ati].RowIdentification,
+					ColumnIdentification: col.AllTests[ati].ColumnIdentification,
+				}
+				if err := c.middlewares.PostAnalysis(testKey, &report.Rows[ri].Columns[ci].AllTests[ati].TestComparison); err != nil {
+					return err
+				}
+			}
 		}
 	}
 
@@ -506,6 +516,7 @@ func (c *ComponentReportGenerator) getRowColumnIdentifications(testIDStr string,
 type cellStatus struct {
 	status         crtest.Status
 	regressedTests []crtype.ReportTestSummary
+	allTests       []crtype.ReportTestSummary
 }
 
 func getNewCellStatus(testID crtest.Identification, testStats testdetails.TestComparison, existingCellStatus *cellStatus) cellStatus {
@@ -519,14 +530,18 @@ func getNewCellStatus(testID crtest.Identification, testStats testdetails.TestCo
 			newCellStatus.status = existingCellStatus.status
 		}
 		newCellStatus.regressedTests = existingCellStatus.regressedTests
+		newCellStatus.allTests = existingCellStatus.allTests
 	} else {
 		newCellStatus.status = testStats.ReportStatus
 	}
+
+	rt := crtype.ReportTestSummary{
+		Identification: testID,
+		TestComparison: testStats,
+	}
+	newCellStatus.allTests = append(newCellStatus.allTests, rt)
+
 	if testStats.ReportStatus < crtest.MissingSample {
-		rt := crtype.ReportTestSummary{
-			Identification: testID,
-			TestComparison: testStats,
-		}
 		newCellStatus.regressedTests = append(newCellStatus.regressedTests, rt)
 	}
 	return newCellStatus
@@ -727,6 +742,10 @@ func buildReport(sortedRows []crtest.RowIdentification, sortedColumns []crtest.C
 				reportColumn.RegressedTests = status.regressedTests
 				sort.Slice(reportColumn.RegressedTests, func(i, j int) bool {
 					return reportColumn.RegressedTests[i].ReportStatus < reportColumn.RegressedTests[j].ReportStatus
+				})
+				reportColumn.AllTests = status.allTests
+				sort.Slice(reportColumn.AllTests, func(i, j int) bool {
+					return reportColumn.AllTests[i].ReportStatus < reportColumn.AllTests[j].ReportStatus
 				})
 			}
 			reportRow.Columns = append(reportRow.Columns, reportColumn)

--- a/pkg/api/componentreadiness/component_report_test.go
+++ b/pkg/api/componentreadiness/component_report_test.go
@@ -1218,12 +1218,16 @@ func TestGenerateComponentReport(t *testing.T) {
 
 					}
 
-					// AllTests should contain at least as many entries as RegressedTests
-					assert.GreaterOrEqual(t, len(report.Rows[ir].Columns[ic].AllTests),
-						len(report.Rows[ir].Columns[ic].RegressedTests),
-						"AllTests should be a superset of RegressedTests for row %d col %d", ir, ic)
-					// Clear AllTests for the deep comparison below; the count check above
-					// validates it is populated.
+					if tc.generator.includeAllTests() {
+						// Level 4 (testId set): AllTests should be a superset of RegressedTests
+						assert.GreaterOrEqual(t, len(report.Rows[ir].Columns[ic].AllTests),
+							len(report.Rows[ir].Columns[ic].RegressedTests),
+							"AllTests should be a superset of RegressedTests for row %d col %d", ir, ic)
+					} else {
+						// Levels 1-3: AllTests is not populated to avoid response bloat
+						assert.Empty(t, report.Rows[ir].Columns[ic].AllTests,
+							"AllTests should be empty at non-test-level for row %d col %d", ir, ic)
+					}
 					report.Rows[ir].Columns[ic].AllTests = nil
 				}
 			}

--- a/pkg/api/componentreadiness/component_report_test.go
+++ b/pkg/api/componentreadiness/component_report_test.go
@@ -1217,6 +1217,14 @@ func TestGenerateComponentReport(t *testing.T) {
 						report.Rows[ir].Columns[ic].RegressedTests[it].FisherExact = nil
 
 					}
+
+					// AllTests should contain at least as many entries as RegressedTests
+					assert.GreaterOrEqual(t, len(report.Rows[ir].Columns[ic].AllTests),
+						len(report.Rows[ir].Columns[ic].RegressedTests),
+						"AllTests should be a superset of RegressedTests for row %d col %d", ir, ic)
+					// Clear AllTests for the deep comparison below; the count check above
+					// validates it is populated.
+					report.Rows[ir].Columns[ic].AllTests = nil
 				}
 			}
 			assert.Equal(t, tc.expectedReport, report, "expected report %+v, got %+v", tc.expectedReport, report)

--- a/pkg/api/componentreadiness/middleware/linkinjector/linkinjector.go
+++ b/pkg/api/componentreadiness/middleware/linkinjector/linkinjector.go
@@ -47,11 +47,6 @@ func (l *LinkInjector) PreAnalysis(testKey crtest.Identification, testStats *tes
 
 // PostAnalysis injects HATEOAS links into test analysis results
 func (l *LinkInjector) PostAnalysis(testKey crtest.Identification, testStats *testdetails.TestComparison) error {
-	// Early return if status is above FixedRegression (i.e. regression has not yet rolled off)
-	if testStats.ReportStatus > crtest.FixedRegression {
-		return nil
-	}
-
 	// Initialize Links map if it doesn't exist
 	if testStats.Links == nil {
 		testStats.Links = make(map[string]string)

--- a/pkg/apis/api/componentreport/types.go
+++ b/pkg/apis/api/componentreport/types.go
@@ -26,6 +26,7 @@ type ReportColumn struct {
 	crtest.ColumnIdentification
 	Status         crtest.Status       `json:"status"`
 	RegressedTests []ReportTestSummary `json:"regressed_tests,omitempty"`
+	AllTests       []ReportTestSummary `json:"all_tests,omitempty"`
 }
 
 type ReportTestSummary struct {

--- a/sippy-ng/src/component_readiness/CompCapTestRow.js
+++ b/sippy-ng/src/component_readiness/CompCapTestRow.js
@@ -12,22 +12,14 @@ import TableRow from '@mui/material/TableRow'
 export default function CompCapTestRow(props) {
   const classes = useContext(ComponentReadinessStyleContext)
 
-  // regressedTestCols is the full test data structure
-  // columnNames is the calculated array of columns
-  // filterVals: the parts of the url containing input values
-  const { regressedTestCols, columnNames, filterVals } = props
+  const { testCols, columnNames } = props
 
   // Put the testName on the left side with no link.
   const testNameColumn = (
-    <TableCell
-      className={classes.componentName}
-      key={regressedTestCols.test_name}
-    >
-      <Tooltip title={regressedTestCols.test_id}>
+    <TableCell className={classes.componentName} key={testCols.test_name}>
+      <Tooltip title={testCols.test_id}>
         <Typography className={classes.crCellName}>
-          {[regressedTestCols.test_suite, regressedTestCols.test_name]
-            .filter(Boolean)
-            .join('.')}
+          {[testCols.test_suite, testCols.test_name].filter(Boolean).join('.')}
         </Typography>
       </Tooltip>
     </TableCell>
@@ -37,13 +29,13 @@ export default function CompCapTestRow(props) {
     <Fragment>
       <TableRow>
         {testNameColumn}
-        {regressedTestCols.columns.map((columnVal, idx) => (
+        {testCols.columns.map((columnVal, idx) => (
           <CompReadyTestCell
             key={'testName-' + idx}
             status={columnVal.status}
-            environment={columnNames[idx]}
-            filterVals={filterVals}
-            regressedTest={columnVal.regressed_tests?.[0] || null}
+            test={
+              columnVal.all_tests?.[0] || columnVal.regressed_tests?.[0] || null
+            }
           />
         ))}
       </TableRow>
@@ -52,7 +44,6 @@ export default function CompCapTestRow(props) {
 }
 
 CompCapTestRow.propTypes = {
-  regressedTestCols: PropTypes.object.isRequired,
+  testCols: PropTypes.object.isRequired,
   columnNames: PropTypes.array.isRequired,
-  filterVals: PropTypes.string.isRequired,
 }

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilities.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilities.js
@@ -214,7 +214,6 @@ export default function CompReadyEnvCapabilities(props) {
         handleRedOnlyCheckboxChange={handleRedOnlyCheckboxChange}
         clearSearches={clearSearches}
         data={data}
-        filterVals={filterVals}
         setTriageActionTaken={setTriageActionTaken}
       />
       <br></br>

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapability.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapability.js
@@ -208,7 +208,6 @@ export default function CompReadyEnvCapability(props) {
         handleRedOnlyCheckboxChange={handleRedOnlyCheckboxChange}
         clearSearches={clearSearches}
         data={data}
-        filterVals={filterVals}
         setTriageActionTaken={setTriageActionTaken}
       />
       <br></br>

--- a/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
+++ b/sippy-ng/src/component_readiness/CompReadyEnvCapabilityTest.js
@@ -202,7 +202,6 @@ export default function CompReadyEnvCapabilityTest(props) {
       </h2>
       <ComponentReadinessToolBar
         data={data}
-        filterVals={filterVals}
         setTriageActionTaken={setTriageActionTaken}
       />
       <br></br>
@@ -238,9 +237,8 @@ export default function CompReadyEnvCapabilityTest(props) {
                 return (
                   <CompCapTestRow
                     key={componentIndex}
-                    regressedTestCols={data.rows[componentIndex]}
+                    testCols={data.rows[componentIndex]}
                     columnNames={columnNames}
-                    filterVals={filterVals}
                   />
                 )
               })

--- a/sippy-ng/src/component_readiness/CompReadyTestCell.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestCell.js
@@ -1,6 +1,5 @@
 import './ComponentReadiness.css'
 import { ComponentReadinessStyleContext } from './ComponentReadiness'
-import { CompReadyVarsContext } from './CompReadyVars'
 import { generateTestDetailsReportLink } from './CompReadyUtils'
 import { Tooltip } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
@@ -12,11 +11,9 @@ import TableCell from '@mui/material/TableCell'
 
 // CompReadyTestCall is for rendering the cells on the right of page4 or page4a
 export default function CompReadyTestCell(props) {
-  const { status, environment, filterVals, regressedTest } = props
+  const { status, test } = props
   const theme = useTheme()
   const classes = useContext(ComponentReadinessStyleContext)
-
-  const { expandEnvironment } = useContext(CompReadyVarsContext)
 
   if (status === undefined) {
     return (
@@ -32,36 +29,29 @@ export default function CompReadyTestCell(props) {
         </TableCell>
       </Tooltip>
     )
-  } else {
-    console.log('regressedTest', regressedTest)
-    return (
-      <TableCell
-        className={classes.crCellResult}
-        style={{
-          textAlign: 'center',
-        }}
-      >
-        {regressedTest ? (
-          <a
-            href={generateTestDetailsReportLink(
-              regressedTest,
-              filterVals,
-              expandEnvironment
-            )}
-          >
-            <CompSeverityIcon status={status} />
-          </a>
-        ) : (
-          <CompSeverityIcon status={status} />
-        )}
-      </TableCell>
-    )
   }
+
+  const link = test ? generateTestDetailsReportLink(test) : null
+
+  return (
+    <TableCell
+      className={classes.crCellResult}
+      style={{
+        textAlign: 'center',
+      }}
+    >
+      {link ? (
+        <a href={link}>
+          <CompSeverityIcon status={status} />
+        </a>
+      ) : (
+        <CompSeverityIcon status={status} />
+      )}
+    </TableCell>
+  )
 }
 
 CompReadyTestCell.propTypes = {
   status: PropTypes.number.isRequired,
-  environment: PropTypes.string.isRequired,
-  filterVals: PropTypes.string.isRequired,
-  regressedTest: PropTypes.object,
+  test: PropTypes.object,
 }

--- a/sippy-ng/src/component_readiness/CompReadyUtils.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.js
@@ -1,7 +1,6 @@
 import { AccessibilityModeContext } from '../components/AccessibilityModeProvider'
 import { alpha, InputBase, Typography } from '@mui/material'
 import { formatInTimeZone } from 'date-fns-tz'
-import { safeEncodeURIComponent } from '../helpers'
 import { styled } from '@mui/styles'
 import Alert from '@mui/material/Alert'
 import blue from './blue.svg'
@@ -758,44 +757,6 @@ export const convertVariantItemsToParam = (groupedVariants) => {
   return param
 }
 
-// Construct a URL with all existing filters plus testId, environment, and testName.
-// This is the url used when you click inside a TableCell on page4 on the right.
-// We pass these arguments to the component that generates the test details report.
-export function generateTestReport(
-  testId,
-  environmentVal,
-  filterVals,
-  componentName,
-  capabilityName,
-  testName,
-  regressedTests
-) {
-  let testBasisRelease = ''
-  console.log(regressedTests)
-  if (
-    typeof regressedTests != 'undefined' &&
-    regressedTests.length > 0 &&
-    typeof regressedTests[0].base_stats != 'undefined'
-  ) {
-    testBasisRelease = regressedTests[0].base_stats.release
-  }
-  const safeComponentName = safeEncodeURIComponent(componentName)
-  const safeTestId = safeEncodeURIComponent(testId)
-  const safeTestName = safeEncodeURIComponent(testName)
-  const safeTestBasisRelease = safeEncodeURIComponent(testBasisRelease)
-  const retUrl =
-    '/component_readiness/test_details' +
-    filterVals +
-    `&testBasisRelease=${safeTestBasisRelease}` +
-    `&testId=${safeTestId}` +
-    environmentVal +
-    `&component=${safeComponentName}` +
-    `&capability=${capabilityName}` +
-    `&testName=${safeTestName}`
-
-  return sortQueryParams(retUrl)
-}
-
 // Convert API URL to a relative UI URL by stripping any scheme+host and
 // swapping the /api/ prefix for /sippy-ng/.  Producing a relative path
 // avoids the bug where the backend embeds localhost (or another internal
@@ -829,42 +790,12 @@ export function getTestDetailsLink(links, viewName) {
   return key ? links[key] : null
 }
 
-// Construct a URL with all existing filters utilizing the necessary info from the regressed test.
-// We pass these arguments to the component that generates the test details report.
-export function generateTestDetailsReportLink(
-  regressedTest,
-  filterVals,
-  expandEnvironment,
-  viewName
-) {
-  // Generate the URL we would have created for comparison
-  const environmentVal = formColumnName({ variants: regressedTest.variants })
-  const safeComponentName = safeEncodeURIComponent(regressedTest.component)
-  const safeTestId = safeEncodeURIComponent(regressedTest.test_id)
-  const safeTestName = safeEncodeURIComponent(regressedTest.test_name)
-  const safeTestBasisRelease = safeEncodeURIComponent(
-    regressedTest.base_stats?.release
-  )
-
-  // The old code generated these URLs here, but now we expect the server to always include them.
-  // I'm keeping backward compatability plus adding a compare function, so we can check the console to see
-  // differences.
-  const generatedUrl =
-    '/sippy-ng/component_readiness/test_details' +
-    filterVals +
-    `&testBasisRelease=${safeTestBasisRelease}` +
-    `&testId=${safeTestId}` +
-    expandEnvironment(environmentVal) +
-    `&component=${safeComponentName}` +
-    `&capability=${regressedTest.capability}` +
-    `&testName=${safeTestName}`
-
-  const testDetailsUrl = getTestDetailsLink(regressedTest.links, viewName)
+export function generateTestDetailsReportLink(test, viewName) {
+  const testDetailsUrl = getTestDetailsLink(test.links, viewName)
   if (testDetailsUrl) {
     return convertApiUrlToUiUrl(testDetailsUrl)
   }
-
-  return generatedUrl
+  return null
 }
 
 const SYMPTOM_COLORS = [

--- a/sippy-ng/src/component_readiness/CompReadyUtils.test.js
+++ b/sippy-ng/src/component_readiness/CompReadyUtils.test.js
@@ -114,11 +114,8 @@ describe('convertApiUrlToUiUrl', () => {
 })
 
 describe('generateTestDetailsReportLink', () => {
-  const filterVals = '?baseRelease=4.18&baseStartTime=2024-01-01'
-  const expandEnvironment = (env) => `&environment=${env}`
-
   test('returns server link converted to UI URL when HATEOAS link is present', () => {
-    const regressedTest = {
+    const test = {
       test_id: 'test-123',
       test_name: 'my test',
       component: 'Networking',
@@ -130,18 +127,14 @@ describe('generateTestDetailsReportLink', () => {
           'http://localhost:8080/api/component_readiness/test_details?testId=test-123&component=Networking',
       },
     }
-    const result = generateTestDetailsReportLink(
-      regressedTest,
-      filterVals,
-      expandEnvironment
-    )
+    const result = generateTestDetailsReportLink(test)
     expect(result).toBe(
       '/sippy-ng/component_readiness/test_details?testId=test-123&component=Networking'
     )
   })
 
-  test('falls back to generated URL when no HATEOAS link exists', () => {
-    const regressedTest = {
+  test('returns null when no HATEOAS link exists', () => {
+    const test = {
       test_id: 'test-123',
       test_name: 'my test',
       component: 'Networking',
@@ -150,12 +143,21 @@ describe('generateTestDetailsReportLink', () => {
       base_stats: { release: '4.18' },
       links: {},
     }
-    const result = generateTestDetailsReportLink(
-      regressedTest,
-      filterVals,
-      expandEnvironment
+    const result = generateTestDetailsReportLink(test)
+    expect(result).toBeNull()
+  })
+
+  test('uses viewName to find view-specific link', () => {
+    const test = {
+      test_id: 'test-456',
+      links: {
+        'test_details:4.18-main':
+          'http://localhost:8080/api/component_readiness/test_details?testId=test-456&view=4.18-main',
+      },
+    }
+    const result = generateTestDetailsReportLink(test, '4.18-main')
+    expect(result).toBe(
+      '/sippy-ng/component_readiness/test_details?testId=test-456&view=4.18-main'
     )
-    expect(result).toContain('/sippy-ng/component_readiness/test_details')
-    expect(result).toContain('testId=test-123')
   })
 })

--- a/sippy-ng/src/component_readiness/ComponentReadiness.js
+++ b/sippy-ng/src/component_readiness/ComponentReadiness.js
@@ -636,7 +636,6 @@ export default function ComponentReadiness(props) {
                           }
                           clearSearches={clearSearches}
                           data={data}
-                          filterVals={getUpdatedUrlParts(varsContext)}
                           setTriageActionTaken={setTriageActionTaken}
                         />
                         {(() => {

--- a/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
+++ b/sippy-ng/src/component_readiness/ComponentReadinessToolBar.js
@@ -55,7 +55,6 @@ export default function ComponentReadinessToolBar(props) {
     clearSearches,
     data,
     setTriageActionTaken,
-    filterVals,
   } = props
 
   const [regressedTests, setRegressedTests] = React.useState([])
@@ -127,11 +126,7 @@ export default function ComponentReadinessToolBar(props) {
       regression_id: test.regression?.id,
       regressed_since: test.regression?.opened,
       last_failure: test.last_failure,
-      details_link: generateTestDetailsReportLink(
-        test,
-        filterVals,
-        varsContext.expandEnvironment
-      ),
+      details_link: generateTestDetailsReportLink(test),
     })
 
     setPageContextForChat({
@@ -184,8 +179,6 @@ export default function ComponentReadinessToolBar(props) {
     varsContext.sampleRelease,
     varsContext.baseRelease,
     varsContext.view,
-    filterVals,
-    varsContext.expandEnvironment,
     setPageContextForChat,
     unsetPageContextForChat,
   ])
@@ -424,7 +417,6 @@ export default function ComponentReadinessToolBar(props) {
         unresolvedTests={unresolvedTests}
         triageEntries={triageEntries}
         setTriageActionTaken={setTriageActionTaken}
-        filterVals={filterVals}
         isOpen={regressedTestDialog}
         close={closeRegressedTestsDialog}
       />
@@ -442,5 +434,4 @@ ComponentReadinessToolBar.propTypes = {
   clearSearches: PropTypes.func,
   data: PropTypes.object,
   setTriageActionTaken: PropTypes.func,
-  filterVals: PropTypes.string.isRequired,
 }

--- a/sippy-ng/src/component_readiness/RegressedTestsModal.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsModal.js
@@ -49,7 +49,6 @@ export default function RegressedTestsModal({
   unresolvedTests,
   triageEntries,
   setTriageActionTaken,
-  filterVals,
   isOpen,
   close,
 }) {
@@ -110,14 +109,12 @@ export default function RegressedTestsModal({
             <RegressedTestsPanel
               regressedTests={unresolvedTests}
               setTriageActionTaken={setTriageActionTaken}
-              filterVals={filterVals}
             />
           </RegressedTestsTabPanel>
           <RegressedTestsTabPanel activeIndex={activeTab} index={1}>
             <RegressedTestsPanel
               regressedTests={regressedTests}
               setTriageActionTaken={setTriageActionTaken}
-              filterVals={filterVals}
             />
           </RegressedTestsTabPanel>
           {triageEntriesExist && (
@@ -125,7 +122,6 @@ export default function RegressedTestsModal({
               <TriagedTestsPanel
                 triageEntries={triageEntries}
                 allRegressedTests={allRegressedTests}
-                filterVals={filterVals}
               />
             </RegressedTestsTabPanel>
           )}
@@ -133,7 +129,6 @@ export default function RegressedTestsModal({
             <RegressedTestsPanel
               regressedTests={allRegressedTests?.[view] || []}
               setTriageActionTaken={setTriageActionTaken}
-              filterVals={filterVals}
             />
           </RegressedTestsTabPanel>
           <Button
@@ -156,7 +151,6 @@ RegressedTestsModal.propTypes = {
   unresolvedTests: PropTypes.array,
   triageEntries: PropTypes.array,
   setTriageActionTaken: PropTypes.func,
-  filterVals: PropTypes.string.isRequired,
   isOpen: PropTypes.bool,
   close: PropTypes.func,
 }

--- a/sippy-ng/src/component_readiness/RegressedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/RegressedTestsPanel.js
@@ -1,5 +1,4 @@
 import { applyFilterModel } from '../datagrid/filterUtils'
-import { CompReadyVarsContext } from './CompReadyVars'
 import { DataGrid } from '@mui/x-data-grid'
 import { FileCopy } from '@mui/icons-material'
 import { formColumnName, generateTestDetailsReportLink } from './CompReadyUtils'
@@ -13,7 +12,7 @@ import CompSeverityIcon from './CompSeverityIcon'
 import GridToolbar from '../datagrid/GridToolbar'
 import IconButton from '@mui/material/IconButton'
 import PropTypes from 'prop-types'
-import React, { Fragment, useContext } from 'react'
+import React, { Fragment } from 'react'
 import UpsertTriageModal from './UpsertTriageModal'
 
 export default function RegressedTestsPanel(props) {
@@ -32,8 +31,7 @@ export default function RegressedTestsPanel(props) {
     SafeJSONParam,
     { updateType: 'replaceIn' }
   )
-  const { expandEnvironment, views, view } = useContext(CompReadyVarsContext)
-  const { filterVals, regressedTests, setTriageActionTaken } = props
+  const { regressedTests, setTriageActionTaken } = props
   const [sortModel, setSortModel] = React.useState([
     { field: 'component', sort: 'asc' },
   ])
@@ -296,11 +294,7 @@ export default function RegressedTestsPanel(props) {
           className="status"
         >
           <a
-            href={generateTestDetailsReportLink(
-              params.row,
-              filterVals,
-              expandEnvironment
-            )}
+            href={generateTestDetailsReportLink(params.row)}
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -423,5 +417,4 @@ export default function RegressedTestsPanel(props) {
 RegressedTestsPanel.propTypes = {
   regressedTests: PropTypes.array,
   setTriageActionTaken: PropTypes.func,
-  filterVals: PropTypes.string.isRequired,
 }

--- a/sippy-ng/src/component_readiness/Triage.js
+++ b/sippy-ng/src/component_readiness/Triage.js
@@ -378,7 +378,6 @@ export default function Triage({ id }) {
       <TriagedRegressionTestList
         allRegressedTests={triage.regressed_tests}
         regressions={triage.regressions}
-        filterVals={`?view=${view}`}
         symptomFilter={symptomFilter}
         symptomSummaries={triage.symptom_summaries}
       />

--- a/sippy-ng/src/component_readiness/TriagePotentialMatches.js
+++ b/sippy-ng/src/component_readiness/TriagePotentialMatches.js
@@ -99,7 +99,7 @@ export default function TriagePotentialMatches({
   const [filterOverlappingJobRuns, setFilterOverlappingJobRuns] =
     React.useState(true)
   const [filterAlreadyTriaged, setFilterAlreadyTriaged] = React.useState(false)
-  const { expandEnvironment, view } = useContext(CompReadyVarsContext)
+  const { view } = useContext(CompReadyVarsContext)
 
   const [autoOpenMatches, setAutoOpenMatches] = useQueryParam(
     'openMatches',
@@ -355,13 +355,8 @@ export default function TriagePotentialMatches({
       valueGetter: (params) => {
         const regressedTest = params.row.regressed_test
         const viewToUse = selectedView || view
-        const filterVals = `?view=${viewToUse}`
-        //TODO(sgoeddel): we should be able to get this link off of the regression,
-        // and stop needing to get the regressedTest off the report at all
         const testDetailsUrl = generateTestDetailsReportLink(
           regressedTest,
-          filterVals,
-          expandEnvironment,
           viewToUse
         )
 

--- a/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
+++ b/sippy-ng/src/component_readiness/TriagedRegressionTestList.js
@@ -1,6 +1,5 @@
 import { applyFilterModel, shouldKeepFilterItem } from '../datagrid/filterUtils'
 import { Chip, Tooltip, Typography } from '@mui/material'
-import { CompReadyVarsContext } from './CompReadyVars'
 import { DataGrid } from '@mui/x-data-grid'
 import { generateTestDetailsReportLink } from './CompReadyUtils'
 import { NumberParam, useQueryParam } from 'use-query-params'
@@ -9,11 +8,9 @@ import { symptomColor } from './CompReadyUtils'
 import CompSeverityIcon from './CompSeverityIcon'
 import GridToolbar from '../datagrid/GridToolbar'
 import PropTypes from 'prop-types'
-import React, { Fragment, useContext } from 'react'
+import React, { Fragment } from 'react'
 
 export default function TriagedRegressionTestList(props) {
-  const { expandEnvironment } = useContext(CompReadyVarsContext)
-
   const [activeRow, setActiveRow] = useQueryParam(
     'regressedModalTestRow',
     NumberParam,
@@ -252,12 +249,7 @@ export default function TriagedRegressionTestList(props) {
               return {
                 status: rt.status,
                 explanations: rt.explanations,
-                url: generateTestDetailsReportLink(
-                  rt,
-                  props.filterVals,
-                  expandEnvironment,
-                  viewName
-                ),
+                url: generateTestDetailsReportLink(rt, viewName),
               }
             },
             renderCell: (params) => {
@@ -369,7 +361,6 @@ TriagedRegressionTestList.propTypes = {
   eventEmitter: PropTypes.object,
   regressions: PropTypes.array,
   allRegressedTests: PropTypes.object,
-  filterVals: PropTypes.string,
   showOnLoad: PropTypes.bool,
   symptomFilter: PropTypes.string,
   symptomSummaries: PropTypes.array,

--- a/sippy-ng/src/component_readiness/TriagedTestsPanel.js
+++ b/sippy-ng/src/component_readiness/TriagedTestsPanel.js
@@ -20,7 +20,6 @@ export default function TriagedTestsPanel(props) {
         <TriagedRegressionTestList
           eventEmitter={eventEmitter}
           allRegressedTests={props.allRegressedTests}
-          filterVals={props.filterVals}
         />
       </Grid>
     </Fragment>
@@ -31,5 +30,4 @@ TriagedTestsPanel.propTypes = {
   triageEntries: PropTypes.array.isRequired,
   triageEntriesPerPage: PropTypes.number,
   allRegressedTests: PropTypes.object,
-  filterVals: PropTypes.string,
 }

--- a/test/e2e/componentreadiness/alltests_links_test.go
+++ b/test/e2e/componentreadiness/alltests_links_test.go
@@ -1,0 +1,110 @@
+package componentreadiness
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openshift/sippy/pkg/apis/api/componentreport"
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/crtest"
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/crview"
+	"github.com/openshift/sippy/test/e2e/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllTestsLinksPresent(t *testing.T) {
+	var views []crview.View
+	err := util.SippyGet("/api/component_readiness/views", &views)
+	require.NoError(t, err, "error fetching views")
+	require.Greater(t, len(views), 0, "no views returned")
+
+	var report componentreport.ComponentReport
+	err = util.SippyGet(fmt.Sprintf("/api/component_readiness?view=%s", views[0].Name), &report)
+	require.NoError(t, err, "error fetching component report")
+	require.Greater(t, len(report.Rows), 0, "component report has no rows")
+
+	t.Run("regressed tests have test_details links in AllTests", func(t *testing.T) {
+		var foundRegression bool
+		for _, row := range report.Rows {
+			for _, col := range row.Columns {
+				if len(col.RegressedTests) == 0 {
+					continue
+				}
+				foundRegression = true
+
+				// Every regressed test should appear in AllTests with a test_details link
+				for _, rt := range col.RegressedTests {
+					assert.NotNil(t, rt.Links, "regressed test %s should have links", rt.TestName)
+					assert.Contains(t, rt.Links, "test_details",
+						"regressed test %s should have a test_details link", rt.TestName)
+				}
+
+				// AllTests should be a superset of RegressedTests
+				assert.GreaterOrEqual(t, len(col.AllTests), len(col.RegressedTests),
+					"AllTests should contain at least as many entries as RegressedTests")
+
+				// Every entry in AllTests should have a test_details link
+				for _, at := range col.AllTests {
+					assert.NotNil(t, at.Links, "AllTests entry %s should have links", at.TestName)
+					assert.Contains(t, at.Links, "test_details",
+						"AllTests entry %s should have a test_details link", at.TestName)
+				}
+			}
+		}
+		if !foundRegression {
+			t.Skip("no regressed tests in report to verify")
+		}
+	})
+
+	t.Run("non-regressed tests have test_details links in AllTests", func(t *testing.T) {
+		var foundNonRegressed bool
+		for _, row := range report.Rows {
+			for _, col := range row.Columns {
+				if len(col.AllTests) == 0 || len(col.RegressedTests) > 0 {
+					continue
+				}
+				// This cell has tests analyzed but none regressed
+				if col.Status == crtest.NotSignificant ||
+					col.Status == crtest.SignificantImprovement ||
+					col.Status == crtest.MissingBasis {
+					foundNonRegressed = true
+
+					for _, at := range col.AllTests {
+						assert.NotNil(t, at.Links,
+							"non-regressed test %s (status %d) should have links", at.TestName, at.ReportStatus)
+						assert.Contains(t, at.Links, "test_details",
+							"non-regressed test %s (status %d) should have a test_details link", at.TestName, at.ReportStatus)
+						assert.Contains(t, at.Links["test_details"], "testId=",
+							"test_details link for %s should contain testId parameter", at.TestName)
+					}
+				}
+			}
+		}
+		if !foundNonRegressed {
+			t.Skip("no non-regressed cells with tests found in report")
+		}
+	})
+
+	t.Run("AllTests is empty only for cells with no test data", func(t *testing.T) {
+		for _, row := range report.Rows {
+			for _, col := range row.Columns {
+				if col.Status == crtest.MissingBasisAndSample {
+					assert.Empty(t, col.AllTests,
+						"MissingBasisAndSample cell should have no AllTests entries")
+				}
+			}
+		}
+	})
+
+	t.Run("RegressedTests unchanged by AllTests addition", func(t *testing.T) {
+		for _, row := range report.Rows {
+			for _, col := range row.Columns {
+				for _, rt := range col.RegressedTests {
+					assert.Less(t, int(rt.ReportStatus), int(crtest.MissingSample),
+						"RegressedTests should only contain tests with regression status, got %d for %s",
+						rt.ReportStatus, rt.TestName)
+				}
+			}
+		}
+	})
+}

--- a/test/e2e/componentreadiness/alltests_links_test.go
+++ b/test/e2e/componentreadiness/alltests_links_test.go
@@ -110,13 +110,17 @@ func TestAllTestsLinksPresent(t *testing.T) {
 	component := l1Row.Component
 	require.NotEmpty(t, component, "level 1 row has empty component")
 
-	// Level 2: get a capability
+	// Level 2: get a capability, preferring one with mixed statuses
 	var l2Report componentreport.ComponentReport
 	err = util.SippyGet(fmt.Sprintf("/api/component_readiness?view=%s&component=%s",
 		url.QueryEscape(viewName), url.QueryEscape(component)), &l2Report)
 	require.NoError(t, err, "error fetching level 2 report")
 	require.Greater(t, len(l2Report.Rows), 0, "level 2 report has no rows for component=%s", component)
-	capability := l2Report.Rows[0].Capability
+	l2Row := findRowWithMixedStatuses(l2Report.Rows)
+	if l2Row == nil {
+		l2Row = &l2Report.Rows[0]
+	}
+	capability := l2Row.Capability
 	require.NotEmpty(t, capability, "level 2 row has empty capability")
 
 	// Level 3: find a test with mixed variant statuses

--- a/test/e2e/componentreadiness/alltests_links_test.go
+++ b/test/e2e/componentreadiness/alltests_links_test.go
@@ -2,6 +2,7 @@ package componentreadiness
 
 import (
 	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/openshift/sippy/pkg/apis/api/componentreport"
@@ -12,16 +13,132 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAllTestsLinksPresent(t *testing.T) {
+func TestAllTestsExcludedFromTopLevel(t *testing.T) {
 	var views []crview.View
 	err := util.SippyGet("/api/component_readiness/views", &views)
 	require.NoError(t, err, "error fetching views")
 	require.Greater(t, len(views), 0, "no views returned")
 
 	var report componentreport.ComponentReport
-	err = util.SippyGet(fmt.Sprintf("/api/component_readiness?view=%s", views[0].Name), &report)
+	err = util.SippyGet(fmt.Sprintf("/api/component_readiness?view=%s", url.QueryEscape(views[0].Name)), &report)
 	require.NoError(t, err, "error fetching component report")
 	require.Greater(t, len(report.Rows), 0, "component report has no rows")
+
+	t.Run("AllTests is empty at top level", func(t *testing.T) {
+		for _, row := range report.Rows {
+			for _, col := range row.Columns {
+				assert.Empty(t, col.AllTests,
+					"AllTests should not be populated at top level (component=%s)", row.Component)
+			}
+		}
+	})
+
+	t.Run("RegressedTests still has links at top level", func(t *testing.T) {
+		var foundRegression bool
+		for _, row := range report.Rows {
+			for _, col := range row.Columns {
+				for _, rt := range col.RegressedTests {
+					foundRegression = true
+					assert.NotNil(t, rt.Links, "regressed test %s should have links", rt.TestName)
+					assert.Contains(t, rt.Links, "test_details",
+						"regressed test %s should have a test_details link", rt.TestName)
+				}
+			}
+		}
+		if !foundRegression {
+			t.Skip("no regressed tests in report to verify")
+		}
+	})
+
+	t.Run("RegressedTests unchanged by AllTests addition", func(t *testing.T) {
+		for _, row := range report.Rows {
+			for _, col := range row.Columns {
+				for _, rt := range col.RegressedTests {
+					assert.Less(t, int(rt.ReportStatus), int(crtest.MissingSample),
+						"RegressedTests should only contain tests with regression status, got %d for %s",
+						rt.ReportStatus, rt.TestName)
+				}
+			}
+		}
+	})
+}
+
+// findRowWithMixedStatuses returns a row that has at least one regressed column
+// and at least one non-regressed column, so the Level 4 report will contain both
+// regressed and non-regressed cells for subtest coverage.
+func findRowWithMixedStatuses(rows []componentreport.ReportRow) *componentreport.ReportRow {
+	for i, row := range rows {
+		hasRegressed := false
+		hasNonRegressed := false
+		for _, col := range row.Columns {
+			if col.Status <= crtest.SignificantTriagedRegression {
+				hasRegressed = true
+			}
+			if col.Status == crtest.NotSignificant ||
+				col.Status == crtest.SignificantImprovement ||
+				col.Status == crtest.MissingBasis {
+				hasNonRegressed = true
+			}
+		}
+		if hasRegressed && hasNonRegressed {
+			return &rows[i]
+		}
+	}
+	return nil
+}
+
+func TestAllTestsLinksPresent(t *testing.T) {
+	// Drill down from Level 1 to Level 4 to find a report with AllTests populated.
+	// At each level, prefer rows with mixed statuses (both regressed and non-regressed
+	// columns) so the Level 4 report exercises both link subtests.
+	var views []crview.View
+	err := util.SippyGet("/api/component_readiness/views", &views)
+	require.NoError(t, err, "error fetching views")
+	require.Greater(t, len(views), 0, "no views returned")
+	viewName := views[0].Name
+
+	// Level 1: find a component with both regressed and non-regressed columns
+	var l1Report componentreport.ComponentReport
+	err = util.SippyGet(fmt.Sprintf("/api/component_readiness?view=%s", url.QueryEscape(viewName)), &l1Report)
+	require.NoError(t, err, "error fetching level 1 report")
+	require.Greater(t, len(l1Report.Rows), 0, "level 1 report has no rows")
+
+	l1Row := findRowWithMixedStatuses(l1Report.Rows)
+	if l1Row == nil {
+		l1Row = &l1Report.Rows[0]
+	}
+	component := l1Row.Component
+	require.NotEmpty(t, component, "level 1 row has empty component")
+
+	// Level 2: get a capability
+	var l2Report componentreport.ComponentReport
+	err = util.SippyGet(fmt.Sprintf("/api/component_readiness?view=%s&component=%s",
+		url.QueryEscape(viewName), url.QueryEscape(component)), &l2Report)
+	require.NoError(t, err, "error fetching level 2 report")
+	require.Greater(t, len(l2Report.Rows), 0, "level 2 report has no rows for component=%s", component)
+	capability := l2Report.Rows[0].Capability
+	require.NotEmpty(t, capability, "level 2 row has empty capability")
+
+	// Level 3: find a test with mixed variant statuses
+	var l3Report componentreport.ComponentReport
+	err = util.SippyGet(fmt.Sprintf("/api/component_readiness?view=%s&component=%s&capability=%s",
+		url.QueryEscape(viewName), url.QueryEscape(component), url.QueryEscape(capability)), &l3Report)
+	require.NoError(t, err, "error fetching level 3 report")
+	require.Greater(t, len(l3Report.Rows), 0, "level 3 report has no rows for component=%s capability=%s", component, capability)
+
+	l3Row := findRowWithMixedStatuses(l3Report.Rows)
+	if l3Row == nil {
+		l3Row = &l3Report.Rows[0]
+	}
+	testID := l3Row.TestID
+	require.NotEmpty(t, testID, "level 3 row has empty testId")
+
+	// Level 4: fetch the test variant report where AllTests should be populated
+	var report componentreport.ComponentReport
+	err = util.SippyGet(fmt.Sprintf("/api/component_readiness?view=%s&component=%s&capability=%s&testId=%s",
+		url.QueryEscape(viewName), url.QueryEscape(component), url.QueryEscape(capability), url.QueryEscape(testID)), &report)
+	require.NoError(t, err, "error fetching level 4 report")
+	require.Greater(t, len(report.Rows), 0, "level 4 report has no rows")
 
 	t.Run("regressed tests have test_details links in AllTests", func(t *testing.T) {
 		var foundRegression bool
@@ -32,18 +149,15 @@ func TestAllTestsLinksPresent(t *testing.T) {
 				}
 				foundRegression = true
 
-				// Every regressed test should appear in AllTests with a test_details link
 				for _, rt := range col.RegressedTests {
 					assert.NotNil(t, rt.Links, "regressed test %s should have links", rt.TestName)
 					assert.Contains(t, rt.Links, "test_details",
 						"regressed test %s should have a test_details link", rt.TestName)
 				}
 
-				// AllTests should be a superset of RegressedTests
 				assert.GreaterOrEqual(t, len(col.AllTests), len(col.RegressedTests),
 					"AllTests should contain at least as many entries as RegressedTests")
 
-				// Every entry in AllTests should have a test_details link
 				for _, at := range col.AllTests {
 					assert.NotNil(t, at.Links, "AllTests entry %s should have links", at.TestName)
 					assert.Contains(t, at.Links, "test_details",
@@ -63,7 +177,6 @@ func TestAllTestsLinksPresent(t *testing.T) {
 				if len(col.AllTests) == 0 || len(col.RegressedTests) > 0 {
 					continue
 				}
-				// This cell has tests analyzed but none regressed
 				if col.Status == crtest.NotSignificant ||
 					col.Status == crtest.SignificantImprovement ||
 					col.Status == crtest.MissingBasis {

--- a/test/e2e/util/cache_manipulator.go
+++ b/test/e2e/util/cache_manipulator.go
@@ -175,7 +175,7 @@ func (c *E2ECacheManipulator) GetReport() (componentreport.ComponentReport, stri
 			log.Warnf("Failed to unmarshal ComponentReport key JSON '%s' from key '%s': %v", jsonPart, key, err)
 			continue
 		}
-		if gk.SampleRelease.Name == Release {
+		if gk.SampleRelease.Name == Release && len(gk.TestIDOptions) == 0 {
 			cacheKey = key
 			break
 		}


### PR DESCRIPTION
UI implementation of TRT-2782.  Relies on https://github.com/openshift/sippy/pull/3761

Allows navigation to non regressed test details:
<img width="1215" height="1456" alt="image" src="https://github.com/user-attachments/assets/b4c0591e-65f3-4376-b2ab-a42340cc5cae" />


Continues to support navigation to regressed tests:
<img width="1201" height="2924" alt="image" src="https://github.com/user-attachments/assets/6bac7b74-0043-4b11-b862-b2e276218eeb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Component readiness (Level 4) now exposes and supports opening navigable test-detail links for all analyzed tests, with backward-compatible fallback to existing regressed-test behavior.
* **Bug Fixes / Improvements**
  * Test-detail link injection now applies to all test statuses.
  * If no server-provided test-detail link is available, the UI no longer creates a fallback link.
* **Documentation**
  * Added/updated backend and frontend implementation plans for the navigation changes.
* **Tests**
  * Added end-to-end coverage validating top-level vs Level 4 link behavior and preserving regressed-test content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->