### PR TITLE
TRT-2812: Fix synthetic test map key collision from PR #3768

### DIFF
--- a/pkg/dataloader/prowloader/extract_test_cases_test.go
+++ b/pkg/dataloader/prowloader/extract_test_cases_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift/sippy/pkg/apis/junit"
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+	"github.com/openshift/sippy/pkg/dataloader/prowloader/types"
 )
 
 func TestExtractTestCases(t *testing.T) {
@@ -15,7 +16,7 @@ func TestExtractTestCases(t *testing.T) {
 	tests := []struct {
 		name     string
 		suite    *junit.TestSuite
-		expected map[testCaseKey]*testCaseEntry
+		expected map[testCaseKey]*types.TestCaseEntry
 	}{
 		{
 			name: "passing test",
@@ -25,7 +26,7 @@ func TestExtractTestCases(t *testing.T) {
 					{Name: "test-a", Duration: 1.5},
 				},
 			},
-			expected: map[testCaseKey]*testCaseEntry{
+			expected: map[testCaseKey]*types.TestCaseEntry{
 				{SuiteName: "openshift-tests", TestName: "test-a"}: {
 					TestName:  "test-a",
 					SuiteName: "openshift-tests",
@@ -42,7 +43,7 @@ func TestExtractTestCases(t *testing.T) {
 					{Name: "test-a", Duration: 2.0, FailureOutput: &junit.FailureOutput{Output: failMsg}},
 				},
 			},
-			expected: map[testCaseKey]*testCaseEntry{
+			expected: map[testCaseKey]*types.TestCaseEntry{
 				{SuiteName: "openshift-tests", TestName: "test-a"}: {
 					TestName:  "test-a",
 					SuiteName: "openshift-tests",
@@ -60,7 +61,7 @@ func TestExtractTestCases(t *testing.T) {
 					{Name: "test-a", SkipMessage: &junit.SkipMessage{Message: "skipped"}},
 				},
 			},
-			expected: map[testCaseKey]*testCaseEntry{},
+			expected: map[testCaseKey]*types.TestCaseEntry{},
 		},
 		{
 			name: "flake from pass then fail",
@@ -71,7 +72,7 @@ func TestExtractTestCases(t *testing.T) {
 					{Name: "test-a", Duration: 2.0, FailureOutput: &junit.FailureOutput{Output: failMsg}},
 				},
 			},
-			expected: map[testCaseKey]*testCaseEntry{
+			expected: map[testCaseKey]*types.TestCaseEntry{
 				{SuiteName: "openshift-tests", TestName: "test-a"}: {
 					TestName:  "test-a",
 					SuiteName: "openshift-tests",
@@ -97,7 +98,7 @@ func TestExtractTestCases(t *testing.T) {
 					},
 				},
 			},
-			expected: map[testCaseKey]*testCaseEntry{
+			expected: map[testCaseKey]*types.TestCaseEntry{
 				{SuiteName: "a.b", TestName: "c"}: {
 					TestName:  "c",
 					SuiteName: "a.b",
@@ -128,7 +129,7 @@ func TestExtractTestCases(t *testing.T) {
 					},
 				},
 			},
-			expected: map[testCaseKey]*testCaseEntry{
+			expected: map[testCaseKey]*types.TestCaseEntry{
 				{SuiteName: "openshift-tests", TestName: "parent-test"}: {
 					TestName:  "parent-test",
 					SuiteName: "openshift-tests",
@@ -147,7 +148,7 @@ func TestExtractTestCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testCases := make(map[testCaseKey]*testCaseEntry)
+			testCases := make(map[testCaseKey]*types.TestCaseEntry)
 			extractTestCases(tt.suite, testCases)
 			assert.Equal(t, tt.expected, testCases)
 		})

--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -42,6 +43,7 @@ import (
 	"github.com/openshift/sippy/pkg/dataloader/prowloader/gcs"
 	"github.com/openshift/sippy/pkg/dataloader/prowloader/github"
 	"github.com/openshift/sippy/pkg/dataloader/prowloader/testconversion"
+	"github.com/openshift/sippy/pkg/dataloader/prowloader/types"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/github/commenter"
@@ -1596,15 +1598,6 @@ type testCaseKey struct {
 	TestName  string
 }
 
-// testCaseEntry holds raw test case data with string names before ID resolution.
-type testCaseEntry struct {
-	TestName  string
-	SuiteName string
-	Status    int
-	Duration  float64
-	Output    *string
-}
-
 func (pl *ProwLoader) prowJobRunTestsFromGCS(ctx context.Context, pj *prow.ProwJob, id, prowJobID uint, prowJobRelease, path string, junitPaths []string) ([]prowJobRunTestRow, int, sippyprocessingv1.JobOverallResult, error) {
 	bkt := pl.gcsClient.Bucket(pj.Spec.DecorationConfig.GCSConfiguration.Bucket)
 	gcsJobRun := gcs.NewGCSJobRun(bkt, path)
@@ -1615,7 +1608,7 @@ func (pl *ProwLoader) prowJobRunTestsFromGCS(ctx context.Context, pj *prow.ProwJ
 		return nil, 0, "", err
 	}
 
-	testCases := make(map[testCaseKey]*testCaseEntry)
+	testCases := make(map[testCaseKey]*types.TestCaseEntry)
 	for _, suite := range suites.Suites {
 		if !db.IsSuiteImportable(suite.Name) {
 			log.Infof("skipping suite %q as it's not listed for import", suite.Name)
@@ -1624,12 +1617,7 @@ func (pl *ProwLoader) prowJobRunTestsFromGCS(ctx context.Context, pj *prow.ProwJ
 		extractTestCases(suite, testCases)
 	}
 
-	oldTestCases := make(map[string]*models.ProwJobRunTest, len(testCases))
-	for _, tc := range testCases {
-		oldTestCases[tc.TestName] = &models.ProwJobRunTest{
-			Status: tc.Status,
-		}
-	}
+	oldTestCases := slices.Collect(maps.Values(testCases))
 	syntheticSuite, jobResult := testconversion.ConvertProwJobRunToSyntheticTests(*pj, oldTestCases, pl.syntheticTestManager)
 
 	if !db.IsSuiteImportable(syntheticSuite.Name) {
@@ -1663,7 +1651,7 @@ func (pl *ProwLoader) prowJobRunTestsFromGCS(ctx context.Context, pj *prow.ProwJ
 	return results, failures, jobResult, nil
 }
 
-func extractTestCases(suite *junit.TestSuite, testCases map[testCaseKey]*testCaseEntry) {
+func extractTestCases(suite *junit.TestSuite, testCases map[testCaseKey]*types.TestCaseEntry) {
 	for _, tc := range suite.TestCases {
 		if testidentification.IsIgnoredTest(tc.Name) {
 			continue
@@ -1682,7 +1670,7 @@ func extractTestCases(suite *junit.TestSuite, testCases map[testCaseKey]*testCas
 		key := testCaseKey{SuiteName: suite.Name, TestName: tc.Name}
 
 		if existing, ok := testCases[key]; !ok {
-			testCases[key] = &testCaseEntry{
+			testCases[key] = &types.TestCaseEntry{
 				TestName:  tc.Name,
 				SuiteName: suite.Name,
 				Status:    int(status),

--- a/pkg/dataloader/prowloader/testconversion/testconversion.go
+++ b/pkg/dataloader/prowloader/testconversion/testconversion.go
@@ -4,12 +4,12 @@ import (
 	"github.com/openshift/sippy/pkg/apis/junit"
 	"github.com/openshift/sippy/pkg/apis/prow"
 	v1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
-	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/openshift/sippy/pkg/dataloader/prowloader/types"
 	"github.com/openshift/sippy/pkg/synthetictests"
 	"github.com/openshift/sippy/pkg/testidentification"
 )
 
-func ConvertProwJobRunToSyntheticTests(pj prow.ProwJob, tests map[string]*models.ProwJobRunTest, manager synthetictests.SyntheticTestManager) (*junit.TestSuite, v1.JobOverallResult) {
+func ConvertProwJobRunToSyntheticTests(pj prow.ProwJob, tests []*types.TestCaseEntry, manager synthetictests.SyntheticTestManager) (*junit.TestSuite, v1.JobOverallResult) {
 	jrr := v1.RawJobRunResult{
 		Job:       pj.Spec.Job,
 		Errored:   pj.Status.State == prow.ErrorState,
@@ -22,35 +22,41 @@ func ConvertProwJobRunToSyntheticTests(pj prow.ProwJob, tests map[string]*models
 	return syntheticTests, jrr.OverallResult
 }
 
-func testsToRawJobRunResult(jrr *v1.RawJobRunResult, tests map[string]*models.ProwJobRunTest) {
-	for name, test := range tests {
-		// Skip non-suite tests (e.g. prowjob-junit, step graph) — their
-		// failures don't represent real test signal.
-		if testidentification.IsNonSuiteTest(name) {
+func testsToRawJobRunResult(jrr *v1.RawJobRunResult, tests []*types.TestCaseEntry) {
+	for _, tc := range tests {
+		if testidentification.IsNonSuiteTest(tc.SuiteName, tc.TestName) {
 			continue
 		}
 
-		switch v1.TestStatus(test.Status) {
+		switch v1.TestStatus(tc.Status) {
 		case v1.TestStatusSuccess, v1.TestStatusFlake: // success, flake(failed one or more times but ultimately succeeded)
 			switch {
-			case testidentification.IsOverallTest(name):
+			case testidentification.IsOverallTest(tc.TestName):
 				jrr.Succeeded = true
 				// if the overall job succeeded, install is always considered successful, even for jobs
 				// that don't have an explicitly defined install test.
-				jrr.InstallStatus = testidentification.Success
-			case testidentification.IsOperatorHealthTest(name):
+				if jrr.InstallStatus != testidentification.Failure {
+					jrr.InstallStatus = testidentification.Success
+				}
+			case testidentification.IsOperatorHealthTest(tc.TestName):
 				jrr.FinalOperatorStates = append(jrr.FinalOperatorStates, v1.OperatorState{
-					Name:  testidentification.GetOperatorNameFromTest(name),
+					Name:  testidentification.GetOperatorNameFromTest(tc.TestName),
 					State: testidentification.Success,
 				})
-			case testidentification.IsInstallStepEquivalent(name):
-				jrr.InstallStatus = testidentification.Success
-			case testidentification.IsUpgradeStartedTest(name):
+			case testidentification.IsInstallStepEquivalent(tc.TestName):
+				if jrr.InstallStatus != testidentification.Failure {
+					jrr.InstallStatus = testidentification.Success
+				}
+			case testidentification.IsUpgradeStartedTest(tc.TestName):
 				jrr.UpgradeStarted = true
-			case testidentification.IsOperatorsUpgradedTest(name):
-				jrr.UpgradeForOperatorsStatus = testidentification.Success
-			case testidentification.IsMachineConfigPoolsUpgradedTest(name):
-				jrr.UpgradeForMachineConfigPoolsStatus = testidentification.Success
+			case testidentification.IsOperatorsUpgradedTest(tc.TestName):
+				if jrr.UpgradeForOperatorsStatus != testidentification.Failure {
+					jrr.UpgradeForOperatorsStatus = testidentification.Success
+				}
+			case testidentification.IsMachineConfigPoolsUpgradedTest(tc.TestName):
+				if jrr.UpgradeForMachineConfigPoolsStatus != testidentification.Failure {
+					jrr.UpgradeForMachineConfigPoolsStatus = testidentification.Success
+				}
 			default:
 				// Any other non-special test contributes to overall test status
 				if jrr.TestsStatus == "" {
@@ -60,26 +66,26 @@ func testsToRawJobRunResult(jrr *v1.RawJobRunResult, tests map[string]*models.Pr
 		case v1.TestStatusFailure:
 			// only add the failing test and name if it has predictive value.  We excluded all the non-predictive ones above except for these
 			// which we use to set various JobRunResult markers
-			if !testidentification.IsOverallTest(name) {
-				jrr.FailedTestNames = append(jrr.FailedTestNames, name)
+			if !testidentification.IsOverallTest(tc.TestName) {
+				jrr.FailedTestNames = append(jrr.FailedTestNames, tc.TestName)
 				jrr.TestFailures++
 			}
 
 			switch {
-			case testidentification.IsOverallTest(name):
+			case testidentification.IsOverallTest(tc.TestName):
 				jrr.Failed = true
-			case testidentification.IsOperatorHealthTest(name):
+			case testidentification.IsOperatorHealthTest(tc.TestName):
 				jrr.FinalOperatorStates = append(jrr.FinalOperatorStates, v1.OperatorState{
-					Name:  testidentification.GetOperatorNameFromTest(name),
+					Name:  testidentification.GetOperatorNameFromTest(tc.TestName),
 					State: testidentification.Failure,
 				})
-			case testidentification.IsInstallStepEquivalent(name):
+			case testidentification.IsInstallStepEquivalent(tc.TestName):
 				jrr.InstallStatus = testidentification.Failure
-			case testidentification.IsUpgradeStartedTest(name):
+			case testidentification.IsUpgradeStartedTest(tc.TestName):
 				jrr.UpgradeStarted = true // this is still true because we definitely started
-			case testidentification.IsOperatorsUpgradedTest(name):
+			case testidentification.IsOperatorsUpgradedTest(tc.TestName):
 				jrr.UpgradeForOperatorsStatus = testidentification.Failure
-			case testidentification.IsMachineConfigPoolsUpgradedTest(name):
+			case testidentification.IsMachineConfigPoolsUpgradedTest(tc.TestName):
 				jrr.UpgradeForMachineConfigPoolsStatus = testidentification.Failure
 			default:
 				jrr.TestsStatus = testidentification.Failure

--- a/pkg/dataloader/prowloader/testconversion/testconversion_test.go
+++ b/pkg/dataloader/prowloader/testconversion/testconversion_test.go
@@ -4,116 +4,96 @@ import (
 	"testing"
 
 	v1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
-	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/openshift/sippy/pkg/dataloader/prowloader/types"
 	"github.com/stretchr/testify/assert"
 )
 
-func successTest() *models.ProwJobRunTest {
-	return &models.ProwJobRunTest{Status: int(v1.TestStatusSuccess)}
+func success(suite, test string) *types.TestCaseEntry {
+	return &types.TestCaseEntry{SuiteName: suite, TestName: test, Status: int(v1.TestStatusSuccess)}
 }
 
-func failureTest() *models.ProwJobRunTest {
-	return &models.ProwJobRunTest{Status: int(v1.TestStatusFailure)}
+func failure(suite, test string) *types.TestCaseEntry {
+	return &types.TestCaseEntry{SuiteName: suite, TestName: test, Status: int(v1.TestStatusFailure)}
 }
 
 func TestTestsToRawJobRunResult(t *testing.T) {
 	tests := []struct {
 		name     string
-		tests    map[string]*models.ProwJobRunTest
+		tests    []*types.TestCaseEntry
 		validate func(t *testing.T, jrr *v1.RawJobRunResult)
 	}{
 		{
-			name: "install step success sets InstallStatus",
-			tests: map[string]*models.ProwJobRunTest{
-				"cluster install.install should succeed: overall": successTest(),
-			},
+			name:  "install step success sets InstallStatus",
+			tests: []*types.TestCaseEntry{success("cluster install", "install should succeed: overall")},
 			validate: func(t *testing.T, jrr *v1.RawJobRunResult) {
 				assert.Equal(t, "Success", jrr.InstallStatus)
 			},
 		},
 		{
-			name: "install step failure sets InstallStatus",
-			tests: map[string]*models.ProwJobRunTest{
-				"cluster install.install should succeed: overall": failureTest(),
-			},
+			name:  "install step failure sets InstallStatus",
+			tests: []*types.TestCaseEntry{failure("cluster install", "install should succeed: overall")},
 			validate: func(t *testing.T, jrr *v1.RawJobRunResult) {
 				assert.Equal(t, "Failure", jrr.InstallStatus)
 			},
 		},
 		{
-			name: "openshift test failure sets TestsStatus",
-			tests: map[string]*models.ProwJobRunTest{
-				"openshift-tests.[sig-apps] example test": failureTest(),
-			},
+			name:  "openshift test failure sets TestsStatus",
+			tests: []*types.TestCaseEntry{failure("openshift-tests", "[sig-apps] example test")},
 			validate: func(t *testing.T, jrr *v1.RawJobRunResult) {
 				assert.Equal(t, "Failure", jrr.TestsStatus)
 				assert.Equal(t, 1, jrr.TestFailures)
 			},
 		},
 		{
-			name: "non-openshift test failure also sets TestsStatus",
-			tests: map[string]*models.ProwJobRunTest{
-				"aro-hcp-tests.some integration test": failureTest(),
-			},
+			name:  "non-openshift test failure also sets TestsStatus",
+			tests: []*types.TestCaseEntry{failure("aro-hcp-tests", "some integration test")},
 			validate: func(t *testing.T, jrr *v1.RawJobRunResult) {
 				assert.Equal(t, "Failure", jrr.TestsStatus)
 				assert.Equal(t, 1, jrr.TestFailures)
 			},
 		},
 		{
-			name: "non-openshift test success sets TestsStatus",
-			tests: map[string]*models.ProwJobRunTest{
-				"aro-hcp-tests.some integration test": successTest(),
-			},
+			name:  "non-openshift test success sets TestsStatus",
+			tests: []*types.TestCaseEntry{success("aro-hcp-tests", "some integration test")},
 			validate: func(t *testing.T, jrr *v1.RawJobRunResult) {
 				assert.Equal(t, "Success", jrr.TestsStatus)
 			},
 		},
 		{
-			name: "prowjob-junit failures are skipped",
-			tests: map[string]*models.ProwJobRunTest{
-				"prowjob-junit.some-step-name": failureTest(),
-			},
+			name:  "prowjob-junit failures are skipped",
+			tests: []*types.TestCaseEntry{failure("prowjob-junit", "some-step-name")},
 			validate: func(t *testing.T, jrr *v1.RawJobRunResult) {
 				assert.Equal(t, 0, jrr.TestFailures)
 				assert.Empty(t, jrr.FailedTestNames)
 			},
 		},
 		{
-			name: "step graph failures are skipped",
-			tests: map[string]*models.ProwJobRunTest{
-				"step graph.some-step": failureTest(),
-			},
+			name:  "step graph failures are skipped",
+			tests: []*types.TestCaseEntry{failure("step graph", "some-step")},
 			validate: func(t *testing.T, jrr *v1.RawJobRunResult) {
 				assert.Equal(t, 0, jrr.TestFailures)
 				assert.Empty(t, jrr.FailedTestNames)
 			},
 		},
 		{
-			name: "Run pipeline step failures are skipped",
-			tests: map[string]*models.ProwJobRunTest{
-				"aro-hcp-tests.Run pipeline step provision": failureTest(),
-			},
+			name:  "Run pipeline step failures are skipped",
+			tests: []*types.TestCaseEntry{failure("aro-hcp-tests", "Run pipeline step provision")},
 			validate: func(t *testing.T, jrr *v1.RawJobRunResult) {
 				assert.Equal(t, 0, jrr.TestFailures)
 				assert.Empty(t, jrr.FailedTestNames)
 			},
 		},
 		{
-			name: "overall test success sets Succeeded and InstallStatus",
-			tests: map[string]*models.ProwJobRunTest{
-				"openshift-tests.Overall": successTest(),
-			},
+			name:  "overall test success sets Succeeded and InstallStatus",
+			tests: []*types.TestCaseEntry{success("openshift-tests", "Overall")},
 			validate: func(t *testing.T, jrr *v1.RawJobRunResult) {
 				assert.True(t, jrr.Succeeded)
 				assert.Equal(t, "Success", jrr.InstallStatus)
 			},
 		},
 		{
-			name: "overall test failure sets Failed",
-			tests: map[string]*models.ProwJobRunTest{
-				"openshift-tests.Overall": failureTest(),
-			},
+			name:  "overall test failure sets Failed",
+			tests: []*types.TestCaseEntry{failure("openshift-tests", "Overall")},
 			validate: func(t *testing.T, jrr *v1.RawJobRunResult) {
 				assert.True(t, jrr.Failed)
 				// Overall failures should not be counted in TestFailures
@@ -121,20 +101,48 @@ func TestTestsToRawJobRunResult(t *testing.T) {
 			},
 		},
 		{
-			name: "upgrade started test sets UpgradeStarted",
-			tests: map[string]*models.ProwJobRunTest{
-				"Cluster upgrade.[sig-cluster-lifecycle] Cluster version operator acknowledges upgrade": successTest(),
-			},
+			name:  "upgrade started test sets UpgradeStarted",
+			tests: []*types.TestCaseEntry{success("Cluster upgrade", "[sig-cluster-lifecycle] Cluster version operator acknowledges upgrade")},
 			validate: func(t *testing.T, jrr *v1.RawJobRunResult) {
 				assert.True(t, jrr.UpgradeStarted)
 			},
 		},
 		{
+			name: "install failure is sticky across suites",
+			tests: []*types.TestCaseEntry{
+				failure("openshift-tests", "install should succeed: overall"),
+				success("openshift-tests-upgrade", "install should succeed: overall"),
+			},
+			validate: func(t *testing.T, jrr *v1.RawJobRunResult) {
+				assert.Equal(t, "Failure", jrr.InstallStatus)
+			},
+		},
+		{
+			name: "upgrade operators failure is sticky across suites",
+			tests: []*types.TestCaseEntry{
+				failure("Cluster upgrade", "[sig-cluster-lifecycle] Cluster completes upgrade"),
+				success("Cluster upgrade", "[sig-cluster-lifecycle] Cluster completes upgrade"),
+			},
+			validate: func(t *testing.T, jrr *v1.RawJobRunResult) {
+				assert.Equal(t, "Failure", jrr.UpgradeForOperatorsStatus)
+			},
+		},
+		{
+			name: "machine config pools failure is sticky across suites",
+			tests: []*types.TestCaseEntry{
+				failure("Cluster upgrade", "[sig-mco] Machine config pools complete upgrade"),
+				success("Cluster upgrade", "[sig-mco] Machine config pools complete upgrade"),
+			},
+			validate: func(t *testing.T, jrr *v1.RawJobRunResult) {
+				assert.Equal(t, "Failure", jrr.UpgradeForMachineConfigPoolsStatus)
+			},
+		},
+		{
 			name: "only infra-only failures produces empty result",
-			tests: map[string]*models.ProwJobRunTest{
-				"prowjob-junit.step1":       failureTest(),
-				"step graph.step2":          failureTest(),
-				"suite.Run pipeline step x": failureTest(),
+			tests: []*types.TestCaseEntry{
+				failure("prowjob-junit", "step1"),
+				failure("step graph", "step2"),
+				failure("suite", "Run pipeline step x"),
 			},
 			validate: func(t *testing.T, jrr *v1.RawJobRunResult) {
 				assert.Equal(t, 0, jrr.TestFailures)

--- a/pkg/dataloader/prowloader/types/types.go
+++ b/pkg/dataloader/prowloader/types/types.go
@@ -1,0 +1,9 @@
+package types
+
+type TestCaseEntry struct {
+	TestName  string
+	SuiteName string
+	Status    int
+	Duration  float64
+	Output    *string
+}

--- a/pkg/testidentification/test_identification.go
+++ b/pkg/testidentification/test_identification.go
@@ -228,20 +228,26 @@ func IsOverallTest(testName string) bool {
 	return testName == "Overall" || strings.HasSuffix(testName, ".Overall")
 }
 
-// nonSuiteTestPatterns contains substrings that identify infrastructure/step-level
-// tests rather than real test signals. Matched against the map key ("suiteName.testName").
+var nonSuiteSuitePatterns = []string{
+	"prowjob-junit",
+	"step graph",
+}
+
 var nonSuiteTestPatterns = []string{
-	"prowjob-junit.",
-	"step graph.",
 	"Run pipeline step",
 	"Run multi-stage test",
 }
 
-// IsNonSuiteTest returns true if the map key (format: "suiteName.testName") belongs to
-// a suite or test that only contains infrastructure/step-level results rather than real test signals.
-func IsNonSuiteTest(mapKey string) bool {
+// IsNonSuiteTest returns true if the suite or test name indicates infrastructure/step-level
+// results rather than real test signals.
+func IsNonSuiteTest(suiteName, testName string) bool {
+	for _, pattern := range nonSuiteSuitePatterns {
+		if strings.Contains(suiteName, pattern) {
+			return true
+		}
+	}
 	for _, pattern := range nonSuiteTestPatterns {
-		if strings.Contains(mapKey, pattern) {
+		if strings.Contains(testName, pattern) {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
- Fix cross-suite test name collision in the prow loader's synthetic test pipeline, introduced by PR #3768
- The `oldTestCases` map was keyed by bare `TestName`, causing collisions in upgrade jobs where the same test appears in both `openshift-tests` and `openshift-tests-upgrade` suites
- Replace `map[string]*models.ProwJobRunTest` with a `[]*types.TestCaseEntry` slice, sharing the type between `prowloader` and `testconversion` via a new `types` sub-package
- Split `IsNonSuiteTest` into separate suite-name and test-name pattern matching so it no longer relies on a combined string format

## Test plan
- [x] `go vet ./pkg/dataloader/prowloader/...` passes
- [x] `make lint` passes
- [x] `make test` passes
- [ ] CI passes
- [x] Verify on staging that synthetic tests are generated correctly for upgrade jobs

## Staging verification

Ran the prow loader locally against the staging database with the fixed code to verify cross-suite test handling in upgrade jobs.

**Setup:** Deleted 33 existing 4.18 upgrade job runs from the last 48h, then re-loaded them with the fix applied.

**Results:**
- Loader processed 49 job runs (143,021 tests) with no errors
- `test_failures` and `overall_result` values match the pre-delete snapshot for all re-loaded runs
- **1,803 tests** appear in both `openshift-tests` and `openshift-tests-upgrade` suites within a single `upgrade-from-stable` run, correctly stored as separate rows per suite
- Different statuses are preserved across suites (e.g., `clusteroperator/authentication should not change condition/Available` shows status 1/success in `openshift-tests` but status 13/failure in `openshift-tests-upgrade`). Previously, one entry would have been silently dropped by the bare-TestName map key collision.

<details>
<summary>Cross-suite test evidence (sample from run 2079341920819089408)</summary>

```
          suite          |                                                            test                                                             | status 
-------------------------+-----------------------------------------------------------------------------------------------------------------------------+--------
 openshift-tests         | API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients             |      1
 openshift-tests-upgrade | API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients             |      1
 openshift-tests         | [bz-apiserver-auth] clusteroperator/authentication should not change condition/Available                                    |      1
 openshift-tests-upgrade | [bz-apiserver-auth] clusteroperator/authentication should not change condition/Available                                    |     13
 openshift-tests         | [bz-apiserver-auth] clusteroperator/authentication should not change condition/Degraded                                     |      1
 openshift-tests-upgrade | [bz-apiserver-auth] clusteroperator/authentication should not change condition/Degraded                                     |      1
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved classification of infrastructure and non-suite test results by separately evaluating suite and test names.
  - Preserved accurate success and failure reporting, including failed test details and status markers.
  - Improved handling of test case metadata such as duration and output during result conversion.

- **Refactor**
  - Standardized test case data handling across result extraction and conversion workflows.
  - Updated validation coverage to reflect the revised test result processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->