### PR TITLE
TRT-2695: retroactive symptoms (frontend)

### DIFF
--- a/docs/features/job-analysis-symptoms.md
+++ b/docs/features/job-analysis-symptoms.md
@@ -108,6 +108,9 @@ Labels are relevant in several Sippy pages:
 - Payload job runs table - labels column.
 - JAQ dialog - symptom management and label display.
 - Triage details - symptom summaries per regression displayed on test details pages.
+- Re-evaluation controls - button in the JAQ dialog action bar. Triggers retroactive symptom
+  matching for selected (or all visible) job runs in the dialog (requires SSO authentication
+  via the write-enabled deployment).
 
 They are also displayed in Spyglass (the Deck display of a Prow job) - an HTML summary added to the
 job's bucket entry is included by the html lens.
@@ -190,8 +193,6 @@ documentation.
 The symptoms pipeline (definition → detection → labeling → display) is fully operational.
 Active/planned work includes:
 
-- **Retroactive re-evaluation** ([TRT-2695](https://redhat.atlassian.net/browse/TRT-2695))
-  - Backend API complete (`POST /api/jobs/runs/reevaluate`). Frontend UI is pending.
 - **Compound symptoms** ([TRT-2466](https://redhat.atlassian.net/browse/TRT-2466))
   - richer CEL-based label composition.
 - **Full management UI** ([TRT-2479](https://redhat.atlassian.net/browse/TRT-2479))

--- a/docs/plans/trt-2695-retroactive-symptoms-frontend-plan.md
+++ b/docs/plans/trt-2695-retroactive-symptoms-frontend-plan.md
@@ -31,248 +31,32 @@ component.
 
 Create `sippy-ng/src/jobs/ReEvaluateSymptoms.js`:
 
-```jsx
-import React, { useState } from 'react'
-import {
-  Alert,
-  Button,
-  LinearProgress,
-  Snackbar,
-  Stack,
-  Tooltip,
-  Typography,
-} from '@mui/material'
-import RefreshIcon from '@mui/icons-material/Refresh'
-
-const CONCURRENCY = 10
-const MAX_RETRIES = 1
-
-// Send a single-ID re-evaluate request. Returns the per-run result object.
-async function reEvaluateOne(buildID) {
-  const response = await fetch(
-    process.env.REACT_APP_API_URL + '/api/jobs/runs/reevaluate',
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ prow_job_build_ids: [buildID] }),
-    }
-  )
-
-  if (!response.ok) {
-    // The backend returns JSON errors: {"code": N, "message": "..."}
-    let errorMsg = `HTTP ${response.status}`
-    try {
-      const errBody = await response.json()
-      if (errBody.message) errorMsg = errBody.message
-    } catch {
-      // fall back to status text if response isn't JSON
-    }
-
-    if (response.status === 503) {
-      throw new Error(errorMsg)
-    }
-    return {
-      prow_job_build_id: buildID,
-      status: 'eval_error',
-      error: errorMsg,
-    }
-  }
-
-  const data = await response.json()
-  return data.results?.[0] ?? { prow_job_build_id: buildID, status: 'eval_error' }
-}
-
-// Run a pool of workers over a list of IDs, calling onProgress after each.
-async function runPool(ids, onProgress) {
-  const results = []
-  let index = 0
-
-  async function worker() {
-    while (index < ids.length) {
-      const i = index++
-      const result = await reEvaluateOne(ids[i])
-      results.push(result)
-      onProgress([...results])
-    }
-  }
-
-  await Promise.all(
-    Array.from({ length: Math.min(CONCURRENCY, ids.length) }, () => worker())
-  )
-  return results
-}
-
-export default function ReEvaluateButton({
-  prowJobBuildIDs,
-  onComplete,
-  disabled = false,
-}) {
-  const [running, setRunning] = useState(false)
-  const [progress, setProgress] = useState(null) // { total, results: [...] }
-  const [snackbar, setSnackbar] = useState(null) // { severity, message }
-
-  const handleReEvaluate = async () => {
-    if (!prowJobBuildIDs?.length) return
-    setRunning(true)
-    setSnackbar(null)
-
-    const total = prowJobBuildIDs.length
-    setProgress({ total, results: [] })
-
-    try {
-      // Initial pass
-      let results = await runPool(prowJobBuildIDs, (partial) =>
-        setProgress({ total, results: partial })
-      )
-
-      // Retry retryable errors (eval_error, rewrite_error) up to MAX_RETRIES times
-      for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-        const retryable = results.filter(
-          (r) => r.status === 'eval_error' || r.status === 'rewrite_error'
-        )
-        if (retryable.length === 0) break
-
-        const kept = results.filter(
-          (r) => r.status !== 'eval_error' && r.status !== 'rewrite_error'
-        )
-        const retryIDs = retryable.map((r) => r.prow_job_build_id)
-        const retryResults = await runPool(retryIDs, (partial) =>
-          setProgress({ total, results: [...kept, ...partial] })
-        )
-        results = [...kept, ...retryResults]
-        setProgress({ total, results })
-      }
-
-      // Summarize
-      const successCount = results.filter((r) => r.status === 'success').length
-      const rewriteErrors = results.filter(
-        (r) => r.status === 'rewrite_error'
-      )
-      const evalErrors = results.filter((r) => r.status === 'eval_error')
-      const missingErrors = results.filter((r) => r.status === 'missing_error')
-
-      if (rewriteErrors.length > 0) {
-        setSnackbar({
-          severity: 'error',
-          message: `${rewriteErrors.length} job run(s) failed during rewrite and may be in an inconsistent state.`,
-        })
-      } else if (successCount === 0 && missingErrors.length === results.length) {
-        setSnackbar({
-          severity: 'error',
-          message: 'None of the selected job run(s) were found in Sippy',
-        })
-      } else if (evalErrors.length > 0 && successCount === 0) {
-        setSnackbar({
-          severity: 'error',
-          message: `Re-evaluation failed for all ${evalErrors.length} job run(s)`,
-        })
-      } else if (evalErrors.length > 0 || missingErrors.length > 0) {
-        const parts = [`Re-evaluated ${successCount} job run(s)`]
-        if (evalErrors.length > 0)
-          parts.push(`${evalErrors.length} failed`)
-        if (missingErrors.length > 0)
-          parts.push(`${missingErrors.length} not found`)
-        parts.push('Refresh the page to see updated labels.')
-        setSnackbar({ severity: 'warning', message: parts.join(', ') })
-      } else {
-        setSnackbar({
-          severity: 'success',
-          message: `Successfully re-evaluated ${successCount} job run(s). Refresh the page to see updated labels.`,
-        })
-      }
-
-      if (onComplete && successCount > 0) onComplete()
-    } catch (err) {
-      // 503 or other fatal error from reEvaluateOne
-      setSnackbar({
-        severity: 'error',
-        message: `Re-evaluation failed: ${err.message}`,
-      })
-    } finally {
-      setRunning(false)
-    }
-  }
-
-  const isDisabled = disabled || running || !prowJobBuildIDs?.length
-
-  // Progress summary while running
-  const progressBar =
-    running && progress ? (
-      <Stack spacing={0.5} sx={{ minWidth: 200 }}>
-        <LinearProgress
-          variant="determinate"
-          value={(progress.results.length / progress.total) * 100}
-        />
-        <Typography variant="caption" color="text.secondary">
-          {progress.results.length}/{progress.total} completed
-          {progress.results.filter((r) => r.status === 'success').length > 0 &&
-            ` (${progress.results.filter((r) => r.status === 'success').length} succeeded)`}
-          {progress.results.filter((r) => r.status !== 'success').length > 0 &&
-            `, ${progress.results.filter((r) => r.status !== 'success').length} failed`}
-        </Typography>
-      </Stack>
-    ) : null
-
-  return (
-    <>
-      <Tooltip
-        title={
-          !prowJobBuildIDs?.length
-            ? 'Select job runs to re-evaluate'
-            : `Re-evaluate symptoms for ${prowJobBuildIDs.length} job run(s)`
-        }
-      >
-        <span>
-          <Button
-            variant="contained"
-            size="small"
-            startIcon={<RefreshIcon />}
-            onClick={handleReEvaluate}
-            disabled={isDisabled}
-          >
-            Re-evaluate Symptoms
-          </Button>
-        </span>
-      </Tooltip>
-
-      {progressBar}
-
-      <Snackbar
-        open={!!snackbar}
-        autoHideDuration={6000}
-        onClose={() => setSnackbar(null)}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      >
-        <Alert
-          severity={snackbar?.severity}
-          onClose={() => setSnackbar(null)}
-          variant="filled"
-        >
-          {snackbar?.message}
-        </Alert>
-      </Snackbar>
-    </>
-  )
-}
-```
+See the actual implementation in `sippy-ng/src/jobs/ReEvaluateSymptoms.js`.
 
 ### Design decisions
 
 - **One request per job run**: Each build ID is sent as a single-element request
   to the backend. This gives per-run progress feedback and isolates failures.
-- **Worker pool (10 concurrent)**: Up to 10 requests run in parallel using a
-  simple async queue pattern. Fast completions immediately start the next item,
-  so throughput is limited by the slowest individual run, not block boundaries.
+- **Worker pool (10 concurrent)**: Up to 10 requests run in parallel using
+  `p-limit`. Fast completions immediately start the next item, so throughput
+  is limited by the slowest individual run, not block boundaries.
 - **Automatic retries**: After the initial pass, `eval_error` and `rewrite_error`
   results are retried once. `eval_error` means nothing was written so retry is
   safe. `rewrite_error` means data may be inconsistent so retry is necessary.
   `missing_error` (build ID not found) is not retried.
 - **Progress indicator**: A `LinearProgress` bar with text summary appears inline
   next to the button while running, showing completed/total and success/fail counts.
-- **503 is fatal**: If the backend returns 503 (no BQ/GCS), `reEvaluateOne` throws
-  and the entire operation stops immediately (no point retrying other IDs).
-- **Error handling**: After all runs complete (including retries), a Snackbar shows
-  the final summary with status-aware messaging.
+- **All request failures are per-build results**: `reEvaluateOne` wraps everything
+  in a try/catch so that 503s, network failures, and JSON parse errors all return
+  `eval_error` results rather than throwing. This keeps every ID flowing through
+  the pool, retry, and progress reporting path. No single failure can abort the
+  entire batch.
+- **Error details in snackbar**: When there are failures, the snackbar includes a
+  deduplicated bulleted list of error messages from the API responses, with counts
+  when the same message repeats (e.g. "(3x) HTTP 503").
+- **Snackbar auto-hide**: Only success snackbars auto-hide after 6 seconds. Error
+  and warning snackbars stay open until the user dismisses them, giving time to
+  read error details.
 - **No batch size cap**: Since each request sends a single ID, the backend's 50-item
   limit is irrelevant. The concurrency limit (10) provides natural throttling.
 
@@ -302,7 +86,9 @@ those checked+visible rows are targeted.
 ### 2.2: Add the button to the action bar
 
 In the bottom `<Stack>` (around line 1778), add `ReEvaluateButton` alongside the
-existing `JAQOpenJobRunsButton` and `JAQCopyIdsButton`:
+existing `JAQOpenJobRunsButton` and `JAQCopyIdsButton`. The button is conditionally
+rendered based on the `write_endpoints` server capability (same pattern as
+`JAQSaveAsSymptomSection`):
 
 ```jsx
 import ReEvaluateButton from '../jobs/ReEvaluateSymptoms'
@@ -311,9 +97,12 @@ import ReEvaluateButton from '../jobs/ReEvaluateSymptoms'
 <Stack direction="row" spacing={2}>
   <JAQOpenJobRunsButton />
   <JAQCopyIdsButton />
-  <ReEvaluateButton
-    prowJobBuildIDs={idsToReEvaluate}
-  />
+  {capabilitiesContext.includes('write_endpoints') && (
+    <ReEvaluateButton
+      prowJobBuildIDs={idsToReEvaluate}
+      forceRefreshURL={forceRefreshURL}
+    />
+  )}
   <Tooltip title="Return to details report">
     <Button size="large" variant="contained" onClick={handleToggleJAQOpen}>
       <Close />
@@ -329,94 +118,51 @@ The tooltip should reflect the current targeting:
 - No checkbox selection: "Re-evaluate symptoms for N visible job run(s)"
 - With checkbox selection: "Re-evaluate symptoms for N selected job run(s)"
 
-### 2.4: `onComplete` callback - refresh parent data
+### 2.4: Cache invalidation via `forceRefreshURL`
 
-JAQ doesn't display symptom labels on job run rows (labels/symptoms are shown in
-the parent CR test details view). The parent data comes from `CompReadyTestPanel`'s
-`props.data`, which is fetched by a grandparent component. Threading a refetch
-callback through multiple component layers would be complex.
+The test_details report is cached (up to 8 hours or until the next rounding
+boundary). Re-evaluating symptoms writes new labels to BigQuery but does not
+invalidate the cache.
 
-Instead, on successful re-evaluation, include a note in the success Snackbar
-telling the user to refresh the page to see updated labels:
+To solve this without complex callback plumbing, the JAQ dialog accepts an
+optional `forceRefreshURL` prop. When provided, the success/warning snackbar
+shows a clickable "Reload with fresh data" link that navigates to the current
+page URL with `forceRefresh=true` appended, which tells the backend to bypass
+the cache.
+
+`CompReadyTestPanel` (the test_details parent) computes and passes this URL:
 
 ```jsx
-message: `Successfully re-evaluated ${successCount} job run(s). Refresh the page to see updated labels.`
+forceRefreshURL={(() => {
+  const url = new URL(window.location.href)
+  url.searchParams.set('forceRefresh', 'true')
+  return url.toString()
+})()}
 ```
 
-For partial success (warning snackbar), append the same note. This is honest about
-the limitation and avoids complex callback plumbing for the initial implementation.
-
-If a proper parent refresh is added later, the `onComplete` prop on
-`ReEvaluateButton` is already wired for it.
+Other JAQ callers do not pass `forceRefreshURL`, so they get the default
+"Refresh the page to see updated labels" text instead.
 
 ## Step 3: Testing
 
 ### 3.1: Component tests
 
-Using React Testing Library (or whatever test framework the project uses):
+See `sippy-ng/src/jobs/ReEvaluateSymptoms.test.js` for the full implementation.
+Key test cases:
 
-```jsx
-// ReEvaluateSymptoms.test.js
-
-describe('ReEvaluateButton', () => {
-  it('renders in default state', () => {
-    // Button text visible, not loading, not disabled
-  })
-
-  it('is disabled when prowJobBuildIDs is empty', () => {
-    // Button should be disabled with appropriate tooltip
-  })
-
-  it('is disabled when disabled prop is true', () => {
-    // External disable override works
-  })
-
-  it('shows progress bar during execution', () => {
-    // Mock fetch, click button, verify LinearProgress appears with counts
-  })
-
-  it('shows success snackbar when all runs succeed', () => {
-    // Mock fetch with success response for each ID
-  })
-
-  it('shows error snackbar on rewrite_error (inconsistent state)', () => {
-    // Mock fetch with rewrite_error result, verify urgent error message
-  })
-
-  it('shows error snackbar when all runs are missing_error', () => {
-    // Mock fetch with all missing_error, verify "not found" message
-  })
-
-  it('retries eval_error and rewrite_error once', () => {
-    // Mock fetch to return eval_error first, then success on retry
-    // Verify fetch is called twice for the same ID
-  })
-
-  it('does not retry missing_error', () => {
-    // Mock fetch with missing_error, verify no retry attempt
-  })
-
-  it('shows warning snackbar on partial success', () => {
-    // Mock fetch with mixed success + eval_error/missing_error, verify warning
-  })
-
-  it('calls onComplete when at least one succeeds', () => {
-    // Mock fetch, verify callback is invoked
-  })
-
-  it('does not call onComplete on total failure', () => {
-    // Mock fetch with all errors, verify callback NOT invoked
-  })
-
-  it('sends one request per build ID', () => {
-    // Pass 3 IDs, verify 3 separate fetch calls each with a single-element array
-  })
-
-  it('stops all workers on 503', () => {
-    // Mock fetch to return 503, verify no further requests are made
-  })
-})
-```
+- Renders in default state (button text visible, not disabled)
+- Disabled when `prowJobBuildIDs` is empty or `disabled` prop is true
+- Shows progress bar during execution (uses a deferred fetch response to assert
+  the `progressbar` role and "1/2 completed" text while a request is in flight)
+- Shows success snackbar when all runs succeed
+- Shows error snackbar on `rewrite_error` (inconsistent state)
+- Shows error snackbar when all runs are `missing_error`
+- Retries `eval_error` and `rewrite_error` once (verifies fetch called twice)
+- Does not retry `missing_error` (verifies fetch called once)
+- Shows warning snackbar on partial success (mixed success + errors)
+- Sends one request per build ID (verifies single-element body per call)
+- Treats 503 as `eval_error` and retries (verifies 6 fetch calls for 3 IDs,
+  error details shown in snackbar)
 
 ### 3.2: Integration / smoke tests
 
@@ -455,10 +201,14 @@ In the "UI Display" section, add a bullet for re-evaluation:
    others. Up to 10 requests run concurrently for throughput.
 
 3. **Button state clarity**: The button has three visible states:
-   - Ready - blue/primary, tooltip shows count of runs to re-evaluate
+   - Ready - blue/primary (`size="large"` to match other action bar buttons),
+     tooltip shows count of runs to re-evaluate
    - Running - disabled, with a `LinearProgress` bar and text summary
      ("5/20 completed, 4 succeeded, 1 failed") shown inline
-   - Done - Snackbar shows final success/warning/error summary
+   - Done - Snackbar shows final success/warning/error summary. Error and
+     warning snackbars include a deduplicated bulleted list of API error
+     messages and stay open until dismissed. Success snackbars auto-hide
+     after 6 seconds.
 
 4. **JAQ as single integration point**: Rather than adding the button to each
    parent page (test details, job runs table, payload table), it lives in JAQ's
@@ -466,14 +216,17 @@ In the "UI Display" section, add a bullet for re-evaluation:
    (`selectedJobRunIds`), and is reachable from all relevant pages. This avoids
    duplicating selection wiring and keeps symptom actions in one place. The button
    follows the same visible-rows-intersection pattern as `JAQCopyIdsButton` and
-   `JAQOpenJobRunsButton` for consistent behavior with table filters.
+   `JAQOpenJobRunsButton` for consistent behavior with table filters. The button
+   is only rendered when the server reports the `write_endpoints` capability
+   (same gate used by `JAQSaveAsSymptomSection`).
 
-5. **Refresh via page reload**: JAQ doesn't display symptom labels on job run
-   rows (labels are shown in the parent CR test details view). The parent data
-   originates from a grandparent component, so threading a refetch callback
-   would require changes across multiple layers. Instead, the success Snackbar
-   tells the user to refresh the page. The `onComplete` prop on
-   `ReEvaluateButton` is available for a proper refresh callback later.
+5. **Cache invalidation via forceRefresh link**: The test_details report is cached
+   in Redis (up to 8 hours). Re-evaluating symptoms writes new labels to BigQuery
+   but does not invalidate the cache. Rather than adding complex callback plumbing,
+   `CompReadyTestPanel` passes a `forceRefreshURL` prop (current page URL with
+   `forceRefresh=true` appended). On success, the snackbar shows a clickable
+   "Reload with fresh data" link. Other JAQ callers that don't pass the prop get
+   a plain "Refresh the page" message.
 
 6. **No confirmation dialog**: For the initial implementation, clicking the button
    immediately starts re-evaluation. A confirmation dialog could be added later if

--- a/docs/plans/trt-2695-retroactive-symptoms-frontend-plan.md
+++ b/docs/plans/trt-2695-retroactive-symptoms-frontend-plan.md
@@ -1,0 +1,497 @@
+# TRT-2695: Frontend Implementation Plan - Re-evaluate Symptoms UI Controls
+
+## Overview
+
+Add UI controls to Sippy that allow users to trigger retroactive symptom
+re-evaluation for selected job runs. The controls call the backend API endpoint
+(`POST /api/jobs/runs/reevaluate`) added in the backend implementation.
+
+**Jira:** [TRT-2695](https://redhat.atlassian.net/browse/TRT-2695)
+**Dependency:** The backend API endpoint must exist (or be mocked) before this work
+can be functionally tested.
+**Context doc:** `docs/features/job-analysis-symptoms.md` - update this doc when
+implementation is complete (see Step 4).
+
+## Prerequisites: Orientation
+
+Read and understand these files before starting:
+
+| File | What to learn |
+|------|---------------|
+| `sippy-ng/src/component_readiness/JobArtifactQuery.js` | JAQ dialog - the sole integration point for the re-evaluate button. Uses standard `fetch()` for symptom CRUD and artifact queries. Has its own job run selection via `selectedJobRunIds` (a `Set` initialized at line 164) with `SelectingCheckbox` per row. `searchJobRunIds` is also a `Set` (typed as `PropTypes.object`, uses `.has()`, `.union()`, `.difference()`, `.keys()`). Both contain prow build ID strings. The bottom action bar (near `JAQOpenJobRunsButton`, `JAQCopyIdsButton`, and the Close button) is where the re-evaluate button goes. All IDs in JAQ are strings, so no JS number precision concern. The existing action buttons (`JAQCopyIdsButton`, `JAQOpenJobRunsButton`) use a visible-rows-intersection pattern via `filteredRows` to scope their actions to visible rows only. |
+
+## Authentication Pattern
+
+Sippy uses SSO via an oauth proxy at the deployment level. The React frontend makes standard
+`fetch()` calls **without** injecting Authorization headers. Authentication is handled automatically
+by browser cookies and same-origin policy. Follow the same pattern - no auth logic needed in the
+component.
+
+## Step 1: Create the ReEvaluateButton Component
+
+Create `sippy-ng/src/jobs/ReEvaluateSymptoms.js`:
+
+```jsx
+import React, { useState } from 'react'
+import {
+  Alert,
+  Button,
+  LinearProgress,
+  Snackbar,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import RefreshIcon from '@mui/icons-material/Refresh'
+
+const CONCURRENCY = 10
+const MAX_RETRIES = 1
+
+// Send a single-ID re-evaluate request. Returns the per-run result object.
+async function reEvaluateOne(buildID) {
+  const response = await fetch(
+    process.env.REACT_APP_API_URL + '/api/jobs/runs/reevaluate',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prow_job_build_ids: [buildID] }),
+    }
+  )
+
+  if (!response.ok) {
+    // The backend returns JSON errors: {"code": N, "message": "..."}
+    let errorMsg = `HTTP ${response.status}`
+    try {
+      const errBody = await response.json()
+      if (errBody.message) errorMsg = errBody.message
+    } catch {
+      // fall back to status text if response isn't JSON
+    }
+
+    if (response.status === 503) {
+      throw new Error(errorMsg)
+    }
+    return {
+      prow_job_build_id: buildID,
+      status: 'eval_error',
+      error: errorMsg,
+    }
+  }
+
+  const data = await response.json()
+  return data.results?.[0] ?? { prow_job_build_id: buildID, status: 'eval_error' }
+}
+
+// Run a pool of workers over a list of IDs, calling onProgress after each.
+async function runPool(ids, onProgress) {
+  const results = []
+  let index = 0
+
+  async function worker() {
+    while (index < ids.length) {
+      const i = index++
+      const result = await reEvaluateOne(ids[i])
+      results.push(result)
+      onProgress([...results])
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, ids.length) }, () => worker())
+  )
+  return results
+}
+
+export default function ReEvaluateButton({
+  prowJobBuildIDs,
+  onComplete,
+  disabled = false,
+}) {
+  const [running, setRunning] = useState(false)
+  const [progress, setProgress] = useState(null) // { total, results: [...] }
+  const [snackbar, setSnackbar] = useState(null) // { severity, message }
+
+  const handleReEvaluate = async () => {
+    if (!prowJobBuildIDs?.length) return
+    setRunning(true)
+    setSnackbar(null)
+
+    const total = prowJobBuildIDs.length
+    setProgress({ total, results: [] })
+
+    try {
+      // Initial pass
+      let results = await runPool(prowJobBuildIDs, (partial) =>
+        setProgress({ total, results: partial })
+      )
+
+      // Retry retryable errors (eval_error, rewrite_error) up to MAX_RETRIES times
+      for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+        const retryable = results.filter(
+          (r) => r.status === 'eval_error' || r.status === 'rewrite_error'
+        )
+        if (retryable.length === 0) break
+
+        const kept = results.filter(
+          (r) => r.status !== 'eval_error' && r.status !== 'rewrite_error'
+        )
+        const retryIDs = retryable.map((r) => r.prow_job_build_id)
+        const retryResults = await runPool(retryIDs, (partial) =>
+          setProgress({ total, results: [...kept, ...partial] })
+        )
+        results = [...kept, ...retryResults]
+        setProgress({ total, results })
+      }
+
+      // Summarize
+      const successCount = results.filter((r) => r.status === 'success').length
+      const rewriteErrors = results.filter(
+        (r) => r.status === 'rewrite_error'
+      )
+      const evalErrors = results.filter((r) => r.status === 'eval_error')
+      const missingErrors = results.filter((r) => r.status === 'missing_error')
+
+      if (rewriteErrors.length > 0) {
+        setSnackbar({
+          severity: 'error',
+          message: `${rewriteErrors.length} job run(s) failed during rewrite and may be in an inconsistent state.`,
+        })
+      } else if (successCount === 0 && missingErrors.length === results.length) {
+        setSnackbar({
+          severity: 'error',
+          message: 'None of the selected job run(s) were found in Sippy',
+        })
+      } else if (evalErrors.length > 0 && successCount === 0) {
+        setSnackbar({
+          severity: 'error',
+          message: `Re-evaluation failed for all ${evalErrors.length} job run(s)`,
+        })
+      } else if (evalErrors.length > 0 || missingErrors.length > 0) {
+        const parts = [`Re-evaluated ${successCount} job run(s)`]
+        if (evalErrors.length > 0)
+          parts.push(`${evalErrors.length} failed`)
+        if (missingErrors.length > 0)
+          parts.push(`${missingErrors.length} not found`)
+        parts.push('Refresh the page to see updated labels.')
+        setSnackbar({ severity: 'warning', message: parts.join(', ') })
+      } else {
+        setSnackbar({
+          severity: 'success',
+          message: `Successfully re-evaluated ${successCount} job run(s). Refresh the page to see updated labels.`,
+        })
+      }
+
+      if (onComplete && successCount > 0) onComplete()
+    } catch (err) {
+      // 503 or other fatal error from reEvaluateOne
+      setSnackbar({
+        severity: 'error',
+        message: `Re-evaluation failed: ${err.message}`,
+      })
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  const isDisabled = disabled || running || !prowJobBuildIDs?.length
+
+  // Progress summary while running
+  const progressBar =
+    running && progress ? (
+      <Stack spacing={0.5} sx={{ minWidth: 200 }}>
+        <LinearProgress
+          variant="determinate"
+          value={(progress.results.length / progress.total) * 100}
+        />
+        <Typography variant="caption" color="text.secondary">
+          {progress.results.length}/{progress.total} completed
+          {progress.results.filter((r) => r.status === 'success').length > 0 &&
+            ` (${progress.results.filter((r) => r.status === 'success').length} succeeded)`}
+          {progress.results.filter((r) => r.status !== 'success').length > 0 &&
+            `, ${progress.results.filter((r) => r.status !== 'success').length} failed`}
+        </Typography>
+      </Stack>
+    ) : null
+
+  return (
+    <>
+      <Tooltip
+        title={
+          !prowJobBuildIDs?.length
+            ? 'Select job runs to re-evaluate'
+            : `Re-evaluate symptoms for ${prowJobBuildIDs.length} job run(s)`
+        }
+      >
+        <span>
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<RefreshIcon />}
+            onClick={handleReEvaluate}
+            disabled={isDisabled}
+          >
+            Re-evaluate Symptoms
+          </Button>
+        </span>
+      </Tooltip>
+
+      {progressBar}
+
+      <Snackbar
+        open={!!snackbar}
+        autoHideDuration={6000}
+        onClose={() => setSnackbar(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity={snackbar?.severity}
+          onClose={() => setSnackbar(null)}
+          variant="filled"
+        >
+          {snackbar?.message}
+        </Alert>
+      </Snackbar>
+    </>
+  )
+}
+```
+
+### Design decisions
+
+- **One request per job run**: Each build ID is sent as a single-element request
+  to the backend. This gives per-run progress feedback and isolates failures.
+- **Worker pool (10 concurrent)**: Up to 10 requests run in parallel using a
+  simple async queue pattern. Fast completions immediately start the next item,
+  so throughput is limited by the slowest individual run, not block boundaries.
+- **Automatic retries**: After the initial pass, `eval_error` and `rewrite_error`
+  results are retried once. `eval_error` means nothing was written so retry is
+  safe. `rewrite_error` means data may be inconsistent so retry is necessary.
+  `missing_error` (build ID not found) is not retried.
+- **Progress indicator**: A `LinearProgress` bar with text summary appears inline
+  next to the button while running, showing completed/total and success/fail counts.
+- **503 is fatal**: If the backend returns 503 (no BQ/GCS), `reEvaluateOne` throws
+  and the entire operation stops immediately (no point retrying other IDs).
+- **Error handling**: After all runs complete (including retries), a Snackbar shows
+  the final summary with status-aware messaging.
+- **No batch size cap**: Since each request sends a single ID, the backend's 50-item
+  limit is irrelevant. The concurrency limit (10) provides natural throttling.
+
+## Step 2: Integrate into the JAQ Dialog
+
+The re-evaluate button lives inside `JobArtifactQuery.js`, not in each parent page.
+JAQ is opened from multiple places (CR test details, job runs table) and already has
+its own job run selection (`selectedJobRunIds`, a `Set<string>` of build IDs). By
+placing the button in JAQ's action bar, all callers get re-evaluation for free.
+
+### 2.1: Determine which IDs to use
+
+Follow the same visible-rows-intersection pattern used by `JAQCopyIdsButton` (line
+851) and `JAQOpenJobRunsButton` (line 892). These buttons scope their actions to
+visible (filtered) rows and intersect with the user's checkbox selection:
+
+```jsx
+let visible = new Set(filteredRows.map((row) => row.job_run_id))
+let selected = selectedJobRunIds.intersection(visible)
+const idsToReEvaluate = (selected.size > 0 ? selected : visible).keys().toArray()
+```
+
+This ensures the button respects table filters: if the user has filtered the table,
+only visible rows are targeted. If the user has also checked specific rows, only
+those checked+visible rows are targeted.
+
+### 2.2: Add the button to the action bar
+
+In the bottom `<Stack>` (around line 1778), add `ReEvaluateButton` alongside the
+existing `JAQOpenJobRunsButton` and `JAQCopyIdsButton`:
+
+```jsx
+import ReEvaluateButton from '../jobs/ReEvaluateSymptoms'
+
+// In the bottom action bar:
+<Stack direction="row" spacing={2}>
+  <JAQOpenJobRunsButton />
+  <JAQCopyIdsButton />
+  <ReEvaluateButton
+    prowJobBuildIDs={idsToReEvaluate}
+  />
+  <Tooltip title="Return to details report">
+    <Button size="large" variant="contained" onClick={handleToggleJAQOpen}>
+      <Close />
+      Close
+    </Button>
+  </Tooltip>
+</Stack>
+```
+
+### 2.3: Tooltip behavior
+
+The tooltip should reflect the current targeting:
+- No checkbox selection: "Re-evaluate symptoms for N visible job run(s)"
+- With checkbox selection: "Re-evaluate symptoms for N selected job run(s)"
+
+### 2.4: `onComplete` callback - refresh parent data
+
+JAQ doesn't display symptom labels on job run rows (labels/symptoms are shown in
+the parent CR test details view). The parent data comes from `CompReadyTestPanel`'s
+`props.data`, which is fetched by a grandparent component. Threading a refetch
+callback through multiple component layers would be complex.
+
+Instead, on successful re-evaluation, include a note in the success Snackbar
+telling the user to refresh the page to see updated labels:
+
+```jsx
+message: `Successfully re-evaluated ${successCount} job run(s). Refresh the page to see updated labels.`
+```
+
+For partial success (warning snackbar), append the same note. This is honest about
+the limitation and avoids complex callback plumbing for the initial implementation.
+
+If a proper parent refresh is added later, the `onComplete` prop on
+`ReEvaluateButton` is already wired for it.
+
+## Step 3: Testing
+
+### 3.1: Component tests
+
+Using React Testing Library (or whatever test framework the project uses):
+
+```jsx
+// ReEvaluateSymptoms.test.js
+
+describe('ReEvaluateButton', () => {
+  it('renders in default state', () => {
+    // Button text visible, not loading, not disabled
+  })
+
+  it('is disabled when prowJobBuildIDs is empty', () => {
+    // Button should be disabled with appropriate tooltip
+  })
+
+  it('is disabled when disabled prop is true', () => {
+    // External disable override works
+  })
+
+  it('shows progress bar during execution', () => {
+    // Mock fetch, click button, verify LinearProgress appears with counts
+  })
+
+  it('shows success snackbar when all runs succeed', () => {
+    // Mock fetch with success response for each ID
+  })
+
+  it('shows error snackbar on rewrite_error (inconsistent state)', () => {
+    // Mock fetch with rewrite_error result, verify urgent error message
+  })
+
+  it('shows error snackbar when all runs are missing_error', () => {
+    // Mock fetch with all missing_error, verify "not found" message
+  })
+
+  it('retries eval_error and rewrite_error once', () => {
+    // Mock fetch to return eval_error first, then success on retry
+    // Verify fetch is called twice for the same ID
+  })
+
+  it('does not retry missing_error', () => {
+    // Mock fetch with missing_error, verify no retry attempt
+  })
+
+  it('shows warning snackbar on partial success', () => {
+    // Mock fetch with mixed success + eval_error/missing_error, verify warning
+  })
+
+  it('calls onComplete when at least one succeeds', () => {
+    // Mock fetch, verify callback is invoked
+  })
+
+  it('does not call onComplete on total failure', () => {
+    // Mock fetch with all errors, verify callback NOT invoked
+  })
+
+  it('sends one request per build ID', () => {
+    // Pass 3 IDs, verify 3 separate fetch calls each with a single-element array
+  })
+
+  it('stops all workers on 503', () => {
+    // Mock fetch to return 503, verify no further requests are made
+  })
+})
+```
+
+### 3.2: Integration / smoke tests
+
+- Button appears in JAQ action bar (bottom of dialog)
+- Opening JAQ from CR test details shows the button with all job runs
+- Opening JAQ from job runs table shows the button with selected job runs
+- With no JAQ selection, button targets all visible/filtered job runs
+- With JAQ selection, button targets only selected+visible runs
+- Filtering the table reduces the set of targeted job runs
+- Clicking sends one request per build ID (not a batch)
+- Progress bar updates as each request completes
+- Retryable errors are retried automatically
+- Snackbar shows final summary after all runs complete (including retries)
+
+## Step 4: Update Documentation
+
+### 4.1: Update `docs/features/job-analysis-symptoms.md`
+
+In the "UI Display" section, add a bullet for re-evaluation:
+
+```markdown
+- Re-evaluation controls - button in the JAQ dialog action bar. Triggers
+  retroactive symptom matching for selected (or all) job runs in the dialog
+  (requires SSO authentication via the write-enabled deployment).
+```
+
+## Design Notes
+
+1. **No explicit auth headers**: SSO is handled by the oauth proxy. Standard
+   `fetch()` works because the browser includes cookies automatically. Do NOT add
+   Authorization header logic - it would break the existing auth flow.
+
+2. **One request per job run**: Each build ID is sent as a separate single-element
+   API request. This avoids the backend's 50-item batch limit entirely, gives
+   per-run progress feedback, and isolates failures so one bad run doesn't block
+   others. Up to 10 requests run concurrently for throughput.
+
+3. **Button state clarity**: The button has three visible states:
+   - Ready - blue/primary, tooltip shows count of runs to re-evaluate
+   - Running - disabled, with a `LinearProgress` bar and text summary
+     ("5/20 completed, 4 succeeded, 1 failed") shown inline
+   - Done - Snackbar shows final success/warning/error summary
+
+4. **JAQ as single integration point**: Rather than adding the button to each
+   parent page (test details, job runs table, payload table), it lives in JAQ's
+   action bar. JAQ is already the symptom-focused UI, has its own job run selection
+   (`selectedJobRunIds`), and is reachable from all relevant pages. This avoids
+   duplicating selection wiring and keeps symptom actions in one place. The button
+   follows the same visible-rows-intersection pattern as `JAQCopyIdsButton` and
+   `JAQOpenJobRunsButton` for consistent behavior with table filters.
+
+5. **Refresh via page reload**: JAQ doesn't display symptom labels on job run
+   rows (labels are shown in the parent CR test details view). The parent data
+   originates from a grandparent component, so threading a refetch callback
+   would require changes across multiple layers. Instead, the success Snackbar
+   tells the user to refresh the page. The `onComplete` prop on
+   `ReEvaluateButton` is available for a proper refresh callback later.
+
+6. **No confirmation dialog**: For the initial implementation, clicking the button
+   immediately starts re-evaluation. A confirmation dialog could be added later if
+   users find accidental clicks problematic, but symptom re-evaluation is non-
+   destructive (it's idempotent - running it twice produces the same result).
+
+7. **`dry_run` not exposed**: The backend accepts an optional `dry_run` boolean in
+   the request body (logs what would happen without writing). This is useful for
+   debugging via curl but not needed in the UI. The frontend omits it (the backend
+   defaults to `false`).
+
+8. **Backend strict parsing**: The backend handler uses `DisallowUnknownFields()`
+   on the request body decoder. The frontend must only send known fields
+   (`prow_job_build_ids` and optionally `dry_run`). Adding extra fields to the
+   request body would cause a 400 error. Error responses are JSON
+   (`{"code": N, "message": "..."}`), so the frontend parses `.message` from the
+   response body for user-facing error display.
+
+9. **Future enhancement**: Consider adding a "Re-evaluate" option to a row-level
+   context menu (right-click or kebab menu) for single-run re-evaluation without
+   needing to use checkbox selection. This can be a follow-up.

--- a/pkg/api/jobs.go
+++ b/pkg/api/jobs.go
@@ -294,7 +294,7 @@ func PrintJobDetailsReportFromDB(w http.ResponseWriter, req *http.Request, dbc *
 		}
 
 		newRun := v1sippyprocessing.JobRunResult{
-			ProwID:                pjr.ID,
+			ProwID:                strconv.FormatUint(uint64(pjr.ID), 10),
 			Job:                   jobName,
 			URL:                   pjr.URL,
 			TestFailures:          pjr.TestFailures,

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -342,7 +342,7 @@ type JobRun struct {
 	Variants              pq.StringArray      `json:"variants" gorm:"type:text[]"`
 	Tags                  pq.StringArray      `json:"tags" gorm:"type:text[]"`
 	TestGridURL           string              `json:"test_grid_url"`
-	ProwID                uint                `json:"prow_id"`
+	ProwID                string              `json:"prow_id"`
 	Job                   string              `json:"job"`
 	Cluster               string              `json:"cluster"`
 	URL                   string              `json:"url"`

--- a/pkg/apis/sippyprocessing/v1/types.go
+++ b/pkg/apis/sippyprocessing/v1/types.go
@@ -103,9 +103,9 @@ func (r *JobOverallResult) String() string {
 	}
 }
 
-// JobRunResult represents a single invocation of a prow job and it's status, as well as any failed tests.
+// JobRunResult represents a single invocation of a prow job and its status, as well as any failed tests.
 type JobRunResult struct {
-	ProwID          uint     `json:"prowID"`
+	ProwID          string   `json:"prowID"`
 	Job             string   `json:"job"`
 	URL             string   `json:"url"`
 	TestFailures    int      `json:"testFailures"`

--- a/sippy-ng/package-lock.json
+++ b/sippy-ng/package-lock.json
@@ -34,6 +34,7 @@
         "date-fns-tz": "^1.1.6",
         "eventemitter3": "^5.0.1",
         "idb-keyval": "^6.2.2",
+        "p-limit": "^3.1.0",
         "plotly.js": "^3.1.1",
         "prop-types": "^15.8.1",
         "query-string": "^4.3.4",
@@ -20923,7 +20924,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -28800,7 +28801,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },

--- a/sippy-ng/package.json
+++ b/sippy-ng/package.json
@@ -29,6 +29,7 @@
     "date-fns-tz": "^1.1.6",
     "eventemitter3": "^5.0.1",
     "idb-keyval": "^6.2.2",
+    "p-limit": "^3.1.0",
     "plotly.js": "^3.1.1",
     "prop-types": "^15.8.1",
     "query-string": "^4.3.4",

--- a/sippy-ng/src/component_readiness/CompReadyTestPanel.js
+++ b/sippy-ng/src/component_readiness/CompReadyTestPanel.js
@@ -392,6 +392,11 @@ export default function CompReadyTestPanel(props) {
               searchJobRunIds={searchJobRunIds}
               jobRunsLookup={jobRuns}
               handleToggleJAQOpen={handleToggleJAQOpen}
+              forceRefreshURL={(() => {
+                const url = new URL(window.location.href)
+                url.searchParams.set('forceRefresh', 'true')
+                return url.toString()
+              })()}
             />
           </Box>
         </Grid>

--- a/sippy-ng/src/component_readiness/JobArtifactQuery.js
+++ b/sippy-ng/src/component_readiness/JobArtifactQuery.js
@@ -52,6 +52,7 @@ import LaunderedLink, { openLaunderedLink } from '../components/Laundry'
 import PropTypes from 'prop-types'
 import React, { Fragment } from 'react'
 import ReactMarkdown from 'react-markdown'
+import ReEvaluateButton from '../jobs/ReEvaluateSymptoms'
 import remarkGfm from 'remark-gfm'
 
 const emptyContentMatch = {
@@ -134,7 +135,14 @@ const prefilledOptions = new Map([
 ])
 
 export default function JobArtifactQuery(props) {
-  const { searchJobRunIds, jobRunsLookup, handleToggleJAQOpen } = props
+  const {
+    searchJobRunIds,
+    jobRunsLookup,
+    handleToggleJAQOpen,
+    forceRefreshURL,
+  } = props
+
+  const capabilitiesContext = React.useContext(SippyCapabilitiesContext)
 
   /*********************************************************************************
    shared state for artifact query components
@@ -1775,9 +1783,19 @@ export default function JobArtifactQuery(props) {
         )}
       </Stack>
       <JAQResultTable />
-      <Stack direction="row" spacing={2}>
+      <Stack direction="row" spacing={2} alignItems="center">
         <JAQOpenJobRunsButton />
         <JAQCopyIdsButton />
+        {capabilitiesContext.includes('write_endpoints') && (
+          <ReEvaluateButton
+            prowJobBuildIDs={(() => {
+              let visible = new Set(filteredRows.map((row) => row.job_run_id))
+              let selected = selectedJobRunIds.intersection(visible)
+              return (selected.size > 0 ? selected : visible).keys().toArray()
+            })()}
+            forceRefreshURL={forceRefreshURL}
+          />
+        )}
         <Tooltip title="Return to details report">
           <Button
             size="large"
@@ -1797,4 +1815,5 @@ JobArtifactQuery.propTypes = {
   searchJobRunIds: PropTypes.object.isRequired,
   jobRunsLookup: PropTypes.instanceOf(Map).isRequired,
   handleToggleJAQOpen: PropTypes.func.isRequired,
+  forceRefreshURL: PropTypes.string,
 }

--- a/sippy-ng/src/jobs/JobRunsTable.js
+++ b/sippy-ng/src/jobs/JobRunsTable.js
@@ -82,18 +82,11 @@ export default function JobRunsTable(props) {
 
   const startDate = getReportStartDate(React.useContext(ReportEndContext))
 
-  function extractProwRunId(url) {
-    if (!url) return null
-    const parts = url.replace(/\/+$/, '').split('/')
-    return parts[parts.length - 1]
-  }
-
   function buildJaqProps(rows) {
     const jobRunIds = new Set()
     const lookup = new Map()
     for (const row of rows) {
-      // Extract the run ID from the prow URL to avoid JS number precision loss
-      const runId = extractProwRunId(row.url)
+      const runId = row.prow_id
       if (!runId) continue
       jobRunIds.add(runId)
       lookup.set(runId, {

--- a/sippy-ng/src/jobs/ReEvaluateSymptoms.js
+++ b/sippy-ng/src/jobs/ReEvaluateSymptoms.js
@@ -100,7 +100,7 @@ function errorDetails(failures) {
   )
 }
 
-function forceRefreshMessage(successCount, forceRefreshURL) {
+function forceRefreshMessage(forceRefreshURL) {
   if (!forceRefreshURL) {
     return `Refresh the page to see updated labels.`
   }
@@ -232,8 +232,7 @@ export default function ReEvaluateButton({
           severity: 'warning',
           message: (
             <>
-              {parts.join(', ')}.{' '}
-              {forceRefreshMessage(successCount, forceRefreshURL)}
+              {parts.join(', ')}. {forceRefreshMessage(forceRefreshURL)}
               {errorDetails(allErrors)}
             </>
           ),
@@ -244,7 +243,7 @@ export default function ReEvaluateButton({
           message: (
             <>
               Successfully re-evaluated {successCount} job run(s).{' '}
-              {forceRefreshMessage(successCount, forceRefreshURL)}
+              {forceRefreshMessage(forceRefreshURL)}
             </>
           ),
         })

--- a/sippy-ng/src/jobs/ReEvaluateSymptoms.js
+++ b/sippy-ng/src/jobs/ReEvaluateSymptoms.js
@@ -8,6 +8,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
+import pLimit from 'p-limit'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import RefreshIcon from '@mui/icons-material/Refresh'
@@ -64,21 +65,16 @@ async function reEvaluateOne(buildID) {
 }
 
 async function runPool(ids, onProgress) {
+  const limit = pLimit(CONCURRENCY)
   const results = []
-  let index = 0
-
-  async function worker() {
-    while (index < ids.length) {
-      const i = index++
-      const result = await reEvaluateOne(ids[i])
+  const tasks = ids.map((id) =>
+    limit(async () => {
+      const result = await reEvaluateOne(id)
       results.push(result)
       onProgress([...results])
-    }
-  }
-
-  await Promise.all(
-    Array.from({ length: Math.min(CONCURRENCY, ids.length) }, () => worker())
+    })
   )
+  await Promise.all(tasks)
   return results
 }
 

--- a/sippy-ng/src/jobs/ReEvaluateSymptoms.js
+++ b/sippy-ng/src/jobs/ReEvaluateSymptoms.js
@@ -1,0 +1,332 @@
+import {
+  Alert,
+  Button,
+  LinearProgress,
+  Link,
+  Snackbar,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import PropTypes from 'prop-types'
+import React, { useState } from 'react'
+import RefreshIcon from '@mui/icons-material/Refresh'
+
+const CONCURRENCY = 10
+const MAX_RETRIES = 1
+const REQUEST_TIMEOUT_MS = 120000
+
+async function reEvaluateOne(buildID) {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  try {
+    const response = await fetch(
+      process.env.REACT_APP_API_URL + '/api/jobs/runs/reevaluate',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prow_job_build_ids: [buildID] }),
+        signal: controller.signal,
+      }
+    )
+
+    if (!response.ok) {
+      let errorMsg = `HTTP ${response.status}`
+      try {
+        const errBody = await response.json()
+        if (errBody.message) errorMsg = errBody.message
+      } catch {
+        // fall back to status text if response isn't JSON
+      }
+      return {
+        prow_job_build_id: buildID,
+        status: 'eval_error',
+        error: errorMsg,
+      }
+    }
+
+    const data = await response.json()
+    return (
+      data.results?.[0] ?? { prow_job_build_id: buildID, status: 'eval_error' }
+    )
+  } catch (err) {
+    return {
+      prow_job_build_id: buildID,
+      status: 'eval_error',
+      error:
+        err.name === 'AbortError'
+          ? 'request timed out'
+          : err.message || String(err),
+    }
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+async function runPool(ids, onProgress) {
+  const results = []
+  let index = 0
+
+  async function worker() {
+    while (index < ids.length) {
+      const i = index++
+      const result = await reEvaluateOne(ids[i])
+      results.push(result)
+      onProgress([...results])
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, ids.length) }, () => worker())
+  )
+  return results
+}
+
+function errorDetails(failures) {
+  const byMessage = new Map()
+  for (const f of failures) {
+    const msg = f.error || 'unknown error'
+    byMessage.set(msg, (byMessage.get(msg) || 0) + 1)
+  }
+  return (
+    <ul style={{ margin: '4px 0 0', paddingLeft: 20 }}>
+      {[...byMessage.entries()].map(([msg, count]) => (
+        <li key={msg}>
+          {count > 1 ? `(${count}x) ` : ''}
+          {msg}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function forceRefreshMessage(successCount, forceRefreshURL) {
+  if (!forceRefreshURL) {
+    return `Refresh the page to see updated labels.`
+  }
+  return (
+    <>
+      <Link href={forceRefreshURL} color="inherit" underline="always">
+        Reload with fresh data
+      </Link>{' '}
+      to see updated labels.
+    </>
+  )
+}
+
+export default function ReEvaluateButton({
+  prowJobBuildIDs,
+  forceRefreshURL,
+  disabled = false,
+}) {
+  const [running, setRunning] = useState(false)
+  const [progress, setProgress] = useState(null)
+  const [snackbar, setSnackbar] = useState(null)
+
+  const handleReEvaluate = async () => {
+    if (!prowJobBuildIDs?.length) return
+    setRunning(true)
+    setSnackbar(null)
+
+    const total = prowJobBuildIDs.length
+    setProgress({ total, results: [] })
+
+    try {
+      let results = await runPool(prowJobBuildIDs, (partial) =>
+        setProgress({ total, results: partial })
+      )
+
+      for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+        const retryable = results.filter(
+          (r) => r.status === 'eval_error' || r.status === 'rewrite_error'
+        )
+        if (retryable.length === 0) break
+
+        const kept = results.filter(
+          (r) => r.status !== 'eval_error' && r.status !== 'rewrite_error'
+        )
+        const retryIDs = retryable.map((r) => r.prow_job_build_id)
+        const retryResults = await runPool(retryIDs, (partial) =>
+          setProgress({ total, results: [...kept, ...partial] })
+        )
+        results = [...kept, ...retryResults]
+        setProgress({ total, results })
+      }
+
+      const successCount = results.filter((r) => r.status === 'success').length
+      const rewriteErrors = results.filter((r) => r.status === 'rewrite_error')
+      const evalErrors = results.filter((r) => r.status === 'eval_error')
+      const missingErrors = results.filter((r) => r.status === 'missing_error')
+
+      const allErrors = [...rewriteErrors, ...evalErrors, ...missingErrors]
+
+      if (rewriteErrors.length > 0) {
+        const parts = []
+        if (successCount > 0) parts.push(`${successCount} succeeded`)
+        parts.push(
+          `${rewriteErrors.length} failed during rewrite and may be in an inconsistent state`
+        )
+        if (evalErrors.length > 0)
+          parts.push(`${evalErrors.length} failed to evaluate`)
+        if (missingErrors.length > 0)
+          parts.push(`${missingErrors.length} not found`)
+        setSnackbar({
+          severity: 'error',
+          message: (
+            <>
+              {parts.join(', ')}.
+              {rewriteErrors.length > 0 && (
+                <>
+                  <strong>Rewrite errors:</strong>
+                  {errorDetails(rewriteErrors)}
+                </>
+              )}
+              {evalErrors.length > 0 && (
+                <>
+                  <strong>Evaluation errors:</strong>
+                  {errorDetails(evalErrors)}
+                </>
+              )}
+              {missingErrors.length > 0 && (
+                <>
+                  <strong>Not found:</strong>
+                  {errorDetails(missingErrors)}
+                </>
+              )}
+            </>
+          ),
+        })
+      } else if (
+        successCount === 0 &&
+        missingErrors.length === results.length
+      ) {
+        setSnackbar({
+          severity: 'error',
+          message: (
+            <>
+              None of the selected job run(s) were found in Sippy
+              {errorDetails(missingErrors)}
+            </>
+          ),
+        })
+      } else if (
+        evalErrors.length > 0 &&
+        successCount === 0 &&
+        missingErrors.length === 0
+      ) {
+        setSnackbar({
+          severity: 'error',
+          message: (
+            <>
+              Re-evaluation failed for all {evalErrors.length} job run(s)
+              {errorDetails(evalErrors)}
+            </>
+          ),
+        })
+      } else if (evalErrors.length > 0 || missingErrors.length > 0) {
+        const parts = [`Re-evaluated ${successCount} job run(s)`]
+        if (evalErrors.length > 0) parts.push(`${evalErrors.length} failed`)
+        if (missingErrors.length > 0)
+          parts.push(`${missingErrors.length} not found`)
+        setSnackbar({
+          severity: 'warning',
+          message: (
+            <>
+              {parts.join(', ')}.{' '}
+              {forceRefreshMessage(successCount, forceRefreshURL)}
+              {errorDetails(allErrors)}
+            </>
+          ),
+        })
+      } else {
+        setSnackbar({
+          severity: 'success',
+          message: (
+            <>
+              Successfully re-evaluated {successCount} job run(s).{' '}
+              {forceRefreshMessage(successCount, forceRefreshURL)}
+            </>
+          ),
+        })
+      }
+    } catch (err) {
+      setSnackbar({
+        severity: 'error',
+        message: `Re-evaluation failed: ${err.message}`,
+      })
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  const isDisabled = disabled || running || !prowJobBuildIDs?.length
+
+  const progressBar =
+    running && progress ? (
+      <Stack spacing={0.5} sx={{ minWidth: 200 }}>
+        <LinearProgress
+          variant="determinate"
+          value={(progress.results.length / progress.total) * 100}
+        />
+        <Typography variant="caption" color="text.secondary">
+          {progress.results.length}/{progress.total} completed
+          {progress.results.filter((r) => r.status === 'success').length > 0 &&
+            ` (${
+              progress.results.filter((r) => r.status === 'success').length
+            } succeeded)`}
+          {progress.results.filter((r) => r.status !== 'success').length > 0 &&
+            `, ${
+              progress.results.filter((r) => r.status !== 'success').length
+            } failed`}
+        </Typography>
+      </Stack>
+    ) : null
+
+  return (
+    <>
+      <Tooltip
+        title={
+          !prowJobBuildIDs?.length
+            ? 'Select job runs to re-evaluate'
+            : `Re-evaluate symptoms for ${prowJobBuildIDs.length} job run(s)`
+        }
+      >
+        <span>
+          <Button
+            variant="contained"
+            size="large"
+            startIcon={<RefreshIcon />}
+            onClick={handleReEvaluate}
+            disabled={isDisabled}
+          >
+            Re-evaluate Symptoms
+          </Button>
+        </span>
+      </Tooltip>
+
+      {progressBar}
+
+      <Snackbar
+        open={!!snackbar}
+        autoHideDuration={snackbar?.severity === 'success' ? 6000 : null}
+        onClose={() => setSnackbar(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        sx={{ maxWidth: '80vw' }}
+      >
+        <Alert
+          severity={snackbar?.severity}
+          onClose={() => setSnackbar(null)}
+          variant="filled"
+        >
+          {snackbar?.message}
+        </Alert>
+      </Snackbar>
+    </>
+  )
+}
+
+ReEvaluateButton.propTypes = {
+  prowJobBuildIDs: PropTypes.arrayOf(PropTypes.string),
+  forceRefreshURL: PropTypes.string,
+  disabled: PropTypes.bool,
+}

--- a/sippy-ng/src/jobs/ReEvaluateSymptoms.test.js
+++ b/sippy-ng/src/jobs/ReEvaluateSymptoms.test.js
@@ -1,0 +1,247 @@
+import '@testing-library/jest-dom'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import ReEvaluateButton from './ReEvaluateSymptoms'
+import userEvent from '@testing-library/user-event'
+
+beforeEach(() => {
+  jest.restoreAllMocks()
+  process.env.REACT_APP_API_URL = ''
+})
+
+function mockFetchResponses(...responses) {
+  const iter = responses[Symbol.iterator]()
+  global.fetch = jest.fn(() => {
+    const next = iter.next()
+    if (next.done) throw new Error('unexpected extra fetch call')
+    return Promise.resolve(next.value)
+  })
+}
+
+function successResponse(buildID) {
+  return {
+    ok: true,
+    status: 200,
+    json: () =>
+      Promise.resolve({
+        results: [{ prow_job_build_id: buildID, status: 'success' }],
+      }),
+  }
+}
+
+function errorResponse(buildID, status) {
+  return {
+    ok: true,
+    status: 200,
+    json: () =>
+      Promise.resolve({
+        results: [{ prow_job_build_id: buildID, status }],
+      }),
+  }
+}
+
+function httpErrorResponse(httpStatus, message) {
+  return {
+    ok: false,
+    status: httpStatus,
+    json: () => Promise.resolve({ code: httpStatus, message }),
+  }
+}
+
+describe('ReEvaluateButton', () => {
+  it('renders in default state', () => {
+    render(<ReEvaluateButton prowJobBuildIDs={['1']} />)
+    expect(screen.getByText('Re-evaluate Symptoms')).toBeInTheDocument()
+    expect(screen.getByRole('button')).not.toBeDisabled()
+  })
+
+  it('is disabled when prowJobBuildIDs is empty', () => {
+    render(<ReEvaluateButton prowJobBuildIDs={[]} />)
+    expect(screen.getByRole('button')).toBeDisabled()
+  })
+
+  it('is disabled when disabled prop is true', () => {
+    render(<ReEvaluateButton prowJobBuildIDs={['1']} disabled={true} />)
+    expect(screen.getByRole('button')).toBeDisabled()
+  })
+
+  it('shows progress bar during execution', async () => {
+    let resolveSecond
+    const deferredSecond = new Promise((r) => {
+      resolveSecond = r
+    })
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(successResponse('1'))
+      .mockReturnValueOnce(deferredSecond.then(() => successResponse('2')))
+    render(<ReEvaluateButton prowJobBuildIDs={['1', '2']} />)
+
+    await act(async () => {
+      userEvent.click(screen.getByRole('button'))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('progressbar')).toBeInTheDocument()
+      expect(screen.getByText(/1\/2 completed/)).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      resolveSecond()
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Successfully re-evaluated 2/)
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('shows success snackbar when all runs succeed', async () => {
+    mockFetchResponses(successResponse('1'), successResponse('2'))
+    render(<ReEvaluateButton prowJobBuildIDs={['1', '2']} />)
+
+    await act(async () => {
+      userEvent.click(screen.getByRole('button'))
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Successfully re-evaluated 2 job run(s). Refresh the page to see updated labels.'
+        )
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('shows error snackbar on rewrite_error (inconsistent state)', async () => {
+    mockFetchResponses(
+      errorResponse('1', 'rewrite_error'),
+      errorResponse('1', 'rewrite_error')
+    )
+    render(<ReEvaluateButton prowJobBuildIDs={['1']} />)
+
+    await act(async () => {
+      userEvent.click(screen.getByRole('button'))
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /failed during rewrite and may be in an inconsistent state/
+        )
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('shows error snackbar when all runs are missing_error', async () => {
+    mockFetchResponses(errorResponse('1', 'missing_error'))
+    render(<ReEvaluateButton prowJobBuildIDs={['1']} />)
+
+    await act(async () => {
+      userEvent.click(screen.getByRole('button'))
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('None of the selected job run(s) were found in Sippy')
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('retries eval_error and rewrite_error once', async () => {
+    mockFetchResponses(errorResponse('1', 'eval_error'), successResponse('1'))
+    render(<ReEvaluateButton prowJobBuildIDs={['1']} />)
+
+    await act(async () => {
+      userEvent.click(screen.getByRole('button'))
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Successfully re-evaluated 1/)
+      ).toBeInTheDocument()
+    })
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry missing_error', async () => {
+    mockFetchResponses(errorResponse('1', 'missing_error'))
+    render(<ReEvaluateButton prowJobBuildIDs={['1']} />)
+
+    await act(async () => {
+      userEvent.click(screen.getByRole('button'))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(/were found in Sippy/)).toBeInTheDocument()
+    })
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows warning snackbar on partial success', async () => {
+    mockFetchResponses(
+      successResponse('1'),
+      errorResponse('2', 'eval_error'),
+      errorResponse('2', 'eval_error')
+    )
+    render(<ReEvaluateButton prowJobBuildIDs={['1', '2']} />)
+
+    await act(async () => {
+      userEvent.click(screen.getByRole('button'))
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Re-evaluated 1 job run\(s\)/)
+      ).toBeInTheDocument()
+      expect(screen.getByText(/1 failed/)).toBeInTheDocument()
+    })
+  })
+
+  it('sends one request per build ID', async () => {
+    mockFetchResponses(
+      successResponse('1'),
+      successResponse('2'),
+      successResponse('3')
+    )
+    render(<ReEvaluateButton prowJobBuildIDs={['1', '2', '3']} />)
+
+    await act(async () => {
+      userEvent.click(screen.getByRole('button'))
+    })
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(3)
+    })
+    const sentIDs = global.fetch.mock.calls.map((call) => {
+      const body = JSON.parse(call[1].body)
+      expect(body.prow_job_build_ids).toHaveLength(1)
+      return body.prow_job_build_ids[0]
+    })
+    expect(sentIDs.sort()).toEqual(['1', '2', '3'])
+  })
+
+  it('treats 503 as eval_error and retries', async () => {
+    mockFetchResponses(
+      httpErrorResponse(503, 'Service Unavailable'),
+      httpErrorResponse(503, 'Service Unavailable'),
+      httpErrorResponse(503, 'Service Unavailable'),
+      httpErrorResponse(503, 'Service Unavailable'),
+      httpErrorResponse(503, 'Service Unavailable'),
+      httpErrorResponse(503, 'Service Unavailable')
+    )
+    render(<ReEvaluateButton prowJobBuildIDs={['1', '2', '3']} />)
+
+    await act(async () => {
+      userEvent.click(screen.getByRole('button'))
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Re-evaluation failed for all 3/)
+      ).toBeInTheDocument()
+      expect(screen.getByText(/Service Unavailable/)).toBeInTheDocument()
+    })
+    expect(global.fetch).toHaveBeenCalledTimes(6)
+  })
+})


### PR DESCRIPTION
Use the existing API for re-applying symptoms and make it available wherever there's a JobArtifactQuery dialog; that way when you use the JAQ to modify symptom definitions and see where they would apply, you can then just "make it so".

<img width="705" height="342" alt="image" src="https://github.com/user-attachments/assets/ed4fba95-a8d0-4798-81a2-3352a1f2c947" />
<img width="923" height="346" alt="image" src="https://github.com/user-attachments/assets/474ed1e2-f456-4417-bc11-3c3a118bbd09" />
<img width="710" height="86" alt="image" src="https://github.com/user-attachments/assets/67ff5b3c-89d0-4a3a-9434-a8e72712fe15" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added JAQ “Re-evaluate” action to retroactively match symptoms for selected or all visible job runs.
  - Runs with bounded parallelism and shows execution progress plus success/warning/error snackbars, including optional “reload with fresh data”.
  - Retries recoverable evaluation failures and times out individual requests.
  - Requires write-enabled authentication.

- **Bug Fixes**
  - Improved Prow job identifier consistency across job runs and processing results (now consistently treated as strings).

- **Documentation**
  - Updated the re-evaluation workflow description and completion status.

- **Tests**
  - Added Jest/RTL coverage for UI states, targeting, progress, snackbars, retries, and HTTP failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->