### PR TITLE
Remove all code references to test_daily_summaries table

### DIFF
--- a/cmd/sippy/backfill.go
+++ b/cmd/sippy/backfill.go
@@ -29,7 +29,7 @@ func NewBackfillFlags() *BackfillFlags {
 
 func (f *BackfillFlags) BindFlags(fs *pflag.FlagSet) {
 	f.DBFlags.BindFlags(fs)
-	fs.StringVar(&f.Table, "table", "", "Table to backfill (daily-summaries, daily-totals, cumulative-summaries)")
+	fs.StringVar(&f.Table, "table", "", "Table to backfill (daily-totals, cumulative-summaries)")
 	fs.StringVar(&f.StartDate, "start-date", "", "Start date (YYYY-MM-DD)")
 	fs.StringVar(&f.EndDate, "end-date", "", "End date (YYYY-MM-DD)")
 }
@@ -41,7 +41,7 @@ func NewBackfillCommand() *cobra.Command {
 		Use:   "backfill",
 		Short: "Backfill a specific summary table for a date range",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			validTables := sets.New[string]("daily-summaries", "daily-totals", "cumulative-summaries")
+			validTables := sets.New[string]("daily-totals", "cumulative-summaries")
 			if f.Table == "" {
 				return fmt.Errorf("--table is required")
 			}

--- a/cmd/sippy/seed_data.go
+++ b/cmd/sippy/seed_data.go
@@ -502,7 +502,7 @@ func seedSyntheticData(dbc *db.DB) error {
 	seedToday := civil.DateOf(time.Now().UTC())
 	seedStart := seedToday.AddDays(-190)
 	seedEnd := seedToday
-	for _, table := range []string{"daily-summaries", "daily-totals", "cumulative-summaries"} {
+	for _, table := range []string{"daily-totals", "cumulative-summaries"} {
 		if err := sippyserver.BackfillData(dbc, table, seedStart, seedEnd); err != nil {
 			return fmt.Errorf("failed to backfill %s: %w", table, err)
 		}

--- a/pkg/db/dailysummary/dailysummary.go
+++ b/pkg/db/dailysummary/dailysummary.go
@@ -65,13 +65,6 @@ type summaryStore interface {
 	AggregateRangeForRelease(start, end civil.Date, release string, skipConflictDetection bool) error
 }
 
-// Refresh aggregates prow_job_run_tests into test_daily_summaries.
-// Returns the earliest date that was refreshed so downstream consumers
-// (cumulative summaries) know which dates may have changed.
-func Refresh(dbc *db.DB) (civil.Date, error) {
-	return refreshSummaries(&pgStore{dbc: dbc, tableName: "test_daily_summaries", dateColumn: "summary_date"})
-}
-
 func refreshSummaries(store summaryStore) (civil.Date, error) {
 	loadStart := time.Now()
 	log.Info("refreshing daily summaries")
@@ -91,19 +84,16 @@ func refreshSummaries(store summaryStore) (civil.Date, error) {
 	return startDate, nil
 }
 
-// Backfill processes an explicit date range without automatic date detection.
-func Backfill(dbc *db.DB, startDate, endDate civil.Date) error {
-	return backfillSummaries(&pgStore{dbc: dbc, tableName: "test_daily_summaries", dateColumn: "summary_date"}, startDate, endDate)
-}
-
-// RefreshTotals aggregates prow_job_run_tests into the partitioned
-// test_daily_totals table. Same logic as Refresh but targets the new table.
-func RefreshTotals(dbc *db.DB) (civil.Date, error) {
+// Refresh aggregates prow_job_run_tests into the partitioned
+// test_daily_totals table. Returns the earliest date that was refreshed
+// so downstream consumers (cumulative summaries) know which dates
+// may have changed.
+func Refresh(dbc *db.DB) (civil.Date, error) {
 	return refreshSummaries(&pgStore{dbc: dbc, tableName: "test_daily_totals", dateColumn: "date"})
 }
 
-// BackfillTotals backfills the partitioned test_daily_totals table.
-func BackfillTotals(dbc *db.DB, startDate, endDate civil.Date) error {
+// Backfill processes an explicit date range without automatic date detection.
+func Backfill(dbc *db.DB, startDate, endDate civil.Date) error {
 	return backfillSummaries(&pgStore{dbc: dbc, tableName: "test_daily_totals", dateColumn: "date"}, startDate, endDate)
 }
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -173,7 +173,6 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 		&models.ChatConversation{},
 		&jobrunscan.Label{},
 		&jobrunscan.Symptom{},
-		&models.TestDailySummary{},
 	}
 
 	// Currently we need RunMigrations to run prior

--- a/pkg/db/migrations/000006_partition_cumulative_tables.up.sql
+++ b/pkg/db/migrations/000006_partition_cumulative_tables.up.sql
@@ -5,7 +5,7 @@
 -- - Level 2: RANGE sub-partition by date (daily granularity)
 --
 -- Tables:
---   - test_daily_totals (partitioned daily aggregates, replaces test_daily_summaries)
+--   - test_daily_totals (partitioned daily aggregates)
 --   - test_cumulative_summaries (prefix sums from test_daily_totals)
 --
 -- Partition creation (release partitions + daily sub-partitions) is handled

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -170,22 +170,7 @@ type TestAnalysisByJobByDate struct {
 	Failures int
 }
 
-// TestDailySummary stores pre-aggregated daily test results used to
-// accelerate matview refreshes. Table managed by migration 000002.
-type TestDailySummary struct {
-	TestID      uint      `gorm:"column:test_id;not null"`
-	ProwJobID   uint      `gorm:"column:prow_job_id;not null"`
-	SuiteID     uint      `gorm:"column:suite_id;not null;default:0"`
-	Release     string    `gorm:"column:release;not null"`
-	SummaryDate time.Time `gorm:"column:summary_date;type:date;not null"`
-	Successes   int32     `gorm:"column:successes;not null;default:0"`
-	Failures    int32     `gorm:"column:failures;not null;default:0"`
-	Flakes      int32     `gorm:"column:flakes;not null;default:0"`
-	Runs        int32     `gorm:"column:runs;not null;default:0"`
-}
-
-// TestDailyTotal is the partitioned replacement for TestDailySummary.
-// Same schema, but partitioned by LIST(release) then RANGE(date).
+// TestDailyTotal stores pre-aggregated daily test results.
 // Table is partitioned (LIST by release, RANGE by date) -
 // schema managed by migration 000006, not AutoMigrate.
 type TestDailyTotal struct {
@@ -200,7 +185,7 @@ type TestDailyTotal struct {
 	Runs      int32      `gorm:"column:runs;not null;default:0"`
 }
 
-// TestCumulativeSummary stores running totals of test_daily_summaries values,
+// TestCumulativeSummary stores running totals of test_daily_totals values,
 // ordered by date. Any date range [start, end] can be computed as
 // cumulative(end) - cumulative(start-1). Keyed by immutable fields only
 // (no variant_combination_id) so variant changes do not invalidate the data.

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -147,12 +147,6 @@ var allMatViewsRefreshMetric = promauto.NewHistogram(prometheus.HistogramOpts{
 	Buckets: []float64{5000, 10000, 30000, 60000, 300000, 600000, 1200000, 1800000, 2400000, 3000000, 3600000},
 })
 
-var dailySummaryRefreshMetric = promauto.NewHistogram(prometheus.HistogramOpts{
-	Name:    "sippy_daily_summary_refresh_millis",
-	Help:    "Milliseconds to refresh the daily summary table",
-	Buckets: []float64{1000, 5000, 10000, 30000, 60000, 300000, 600000, 1200000},
-})
-
 var cumulativeSummaryRefreshMetric = promauto.NewHistogram(prometheus.HistogramOpts{
 	Name:    "sippy_cumulative_summary_refresh_millis",
 	Help:    "Milliseconds to refresh the cumulative summary tables",
@@ -400,14 +394,8 @@ type RefreshOptions struct {
 func RefreshData(dbc *db.DB, cacheClient cache.Cache, opts RefreshOptions) error {
 	log.Infof("Refreshing data")
 
-	summaryStart := time.Now()
-	if _, err := dailysummary.Refresh(dbc); err != nil {
-		return fmt.Errorf("failed to refresh daily summaries: %w", err)
-	}
-	dailySummaryRefreshMetric.Observe(float64(time.Since(summaryStart).Milliseconds()))
-
 	totalsStart := time.Now()
-	earliestTotalsChanged, err := dailysummary.RefreshTotals(dbc)
+	earliestTotalsChanged, err := dailysummary.Refresh(dbc)
 	if err != nil {
 		return fmt.Errorf("failed to refresh daily totals: %w", err)
 	}
@@ -434,10 +422,8 @@ func BackfillData(dbc *db.DB, table string, startDate, endDate civil.Date) error
 	}).Info("Backfilling table")
 
 	switch table {
-	case "daily-summaries":
-		return dailysummary.Backfill(dbc, startDate, endDate)
 	case "daily-totals":
-		return dailysummary.BackfillTotals(dbc, startDate, endDate)
+		return dailysummary.Backfill(dbc, startDate, endDate)
 	case "cumulative-summaries":
 		return cumulativesummary.Backfill(dbc, startDate, endDate)
 	default:

--- a/scripts/backfill-summaries.sh
+++ b/scripts/backfill-summaries.sh
@@ -6,7 +6,7 @@
 #   ./scripts/backfill-summaries.sh --table TABLE [OPTIONS]
 #
 # Options:
-#   --table TABLE     Table to backfill (daily-summaries, daily-totals,
+#   --table TABLE     Table to backfill (daily-totals,
 #                     cumulative-summaries) [required]
 #   --days N          Number of days to backfill (default: 91)
 #   --namespace NS    Kubernetes namespace (default: sippy)
@@ -56,15 +56,15 @@ fi
 
 if [[ -z "$TABLE" ]]; then
     echo "Error: --table is required" >&2
-    echo "Valid tables: daily-summaries, daily-totals, cumulative-summaries" >&2
+    echo "Valid tables: daily-totals, cumulative-summaries" >&2
     exit 1
 fi
 
 case "$TABLE" in
-    daily-summaries|daily-totals|cumulative-summaries) ;;
+    daily-totals|cumulative-summaries) ;;
     *)
         echo "Error: invalid table '$TABLE'" >&2
-        echo "Valid tables: daily-summaries, daily-totals, cumulative-summaries" >&2
+        echo "Valid tables: daily-totals, cumulative-summaries" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary
- Remove `Refresh`/`Backfill` functions that wrote to the now-unused `test_daily_summaries` table
- Rename `RefreshTotals`/`BackfillTotals` to `Refresh`/`Backfill` since `test_daily_totals` is the only target
- Remove `TestDailySummary` model, AutoMigrate entry, and `sippy_daily_summary_refresh_millis` Prometheus metric
- Remove `"daily-summaries"` from backfill CLI and seed data

The `test_daily_totals` (partitioned) table fully replaced `test_daily_summaries`. Nothing reads from the old table, so this PR stops writing to it. The table itself will be dropped via a follow-up migration after this deploys.

## Test plan
- [x] `make lint` passes
- [x] `make test` passes
- [x] `make e2e` passes
- [x] `go vet` passes on changed packages
- [x] `go build ./cmd/sippy/...` compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Daily aggregation refresh and backfill now use the consolidated daily totals table.
  - Database schema updates now include chat conversations, job labels, and symptoms.

- **Bug Fixes**
  - Backfill commands now accept only `daily-totals` and `cumulative-summaries`.
  - Synthetic data refresh no longer processes the deprecated daily summaries table.

- **Refactor**
  - Replaced daily summary terminology with daily totals across aggregation and reporting workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->