### PR TITLE
NO-JIRA: Add CASCADE to migration dropping variant_combination_id

### DIFF
--- a/pkg/db/migrations/000005_drop_daily_summary_variant_combination.up.sql
+++ b/pkg/db/migrations/000005_drop_daily_summary_variant_combination.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE test_daily_summaries DROP COLUMN IF EXISTS variant_combination_id;
+ALTER TABLE test_daily_summaries DROP COLUMN IF EXISTS variant_combination_id CASCADE;


### PR DESCRIPTION
Orphaned materialized views (prow_test_report_2d_matview, prow_test_report_7d_matview) depend on the variant_combination_id column, blocking the migration. These matviews are no longer referenced in code. CASCADE drops them automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration reliability by safely removing an obsolete column only when present.
  * Automatically handles related database objects during the migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->