### PR TITLE
Improvements and fixes for new Feature Gate page

### DIFF
--- a/cmd/sippy/seed_data.go
+++ b/cmd/sippy/seed_data.go
@@ -374,7 +374,7 @@ var syntheticTests = []syntheticTestSpec{
 		},
 	},
 	{
-		testID: "test-cap-aws-dual-stack-install", testName: "install should succeed: overall",
+		testID: "test-cap-aws-dual-stack-install", testName: "install should succeed: infrastructure",
 		component: "Installer / openshift-installer", capabilities: []string{"install"},
 		jobCounts: map[string]map[string]testCount{
 			awsAmd64CapabilityAWSDualStackInstall: {"4.22": {50, 47, 0}},

--- a/cmd/sippy/seed_data.go
+++ b/cmd/sippy/seed_data.go
@@ -185,12 +185,22 @@ var syntheticJobs = []syntheticJobDef{
 			"Capability": "NetworkSegmentation",
 		},
 	},
+	{
+		nameTemplate: "periodic-ci-openshift-release-master-ci-%s-e2e-aws-ovn-amd64-capability-awsdualstackinstall",
+		variants: map[string]string{
+			"Platform": "aws", "Architecture": "amd64", "Network": "ovn",
+			"Topology": "ha", "Installer": "ipi", "FeatureSet": "default",
+			"Suite": "parallel", "Upgrade": "none", "LayeredProduct": "none",
+			"Capability": "AWSDualStackInstall",
+		},
+	},
 }
 
 // Job template constants for referencing specific jobs in test specs.
 const awsAmd64Parallel = "periodic-ci-openshift-release-master-ci-%s-e2e-aws-ovn-amd64"
 const awsArm64Parallel = "periodic-ci-openshift-release-master-ci-%s-e2e-aws-ovn-arm64"
 const gcpAmd64Parallel = "periodic-ci-openshift-release-master-ci-%s-e2e-gcp-ovn-amd64"
+const awsAmd64CapabilityAWSDualStackInstall = "periodic-ci-openshift-release-master-ci-%s-e2e-aws-ovn-amd64-capability-awsdualstackinstall"
 
 // allJobTemplates returns name templates from syntheticJobs for use in test specs
 // that should run on every job (e.g. install tests).
@@ -361,6 +371,13 @@ var syntheticTests = []syntheticTestSpec{
 		component: "Installer / openshift-installer", capabilities: []string{"AWSDualStackInstall"},
 		jobCounts: map[string]map[string]testCount{
 			awsAmd64Parallel: {"4.22": {50, 48, 0}},
+		},
+	},
+	{
+		testID: "test-cap-aws-dual-stack-install", testName: "install should succeed: overall",
+		component: "Installer / openshift-installer", capabilities: []string{"install"},
+		jobCounts: map[string]map[string]testCount{
+			awsAmd64CapabilityAWSDualStackInstall: {"4.22": {50, 47, 0}},
 		},
 	},
 	// --- Install / health indicator tests: run on every job, every release ---

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -750,9 +750,16 @@ func injectFeatureGateHATEOASLinks(fg *apitype.FeatureGate, release, baseAPIURL,
 	}
 	fg.Links["tests_by_annotation"] = buildFilteredTestsURL(baseAPIURL, release, annotationFilter)
 
