### PR TITLE
NO-JIRA: Populate regression views when seeding synthetic data

### DIFF
--- a/cmd/sippy/seed_data.go
+++ b/cmd/sippy/seed_data.go
@@ -867,6 +867,11 @@ func syncRegressions(dbc *db.DB) error {
 		if err != nil {
 			return fmt.Errorf("error syncing regressions for view %s: %w", view.Name, err)
 		}
+		for _, reg := range activeRegs {
+			if err := backend.UpsertRegressionView(reg.ID, view.Name); err != nil {
+				return fmt.Errorf("error upserting view %s for regression %d: %w", view.Name, reg.ID, err)
+			}
+		}
 
 		// Close regressions no longer in the report
 		allRegs, err := backend.ListCurrentRegressionsForRelease(view.SampleRelease.Name)


### PR DESCRIPTION
The seed data's syncRegressions function was not calling UpsertRegressionView after syncing regressions, so regression_views rows were never created. This caused the "Link additional matching regressions" triage button to fail with "no view provided" because the frontend derives available views from regression view data.

Matches the production code path in regressioncacheloader which calls UpsertRegressionView for each active regression after SyncRegressionsForReport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regression tracking by ensuring active regressions are correctly linked to their associated views during synchronization.
  * Added clearer error reporting when regression links cannot be updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->