### PR TITLE
Add ROSA production jobs to rosa-production Sippy view

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -96,7 +96,14 @@ releases:
       - "^periodic-ci-openshift-.*-master-rosa-sts-e2e-promotion-int$"
   rosa-production:
     synthetic: true
-    jobs: {}
+    jobs:
+      # ROSA CLI e2e tests targeting production (exact match takes priority over rosa-stage regex)
+      periodic-ci-openshift-rosa-master-e2e-rosa-hcp-advanced-prod-critical-high-f3: true
+      periodic-ci-openshift-rosa-master-e2e-rosa-sts-advanced-prod-critical-high-f3: true
+      periodic-ci-openshift-rosa-master-e2e-rosa-sts-upgrade-y-stream-prod-f3: true
+    regexp:
+      # OCM FVT production
+      - "^periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-.*-production-.*"
   rrp-integration:
     synthetic: true
     jobs:


### PR DESCRIPTION
## Summary
- The `rosa-production` view was empty (`jobs: {}`), so production FVT and CLI e2e jobs were not indexed in Sippy
- This caused the daily CI health report (chai-bot) to skip the production category as "no runs"
- Add regex patterns to match OCM FVT production jobs and ROSA CLI e2e jobs targeting prod

## Jobs matched
- `periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-*-production-*` (OCM FVT prod)
- `periodic-ci-openshift-rosa-master-e2e-rosa-*-prod-*` (ROSA CLI prod tests)

## Test plan
- [ ] Verify `rosa-production` view shows jobs after deployment
- [ ] Verify no staging/integration jobs leak into the production view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Enabled production OCM functional verification runs.
  * Enabled ROSA CLI end-to-end tests for production-matching jobs, including updates to the job selection rules used for production runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->