### PR TITLE
Fix e2e failure due to seed postgres jobs missing release variant

### DIFF
--- a/cmd/sippy/seed_data.go
+++ b/cmd/sippy/seed_data.go
@@ -512,7 +512,12 @@ func seedProwJobs(dbc *db.DB) error {
 	for _, release := range syntheticReleases {
 		for _, job := range syntheticJobs {
 			name := fmt.Sprintf(job.nameTemplate, release)
-			variants := variantMapToArray(job.variants)
+			allVariants := make(map[string]string, len(job.variants)+1)
+			for k, v := range job.variants {
+				allVariants[k] = v
+			}
+			allVariants["Release"] = release
+			variants := variantMapToArray(allVariants)
 			prowJob := models.ProwJob{
 				Kind:     models.ProwKind("periodic"),
 				Name:     name,

--- a/e2e-scripts/sippy-e2e-sippy-e2e-test-commands.sh
+++ b/e2e-scripts/sippy-e2e-sippy-e2e-test-commands.sh
@@ -194,6 +194,9 @@ for VIEW in $(echo "$VIEWS" | grep -o '"name":"[^"]*"' | cut -d'"' -f4); do
 done
 echo "Cache priming complete"
 
+# Export GCS credential so BigQuery-dependent e2e tests (e.g. TestRegressionCacheLoader) can run.
+export GCS_SA_JSON_PATH="${GCS_CRED}"
+
 # only 1 in parallel, some tests will clash if run at the same time
 gotestsum --junitfile ${ARTIFACT_DIR}/junit_e2e.xml -- ./test/e2e/... -v -p 1 -coverprofile=${ARTIFACT_DIR}/e2e-test-coverage.out -coverpkg=./pkg/...,./cmd/...
 TEST_EXIT=$?


### PR DESCRIPTION
fixes 

=== FAIL: test/e2e/componentreadiness TestRegressionCacheLoader (1.27s)
...
    componentreadiness_test.go:86:                                                                                                                                                                                        08:56:29 [83/3805]
                Error Trace:    /Users/dgoodwin/go/src/github.com/openshift/sippy/test/e2e/componentreadiness/componentreadiness_test.go:86
                Error:          Should be empty, but was [component report generation encountered errors: googleapi: Error 400: Unrecognized name: jv_Release; Did you mean release? at [86:844], invalidQuery; googleapi: Error 400: Unrecognized name: jv_Release; Did you mean release? at [86:844], invalidQuery]
                Test:           TestRegressionCacheLoader
                Messages:       regression cache loader had errors: [component report generation encountered errors: googleapi: Error 400: Unrecognized name: jv_Release; Did you mean release? at [86:844], invalidQuery; googleapi: Error
400: Unrecognized name: jv_Release; Did you mean release? at [86:844], invalidQuery]

Failing locally but not in presubmits because GCS_SA_JSON_PATH is not defined in the path the presubmit follows, so the test was skipped. I don't think this was expected.

There's something fishy here, a postgres variants change to fix a bigquery query failure, it appears related to how we cache TestAllVariants, and I'm not totally clear what parts of e2e testing are using postgres vs bigquery providers. 
