### PR TITLE
TRT-2741: Add ga-test-status to default loaders

### DIFF
--- a/cmd/sippy/load.go
+++ b/cmd/sippy/load.go
@@ -100,7 +100,7 @@ func (f *LoadFlags) BindFlags(fs *pflag.FlagSet) {
 	f.JiraFlags.BindFlags(fs)
 
 	fs.BoolVar(&f.InitDatabase, "init-database", false, "Migrate the DB before loading")
-	fs.StringArrayVar(&f.Loaders, "loader", []string{"release-definitions", "prow", "releases", "jira", "github", "bugs", "test-mapping", "feature-gates"}, "Which data sources to use for data loading")
+	fs.StringArrayVar(&f.Loaders, "loader", []string{"release-definitions", "prow", "releases", "jira", "github", "bugs", "test-mapping", "feature-gates", "ga-test-status"}, "Which data sources to use for data loading")
 	fs.StringArrayVar(&f.Releases, "release", f.Releases, "Which releases to load (one per arg instance)")
 	fs.StringArrayVar(&f.Architectures, "arch", f.Architectures, "Which architectures to load (one per arg instance)")
 	fs.StringVar(&f.JobVariantsInputFile, "job-variants-input-file", "expected-job-variants.json", "JSON input file for the job-variants loader")


### PR DESCRIPTION
## Summary

- Adds `ga-test-status` to the default loader list so it runs as part of the regular `fetchdata` cronjob
- Placed last in the list since it depends on the prow loader having populated dimension tables (tests, prow_jobs, suites)

## Evidence

Production load of all 18 GA releases completed in under 6 minutes when running in-cluster:

| Release | BQ fetch | COPY to temp | INSERT...SELECT | Total |
|---------|----------|-------------|-----------------|-------|
| 4.22 (4.7M rows) | 33s | 13s | 28s | 41s |
| 4.21 (3.9M rows) | 22s | 11s | 26s | 37s |
| 4.20 (3.0M rows) | 18s | 8s | 20s | 28s |
| 4.19 (2.2M rows) | 17s | 7s | 14s | 21s |
| 4.18 (1.2M rows) | 15s | 3s | 7s | 11s |
| 4.17-4.13 | 13-15s | 1-2s | 2-3s | 3-5s |
| **Total** | | | | **~6 min** |

The loader is idempotent (skips releases already loaded with matching GA date), so on subsequent runs it only processes new GA releases.

## Test plan

- [x] `go build` compiles
- [x] Verified production load timing justifies inclusion in default loaders

🤖 Generated with [Claude Code](https://claude.com/claude-code)