### PR TITLE
Fix flaky Test_RegressionViews/upsert_creates_a_new_regression_view

### DIFF
--- a/test/e2e/componentreadiness/regressiontracker/regressiontracker_test.go
+++ b/test/e2e/componentreadiness/regressiontracker/regressiontracker_test.go
@@ -869,7 +869,8 @@ func Test_RegressionViews(t *testing.T) {
 		defer cleanupAllRegressions(dbc)
 		defer cleanupRegressionViews(dbc)
 
-		beforeCreate := time.Now()
+		var beforeCreate time.Time
+		require.NoError(t, dbc.DB.Raw("SELECT NOW()").Scan(&beforeCreate).Error)
 		reg, err := tracker.OpenRegression(view, newRegSummary("upsert-create"))
 		require.NoError(t, err)
 
@@ -964,7 +965,7 @@ func Test_RegressionViews(t *testing.T) {
 		err = tracker.UpsertRegressionView(reg.ID, "4.19-ppc64le")
 		require.NoError(t, err)
 
-		beforeDeactivate := time.Now()
+		beforeDeactivate := time.Now().Truncate(time.Microsecond)
 
 		// Only 4.19-main is still active
 		activeViewMap := map[uint][]string{


### PR DESCRIPTION
## Summary
- Fix flaky `Test_RegressionViews/upsert_creates_a_new_regression_view` e2e test that intermittently fails with "opened_at should be >= test start time"
- Root cause: test compared Go's `time.Now()` (nanosecond precision, process clock) against PostgreSQL's `NOW()` (microsecond precision, DB clock), which are independent clocks that can diverge
- Align each "before" timestamp with the clock that produces the stored value: `SELECT NOW()` for the `UpsertRegressionView` case (SQL `NOW()`), `Truncate(time.Microsecond)` for the `DeactivateRolledOffViews` case (Go `time.Now()`)

## Test plan
- [x] `make e2e` passes (108 tests, 0 failures)
- [x] The previously flaky subtest `upsert_creates_a_new_regression_view` passes
- [x] Independent code review completed (1 finding addressed: added error check on `SELECT NOW()` scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regression view test reliability by aligning timestamp comparisons with database precision.
  * Prevented intermittent failures when validating view creation and deactivation times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->