### PR TITLE
TRT-2789: publish 5.0 metrics from view that omits OS variant

### DIFF
--- a/pkg/api/disruption_report.go
+++ b/pkg/api/disruption_report.go
@@ -23,15 +23,6 @@ func GetDisruptionVsPrevGAReportFromBigQuery(ctx context.Context, client *bigque
 	return GetDataFromCacheOrGenerate[apitype.DisruptionReport](ctx, client.Cache, cache.RequestOptions{}, NewCacheSpec(generator, "", nil), generator.GenerateReport, apitype.DisruptionReport{})
 }
 
-func GetDisruptionVsTwoWeeksAgoReportFromBigQuery(ctx context.Context, client *bigquery.Client) (apitype.DisruptionReport, []error) {
-	generator := disruptionReportGenerator{
-		client:   client,
-		ViewName: "BackendDisruptionPercentilesDeltaCurrentVs14DaysAgoV2",
-	}
-
-	return GetDataFromCacheOrGenerate[apitype.DisruptionReport](ctx, client.Cache, cache.RequestOptions{}, NewCacheSpec(generator, "", nil), generator.GenerateReport, apitype.DisruptionReport{})
-}
-
 type disruptionReportGenerator struct {
 	client   *bigquery.Client
 	ViewName string

--- a/pkg/api/disruption_report.go
+++ b/pkg/api/disruption_report.go
@@ -16,8 +16,9 @@ import (
 
 func GetDisruptionVsPrevGAReportFromBigQuery(ctx context.Context, client *bigquery.Client) (apitype.DisruptionReport, []error) {
 	generator := disruptionReportGenerator{
-		client:   client,
-		ViewName: "BackendDisruptionPercentilesDeltaCurrentVsPrevGAV2",
+		client: client,
+		// ViewName: "BackendDisruptionPercentilesDeltaCurrentVsPrevGAV2",
+		ViewName: "BackendDisruptionPercentilesDeltaCurrentVsPrevGAV5", // for 5.0 per TRT-2789
 	}
 
 	return GetDataFromCacheOrGenerate[apitype.DisruptionReport](ctx, client.Cache, cache.RequestOptions{}, NewCacheSpec(generator, "", nil), generator.GenerateReport, apitype.DisruptionReport{})


### PR DESCRIPTION
disruption alerts are driven by sippy reporting metrics to prometheus. sippy reads from a bigquery view to do this; while we are looking at 5.0 disruption data, we will want to look at the new view that was created for this purpose to deliberately not partition data by the OS variant. likely this part can be reverted once 5.0 is GA.

also deleted some dead code for looking at a different view. probably no need to bring that back later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated disruption reports to use the latest data view, improving accuracy for the 5.0 release.
  * Preserved the existing three-day reporting window and report format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->