### PR TITLE
Drop orphaned matviews before dropping test_daily_summaries

### DIFF
--- a/pkg/db/migrations/000007_drop_test_daily_summaries.up.sql
+++ b/pkg/db/migrations/000007_drop_test_daily_summaries.up.sql
@@ -1,1 +1,5 @@
+DROP MATERIALIZED VIEW IF EXISTS prow_test_report_7d_collapsed_matview;
+DROP MATERIALIZED VIEW IF EXISTS prow_test_report_2d_collapsed_matview;
+DROP MATERIALIZED VIEW IF EXISTS prow_test_report_7d_matview;
+DROP MATERIALIZED VIEW IF EXISTS prow_test_report_2d_matview;
 DROP TABLE IF EXISTS test_daily_summaries;


### PR DESCRIPTION
## Summary
- Migration 000007 fails in prod because orphaned materialized views (`prow_test_report_{2d,7d}_matview` and their collapsed variants) still reference `test_daily_summaries`
- Drop all four matviews before the table so the migration succeeds without CASCADE

These matviews are not referenced anywhere in the codebase and were already manually dropped from prod to unblock the current deploy.

## Test plan
- [x] `make verify-migrations` passes
- [x] Verified no code references these matviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed obsolete test report summary views and the related daily summaries table during database migration.
  - Added safeguards so the migration completes successfully even when these database objects are already absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->