### PR TITLE
Scope last_pass CTE to requested release in job_results

### DIFF
--- a/pkg/db/functions.go
+++ b/pkg/db/functions.go
@@ -130,7 +130,7 @@ results AS (
         group by prow_jobs.name, prow_jobs.variants
 ),
 last_pass AS (
-	SELECT prow_job_id, max(timestamp) as last_pass from prow_job_runs where overall_result = 'S' group by prow_job_id
+	SELECT prow_job_id, max(timestamp) as last_pass from prow_job_runs where overall_result = 'S' AND prow_job_release = $1 group by prow_job_id
 )
 SELECT pj_name,
        pj_variants,


### PR DESCRIPTION
## Summary

- Adds `prow_job_release = $1` filter to the `last_pass` CTE in the `job_results` SQL function, matching the pattern used by every other CTE in the function
- The filter is logically redundant (each `prow_job_id` belongs to exactly one release), so results are unchanged, but it lets Postgres skip runs from other releases during aggregation

## Benchmarks (staging, 560K rows, 34 releases)

| Release | Current (ms) | Optimized (ms) | Savings |
|---|---|---|---|
| 4.19 (21K rows) | 186 | 137 | 26% |
| 4.22 (94K rows) | 475 | 438 | 8% |
| 5.0 (111K rows) | 585 | 548 | 6% |
| Presubmits (168K rows) | 1202 | 1185 | 1.4% |

Results verified identical (zero diff) between current and optimized output.

## Test plan

- [x] Benchmarked on staging database
- [x] Verified output parity (zero differences)
- [x] `go vet` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)