### PR TITLE
TRT-2273: Optimize /api/tests/recent_failures query performance

### DIFF
--- a/pkg/api/recent_test_failures.go
+++ b/pkg/api/recent_test_failures.go
@@ -1,75 +1,50 @@
 package api
 
 import (
+	"fmt"
 	"time"
+
+	"cloud.google.com/go/civil"
+	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/filter"
 )
+
+const maxTestIDsPerQuery = 500
 
 // GetRecentTestFailures returns tests that failed within the given period, optionally
 // excluding tests that also failed in a previous period (to surface only new regressions).
 func GetRecentTestFailures(
 	dbc *db.DB,
 	release string,
-	period time.Duration,
-	previousPeriod *time.Duration,
+	periodDays int,
+	previousPeriodDays *int,
 	includeOutputs bool,
 	filterOpts *filter.FilterOptions,
 	pagination *apitype.Pagination,
 	reportEnd time.Time,
 ) (*apitype.PaginationResult, error) {
-	periodStart := reportEnd.Add(-period)
+	// Align to full calendar days for partition pruning. AddDays(1) ensures the
+	// entire day containing reportEnd is included; endDate is exclusive.
+	endDate := civil.DateOf(reportEnd.UTC()).AddDays(1)
+	startDate := endDate.AddDays(-periodDays)
 
-	q := dbc.DB.Table("prow_job_run_tests").
-		Joins("JOIN prow_job_runs ON prow_job_runs.id = prow_job_run_tests.prow_job_run_id").
-		Joins("JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id").
-		Joins("JOIN tests ON tests.id = prow_job_run_tests.test_id").
-		Joins("LEFT JOIN suites ON suites.id = prow_job_run_tests.suite_id").
-		Joins("LEFT JOIN test_ownerships ON test_ownerships.test_id = tests.id").
-		Where("prow_job_runs.timestamp >= ? AND prow_job_runs.timestamp < ?", periodStart, reportEnd).
-		Where("prow_job_runs.prow_job_release = ?", release).
-		Where("prow_job_run_tests.prow_job_run_timestamp >= ? AND prow_job_run_tests.prow_job_run_timestamp < ?", periodStart, reportEnd).
-		Where("prow_job_run_tests.status = ?", int(sippyprocessingv1.TestStatusFailure)).
-		Where("prow_jobs.release = ?", release).
-		Where("prow_job_run_tests.prow_job_run_release = ?", release).
-		Where("prow_job_run_tests.deleted_at IS NULL").
-		Where("prow_job_runs.deleted_at IS NULL").
-		Where("prow_jobs.deleted_at IS NULL").
-		Where("tests.deleted_at IS NULL").
-		Group("tests.id, tests.name, suites.name, test_ownerships.jira_component").
-		Select(`
-			tests.id AS test_id,
-			tests.name AS test_name,
-			suites.name AS suite_name,
-			test_ownerships.jira_component AS jira_component,
-			COUNT(*) AS failure_count,
-			MIN(prow_job_runs.timestamp) AS first_failure,
-			MAX(prow_job_runs.timestamp) AS last_failure`)
-
-	if previousPeriod != nil {
-		prevStart := periodStart.Add(-*previousPeriod)
-		q = q.Where(`NOT EXISTS (
-			SELECT 1
-			FROM prow_job_run_tests prev_t
-			JOIN prow_job_runs prev_r ON prev_r.id = prev_t.prow_job_run_id
-			JOIN prow_jobs prev_j ON prev_j.id = prev_r.prow_job_id
-			WHERE prev_t.test_id = tests.id
-			  AND prev_t.status = ?
-			  AND prev_r.timestamp >= ? AND prev_r.timestamp < ?
-			  AND prev_r.prow_job_release = ?
-			  AND prev_t.prow_job_run_timestamp >= ? AND prev_t.prow_job_run_timestamp < ?
-			  AND prev_j.release = ?
-			  AND prev_t.prow_job_run_release = ?
-			  AND prev_t.deleted_at IS NULL
-			  AND prev_r.deleted_at IS NULL
-			  AND prev_j.deleted_at IS NULL
-		)`, int(sippyprocessingv1.TestStatusFailure), prevStart, periodStart, release, prevStart, periodStart, release, release)
+	var q *gorm.DB
+	if previousPeriodDays != nil {
+		var err error
+		q, err = buildRecentFailuresWithPrevPeriodFilter(dbc, release, startDate, endDate, *previousPeriodDays)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		q = buildRecentFailuresQuery(dbc, release, startDate, endDate)
 	}
 
-	// Wrap the aggregated query as a subquery so we can apply filters/sort/pagination
 	subquery := dbc.DB.Table("(?) AS recent_failures", q)
 
 	filteredQuery, err := filter.FilterableDBResult(subquery, filterOpts, apitype.RecentTestFailure{})
@@ -105,89 +80,22 @@ func GetRecentTestFailures(
 
 		// Bound the last_pass lookback to the total analysis window (period + previousPeriod)
 		// to avoid scanning the entire history for large releases.
-		lastPassLookback := periodStart
-		if previousPeriod != nil {
-			lastPassLookback = periodStart.Add(-*previousPeriod)
-		}
-		var lastPasses []struct {
-			TestID   uint       `gorm:"column:test_id"`
-			LastPass *time.Time `gorm:"column:last_pass"`
-		}
-		if err := dbc.DB.Table("prow_job_run_tests").
-			Joins("JOIN prow_job_runs ON prow_job_runs.id = prow_job_run_tests.prow_job_run_id").
-			Joins("JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id").
-			Where("prow_job_run_tests.test_id IN ?", testIDs).
-			Where("prow_job_run_tests.status = ?", int(sippyprocessingv1.TestStatusSuccess)).
-			Where("prow_job_runs.timestamp >= ?", lastPassLookback).
-			Where("prow_job_runs.prow_job_release = ?", release).
-			Where("prow_job_run_tests.prow_job_run_timestamp >= ?", lastPassLookback).
-			Where("prow_jobs.release = ?", release).
-			Where("prow_job_run_tests.prow_job_run_release = ?", release).
-			Where("prow_job_run_tests.deleted_at IS NULL").
-			Where("prow_job_runs.deleted_at IS NULL").
-			Where("prow_jobs.deleted_at IS NULL").
-			Group("prow_job_run_tests.test_id").
-			Select("prow_job_run_tests.test_id AS test_id, MAX(prow_job_runs.timestamp) AS last_pass").
-			Scan(&lastPasses).Error; err != nil {
-			return nil, err
+		lastPassLookbackDate := startDate
+		if previousPeriodDays != nil {
+			lastPassLookbackDate = startDate.AddDays(-*previousPeriodDays)
 		}
 
-		lastPassByTestID := make(map[uint]*time.Time)
-		for _, lp := range lastPasses {
-			lastPassByTestID[lp.TestID] = lp.LastPass
+		lastPassByTestID, err := findLastPassIterative(dbc, testIDs, release, endDate, lastPassLookbackDate)
+		if err != nil {
+			return nil, err
 		}
 		for i := range results {
 			results[i].LastPass = lastPassByTestID[results[i].TestID]
 		}
 
 		if includeOutputs {
-			var outputs []struct {
-				TestID       uint      `gorm:"column:test_id"`
-				ProwJobRunID uint      `gorm:"column:prow_job_run_id"`
-				ProwJobName  string    `gorm:"column:prow_job_name"`
-				ProwJobURL   string    `gorm:"column:prow_job_url"`
-				FailedAt     time.Time `gorm:"column:failed_at"`
-				Output       string    `gorm:"column:output"`
-			}
-
-			if err := dbc.DB.Table("prow_job_run_tests").
-				Joins("JOIN prow_job_runs ON prow_job_runs.id = prow_job_run_tests.prow_job_run_id").
-				Joins("JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id").
-				Joins("LEFT JOIN prow_job_run_test_outputs ON prow_job_run_test_outputs.prow_job_run_test_id = prow_job_run_tests.id").
-				Where("prow_job_run_tests.test_id IN ?", testIDs).
-				Where("prow_job_run_tests.status = ?", int(sippyprocessingv1.TestStatusFailure)).
-				Where("prow_job_runs.timestamp >= ? AND prow_job_runs.timestamp < ?", periodStart, reportEnd).
-				Where("prow_job_runs.prow_job_release = ?", release).
-				Where("prow_job_run_tests.prow_job_run_timestamp >= ? AND prow_job_run_tests.prow_job_run_timestamp < ?", periodStart, reportEnd).
-				Where("prow_jobs.release = ?", release).
-				Where("prow_job_run_tests.prow_job_run_release = ?", release).
-				Where("prow_job_run_tests.deleted_at IS NULL").
-				Where("prow_job_runs.deleted_at IS NULL").
-				Where("prow_jobs.deleted_at IS NULL").
-				Select(`
-					prow_job_run_tests.test_id AS test_id,
-					prow_job_runs.id AS prow_job_run_id,
-					prow_jobs.name AS prow_job_name,
-					prow_job_runs.url AS prow_job_url,
-					prow_job_runs.timestamp AS failed_at,
-					COALESCE(prow_job_run_test_outputs.output, '') AS output`).
-				Scan(&outputs).Error; err != nil {
+			if err := attachOutputs(dbc, results, testIDs, release, startDate, endDate); err != nil {
 				return nil, err
-			}
-
-			outputsByTestID := make(map[uint][]apitype.RecentTestFailureOutput)
-			for _, o := range outputs {
-				outputsByTestID[o.TestID] = append(outputsByTestID[o.TestID], apitype.RecentTestFailureOutput{
-					ProwJobRunID: o.ProwJobRunID,
-					ProwJobName:  o.ProwJobName,
-					ProwJobURL:   o.ProwJobURL,
-					FailedAt:     o.FailedAt,
-					Output:       o.Output,
-				})
-			}
-
-			for i := range results {
-				results[i].Outputs = outputsByTestID[results[i].TestID]
 			}
 		}
 	}
@@ -198,4 +106,249 @@ func GetRecentTestFailures(
 		PageSize:  pagination.PerPage,
 		Page:      pagination.Page,
 	}, nil
+}
+
+// recentFailuresMainSQL returns the core aggregation SQL and its parameters.
+// Both the simple and previous-period-filtered paths share this fragment.
+func recentFailuresMainSQL(release string, startDate, endDate civil.Date) (string, []interface{}) {
+	sql := `SELECT tests.id AS test_id,
+			tests.name AS test_name,
+			suites.name AS suite_name,
+			test_ownerships.jira_component AS jira_component,
+			COUNT(*) AS failure_count,
+			MIN(prow_job_runs.timestamp) AS first_failure,
+			MAX(prow_job_runs.timestamp) AS last_failure
+		FROM prow_job_run_tests
+		JOIN prow_job_runs ON prow_job_runs.id = prow_job_run_tests.prow_job_run_id
+		JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id
+		JOIN tests ON tests.id = prow_job_run_tests.test_id
+		LEFT JOIN suites ON suites.id = prow_job_run_tests.suite_id
+		LEFT JOIN test_ownerships ON test_ownerships.test_id = tests.id AND test_ownerships.deleted_at IS NULL
+		WHERE prow_job_runs.timestamp >= ? AND prow_job_runs.timestamp < ?
+			AND prow_job_runs.prow_job_release = ?
+			AND prow_job_run_tests.prow_job_run_timestamp >= ? AND prow_job_run_tests.prow_job_run_timestamp < ?
+			AND prow_job_run_tests.status = ?
+			AND prow_jobs.release = ?
+			AND prow_job_run_tests.prow_job_run_release = ?
+			AND prow_job_run_tests.deleted_at IS NULL
+			AND prow_job_runs.deleted_at IS NULL
+			AND prow_jobs.deleted_at IS NULL
+			AND tests.deleted_at IS NULL
+		GROUP BY tests.id, tests.name, suites.name, test_ownerships.jira_component`
+
+	params := []interface{}{
+		startDate, endDate, release,
+		startDate, endDate,
+		int(sippyprocessingv1.TestStatusFailure),
+		release, release,
+	}
+	return sql, params
+}
+
+// buildRecentFailuresQuery builds the main aggregation query without any previous-period filtering.
+func buildRecentFailuresQuery(dbc *db.DB, release string, startDate, endDate civil.Date) *gorm.DB {
+	sql, params := recentFailuresMainSQL(release, startDate, endDate)
+	return dbc.DB.Raw("("+sql+")", params...)
+}
+
+// buildRecentFailuresWithPrevPeriodFilter wraps the main aggregation as a CTE,
+// then anti-joins against test_cumulative_summaries to exclude tests that also
+// failed in the previous period. The cumulative summaries are pre-aggregated
+// per test_id (summing across all prow_job_id/suite_id combos) before comparing.
+func buildRecentFailuresWithPrevPeriodFilter(
+	dbc *db.DB,
+	release string,
+	startDate, endDate civil.Date,
+	previousPeriodDays int,
+) (*gorm.DB, error) {
+	mainSQL, mainParams := recentFailuresMainSQL(release, startDate, endDate)
+
+	prevPeriod := query.DateRange{
+		Start: startDate.AddDays(-previousPeriodDays),
+		End:   startDate,
+	}
+	if err := query.ResolveDateRanges(dbc, release, &prevPeriod); err != nil {
+		return nil, err
+	}
+	cumEndDate := prevPeriod.End.AddDays(-1).String()
+	cumStartDate := prevPeriod.Start.AddDays(-1).String()
+
+	rawSQL := fmt.Sprintf(`(
+		WITH main_agg AS (%s),
+		prev_failures AS (
+			SELECT cum_end_agg.test_id
+			FROM (
+				SELECT test_id, SUM(prefix_sum_failures) AS total_failures
+				FROM test_cumulative_summaries
+				WHERE release = ? AND date = ?
+					AND test_id IN (SELECT test_id FROM main_agg)
+				GROUP BY test_id
+			) cum_end_agg
+			LEFT JOIN (
+				SELECT test_id, SUM(prefix_sum_failures) AS total_failures
+				FROM test_cumulative_summaries
+				WHERE release = ? AND date = ?
+					AND test_id IN (SELECT test_id FROM main_agg)
+				GROUP BY test_id
+			) cum_start_agg ON cum_start_agg.test_id = cum_end_agg.test_id
+			WHERE (cum_end_agg.total_failures - COALESCE(cum_start_agg.total_failures, 0)) > 0
+		)
+		SELECT m.*
+		FROM main_agg m
+		WHERE m.test_id NOT IN (SELECT test_id FROM prev_failures)
+	)`, mainSQL)
+
+	params := append(mainParams, release, cumEndDate, release, cumStartDate)
+	return dbc.DB.Raw(rawSQL, params...), nil
+}
+
+// findLastPassIterative scans backwards one day at a time from endDate, looking
+// for the most recent successful run for each test_id. Each iteration queries only
+// the remaining unfound IDs, and scans a single daily partition.
+func findLastPassIterative(
+	dbc *db.DB,
+	testIDs []uint,
+	release string,
+	endDate, lookbackDate civil.Date,
+) (map[uint]*time.Time, error) {
+	lastPassByTestID := make(map[uint]*time.Time, len(testIDs))
+
+	toSearch := make([]uint, len(testIDs))
+	copy(toSearch, testIDs)
+	notFound := make([]uint, 0, len(testIDs))
+
+	windowEnd := endDate
+	statusSuccess := int(sippyprocessingv1.TestStatusSuccess)
+
+	for len(toSearch) > 0 {
+		windowStart := windowEnd.AddDays(-1)
+		if windowStart.Before(lookbackDate) {
+			windowStart = lookbackDate
+		}
+		if !windowStart.Before(windowEnd) {
+			break
+		}
+
+		for batchStart := 0; batchStart < len(toSearch); batchStart += maxTestIDsPerQuery {
+			batchEnd := batchStart + maxTestIDsPerQuery
+			if batchEnd > len(toSearch) {
+				batchEnd = len(toSearch)
+			}
+			batch := toSearch[batchStart:batchEnd]
+
+			var passes []struct {
+				TestID   uint      `gorm:"column:test_id"`
+				LastPass time.Time `gorm:"column:last_pass"`
+			}
+
+			if err := dbc.DB.Table("prow_job_run_tests").
+				Joins("JOIN prow_job_runs ON prow_job_runs.id = prow_job_run_tests.prow_job_run_id").
+				Where("prow_job_run_tests.test_id IN ?", batch).
+				Where("prow_job_run_tests.status = ?", statusSuccess).
+				Where("prow_job_run_tests.prow_job_run_timestamp >= ? AND prow_job_run_tests.prow_job_run_timestamp < ?", windowStart, windowEnd).
+				Where("prow_job_run_tests.prow_job_run_release = ?", release).
+				Where("prow_job_runs.prow_job_release = ?", release).
+				Where("prow_job_run_tests.deleted_at IS NULL").
+				Where("prow_job_runs.deleted_at IS NULL").
+				Group("prow_job_run_tests.test_id").
+				Select("prow_job_run_tests.test_id AS test_id, MAX(prow_job_runs.timestamp) AS last_pass").
+				Scan(&passes).Error; err != nil {
+				return nil, err
+			}
+
+			for i := range passes {
+				t := passes[i].LastPass
+				lastPassByTestID[passes[i].TestID] = &t
+			}
+		}
+
+		for _, id := range toSearch {
+			if _, ok := lastPassByTestID[id]; !ok {
+				notFound = append(notFound, id)
+			}
+		}
+
+		log.WithFields(log.Fields{
+			"windowStart": windowStart.String(),
+			"windowEnd":   windowEnd.String(),
+			"found":       len(toSearch) - len(notFound),
+			"remaining":   len(notFound),
+		}).Debug("last_pass iterative scan progress")
+
+		toSearch, notFound = notFound, toSearch[:0]
+		windowEnd = windowStart
+	}
+
+	return lastPassByTestID, nil
+}
+
+// attachOutputs fetches individual failure outputs and attaches them to the results.
+func attachOutputs(
+	dbc *db.DB,
+	results []apitype.RecentTestFailure,
+	testIDs []uint,
+	release string,
+	startDate, endDate civil.Date,
+) error {
+	outputsByTestID := make(map[uint][]apitype.RecentTestFailureOutput)
+
+	for batchStart := 0; batchStart < len(testIDs); batchStart += maxTestIDsPerQuery {
+		batchEnd := batchStart + maxTestIDsPerQuery
+		if batchEnd > len(testIDs) {
+			batchEnd = len(testIDs)
+		}
+		batch := testIDs[batchStart:batchEnd]
+
+		var outputs []struct {
+			TestID       uint      `gorm:"column:test_id"`
+			ProwJobRunID uint      `gorm:"column:prow_job_run_id"`
+			ProwJobName  string    `gorm:"column:prow_job_name"`
+			ProwJobURL   string    `gorm:"column:prow_job_url"`
+			FailedAt     time.Time `gorm:"column:failed_at"`
+			Output       string    `gorm:"column:output"`
+		}
+
+		if err := dbc.DB.Table("prow_job_run_tests").
+			Joins("JOIN prow_job_runs ON prow_job_runs.id = prow_job_run_tests.prow_job_run_id").
+			Joins("JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id").
+			Joins(`LEFT JOIN prow_job_run_test_outputs ON prow_job_run_test_outputs.prow_job_run_test_id = prow_job_run_tests.id
+				AND prow_job_run_test_outputs.prow_job_run_test_release = prow_job_run_tests.prow_job_run_release
+				AND prow_job_run_test_outputs.prow_job_run_test_timestamp >= ? AND prow_job_run_test_outputs.prow_job_run_test_timestamp < ?`, startDate, endDate).
+			Where("prow_job_run_tests.test_id IN ?", batch).
+			Where("prow_job_run_tests.status = ?", int(sippyprocessingv1.TestStatusFailure)).
+			Where("prow_job_runs.timestamp >= ? AND prow_job_runs.timestamp < ?", startDate, endDate).
+			Where("prow_job_runs.prow_job_release = ?", release).
+			Where("prow_job_run_tests.prow_job_run_timestamp >= ? AND prow_job_run_tests.prow_job_run_timestamp < ?", startDate, endDate).
+			Where("prow_jobs.release = ?", release).
+			Where("prow_job_run_tests.prow_job_run_release = ?", release).
+			Where("prow_job_run_tests.deleted_at IS NULL").
+			Where("prow_job_runs.deleted_at IS NULL").
+			Where("prow_jobs.deleted_at IS NULL").
+			Select(`
+				prow_job_run_tests.test_id AS test_id,
+				prow_job_runs.id AS prow_job_run_id,
+				prow_jobs.name AS prow_job_name,
+				prow_job_runs.url AS prow_job_url,
+				prow_job_runs.timestamp AS failed_at,
+				COALESCE(prow_job_run_test_outputs.output, '') AS output`).
+			Scan(&outputs).Error; err != nil {
+			return err
+		}
+
+		for _, o := range outputs {
+			outputsByTestID[o.TestID] = append(outputsByTestID[o.TestID], apitype.RecentTestFailureOutput{
+				ProwJobRunID: o.ProwJobRunID,
+				ProwJobName:  o.ProwJobName,
+				ProwJobURL:   o.ProwJobURL,
+				FailedAt:     o.FailedAt,
+				Output:       o.Output,
+			})
+		}
+	}
+
+	for i := range results {
+		results[i].Outputs = outputsByTestID[results[i].TestID]
+	}
+
+	return nil
 }

--- a/pkg/db/query/cumulative_query.go
+++ b/pkg/db/query/cumulative_query.go
@@ -139,12 +139,12 @@ func TestReportQuery(dbc *db.DB, release string, sample, base DateRange, nameMat
 	return testReportPreAgg(dbc, release, sample, base, nameMatches)
 }
 
-// resolveDateRanges clamps the Start and End of each DateRange to the latest
+// ResolveDateRanges clamps the Start and End of each DateRange to the latest
 // available date (+1, since DateRange uses half-open intervals) for the release
 // in test_cumulative_summaries. This ensures the planner sees literal dates it
 // can use for partition pruning, and handles cases where data hasn't been
 // backfilled up to the requested dates.
-func resolveDateRanges(dbc *db.DB, release string, ranges ...*DateRange) error {
+func ResolveDateRanges(dbc *db.DB, release string, ranges ...*DateRange) error {
 	var maxDate *civil.Date
 	row := dbc.DB.Table("test_cumulative_summaries").
 		Select("MAX(date)").
@@ -267,7 +267,7 @@ func processedFilterConditions(f *filter.Filter) (conditions []string, args []an
 // dates to the three prefix sum lookup dates used by the 3-way self-join
 // (each shifted by -1 day): end (e), boundary (m), and start (s).
 func resolvePrefixSumDates(dbc *db.DB, release string, sample, base *DateRange) (end, boundary, start civil.Date, err error) {
-	if err = resolveDateRanges(dbc, release, sample, base); err != nil {
+	if err = ResolveDateRanges(dbc, release, sample, base); err != nil {
 		return
 	}
 	if sample.Start != base.End {

--- a/pkg/db/query/feature_gates.go
+++ b/pkg/db/query/feature_gates.go
@@ -17,7 +17,7 @@ func GetFeatureGatesFromDB(dbc *db.DB, release string, filterOpts *filter.Filter
 	// at least once, filtering out tests that merely have carried-forward rows.
 	tomorrow := civil.DateOf(time.Now().UTC()).AddDays(1)
 	dr := DateRange{Start: tomorrow.AddDays(-8), End: tomorrow}
-	if err := resolveDateRanges(dbc, release, &dr); err != nil {
+	if err := ResolveDateRanges(dbc, release, &dr); err != nil {
 		return nil, err
 	}
 	lookupEnd := dr.End.AddDays(-1)

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -357,10 +357,10 @@ func getBenchmarkCases(asOf time.Time) []benchmarkCase {
 		{
 			name: "RecentTestFailures",
 			fn: func(dbc *db.DB) error {
-				period := 7 * 24 * time.Hour
-				previousPeriod := 7 * 24 * time.Hour
+				periodDays := 7
+				previousPeriodDays := 7
 				pagination := &apitype.Pagination{PerPage: 20, Page: 0}
-				result, err := api.GetRecentTestFailures(dbc, benchmarkRelease, period, &previousPeriod, false, &filter.FilterOptions{Filter: &filter.Filter{}}, pagination, asOf)
+				result, err := api.GetRecentTestFailures(dbc, benchmarkRelease, periodDays, &previousPeriodDays, false, &filter.FilterOptions{Filter: &filter.Filter{}}, pagination, asOf)
 				if err == nil {
 					log.Printf("RecentTestFailures: %d rows", result.TotalRows)
 				}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -871,32 +871,32 @@ func (s *Server) jsonGetRecentTestFailures(w http.ResponseWriter, req *http.Requ
 		return
 	}
 
-	periodStr := s.getParamOrFail(w, req, "period")
-	if periodStr == "" {
+	periodDaysStr := s.getParamOrFail(w, req, "periodDays")
+	if periodDaysStr == "" {
 		return
 	}
-	period, err := time.ParseDuration(periodStr)
+	periodDays, err := strconv.Atoi(periodDaysStr)
 	if err != nil {
-		failureResponse(w, http.StatusBadRequest, fmt.Sprintf("invalid period duration: %s", err.Error()))
+		failureResponse(w, http.StatusBadRequest, fmt.Sprintf("invalid periodDays value: %s", err.Error()))
 		return
 	}
-	if period <= 0 {
-		failureResponse(w, http.StatusBadRequest, "period must be a positive duration")
+	if periodDays <= 0 {
+		failureResponse(w, http.StatusBadRequest, "periodDays must be a positive integer")
 		return
 	}
 
-	var previousPeriod *time.Duration
-	if pp := param.SafeRead(req, "previousPeriod"); pp != "" {
-		d, err := time.ParseDuration(pp)
+	var previousPeriodDays *int
+	if pp := param.SafeRead(req, "previousPeriodDays"); pp != "" {
+		d, err := strconv.Atoi(pp)
 		if err != nil {
-			failureResponse(w, http.StatusBadRequest, fmt.Sprintf("invalid previousPeriod duration: %s", err.Error()))
+			failureResponse(w, http.StatusBadRequest, fmt.Sprintf("invalid previousPeriodDays value: %s", err.Error()))
 			return
 		}
 		if d <= 0 {
-			failureResponse(w, http.StatusBadRequest, "previousPeriod must be a positive duration")
+			failureResponse(w, http.StatusBadRequest, "previousPeriodDays must be a positive integer")
 			return
 		}
-		previousPeriod = &d
+		previousPeriodDays = &d
 	}
 
 	includeOutputs, err := param.ReadBool(req, "includeOutputs", false)
@@ -917,7 +917,7 @@ func (s *Server) jsonGetRecentTestFailures(w http.ResponseWriter, req *http.Requ
 		return
 	}
 
-	result, err := api.GetRecentTestFailures(s.db, release, period, previousPeriod, includeOutputs, filterOpts, pagination, s.GetReportEnd())
+	result, err := api.GetRecentTestFailures(s.db, release, periodDays, previousPeriodDays, includeOutputs, filterOpts, pagination, s.GetReportEnd())
 	if err != nil {
 		failureResponseWithError(w, "error querying recent test failures", err)
 		return

--- a/pkg/util/param/param.go
+++ b/pkg/util/param/param.go
@@ -74,8 +74,9 @@ var paramRegexp = map[string]*regexp.Regexp{
 	"beforeContext":      uintRegexp,
 	"afterContext":       uintRegexp,
 	// recent test failures params
-	"previousPeriod": wordRegexp,
-	"includeOutputs": boolRegexp,
+	"periodDays":         uintRegexp,
+	"previousPeriodDays": uintRegexp,
+	"includeOutputs":     boolRegexp,
 	// pull request test results params
 	"limit": uintRegexp,
 }

--- a/sippy-ng/src/releases/RecentTestFailures.jsx
+++ b/sippy-ng/src/releases/RecentTestFailures.jsx
@@ -343,6 +343,8 @@ FailureRow.propTypes = {
   row: PropTypes.object.isRequired,
 }
 
+const pluralDays = (n) => (n === 1 ? 'day' : 'days')
+
 export default function RecentTestFailures(props) {
   const classes = useStyles()
 
@@ -356,8 +358,8 @@ export default function RecentTestFailures(props) {
   const [page, setPage] = React.useState(0)
   const [rowsPerPage, setRowsPerPage] = React.useState(props.limit || 5)
 
-  const period = props.period || '24h'
-  const previousPeriod = props.previousPeriod || '72h'
+  const periodDays = props.periodDays || 1
+  const previousPeriodDays = props.previousPeriodDays || 3
   const includeOutputs =
     props.includeOutputs !== undefined ? props.includeOutputs : true
 
@@ -368,8 +370,8 @@ export default function RecentTestFailures(props) {
       import.meta.env.VITE_API_URL +
       '/api/tests/recent_failures' +
       `?release=${safeEncodeURIComponent(props.release)}` +
-      `&period=${safeEncodeURIComponent(period)}` +
-      `&previousPeriod=${safeEncodeURIComponent(previousPeriod)}` +
+      `&periodDays=${periodDays}` +
+      `&previousPeriodDays=${previousPeriodDays}` +
       `&includeOutputs=${includeOutputs}` +
       `&sortField=${safeEncodeURIComponent(orderBy)}` +
       `&sort=${safeEncodeURIComponent(order)}` +
@@ -400,7 +402,15 @@ export default function RecentTestFailures(props) {
 
   useEffect(() => {
     fetchData()
-  }, [props.release, period, previousPeriod, orderBy, order, page, rowsPerPage])
+  }, [
+    props.release,
+    periodDays,
+    previousPeriodDays,
+    orderBy,
+    order,
+    page,
+    rowsPerPage,
+  ])
 
   const handleSort = (field) => {
     const isAsc = orderBy === field && order === 'asc'
@@ -427,7 +437,11 @@ export default function RecentTestFailures(props) {
           {title}
         </Typography>
         <Tooltip
-          title={`Tests that failed in the last ${period} but did not fail in the ${previousPeriod} before that. This helps surface new regressions.`}
+          title={`Tests that failed in the last ${periodDays} ${pluralDays(
+            periodDays
+          )} but did not fail in the ${previousPeriodDays} ${pluralDays(
+            previousPeriodDays
+          )} before that. This helps surface new regressions.`}
         >
           <InfoIcon className={classes.infoIcon} />
         </Tooltip>
@@ -459,8 +473,9 @@ export default function RecentTestFailures(props) {
             No new test failures detected
           </Typography>
           <Typography variant="caption" color="text.secondary">
-            No tests started failing in the last {period} that were not already
-            failing in the prior {previousPeriod}.
+            No tests started failing in the last {periodDays}{' '}
+            {pluralDays(periodDays)} that were not already failing in the prior{' '}
+            {previousPeriodDays} {pluralDays(previousPeriodDays)}.
           </Typography>
         </Box>
       ) : (
@@ -531,8 +546,8 @@ export default function RecentTestFailures(props) {
 
 RecentTestFailures.propTypes = {
   release: PropTypes.string.isRequired,
-  period: PropTypes.string,
-  previousPeriod: PropTypes.string,
+  periodDays: PropTypes.number,
+  previousPeriodDays: PropTypes.number,
   includeOutputs: PropTypes.bool,
   limit: PropTypes.number,
   sortField: PropTypes.string,


### PR DESCRIPTION
@coderabbitai ignore

## Summary

- Rewrites `/api/tests/recent_failures` queries for partition pruning: aligns all date boundaries to calendar days using `civil.Date`, adds release/timestamp predicates to every JOIN so Postgres can prune `prow_job_run_tests`, `prow_job_runs`, and `prow_job_run_test_outputs` partitions.
- Replaces the previous-period exclusion with a CTE that pre-aggregates `test_cumulative_summaries` per test_id (summing across prow_job_id/suite_id combos) before comparing, and clamps dates via `ResolveDateRanges` to avoid querying cumulative data that hasn't been populated yet.
- Adds an iterative backwards scan for `last_pass` (one daily partition at a time) with batched IN clauses (500 IDs per query) to avoid large sequential scans.
- Batches the outputs LEFT JOIN at 500 test IDs per query to keep plan complexity bounded.

## Breaking API change

The query parameters `period` and `previousPeriod` (which accepted Go duration strings like `168h`) are replaced by `periodDays` and `previousPeriodDays` (plain integers). The only caller is `RecentTestFailures.jsx`, updated in this PR.

## Test plan

- [x] `make lint && make test && make e2e` pass
- [ ] Deploy to staging and verify `/api/tests/recent_failures?release=4.19&periodDays=1&previousPeriodDays=3` returns results with correct timing
- [ ] Verify `periodDays=7&previousPeriodDays=7` (larger window) works
- [ ] Verify `includeOutputs=true` attaches failure outputs
- [ ] Verify omitting `previousPeriodDays` returns all failures (no CTE path)
- [ ] Check `EXPLAIN ANALYZE` shows partition pruning on `prow_job_run_tests` and `prow_job_run_test_outputs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recent test failures now use calendar-day windows, with support for comparing a current period against a previous period.
  * Updated controls and messaging clearly describe failure data by number of days.
  * Optional failure outputs and most recent successful runs are included more consistently.

* **Bug Fixes**
  * Improved date-range handling for accurate, inclusive/exclusive reporting windows.
  * Added validation for invalid or missing day-based query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->