### PR TITLE
TRT-2810: fix GCS glob pattern to match all JUnit XML files

### DIFF
--- a/pkg/dataloader/prowloader/gcs/gcs_jobrun.go
+++ b/pkg/dataloader/prowloader/gcs/gcs_jobrun.go
@@ -18,7 +18,7 @@ import (
 const TestFailureSummaryFilePrefix = "risk-analysis"
 
 const (
-	GlobJunitXML      = "**junit*.xml"
+	GlobJunitXML      = "**junit**.xml"
 	GlobEventsJSON    = "**/gather-extra/artifacts/events.json"
 	GlobIntervalsJSON = "**e2e-events*.json"
 	GlobTimelinesJSON = "**e2e-timelines*.json"


### PR DESCRIPTION
## Summary

PR #3768 switched GCS file discovery from client-side regex to server-side `MatchGlob`. The old regex `/.*junit.*xml` matched against the full object path (including directory names), while the new glob `**junit*.xml` only matched files with `junit` in the filename because single `*` cannot cross directory boundaries (`/`).

This caused **~65% of test results to be silently dropped** per job run (~4,100 of ~6,530 tests). The critical file `e2e-monitor-tests__*.xml` (containing ~1,891 monitor invariant test cases) lives in a `junit/` directory but its filename does not contain "junit".

**Fix:** Change `**junit*.xml` to `**junit**.xml` so the second `**` crosses the `/` boundary and matches both filename-based and directory-based junit paths.

**Jira:** [TRT-2810](https://redhat.atlassian.net/browse/TRT-2810)

## Mitigation plan

See [TRT-2810](https://redhat.atlassian.net/browse/TRT-2810) for the full data backfill runbook (partition truncation, re-ingestion, summary backfill).

## Verification

### GCS file coverage

Listed all `.xml` files in GCS for job run `2079488235343450112` (`periodic-ci-shiftstack-ci-release-4.18-techpreview-e2e-openstack-ovn-techpreview`). Every JUnit XML file contains "junit" in its path, so `**junit**.xml` matches all 9:

| # | Path | Matched via |
|---|---|---|
| 1 | `junit/junit_install_status.xml` | dir + filename |
| 2 | `junit/junit_symptoms.xml` | dir + filename |
| 3 | `junit_install.xml` | filename |
| 4 | `junit/e2e-monitor-tests__*.xml` | **dir name only** (missed by old glob) |
| 5 | `junit/junit_e2e__*.xml` | dir + filename |
| 6 | `junit_node_ready.xml` | filename |
| 7 | `junit_nodes.xml` | filename |
| 8 | `junit_operator.xml` | filename |
| 9 | `prowjob_junit.xml` | filename |

No `.xml` files in the job run are missed by the new pattern.

### Staging load test

Built the fix as `sippy-staging:test-glob-fix` and ran a one-off prow loader job against the staging database (`--prow-load-since=2026-07-21T06:00:00Z`, `--arch=amd64`, `--loader=prow`). Compared test counts for the same job run in staging (fixed glob) vs production (broken glob):

| Suite | Staging (fixed) | Production (broken) |
|---|---|---|
| openshift-tests | **3,274** | **1,553** |
| Other suites | 62 | 62 |
| **Total** | **3,336** | **1,615** |

The fix recovers **1,721 tests** in the `openshift-tests` suite (from the previously missed `e2e-monitor-tests__*.xml` file). Non-openshift-tests suites are identical.

### No regressions

Exported all test names from both databases for the same job run and diffed them. Every test present in production is also present in staging (zero missing). The fix is purely additive.

### Pattern comparison

| Pattern | Semantics | Files matched | Includes monitor tests? |
|---|---|---|---|
| `**junit*.xml` (broken) | `*` cannot cross `/` | 7-8 | No |
| `**junit**.xml` (fix) | `**` crosses `/` | **9** | **Yes** |

## Test plan

- [x] `go vet` passes
- [x] `go build` passes
- [x] Verified all 9 JUnit XML files in GCS matched by `**junit**.xml` (via debug pod)
- [x] Verified `**junit*.xml` misses `e2e-monitor-tests__*.xml` (confirmed root cause)
- [x] Staging load test: 3,336 tests ingested vs 1,615 in production for same job run
- [x] No regressions: every production test present in staging
- [ ] After deploy: verify new loader runs ingest full test counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)