### PR TITLE
Fix cross-provider variant cache contamination

### DIFF
--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -67,12 +67,7 @@ func GetComponentTestVariants(ctx context.Context, provider dataprovider.DataPro
 
 func GetJobVariants(ctx context.Context, provider dataprovider.DataProvider) (crtest.JobVariants,
 	[]error) {
-	generator := ComponentReportGenerator{
-		dataProvider: provider,
-	}
-
-	return api.GetDataFromCacheOrGenerate[crtest.JobVariants](ctx, provider.Cache(), cache.RequestOptions{},
-		api.NewCacheSpec(generator, "TestAllVariants~", nil), generator.GenerateJobVariants, crtest.JobVariants{})
+	return provider.QueryJobVariants(ctx)
 }
 
 func GetComponentReport(
@@ -266,10 +261,6 @@ func (c *ComponentReportGenerator) GenerateCacheVariants(ctx context.Context) (C
 	}, errs
 }
 
-func (c *ComponentReportGenerator) GenerateJobVariants(ctx context.Context) (crtest.JobVariants, []error) {
-	return c.dataProvider.QueryJobVariants(ctx)
-}
-
 func (c *ComponentReportGenerator) getCache() cache.Cache {
 	return c.dataProvider.Cache()
 }
@@ -328,11 +319,6 @@ func (c *ComponentReportGenerator) GenerateReport(ctx context.Context) (crtype.C
 func (c *ComponentReportGenerator) getTestStatus(ctx context.Context) (crstatus.ReportTestStatus, []error) {
 	before := time.Now()
 	fLog := log.WithField("func", "getTestStatus")
-	allJobVariants, errs := GetJobVariants(ctx, c.dataProvider)
-	if len(errs) > 0 {
-		fLog.Errorf("failed to get job variants")
-		return crstatus.ReportTestStatus{}, errs
-	}
 
 	var baseStatus, sampleStatus map[string]crstatus.TestStatus
 	baseStatusCh := make(chan map[string]crstatus.TestStatus) // TODO: not hooked up yet, just in place for the interface for now
@@ -346,11 +332,11 @@ func (c *ComponentReportGenerator) getTestStatus(ctx context.Context) (crstatus.
 	statusErrsDoneCh := make(chan struct{}) // To signal when all processing is done
 
 	// generate inputs to the channels
-	c.middlewares.Query(ctx, wg, allJobVariants, baseStatusCh, sampleStatusCh, errCh)
-	goInterruptible(ctx, wg, func() { baseStatus, baseErrs = c.dataProvider.QueryBaseTestStatus(ctx, c.ReqOptions, allJobVariants) })
+	c.middlewares.Query(ctx, wg, baseStatusCh, sampleStatusCh, errCh)
+	goInterruptible(ctx, wg, func() { baseStatus, baseErrs = c.dataProvider.QueryBaseTestStatus(ctx, c.ReqOptions) })
 	goInterruptible(ctx, wg, func() {
 		fLog.Infof("running sample query with includeVariants: %+v", c.ReqOptions.VariantOption.IncludeVariants)
-		status, errs := c.dataProvider.QuerySampleTestStatus(ctx, c.ReqOptions, allJobVariants, c.ReqOptions.VariantOption.IncludeVariants, c.ReqOptions.SampleRelease.Start, c.ReqOptions.SampleRelease.End)
+		status, errs := c.dataProvider.QuerySampleTestStatus(ctx, c.ReqOptions, c.ReqOptions.VariantOption.IncludeVariants, c.ReqOptions.SampleRelease.Start, c.ReqOptions.SampleRelease.End)
 		fLog.Infof("received %d test statuses and %d errors from sample query", len(status), len(errs))
 		sampleStatusCh <- status
 		for _, err := range errs {
@@ -397,6 +383,7 @@ func (c *ComponentReportGenerator) getTestStatus(ctx context.Context) (crstatus.
 	<-statusErrsDoneCh
 	fLog.Infof("total test statuses: %d", len(sampleStatus))
 
+	var errs []error
 	if len(baseErrs) != 0 || len(sampleErrs) != 0 {
 		errs = append(errs, baseErrs...)
 		errs = append(errs, sampleErrs...)

--- a/pkg/api/componentreadiness/dataprovider/bigquery/provider.go
+++ b/pkg/api/componentreadiness/dataprovider/bigquery/provider.go
@@ -2,6 +2,7 @@ package bigquery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -49,8 +50,11 @@ func (p *BigQueryProvider) Cache() apiCache.Cache {
 
 // --- TestStatusQuerier ---
 
-func (p *BigQueryProvider) QueryBaseTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions,
-	allJobVariants crtest.JobVariants) (map[string]crstatus.TestStatus, []error) {
+func (p *BigQueryProvider) QueryBaseTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions) (map[string]crstatus.TestStatus, []error) {
+	allJobVariants, errs := p.QueryJobVariants(ctx)
+	if len(errs) > 0 {
+		return nil, errs
+	}
 
 	generator := NewBaseQueryGenerator(p.client, reqOptions, allJobVariants)
 	result, errs := apiPkg.GetDataFromCacheOrGenerate[crstatus.ReportTestStatus](
@@ -64,9 +68,12 @@ func (p *BigQueryProvider) QueryBaseTestStatus(ctx context.Context, reqOptions r
 }
 
 func (p *BigQueryProvider) QuerySampleTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions,
-	allJobVariants crtest.JobVariants,
 	includeVariants map[string][]string,
 	start, end time.Time) (map[string]crstatus.TestStatus, []error) {
+	allJobVariants, errs := p.QueryJobVariants(ctx)
+	if len(errs) > 0 {
+		return nil, errs
+	}
 
 	generator := NewSampleQueryGenerator(p.client, reqOptions, allJobVariants, includeVariants, start, end)
 	result, errs := apiPkg.GetDataFromCacheOrGenerate[crstatus.ReportTestStatus](
@@ -81,8 +88,11 @@ func (p *BigQueryProvider) QuerySampleTestStatus(ctx context.Context, reqOptions
 
 // --- TestDetailsQuerier ---
 
-func (p *BigQueryProvider) QueryBaseJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions,
-	allJobVariants crtest.JobVariants) (map[string][]crstatus.TestJobRunRows, []error) {
+func (p *BigQueryProvider) QueryBaseJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions) (map[string][]crstatus.TestJobRunRows, []error) {
+	allJobVariants, errs := p.QueryJobVariants(ctx)
+	if len(errs) > 0 {
+		return nil, errs
+	}
 
 	generator := NewBaseTestDetailsQueryGenerator(
 		log.WithField("func", "QueryBaseJobRunTestStatus"),
@@ -101,9 +111,12 @@ func (p *BigQueryProvider) QueryBaseJobRunTestStatus(ctx context.Context, reqOpt
 }
 
 func (p *BigQueryProvider) QuerySampleJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions,
-	allJobVariants crtest.JobVariants,
 	includeVariants map[string][]string,
 	start, end time.Time) (map[string][]crstatus.TestJobRunRows, []error) {
+	allJobVariants, errs := p.QueryJobVariants(ctx)
+	if len(errs) > 0 {
+		return nil, errs
+	}
 
 	generator := NewSampleTestDetailsQueryGenerator(p.client, reqOptions, allJobVariants, includeVariants, start, end)
 	result, errs := apiPkg.GetDataFromCacheOrGenerate[crstatus.TestJobRunStatuses](
@@ -118,7 +131,18 @@ func (p *BigQueryProvider) QuerySampleJobRunTestStatus(ctx context.Context, reqO
 
 // --- MetadataQuerier ---
 
+type jobVariantsCacheKey struct {
+	Dataset string
+}
+
 func (p *BigQueryProvider) QueryJobVariants(ctx context.Context) (crtest.JobVariants, []error) {
+	return apiPkg.GetDataFromCacheOrGenerate[crtest.JobVariants](
+		ctx, p.client.Cache, apiCache.RequestOptions{},
+		apiPkg.NewCacheSpec(jobVariantsCacheKey{Dataset: p.client.Dataset}, "BQJobVariants~", nil),
+		p.queryJobVariantsFromBQ, crtest.JobVariants{})
+}
+
+func (p *BigQueryProvider) queryJobVariantsFromBQ(ctx context.Context) (crtest.JobVariants, []error) {
 	variants := crtest.JobVariants{Variants: map[string][]string{}}
 	queryString := fmt.Sprintf(`SELECT variant_name, ARRAY_AGG(DISTINCT variant_value ORDER BY variant_value) AS variant_values
 					FROM
@@ -201,8 +225,11 @@ func (p *BigQueryProvider) QueryUniqueVariantValues(ctx context.Context, field s
 // --- JobQuerier ---
 
 func (p *BigQueryProvider) QueryJobRuns(ctx context.Context, reqOptions reqopts.RequestOptions,
-	allJobVariants crtest.JobVariants,
 	release string, start, end time.Time) (map[string]dataprovider.JobRunStats, error) {
+	allJobVariants, errs := p.QueryJobVariants(ctx)
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("fetching job variants: %w", errors.Join(errs...))
+	}
 
 	joinVariants := ""
 	for _, v := range sortedKeys(allJobVariants.Variants) {

--- a/pkg/api/componentreadiness/dataprovider/interface.go
+++ b/pkg/api/componentreadiness/dataprovider/interface.go
@@ -14,23 +14,19 @@ import (
 // TestStatusQuerier fetches aggregated test pass/fail counts.
 type TestStatusQuerier interface {
 	// QueryBaseTestStatus returns test status for the basis release.
-	QueryBaseTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions,
-		allJobVariants crtest.JobVariants) (map[string]crstatus.TestStatus, []error)
+	QueryBaseTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions) (map[string]crstatus.TestStatus, []error)
 
 	// QuerySampleTestStatus returns test status for the sample release.
 	QuerySampleTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions,
-		allJobVariants crtest.JobVariants,
 		includeVariants map[string][]string,
 		start, end time.Time) (map[string]crstatus.TestStatus, []error)
 }
 
 // TestDetailsQuerier fetches per-job-run test breakdowns used for test details reports.
 type TestDetailsQuerier interface {
-	QueryBaseJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions,
-		allJobVariants crtest.JobVariants) (map[string][]crstatus.TestJobRunRows, []error)
+	QueryBaseJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions) (map[string][]crstatus.TestJobRunRows, []error)
 
 	QuerySampleJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions,
-		allJobVariants crtest.JobVariants,
 		includeVariants map[string][]string,
 		start, end time.Time) (map[string][]crstatus.TestJobRunRows, []error)
 }
@@ -55,7 +51,6 @@ type MetadataQuerier interface {
 type JobQuerier interface {
 	// QueryJobRuns returns pass/fail statistics per job for a release in a time window.
 	QueryJobRuns(ctx context.Context, reqOptions reqopts.RequestOptions,
-		allJobVariants crtest.JobVariants,
 		release string, start, end time.Time) (map[string]JobRunStats, error)
 
 	// QueryJobVariantValues returns variant key/value pairs for the given jobs.

--- a/pkg/api/componentreadiness/dataprovider/postgres/provider.go
+++ b/pkg/api/componentreadiness/dataprovider/postgres/provider.go
@@ -340,7 +340,7 @@ GROUP BY tow.unique_id, t.name, s.name, tow.component, tow.capabilities, d.prow_
 `
 
 func (p *PostgresProvider) queryTestStatus(ctx context.Context, release string, start, end time.Time,
-	_ crtest.JobVariants, includeVariants map[string][]string,
+	includeVariants map[string][]string,
 	dbGroupBy map[string]bool) (map[string]crstatus.TestStatus, []error) {
 
 	var rows []testStatusRow
@@ -436,8 +436,7 @@ func (p *PostgresProvider) fetchJobVariantsByIDs(ids []uint) (map[uint]map[strin
 	return result, nil
 }
 
-func (p *PostgresProvider) QueryBaseTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions,
-	allJobVariants crtest.JobVariants) (map[string]crstatus.TestStatus, []error) {
+func (p *PostgresProvider) QueryBaseTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions) (map[string]crstatus.TestStatus, []error) {
 
 	dbGroupBy := make(map[string]bool, reqOptions.VariantOption.DBGroupBy.Len())
 	for _, k := range sets.List(reqOptions.VariantOption.DBGroupBy) {
@@ -454,14 +453,12 @@ func (p *PostgresProvider) QueryBaseTestStatus(ctx context.Context, reqOptions r
 		reqOptions.BaseRelease.Name,
 		reqOptions.BaseRelease.Start,
 		reqOptions.BaseRelease.End,
-		allJobVariants,
 		includeVariants,
 		dbGroupBy,
 	)
 }
 
 func (p *PostgresProvider) QuerySampleTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions,
-	allJobVariants crtest.JobVariants,
 	includeVariants map[string][]string,
 	start, end time.Time) (map[string]crstatus.TestStatus, []error) {
 
@@ -478,7 +475,6 @@ func (p *PostgresProvider) QuerySampleTestStatus(ctx context.Context, reqOptions
 		ctx,
 		reqOptions.SampleRelease.Name,
 		start, end,
-		allJobVariants,
 		includeVariants,
 		dbGroupBy,
 	)
@@ -529,7 +525,7 @@ ORDER BY pjr.timestamp
 `
 
 func (p *PostgresProvider) queryTestDetails(ctx context.Context, release string, start, end time.Time,
-	reqOptions reqopts.RequestOptions, _ crtest.JobVariants,
+	reqOptions reqopts.RequestOptions,
 	includeVariants map[string][]string) (map[string][]crstatus.TestJobRunRows, []error) {
 
 	var rows []testDetailRow
@@ -639,19 +635,17 @@ func (p *PostgresProvider) queryTestDetails(ctx context.Context, release string,
 	return result, nil
 }
 
-func (p *PostgresProvider) QueryBaseJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions,
-	allJobVariants crtest.JobVariants) (map[string][]crstatus.TestJobRunRows, []error) {
+func (p *PostgresProvider) QueryBaseJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions) (map[string][]crstatus.TestJobRunRows, []error) {
 
 	return p.queryTestDetails(
 		ctx,
 		reqOptions.BaseRelease.Name,
 		reqOptions.BaseRelease.Start, reqOptions.BaseRelease.End,
-		reqOptions, allJobVariants, reqOptions.VariantOption.IncludeVariants,
+		reqOptions, reqOptions.VariantOption.IncludeVariants,
 	)
 }
 
 func (p *PostgresProvider) QuerySampleJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions,
-	allJobVariants crtest.JobVariants,
 	includeVariants map[string][]string,
 	start, end time.Time) (map[string][]crstatus.TestJobRunRows, []error) {
 
@@ -659,14 +653,13 @@ func (p *PostgresProvider) QuerySampleJobRunTestStatus(ctx context.Context, reqO
 		ctx,
 		reqOptions.SampleRelease.Name,
 		start, end,
-		reqOptions, allJobVariants, includeVariants,
+		reqOptions, includeVariants,
 	)
 }
 
 // --- JobQuerier ---
 
 func (p *PostgresProvider) QueryJobRuns(ctx context.Context, reqOptions reqopts.RequestOptions,
-	allJobVariants crtest.JobVariants,
 	release string, start, end time.Time) (map[string]dataprovider.JobRunStats, error) {
 
 	type jobRunRow struct {

--- a/pkg/api/componentreadiness/middleware/interface.go
+++ b/pkg/api/componentreadiness/middleware/interface.go
@@ -16,11 +16,11 @@ type Middleware interface {
 	// Query phase allows middleware to inject additional TestStatus beyond the normal base/sample queries.
 	// Base and sample status can be submitted using the provided channels for a map of ALL test keys
 	// (ID plus variant info serialized) to TestStatus.
-	Query(ctx context.Context, wg *sync.WaitGroup, allJobVariants crtest.JobVariants,
+	Query(ctx context.Context, wg *sync.WaitGroup,
 		baseStatusCh, sampleStatusCh chan map[string]crstatus.TestStatus, errCh chan error)
 
 	// QueryTestDetails phase allow middleware to load data that will later be used.
-	QueryTestDetails(ctx context.Context, wg *sync.WaitGroup, errCh chan error, allJobVariants crtest.JobVariants)
+	QueryTestDetails(ctx context.Context, wg *sync.WaitGroup, errCh chan error)
 
 	// PreAnalysis gives middleware opportunity to adjust test analysis data prior to running analysis.
 	// Implementations can alter base/sample data as needed, request confidence levels, and add explanations for

--- a/pkg/api/componentreadiness/middleware/linkinjector/linkinjector.go
+++ b/pkg/api/componentreadiness/middleware/linkinjector/linkinjector.go
@@ -32,11 +32,11 @@ type LinkInjector struct {
 	baseURL    string
 }
 
-func (l *LinkInjector) Query(ctx context.Context, wg *sync.WaitGroup, allJobVariants crtest.JobVariants, baseStatusCh, sampleStatusCh chan map[string]crstatus.TestStatus, errCh chan error) {
+func (l *LinkInjector) Query(_ context.Context, _ *sync.WaitGroup, _, _ chan map[string]crstatus.TestStatus, _ chan error) {
 	// unused
 }
 
-func (l *LinkInjector) QueryTestDetails(ctx context.Context, wg *sync.WaitGroup, errCh chan error, allJobVariants crtest.JobVariants) {
+func (l *LinkInjector) QueryTestDetails(_ context.Context, _ *sync.WaitGroup, _ chan error) {
 	// unused
 }
 

--- a/pkg/api/componentreadiness/middleware/list.go
+++ b/pkg/api/componentreadiness/middleware/list.go
@@ -11,17 +11,17 @@ import (
 
 type List []Middleware
 
-func (l List) Query(ctx context.Context, wg *sync.WaitGroup, allJobVariants crtest.JobVariants, baseStatusCh, sampleStatusCh chan map[string]crstatus.TestStatus, errCh chan error) {
+func (l List) Query(ctx context.Context, wg *sync.WaitGroup, baseStatusCh, sampleStatusCh chan map[string]crstatus.TestStatus, errCh chan error) {
 	// Invoke the Query phase for each middleware configured:
 	for _, mw := range l {
-		mw.Query(ctx, wg, allJobVariants, baseStatusCh, sampleStatusCh, errCh)
+		mw.Query(ctx, wg, baseStatusCh, sampleStatusCh, errCh)
 	}
 }
 
-func (l List) QueryTestDetails(ctx context.Context, wg *sync.WaitGroup, errCh chan error, allJobVariants crtest.JobVariants) {
+func (l List) QueryTestDetails(ctx context.Context, wg *sync.WaitGroup, errCh chan error) {
 	// Invoke the QueryTestDetails phase for each middleware configured:
 	for _, mw := range l {
-		mw.QueryTestDetails(ctx, wg, errCh, allJobVariants)
+		mw.QueryTestDetails(ctx, wg, errCh)
 	}
 }
 

--- a/pkg/api/componentreadiness/middleware/regressionallowances/regressionallowances.go
+++ b/pkg/api/componentreadiness/middleware/regressionallowances/regressionallowances.go
@@ -40,7 +40,7 @@ type RegressionAllowances struct {
 	regressionGetterFunc func(releaseString string, variant crtest.ColumnIdentification, testID string) *regressionallowances.IntentionalRegression
 }
 
-func (r *RegressionAllowances) Query(_ context.Context, _ *sync.WaitGroup, _ crtest.JobVariants,
+func (r *RegressionAllowances) Query(_ context.Context, _ *sync.WaitGroup,
 	_, _ chan map[string]crstatus.TestStatus, _ chan error) {
 	// unused
 }
@@ -148,7 +148,7 @@ func (r *RegressionAllowances) adjustAnalysisParameters(testStats *testdetails.T
 	}
 }
 
-func (r *RegressionAllowances) QueryTestDetails(ctx context.Context, wg *sync.WaitGroup, errCh chan error, allJobVariants crtest.JobVariants) {
+func (r *RegressionAllowances) QueryTestDetails(_ context.Context, _ *sync.WaitGroup, _ chan error) {
 }
 
 func (r *RegressionAllowances) PreTestDetailsAnalysis(testKey crtest.KeyWithVariants, status *crstatus.TestJobRunStatuses) error {

--- a/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
+++ b/pkg/api/componentreadiness/middleware/regressiontracker/regressiontracker.go
@@ -66,14 +66,14 @@ type RegressionTracker struct {
 	hasLoadedRegressions bool
 }
 
-func (r *RegressionTracker) Query(ctx context.Context, wg *sync.WaitGroup, allJobVariants crtest.JobVariants, baseStatusCh, sampleStatusCh chan map[string]crstatus.TestStatus, errCh chan error) {
+func (r *RegressionTracker) Query(ctx context.Context, wg *sync.WaitGroup, baseStatusCh, sampleStatusCh chan map[string]crstatus.TestStatus, errCh chan error) {
 	err := r.ensureRegressionsLoaded()
 	if err != nil {
 		utils.EnqueueAsync(wg, errCh, err)
 	}
 }
 
-func (r *RegressionTracker) QueryTestDetails(ctx context.Context, wg *sync.WaitGroup, errCh chan error, allJobVariants crtest.JobVariants) {
+func (r *RegressionTracker) QueryTestDetails(ctx context.Context, wg *sync.WaitGroup, errCh chan error) {
 	err := r.ensureRegressionsLoaded()
 	if err != nil {
 		utils.EnqueueAsync(wg, errCh, err)

--- a/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
+++ b/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
@@ -71,7 +71,7 @@ func (r *ReleaseFallback) Analyze(testID string, variants map[string]string, rep
 	return nil
 }
 
-func (r *ReleaseFallback) Query(ctx context.Context, wg *sync.WaitGroup, allJobVariants crtest.JobVariants,
+func (r *ReleaseFallback) Query(ctx context.Context, wg *sync.WaitGroup,
 	_, _ chan map[string]crstatus.TestStatus, errCh chan error) {
 	wg.Add(1)
 	go func() {
@@ -81,7 +81,7 @@ func (r *ReleaseFallback) Query(ctx context.Context, wg *sync.WaitGroup, allJobV
 			r.log.Infof("Context canceled while fetching fallback query status")
 			return
 		default:
-			errs := r.getFallbackBaseQueryStatus(ctx, allJobVariants, r.reqOptions.BaseRelease.Name, r.reqOptions.BaseRelease.Start, r.reqOptions.BaseRelease.End)
+			errs := r.getFallbackBaseQueryStatus(ctx, r.reqOptions.BaseRelease.Name, r.reqOptions.BaseRelease.Start, r.reqOptions.BaseRelease.End)
 			if len(errs) > 0 {
 				for _, err := range errs {
 					errCh <- err
@@ -171,9 +171,8 @@ func (r *ReleaseFallback) PostAnalysis(testKey crtest.Identification, testStats 
 }
 
 func (r *ReleaseFallback) getFallbackBaseQueryStatus(ctx context.Context,
-	allJobVariants crtest.JobVariants,
 	release string, start, end time.Time) []error {
-	generator := newFallbackTestQueryReleasesGenerator(r.dataProvider, r.reqOptions, allJobVariants, release, start, end, r.releaseConfigs)
+	generator := newFallbackTestQueryReleasesGenerator(r.dataProvider, r.reqOptions, release, start, end, r.releaseConfigs)
 
 	cachedFallbackTestStatuses, errs := api.GetDataFromCacheOrGenerate[*FallbackReleases](
 		ctx, r.dataProvider.Cache(), r.reqOptions.CacheOption,
@@ -189,7 +188,7 @@ func (r *ReleaseFallback) getFallbackBaseQueryStatus(ctx context.Context,
 	return nil
 }
 
-func (r *ReleaseFallback) QueryTestDetails(ctx context.Context, wg *sync.WaitGroup, errCh chan error, allJobVariants crtest.JobVariants) {
+func (r *ReleaseFallback) QueryTestDetails(ctx context.Context, wg *sync.WaitGroup, errCh chan error) {
 	r.log.Infof("Querying fallback override test statuses for %d test ID options", len(r.reqOptions.TestIDOptions))
 
 	// Lookup all release dates, we're going to need them
@@ -241,7 +240,7 @@ func (r *ReleaseFallback) QueryTestDetails(ctx context.Context, wg *sync.WaitGro
 				fallbackReqOpts.BaseRelease.End = *end
 				fallbackReqOpts.TestIDOptions = testIDOpts
 
-				baseStatus, bsErrs := r.dataProvider.QueryBaseJobRunTestStatus(ctx, fallbackReqOpts, allJobVariants)
+				baseStatus, bsErrs := r.dataProvider.QueryBaseJobRunTestStatus(ctx, fallbackReqOpts)
 
 				for _, bsErr := range bsErrs {
 					errCh <- bsErr
@@ -297,7 +296,6 @@ func (r *ReleaseFallback) TestDetailsAnalyze(report *testdetails.Report) error {
 type fallbackTestQueryReleasesGenerator struct {
 	dataProvider               dataprovider.DataProvider
 	cacheOption                apiCache.RequestOptions
-	allJobVariants             crtest.JobVariants
 	BaseRelease                string
 	BaseStart                  time.Time
 	BaseEnd                    time.Time
@@ -310,7 +308,6 @@ type fallbackTestQueryReleasesGenerator struct {
 func newFallbackTestQueryReleasesGenerator(
 	provider dataprovider.DataProvider,
 	reqOptions reqopts.RequestOptions,
-	allJobVariants crtest.JobVariants,
 	release string, start, end time.Time,
 	releaseConfigs []v1.Release,
 ) fallbackTestQueryReleasesGenerator {
@@ -318,7 +315,6 @@ func newFallbackTestQueryReleasesGenerator(
 	generator := fallbackTestQueryReleasesGenerator{
 		dataProvider:   provider,
 		cacheOption:    reqOptions.CacheOption,
-		allJobVariants: allJobVariants,
 		BaseRelease:    release,
 		BaseStart:      start,
 		BaseEnd:        end,
@@ -461,7 +457,7 @@ func (f *fallbackTestQueryReleasesGenerator) getTestFallbackRelease(ctx context.
 	fallbackReqOpts.BaseRelease.Start = start
 	fallbackReqOpts.BaseRelease.End = end
 
-	baseStatus, errs := f.dataProvider.QueryBaseTestStatus(ctx, fallbackReqOpts, f.allJobVariants)
+	baseStatus, errs := f.dataProvider.QueryBaseTestStatus(ctx, fallbackReqOpts)
 	if len(errs) > 0 {
 		return crstatus.ReportTestStatus{}, errs
 	}

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -335,7 +335,6 @@ func (c *ComponentReportGenerator) GenerateDetailsReportForTest(
 
 func (c *ComponentReportGenerator) getBaseJobRunTestStatus(
 	ctx context.Context,
-	allJobVariants crtest.JobVariants,
 	baseRelease string,
 	baseStart time.Time,
 	baseEnd time.Time) (map[string][]crstatus.TestJobRunRows, []error) {
@@ -344,32 +343,26 @@ func (c *ComponentReportGenerator) getBaseJobRunTestStatus(
 	reqOpts.BaseRelease.Name = baseRelease
 	reqOpts.BaseRelease.Start = baseStart
 	reqOpts.BaseRelease.End = baseEnd
-	return c.dataProvider.QueryBaseJobRunTestStatus(ctx, reqOpts, allJobVariants)
+	return c.dataProvider.QueryBaseJobRunTestStatus(ctx, reqOpts)
 }
 
 func (c *ComponentReportGenerator) getSampleJobRunTestStatus(
 	ctx context.Context,
-	allJobVariants crtest.JobVariants,
 	includeVariants map[string][]string,
 	start, end time.Time) (map[string][]crstatus.TestJobRunRows, []error) {
 
-	return c.dataProvider.QuerySampleJobRunTestStatus(ctx, c.ReqOptions, allJobVariants, includeVariants, start, end)
+	return c.dataProvider.QuerySampleJobRunTestStatus(ctx, c.ReqOptions, includeVariants, start, end)
 }
 
 func (c *ComponentReportGenerator) getJobRunTestStatus(ctx context.Context) (crstatus.TestJobRunStatuses, []error) {
 	fLog := logrus.WithField("func", "getJobRunTestStatus")
-	allJobVariants, errs := GetJobVariants(ctx, c.dataProvider)
-	if len(errs) > 0 {
-		logrus.Errorf("failed to get job variants")
-		return crstatus.TestJobRunStatuses{}, errs
-	}
 	var baseStatus, sampleStatus map[string][]crstatus.TestJobRunRows
 	var baseErrs, sampleErrs []error
 	wg := sync.WaitGroup{}
 
 	errCh := make(chan error)
 
-	c.middlewares.QueryTestDetails(ctx, &wg, errCh, allJobVariants)
+	c.middlewares.QueryTestDetails(ctx, &wg, errCh)
 
 	wg.Add(1)
 	go func() {
@@ -379,7 +372,7 @@ func (c *ComponentReportGenerator) getJobRunTestStatus(ctx context.Context) (crs
 			logrus.Infof("Context canceled while fetching base job run test status")
 			return
 		default:
-			baseStatus, baseErrs = c.getBaseJobRunTestStatus(ctx, allJobVariants, c.ReqOptions.BaseRelease.Name, c.ReqOptions.BaseRelease.Start, c.ReqOptions.BaseRelease.End)
+			baseStatus, baseErrs = c.getBaseJobRunTestStatus(ctx, c.ReqOptions.BaseRelease.Name, c.ReqOptions.BaseRelease.Start, c.ReqOptions.BaseRelease.End)
 		}
 	}()
 
@@ -392,7 +385,7 @@ func (c *ComponentReportGenerator) getJobRunTestStatus(ctx context.Context) (crs
 			return
 		default:
 			fLog.Infof("running sample status query with includeVariants: %+v", c.ReqOptions.VariantOption.IncludeVariants)
-			status, errs := c.getSampleJobRunTestStatus(ctx, allJobVariants, c.ReqOptions.VariantOption.IncludeVariants,
+			status, errs := c.getSampleJobRunTestStatus(ctx, c.ReqOptions.VariantOption.IncludeVariants,
 				c.ReqOptions.SampleRelease.Start, c.ReqOptions.SampleRelease.End)
 			fLog.Infof("received %d test statuses and %d errors from sample query", len(status), len(errs))
 			sampleStatus = status
@@ -411,6 +404,7 @@ func (c *ComponentReportGenerator) getJobRunTestStatus(ctx context.Context) (crs
 	}
 
 	fLog.Infof("total test statuses: %d", len(sampleStatus))
+	var errs []error
 	if len(baseErrs) != 0 || len(sampleErrs) != 0 || len(middlewareErrs) != 0 {
 		errs = append(errs, baseErrs...)
 		errs = append(errs, sampleErrs...)


### PR DESCRIPTION
## Summary

- Moves variant caching inside the BigQuery provider with a provider-specific cache key (`BQJobVariants~`), eliminating the shared `TestAllVariants~` key that caused cross-provider cache contamination
- Removes `allJobVariants` parameter from the `DataProvider` interface and middleware since it was a BigQuery implementation detail the Postgres provider always ignored
- Simplifies `GetJobVariants` from a cache-wrapping generator to a direct pass-through to `provider.QueryJobVariants`

## Test plan

- [x] `go vet ./pkg/... ./test/...` passes
- [x] `go test ./pkg/...` passes
- [x] `make e2e` (the originally failing `TestRegressionCacheLoader` requires `GCS_SA_JSON_PATH`; verified it is no longer affected by the shared cache key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved component readiness report queries by reducing redundant data retrieval.
  * Added caching for job variant lookups to improve response times.

* **Reliability**
  * Enhanced error aggregation and handling when retrieving job data.
  * Simplified concurrent status and test-detail processing for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->