+	// Installer gates currently run a broad conformance suite where full passes aren't
+	// required, so "install should succeed" is the meaningful signal. Switch to
+	// "openshift-tests should work" once installer jobs run a minimal conformance suite.
+	capabilityTestName := "openshift-tests should work"
+	if strings.Contains(fg.FeatureGate, "Install") {
+		capabilityTestName = "install should succeed"
+	}
 	capabilityFilter := filter.Filter{
 		Items: []filter.FilterItem{
-			{Field: "name", Operator: filter.OperatorContains, Value: "openshift-tests should work"},
+			{Field: "name", Operator: filter.OperatorContains, Value: capabilityTestName},
 			{Field: "variants", Operator: filter.OperatorContains, Value: fmt.Sprintf("Capability:%s", fg.FeatureGate)},
 		},
 		LinkOperator: filter.LinkOperatorAnd,

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -760,7 +760,7 @@ func injectFeatureGateHATEOASLinks(fg *apitype.FeatureGate, release, baseAPIURL,
 	fg.Links["tests_by_capability"] = buildFilteredTestsURL(baseAPIURL, release, capabilityFilter)
 
 	fg.Links["ui_detail"] = fmt.Sprintf(
-		"%s/feature_gates/%s/%s",
+		"%s/sippy-ng/feature_gates/%s/%s",
 		baseFrontendURL, release, url.PathEscape(fg.FeatureGate))
 }
 

--- a/sippy-ng/src/App.js
+++ b/sippy-ng/src/App.js
@@ -260,12 +260,23 @@ const JobsWrapper = () => {
 }
 
 const FeatureGateDetailWrapper = () => {
-  let { release, feature_gate } = useParams()
+  const { release, feature_gate } = useParams()
   const navigate = useNavigate()
+  const releases = React.useContext(ReleasesContext)
+
+  const effectiveRelease =
+    release === 'latest' ? findFirstNonGARelease(releases) : release
+
+  React.useEffect(() => {
+    if (release === 'latest' && effectiveRelease) {
+      navigate(`/feature_gates/${effectiveRelease}/${feature_gate}`, {
+        replace: true,
+      })
+    }
+  }, [release, effectiveRelease, feature_gate, navigate])
 
   if (release === 'latest') {
-    release = findFirstNonGARelease(React.useContext(ReleasesContext))
-    navigate(`/feature_gates/${release}/${feature_gate}`, { replace: true })
+    return null
   }
 
   return (

--- a/sippy-ng/src/tests/FeatureGateDetail.js
+++ b/sippy-ng/src/tests/FeatureGateDetail.js
@@ -7,11 +7,13 @@ import {
   Container,
   Tab,
   Tabs,
+  Tooltip,
   Typography,
 } from '@mui/material'
 import { Link } from 'react-router-dom'
 import { safeEncodeURIComponent } from '../helpers'
 import Alert from '@mui/material/Alert'
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import PropTypes from 'prop-types'
 import React, { Fragment, useEffect } from 'react'
 import SimpleBreadcrumbs from '../components/SimpleBreadcrumbs'
@@ -154,6 +156,16 @@ export default function FeatureGateDetail(props) {
             </Typography>
             <Typography variant="body1" sx={{ mb: 1 }}>
               <strong>Total Test Count:</strong> {gate.unique_test_count}
+              <Tooltip title="Unique test names. The tables below may show more rows due to per-variant breakdowns.">
+                <HelpOutlineIcon
+                  fontSize="small"
+                  sx={{
+                    ml: 0.5,
+                    verticalAlign: 'middle',
+                    color: 'text.secondary',
+                  }}
+                />
+              </Tooltip>
             </Typography>
             <Typography variant="body1" component="div">
               <strong>Enabled:</strong>{' '}

--- a/sippy-ng/src/tests/FeatureGateDetail.js
+++ b/sippy-ng/src/tests/FeatureGateDetail.js
@@ -9,126 +9,13 @@ import {
   Tabs,
   Typography,
 } from '@mui/material'
-import { DataGrid } from '@mui/x-data-grid'
-import { filterFor, multiple, safeEncodeURIComponent } from '../helpers'
 import { Link } from 'react-router-dom'
+import { safeEncodeURIComponent } from '../helpers'
 import Alert from '@mui/material/Alert'
 import PropTypes from 'prop-types'
 import React, { Fragment, useEffect } from 'react'
 import SimpleBreadcrumbs from '../components/SimpleBreadcrumbs'
-
-function TestResultsSection({ title, apiUrl, release, extraFilters = [] }) {
-  const [rows, setRows] = React.useState([])
-  const [isLoaded, setLoaded] = React.useState(false)
-  const [fetchError, setFetchError] = React.useState('')
-  const [sortModel, setSortModel] = React.useState([
-    { field: 'current_pass_percentage', sort: 'asc' },
-  ])
-
-  useEffect(() => {
-    if (!apiUrl) {
-      setRows([])
-      setLoaded(true)
-      return
-    }
-    setLoaded(false)
-    setFetchError('')
-
-    fetch(apiUrl)
-      .then((response) => {
-        if (response.status !== 200) {
-          throw new Error('server returned ' + response.status)
-        }
-        return response.json()
-      })
-      .then((json) => {
-        setRows(json || [])
-        setLoaded(true)
-      })
-      .catch((error) => {
-        setFetchError('Could not retrieve ' + title + ': ' + error)
-        setLoaded(true)
-      })
-  }, [apiUrl, title])
-
-  const columns = [
-    {
-      field: 'name',
-      headerName: 'Test Name',
-      flex: 4,
-      renderCell: (params) => {
-        const path =
-          `/tests/${release}/details?` +
-          multiple(filterFor('name', 'equals', params.value), ...extraFilters)
-        return <Link to={path}>{params.value}</Link>
-      },
-    },
-    {
-      field: 'current_successes',
-      headerName: 'Current Successes',
-      type: 'number',
-      flex: 1,
-    },
-    {
-      field: 'current_failures',
-      headerName: 'Current Failures',
-      type: 'number',
-      flex: 1,
-    },
-    {
-      field: 'current_flakes',
-      headerName: 'Current Flakes',
-      type: 'number',
-      flex: 1,
-    },
-    {
-      field: 'current_pass_percentage',
-      headerName: 'Current Pass %',
-      type: 'number',
-      flex: 1,
-      renderCell: (params) =>
-        params.value != null ? params.value.toFixed(2) + '%' : '',
-    },
-    {
-      field: 'current_runs',
-      headerName: 'Current Runs',
-      type: 'number',
-      flex: 1,
-    },
-  ]
-
-  if (fetchError) {
-    return <Alert severity="error">{fetchError}</Alert>
-  }
-
-  return (
-    <Box sx={{ mt: 2 }}>
-      <Typography variant="h6" sx={{ mb: 1 }}>
-        {title} ({isLoaded ? rows.length : '...'} tests)
-      </Typography>
-      <DataGrid
-        loading={!isLoaded}
-        rows={rows}
-        columns={columns}
-        getRowId={(row) => row.name}
-        getRowHeight={() => 'auto'}
-        autoHeight={true}
-        rowsPerPageOptions={[10, 25, 50]}
-        pageSize={25}
-        sortModel={sortModel}
-        onSortModelChange={setSortModel}
-        disableSelectionOnClick
-      />
-    </Box>
-  )
-}
-
-TestResultsSection.propTypes = {
-  title: PropTypes.string.isRequired,
-  apiUrl: PropTypes.string,
-  release: PropTypes.string.isRequired,
-  extraFilters: PropTypes.array,
-}
+import TestTable from './TestTable'
 
 export default function FeatureGateDetail(props) {
   const { release, featureGate } = props
@@ -179,6 +66,40 @@ export default function FeatureGateDetail(props) {
         setLoaded(true)
       })
   }, [release, featureGate])
+
+  const annotationFilter = {
+    items: [
+      {
+        columnField: 'name',
+        operatorValue: 'contains',
+        value: `FeatureGate:${featureGate}]`,
+      },
+    ],
+  }
+
+  // Installer gates currently run a broad conformance suite where full passes
+  // aren't required, so "install should succeed" is the meaningful signal.
+  // Switch to "openshift-tests should work" once installer jobs run a minimal
+  // conformance suite.
+  const capabilityTestName = featureGate.includes('Install')
+    ? 'install should succeed'
+    : 'openshift-tests should work'
+
+  const capabilityFilter = {
+    items: [
+      {
+        columnField: 'name',
+        operatorValue: 'contains',
+        value: capabilityTestName,
+      },
+      {
+        columnField: 'variants',
+        operatorValue: 'has entry containing',
+        value: `Capability:${featureGate}`,
+      },
+    ],
+    linkOperator: 'and',
+  }
 
   if (fetchError) {
     return (
@@ -255,26 +176,21 @@ export default function FeatureGateDetail(props) {
           </Tabs>
         </Box>
 
-        {activeTab === 0 && gate.links && (
-          <TestResultsSection
-            title="Tests tagged with FeatureGate annotation"
-            apiUrl={gate.links.tests_by_annotation}
+        {activeTab === 0 && (
+          <TestTable
+            key={'fg-annotation-' + featureGate}
             release={release}
+            collapse={false}
+            filterModel={annotationFilter}
           />
         )}
 
-        {activeTab === 1 && gate.links && (
-          <TestResultsSection
-            title="Tests matching capability variant"
-            apiUrl={gate.links.tests_by_capability}
+        {activeTab === 1 && (
+          <TestTable
+            key={'fg-capability-' + featureGate}
             release={release}
-            extraFilters={[
-              filterFor(
-                'variants',
-                'has entry containing',
-                `Capability:${featureGate}`
-              ),
-            ]}
+            collapse={false}
+            filterModel={capabilityFilter}
           />
         )}
       </Container>

--- a/sippy-ng/src/tests/FeatureGateDetail.js
+++ b/sippy-ng/src/tests/FeatureGateDetail.js
@@ -71,6 +71,7 @@ export default function FeatureGateDetail(props) {
 
   const tabAutoSelected = React.useRef(false)
 
+  // <= 1 because the API always returns an implicit "Overall" row
   const handleAnnotationDataLoaded = React.useCallback((count) => {
     if (!tabAutoSelected.current && count <= 1) {
       setActiveTab(1)

--- a/sippy-ng/src/tests/FeatureGateDetail.js
+++ b/sippy-ng/src/tests/FeatureGateDetail.js
@@ -10,14 +10,14 @@ import {
   Typography,
 } from '@mui/material'
 import { DataGrid } from '@mui/x-data-grid'
+import { filterFor, multiple, safeEncodeURIComponent } from '../helpers'
 import { Link } from 'react-router-dom'
-import { pathForTestByVariant, safeEncodeURIComponent } from '../helpers'
 import Alert from '@mui/material/Alert'
 import PropTypes from 'prop-types'
 import React, { Fragment, useEffect } from 'react'
 import SimpleBreadcrumbs from '../components/SimpleBreadcrumbs'
 
-function TestResultsSection({ title, apiUrl, release }) {
+function TestResultsSection({ title, apiUrl, release, extraFilters = [] }) {
   const [rows, setRows] = React.useState([])
   const [isLoaded, setLoaded] = React.useState(false)
   const [fetchError, setFetchError] = React.useState('')
@@ -56,11 +56,12 @@ function TestResultsSection({ title, apiUrl, release }) {
       field: 'name',
       headerName: 'Test Name',
       flex: 4,
-      renderCell: (params) => (
-        <Link to={pathForTestByVariant(release, params.value)}>
-          {params.value}
-        </Link>
-      ),
+      renderCell: (params) => {
+        const path =
+          `/tests/${release}/details?` +
+          multiple(filterFor('name', 'equals', params.value), ...extraFilters)
+        return <Link to={path}>{params.value}</Link>
+      },
     },
     {
       field: 'current_successes',
@@ -126,6 +127,7 @@ TestResultsSection.propTypes = {
   title: PropTypes.string.isRequired,
   apiUrl: PropTypes.string,
   release: PropTypes.string.isRequired,
+  extraFilters: PropTypes.array,
 }
 
 export default function FeatureGateDetail(props) {
@@ -266,6 +268,13 @@ export default function FeatureGateDetail(props) {
             title="Tests matching capability variant"
             apiUrl={gate.links.tests_by_capability}
             release={release}
+            extraFilters={[
+              filterFor(
+                'variants',
+                'has entry containing',
+                `Capability:${featureGate}`
+              ),
+            ]}
           />
         )}
       </Container>

--- a/sippy-ng/src/tests/FeatureGateDetail.js
+++ b/sippy-ng/src/tests/FeatureGateDetail.js
@@ -69,6 +69,15 @@ export default function FeatureGateDetail(props) {
       })
   }, [release, featureGate])
 
+  const tabAutoSelected = React.useRef(false)
+
+  const handleAnnotationDataLoaded = React.useCallback((count) => {
+    if (!tabAutoSelected.current && count <= 1) {
+      setActiveTab(1)
+      tabAutoSelected.current = true
+    }
+  }, [])
+
   const annotationFilter = {
     items: [
       {
@@ -188,23 +197,24 @@ export default function FeatureGateDetail(props) {
           </Tabs>
         </Box>
 
-        {activeTab === 0 && (
+        <Box sx={{ display: activeTab === 0 ? 'block' : 'none' }}>
           <TestTable
             key={'fg-annotation-' + featureGate}
             release={release}
             collapse={false}
             filterModel={annotationFilter}
+            onDataLoaded={handleAnnotationDataLoaded}
           />
-        )}
+        </Box>
 
-        {activeTab === 1 && (
+        <Box sx={{ display: activeTab === 1 ? 'block' : 'none' }}>
           <TestTable
             key={'fg-capability-' + featureGate}
             release={release}
             collapse={false}
             filterModel={capabilityFilter}
           />
-        )}
+        </Box>
       </Container>
     </Fragment>
   )

--- a/sippy-ng/src/tests/FeatureGates.js
+++ b/sippy-ng/src/tests/FeatureGates.js
@@ -296,7 +296,9 @@ export default function FeatureGates(props) {
     if (params.row.links && params.row.links.ui_detail) {
       try {
         const url = new URL(params.row.links.ui_detail)
-        return url.pathname
+        const basename = '/sippy-ng'
+        const path = url.pathname
+        return path.startsWith(basename) ? path.slice(basename.length) : path
       } catch (e) {
         // fall through
       }

--- a/sippy-ng/src/tests/TestTable.js
+++ b/sippy-ng/src/tests/TestTable.js
@@ -962,13 +962,13 @@ function TestTable(props) {
         return response.json()
       })
       .then((json) => {
-        if (json != null) {
-          setRows(json)
-        } else {
-          setRows([])
-        }
+        const data = json != null ? json : []
+        setRows(data)
         setLoaded(true)
         setSearching(false)
+        if (props.onDataLoaded) {
+          props.onDataLoaded(data.length)
+        }
       })
       .catch((error) => {
         setFetchError(
@@ -991,10 +991,12 @@ function TestTable(props) {
       setSearching(true)
       fetchData()
     } else {
-      // Mark as loaded so we don't show loading spinner, and clear any stale data
       setRows([])
       setLoaded(true)
       setSearching(false)
+      if (props.onDataLoaded) {
+        props.onDataLoaded(0)
+      }
     }
 
     prevLocation.current = location
@@ -1178,6 +1180,7 @@ TestTable.propTypes = {
   sortField: PropTypes.string,
   rowsPerPageOptions: PropTypes.array,
   view: PropTypes.string,
+  onDataLoaded: PropTypes.func,
 }
 
 export default withStyles(generateClasses(TEST_THRESHOLDS))(TestTable)

--- a/test/e2e/feature_gates_test.go
+++ b/test/e2e/feature_gates_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/openshift/sippy/pkg/apis/api"
@@ -54,8 +55,14 @@ func TestFeatureGatesHATEOASLinks(t *testing.T) {
 			testsCapability, ok := fg.Links["tests_by_capability"]
 			assert.True(t, ok, "missing tests_by_capability link")
 			assert.Contains(t, testsCapability, "/api/tests?release="+util.Release)
-			assert.Contains(t, testsCapability, "openshift-tests+should+work")
 			assert.Contains(t, testsCapability, "Capability%3A"+fg.FeatureGate)
+			if strings.Contains(fg.FeatureGate, "Install") {
+				assert.Contains(t, testsCapability, "install+should+succeed",
+					"Install gates should use install test for capability link")
+			} else {
+				assert.Contains(t, testsCapability, "openshift-tests+should+work",
+					"non-Install gates should use openshift-tests for capability link")
+			}
 
 			uiDetail, ok := fg.Links["ui_detail"]
 			assert.True(t, ok, "missing ui_detail link")
@@ -111,6 +118,32 @@ func TestFeatureGatesCapabilityLinkFollowable(t *testing.T) {
 	assert.Greater(t, len(tests), 0, "expected tests when following tests_by_capability link for NetworkSegmentation")
 	for _, test := range tests {
 		assert.Contains(t, test.Name, "openshift-tests should work", "test name should contain openshift-tests should work")
+	}
+}
+
+func TestFeatureGatesInstallCapabilityLinkFollowable(t *testing.T) {
+	var gates []api.FeatureGate
+	err := util.SippyGet("/api/feature_gates?release="+util.Release, &gates)
+	require.NoError(t, err)
+
+	gatesByName := make(map[string]api.FeatureGate)
+	for _, g := range gates {
+		gatesByName[g.FeatureGate] = g
+	}
+
+	fg, ok := gatesByName["AWSDualStackInstall"]
+	require.True(t, ok, "AWSDualStackInstall not found")
+
+	link := fg.Links["tests_by_capability"]
+	require.NotEmpty(t, link)
+
+	var tests []api.Test
+	err = util.SippyGetAbsolute(link, &tests)
+	require.NoError(t, err, "failed to follow tests_by_capability link")
+	assert.Greater(t, len(tests), 0, "expected tests when following tests_by_capability link for AWSDualStackInstall")
+	for _, test := range tests {
+		assert.Contains(t, test.Name, "install should succeed",
+			"install gate capability tests should match install tests")
 	}
 }
 

--- a/test/e2e/feature_gates_test.go
+++ b/test/e2e/feature_gates_test.go
@@ -143,7 +143,7 @@ func TestFeatureGatesInstallCapabilityLinkFollowable(t *testing.T) {
 	assert.Greater(t, len(tests), 0, "expected tests when following tests_by_capability link for AWSDualStackInstall")
 	for _, test := range tests {
 		assert.Contains(t, test.Name, "install should succeed",
-			"install gate capability tests should match install tests")
+			"install gate capability tests should contain install tests")
 	}
 }
 


### PR DESCRIPTION
- **Fix hook ordering**
- **Fix ui_details links for feature gates**
- **Continue using install success for install feature gates**
- **Fix clickthrough on test details from fg details page**
- **Re-use test details table on feature gate details page**
- **Tooltip for why test count differs from table**
- **Auto-display tests by capability if annotations tab is empty**

I was a bit ambitious with the move to capability jobs and all tests should pass, this is not feasible for installer gates in flight as they still run full test suites that fully pass very rarely, and no true conformance suite exists yet. For now, install gates will return to requiring good pass results for install should succeed tests as they did before.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added AWS dual-stack installation capability test coverage for release 4.22.
  - Feature gate details now show capability-specific test results, including installation tests.
  - Added explanatory help text for the Total Test Count metric.
- **Bug Fixes**
  - Improved feature gate links for installation and non-installation capabilities.
  - Fixed navigation when viewing the latest release.
  - Corrected feature gate detail links across frontend routes.
- **Tests**
  - Added end-to-end coverage confirming AWS dual-stack capability links return installation test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->