### PR TITLE
NO-JIRA: Fix MCP sippy_ng_start readiness check URL

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -532,16 +532,16 @@ async def sippy_ng_start(
     if existing:
         if not restart:
             pids = ", ".join(str(p) for p in existing)
-            err = await _wait_for_url("http://127.0.0.1:3000/sippy-ng", 120, existing)
+            err = await _wait_for_url("http://127.0.0.1:3000/sippy-ng/", 120, existing)
             if err:
                 return (
                     f"sippy_ng_start already running (pid(s) {pids}) but {err}. "
-                    f"Typical URL: http://127.0.0.1:3000/sippy-ng log: {log_path}. "
+                    f"Typical URL: http://127.0.0.1:3000/sippy-ng/ log: {log_path}. "
                     f"Call with restart=True to restart."
                 )
             return (
                 f"sippy_ng_start already running and ready (pid(s) {pids}). "
-                f"Typical URL: http://127.0.0.1:3000/sippy-ng log: {log_path}. "
+                f"Typical URL: http://127.0.0.1:3000/sippy-ng/ log: {log_path}. "
                 f"Call with restart=True to restart."
             )
         await _stop_pids(existing)
@@ -556,12 +556,12 @@ async def sippy_ng_start(
         cwd=ng_dir,
         log_path=log_path,
         env=env,
-        ready_url="http://127.0.0.1:3000/sippy-ng",
+        ready_url="http://127.0.0.1:3000/sippy-ng/",
     )
     if isinstance(pid_or_err, str):
         return pid_or_err
     return (
-        f"sippy_ng_start started and ready (pid {pid_or_err}). URL: http://127.0.0.1:3000/sippy-ng "
+        f"sippy_ng_start started and ready (pid {pid_or_err}). URL: http://127.0.0.1:3000/sippy-ng/ "
         f"log: {log_path}"
     )
 


### PR DESCRIPTION
Vite returns 404 for /sippy-ng but 200 for /sippy-ng/ (with trailing slash), causing the readiness check to always time out. Add the trailing slash to all readiness and status URLs.

I discovered this during the migration, but want this separate from the migration to Vite to simplify things.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated application readiness checks to use the correct trailing-slash URL.
  - Updated start-up status and error messages to consistently display the correct application address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->