### PR TITLE
TRT-2815: Add partition pruning to payload test failure queries

### DIFF
--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -231,7 +231,7 @@ func GetPayloadTestFailures(dbc *db.DB, payloadTag string, logger log.FieldLogge
 	// a matview for the failed tests in the last two weeks.
 
 	// Query all test failures for the given payload stream in the last two weeks:
-	failedTests, err := query.GetTestFailuresForPayload(dbc.DB, payloadTag)
+	failedTests, err := query.GetTestFailuresForPayload(dbc.DB, payloadTag, payload.Release, payload.ReleaseTime)
 	if err != nil {
 		logger.WithError(err).Error("unable to list test failures for payload")
 		return nil, err

--- a/pkg/db/query/payload_queries.go
+++ b/pkg/db/query/payload_queries.go
@@ -47,7 +47,7 @@ func GetLastAcceptedByArchitectureAndStream(db *gorm.DB, release string, reportE
 	return results, nil
 }
 
-func GetTestFailuresForPayload(db *gorm.DB, payloadTag string) ([]models.PayloadFailedTest, error) {
+func GetTestFailuresForPayload(db *gorm.DB, payloadTag, release string, releaseTime time.Time) ([]models.PayloadFailedTest, error) {
 	results := make([]models.PayloadFailedTest, 0)
 	result := db.Raw(`SELECT DISTINCT
 	rt.release,
@@ -75,11 +75,13 @@ func GetTestFailuresForPayload(db *gorm.DB, payloadTag string) ([]models.Payload
 	/*AND rjr.kind = 'Blocking'*/
 	AND rjr.State = 'Failed'
 	AND pjrt.prow_job_run_id = rjr.prow_job_run_id
+	AND pjrt.prow_job_run_release = ?
+	AND pjrt.prow_job_run_timestamp >= ?
 	AND pjrt.status = 12
 	AND t.id = pjrt.test_id
 	AND pjr.id = pjrt.prow_job_run_id
 	AND pj.id = pjr.prow_job_id
-	ORDER BY pjrt.id DESC`, payloadTag).Scan(&results)
+	ORDER BY pjrt.id DESC`, payloadTag, release, releaseTime).Scan(&results)
 
 	if result.Error != nil {
 		return nil, result.Error

--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -306,6 +306,8 @@ WHERE
     AND rjr.kind = 'Blocking'
     AND rjr.State = 'Failed'
     AND pjrt.prow_job_run_id = rjr.prow_job_run_id
+    AND pjrt.prow_job_run_release = rt.release
+    AND pjrt.prow_job_run_timestamp = pjr.timestamp
     AND pjrt.status = 12
     AND t.id = pjrt.test_id
     AND pjr.id = pjrt.prow_job_run_id


### PR DESCRIPTION
## Summary

- `GetTestFailuresForPayload` and `payloadTestFailuresMatView` join `prow_job_run_tests` (~3,500 partitions) without filtering on partition keys, causing the planner to exceed 60s and the `/api/payloads/test_failures` endpoint to time out.
- Pass `release` and `releaseTime` from the already-loaded `ReleaseTag` as bind parameters for static LIST partition pruning and a RANGE lower bound.
- Add equivalent join-based hints to the matview for runtime pruning during refresh.

## Benchmarks (staging, release 5.0 nightly-multi payload)

| Metric | Before | After |
|---|---|---|
| Planning time | >60s (timeout) | ~6ms |
| Execution time | >90s (timeout) | ~115ms |
| Partitions scanned | ~3,500 | 2-5 |

## Test plan

- [x] `EXPLAIN ANALYZE` on staging confirms 2-5 partitions scanned, 6ms planning, 115ms execution
- [x] Result correctness verified: identical row counts with and without pruning filters
- [x] `make lint` passes
- [x] `make test` passes
- [x] `make e2e` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test failure results for payloads by matching the associated release and release timestamp.
  * Reduced the chance of displaying failures from unrelated releases or runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->