### PR TITLE
TRT-2805: Optimize /api/tests/recent_failures query performance

### DIFF
--- a/pkg/api/recent_test_failures.go
+++ b/pkg/api/recent_test_failures.go
@@ -1,12 +1,18 @@
 package api
 
 import (
+	"fmt"
 	"time"
+
+	"cloud.google.com/go/civil"
+	"golang.org/x/sync/errgroup"
+	"gorm.io/gorm"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	sippyprocessingv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/filter"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // GetRecentTestFailures returns tests that failed within the given period, optionally
@@ -23,53 +29,8 @@ func GetRecentTestFailures(
 ) (*apitype.PaginationResult, error) {
 	periodStart := reportEnd.Add(-period)
 
-	q := dbc.DB.Table("prow_job_run_tests").
-		Joins("JOIN prow_job_runs ON prow_job_runs.id = prow_job_run_tests.prow_job_run_id").
-		Joins("JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id").
-		Joins("JOIN tests ON tests.id = prow_job_run_tests.test_id").
-		Joins("LEFT JOIN suites ON suites.id = prow_job_run_tests.suite_id").
-		Joins("LEFT JOIN test_ownerships ON test_ownerships.test_id = tests.id").
-		Where("prow_job_runs.timestamp >= ? AND prow_job_runs.timestamp < ?", periodStart, reportEnd).
-		Where("prow_job_runs.prow_job_release = ?", release).
-		Where("prow_job_run_tests.prow_job_run_timestamp >= ? AND prow_job_run_tests.prow_job_run_timestamp < ?", periodStart, reportEnd).
-		Where("prow_job_run_tests.status = ?", int(sippyprocessingv1.TestStatusFailure)).
-		Where("prow_jobs.release = ?", release).
-		Where("prow_job_run_tests.prow_job_run_release = ?", release).
-		Where("prow_job_run_tests.deleted_at IS NULL").
-		Where("prow_job_runs.deleted_at IS NULL").
-		Where("prow_jobs.deleted_at IS NULL").
-		Where("tests.deleted_at IS NULL").
-		Group("tests.id, tests.name, suites.name, test_ownerships.jira_component").
-		Select(`
-			tests.id AS test_id,
-			tests.name AS test_name,
-			suites.name AS suite_name,
-			test_ownerships.jira_component AS jira_component,
-			COUNT(*) AS failure_count,
-			MIN(prow_job_runs.timestamp) AS first_failure,
-			MAX(prow_job_runs.timestamp) AS last_failure`)
+	q := buildRecentFailuresQuery(dbc, release, periodStart, reportEnd, previousPeriod)
 
-	if previousPeriod != nil {
-		prevStart := periodStart.Add(-*previousPeriod)
-		q = q.Where(`NOT EXISTS (
-			SELECT 1
-			FROM prow_job_run_tests prev_t
-			JOIN prow_job_runs prev_r ON prev_r.id = prev_t.prow_job_run_id
-			JOIN prow_jobs prev_j ON prev_j.id = prev_r.prow_job_id
-			WHERE prev_t.test_id = tests.id
-			  AND prev_t.status = ?
-			  AND prev_r.timestamp >= ? AND prev_r.timestamp < ?
-			  AND prev_r.prow_job_release = ?
-			  AND prev_t.prow_job_run_timestamp >= ? AND prev_t.prow_job_run_timestamp < ?
-			  AND prev_j.release = ?
-			  AND prev_t.prow_job_run_release = ?
-			  AND prev_t.deleted_at IS NULL
-			  AND prev_r.deleted_at IS NULL
-			  AND prev_j.deleted_at IS NULL
-		)`, int(sippyprocessingv1.TestStatusFailure), prevStart, periodStart, release, prevStart, periodStart, release, release)
-	}
-
-	// Wrap the aggregated query as a subquery so we can apply filters/sort/pagination
 	subquery := dbc.DB.Table("(?) AS recent_failures", q)
 
 	filteredQuery, err := filter.FilterableDBResult(subquery, filterOpts, apitype.RecentTestFailure{})
@@ -78,116 +39,70 @@ func GetRecentTestFailures(
 	}
 
 	var rowCount int64
-	if err := filteredQuery.Count(&rowCount).Error; err != nil {
+	results := make([]apitype.RecentTestFailure, 0)
+
+	scanQuery := filteredQuery.Session(&gorm.Session{NewDB: false})
+	if pagination != nil {
+		scanQuery = scanQuery.Limit(pagination.PerPage).Offset(pagination.Page * pagination.PerPage)
+	}
+
+	var g errgroup.Group
+	g.Go(func() error {
+		return scanQuery.Scan(&results).Error
+	})
+	if pagination != nil {
+		countQuery := filteredQuery.Session(&gorm.Session{NewDB: false})
+		g.Go(func() error {
+			return countQuery.Count(&rowCount).Error
+		})
+	}
+	if err := g.Wait(); err != nil {
 		return nil, err
 	}
 
 	if pagination == nil {
+		rowCount = int64(len(results))
 		pagination = &apitype.Pagination{
-			PerPage: int(rowCount),
+			PerPage: len(results),
 			Page:    0,
 		}
-	} else {
-		filteredQuery = filteredQuery.Limit(pagination.PerPage).Offset(pagination.Page * pagination.PerPage)
-	}
-
-	results := make([]apitype.RecentTestFailure, 0)
-	res := filteredQuery.Scan(&results)
-	if res.Error != nil {
-		return nil, res.Error
 	}
 
 	if len(results) > 0 {
-		testIDs := make([]uint, len(results))
-		for i, r := range results {
-			testIDs[i] = r.TestID
+		pageKeys := make([]testSuiteKey, 0, len(results))
+		for _, r := range results {
+			key := testSuiteKey{testID: r.TestID}
+			if r.SuiteID != nil {
+				key.suiteID = *r.SuiteID
+			}
+			pageKeys = append(pageKeys, key)
 		}
 
-		// Bound the last_pass lookback to the total analysis window (period + previousPeriod)
-		// to avoid scanning the entire history for large releases.
-		lastPassLookback := periodStart
-		if previousPeriod != nil {
-			lastPassLookback = periodStart.Add(-*previousPeriod)
+		var lastPassMap map[testSuiteKey]*time.Time
+		var outputMap map[testSuiteKey][]apitype.RecentTestFailureOutput
+
+		var followUp errgroup.Group
+		followUp.Go(func() error {
+			var err error
+			lastPassMap, err = findLastPass(dbc, pageKeys, release, reportEnd)
+			return err
+		})
+		if includeOutputs {
+			followUp.Go(func() error {
+				var err error
+				outputMap, err = fetchOutputs(dbc, pageKeys, release, periodStart, reportEnd)
+				return err
+			})
 		}
-		var lastPasses []struct {
-			TestID   uint       `gorm:"column:test_id"`
-			LastPass *time.Time `gorm:"column:last_pass"`
-		}
-		if err := dbc.DB.Table("prow_job_run_tests").
-			Joins("JOIN prow_job_runs ON prow_job_runs.id = prow_job_run_tests.prow_job_run_id").
-			Joins("JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id").
-			Where("prow_job_run_tests.test_id IN ?", testIDs).
-			Where("prow_job_run_tests.status = ?", int(sippyprocessingv1.TestStatusSuccess)).
-			Where("prow_job_runs.timestamp >= ?", lastPassLookback).
-			Where("prow_job_runs.prow_job_release = ?", release).
-			Where("prow_job_run_tests.prow_job_run_timestamp >= ?", lastPassLookback).
-			Where("prow_jobs.release = ?", release).
-			Where("prow_job_run_tests.prow_job_run_release = ?", release).
-			Where("prow_job_run_tests.deleted_at IS NULL").
-			Where("prow_job_runs.deleted_at IS NULL").
-			Where("prow_jobs.deleted_at IS NULL").
-			Group("prow_job_run_tests.test_id").
-			Select("prow_job_run_tests.test_id AS test_id, MAX(prow_job_runs.timestamp) AS last_pass").
-			Scan(&lastPasses).Error; err != nil {
+		if err := followUp.Wait(); err != nil {
 			return nil, err
 		}
 
-		lastPassByTestID := make(map[uint]*time.Time)
-		for _, lp := range lastPasses {
-			lastPassByTestID[lp.TestID] = lp.LastPass
-		}
 		for i := range results {
-			results[i].LastPass = lastPassByTestID[results[i].TestID]
-		}
-
-		if includeOutputs {
-			var outputs []struct {
-				TestID       uint      `gorm:"column:test_id"`
-				ProwJobRunID uint      `gorm:"column:prow_job_run_id"`
-				ProwJobName  string    `gorm:"column:prow_job_name"`
-				ProwJobURL   string    `gorm:"column:prow_job_url"`
-				FailedAt     time.Time `gorm:"column:failed_at"`
-				Output       string    `gorm:"column:output"`
-			}
-
-			if err := dbc.DB.Table("prow_job_run_tests").
-				Joins("JOIN prow_job_runs ON prow_job_runs.id = prow_job_run_tests.prow_job_run_id").
-				Joins("JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id").
-				Joins("LEFT JOIN prow_job_run_test_outputs ON prow_job_run_test_outputs.prow_job_run_test_id = prow_job_run_tests.id").
-				Where("prow_job_run_tests.test_id IN ?", testIDs).
-				Where("prow_job_run_tests.status = ?", int(sippyprocessingv1.TestStatusFailure)).
-				Where("prow_job_runs.timestamp >= ? AND prow_job_runs.timestamp < ?", periodStart, reportEnd).
-				Where("prow_job_runs.prow_job_release = ?", release).
-				Where("prow_job_run_tests.prow_job_run_timestamp >= ? AND prow_job_run_tests.prow_job_run_timestamp < ?", periodStart, reportEnd).
-				Where("prow_jobs.release = ?", release).
-				Where("prow_job_run_tests.prow_job_run_release = ?", release).
-				Where("prow_job_run_tests.deleted_at IS NULL").
-				Where("prow_job_runs.deleted_at IS NULL").
-				Where("prow_jobs.deleted_at IS NULL").
-				Select(`
-					prow_job_run_tests.test_id AS test_id,
-					prow_job_runs.id AS prow_job_run_id,
-					prow_jobs.name AS prow_job_name,
-					prow_job_runs.url AS prow_job_url,
-					prow_job_runs.timestamp AS failed_at,
-					COALESCE(prow_job_run_test_outputs.output, '') AS output`).
-				Scan(&outputs).Error; err != nil {
-				return nil, err
-			}
-
-			outputsByTestID := make(map[uint][]apitype.RecentTestFailureOutput)
-			for _, o := range outputs {
-				outputsByTestID[o.TestID] = append(outputsByTestID[o.TestID], apitype.RecentTestFailureOutput{
-					ProwJobRunID: o.ProwJobRunID,
-					ProwJobName:  o.ProwJobName,
-					ProwJobURL:   o.ProwJobURL,
-					FailedAt:     o.FailedAt,
-					Output:       o.Output,
-				})
-			}
-
-			for i := range results {
-				results[i].Outputs = outputsByTestID[results[i].TestID]
+			key := pageKeys[i]
+			results[i].LastPass = lastPassMap[key]
+			if outputMap != nil {
+				results[i].Outputs = outputMap[key]
 			}
 		}
 	}
@@ -198,4 +113,194 @@ func GetRecentTestFailures(
 		PageSize:  pagination.PerPage,
 		Page:      pagination.Page,
 	}, nil
+}
+
+// buildRecentFailuresQuery builds the main aggregation query using a reversed join
+// order (prow_job_run_tests first, filtered by the status index) and deferred
+// dimension lookups (tests/suites/test_ownerships joined after aggregation).
+func buildRecentFailuresQuery(
+	dbc *db.DB,
+	release string,
+	periodStart, reportEnd time.Time,
+	previousPeriod *time.Duration,
+) *gorm.DB {
+	statusFailure := int(sippyprocessingv1.TestStatusFailure)
+
+	innerSQL := `SELECT pjrt.test_id, pjrt.suite_id,
+			COUNT(*) AS failure_count,
+			MIN(pjrt.prow_job_run_timestamp) AS first_failure,
+			MAX(pjrt.prow_job_run_timestamp) AS last_failure
+		FROM prow_job_run_tests pjrt
+		WHERE pjrt.status = ?
+			AND pjrt.prow_job_run_release = ?
+			AND pjrt.prow_job_run_timestamp >= ? AND pjrt.prow_job_run_timestamp < ?
+			AND pjrt.deleted_at IS NULL`
+
+	params := []interface{}{
+		statusFailure, release, periodStart, reportEnd,
+	}
+
+	if previousPeriod != nil {
+		prevStart := periodStart.Add(-*previousPeriod)
+		innerSQL += `
+			AND NOT EXISTS (
+				SELECT 1 FROM prow_job_run_tests prev_t
+				WHERE prev_t.test_id = pjrt.test_id
+					AND prev_t.suite_id IS NOT DISTINCT FROM pjrt.suite_id
+					AND prev_t.status = ?
+					AND prev_t.prow_job_run_release = ?
+					AND prev_t.prow_job_run_timestamp >= ? AND prev_t.prow_job_run_timestamp < ?
+					AND prev_t.deleted_at IS NULL
+			)`
+		params = append(params,
+			statusFailure, release, prevStart, periodStart,
+		)
+	}
+
+	innerSQL += `
+		GROUP BY pjrt.test_id, pjrt.suite_id`
+
+	outerSQL := fmt.Sprintf(`SELECT agg.test_id, agg.suite_id, t.name AS test_name, s.name AS suite_name,
+			tow.jira_component AS jira_component,
+			agg.failure_count, agg.first_failure, agg.last_failure
+		FROM (%s) agg
+		JOIN tests t ON t.id = agg.test_id AND t.deleted_at IS NULL
+		LEFT JOIN suites s ON s.id = agg.suite_id
+		LEFT JOIN test_ownerships tow ON tow.test_id = agg.test_id AND tow.suite_id IS NOT DISTINCT FROM agg.suite_id AND tow.deleted_at IS NULL`, innerSQL)
+
+	return dbc.DB.Raw(outerSQL, params...)
+}
+
+type testSuiteKey struct {
+	testID  uint
+	suiteID uint // 0 represents NULL suite_id
+}
+
+// findLastPass finds the most recent successful run for each (test_id, suite_id)
+// pair by sliding backwards one day at a time from reportEnd. This approach
+// ensures each query hits a single partition for fast execution while
+// guaranteeing the actual last pass is found (up to 90 days back).
+func findLastPass(
+	dbc *db.DB,
+	keys []testSuiteKey,
+	release string,
+	reportEnd time.Time,
+) (map[testSuiteKey]*time.Time, error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
+
+	remaining := sets.New(keys...)
+	result := make(map[testSuiteKey]*time.Time, len(keys))
+
+	endDate := civil.DateOf(reportEnd.UTC())
+	limitDate := endDate.AddDays(-90)
+
+	for date := endDate; remaining.Len() > 0 && !date.Before(limitDate); date = date.AddDays(-1) {
+		testIDs := testIDsFromKeys(remaining)
+
+		var passes []struct {
+			TestID   uint      `gorm:"column:test_id"`
+			SuiteID  *uint     `gorm:"column:suite_id"`
+			LastPass time.Time `gorm:"column:last_pass"`
+		}
+
+		if err := dbc.DB.Table("prow_job_run_tests pjrt").
+			Where("pjrt.test_id IN ?", testIDs).
+			Where("pjrt.status = ?", int(sippyprocessingv1.TestStatusSuccess)).
+			Where("pjrt.prow_job_run_release = ?", release).
+			Where("pjrt.prow_job_run_timestamp >= ? AND pjrt.prow_job_run_timestamp < ?", date, date.AddDays(1)).
+			Where("pjrt.deleted_at IS NULL").
+			Group("pjrt.test_id, pjrt.suite_id").
+			Select("pjrt.test_id AS test_id, pjrt.suite_id AS suite_id, MAX(pjrt.prow_job_run_timestamp) AS last_pass").
+			Scan(&passes).Error; err != nil {
+			return nil, err
+		}
+
+		for i := range passes {
+			key := testSuiteKey{testID: passes[i].TestID}
+			if passes[i].SuiteID != nil {
+				key.suiteID = *passes[i].SuiteID
+			}
+			if remaining.Has(key) {
+				t := passes[i].LastPass
+				result[key] = &t
+				remaining.Delete(key)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func testIDsFromKeys(keys sets.Set[testSuiteKey]) []uint {
+	ids := sets.New[uint]()
+	for key := range keys {
+		ids.Insert(key.testID)
+	}
+	return ids.UnsortedList()
+}
+
+// fetchOutputs retrieves individual failure outputs for the given test/suite
+// pairs, grouped by (test_id, suite_id). Operates only on the current page.
+func fetchOutputs(
+	dbc *db.DB,
+	keys []testSuiteKey,
+	release string,
+	periodStart, reportEnd time.Time,
+) (map[testSuiteKey][]apitype.RecentTestFailureOutput, error) {
+	testIDs := testIDsFromKeys(sets.New(keys...))
+
+	var outputs []struct {
+		TestID       uint      `gorm:"column:test_id"`
+		SuiteID      *uint     `gorm:"column:suite_id"`
+		ProwJobRunID uint      `gorm:"column:prow_job_run_id"`
+		ProwJobName  string    `gorm:"column:prow_job_name"`
+		ProwJobURL   string    `gorm:"column:prow_job_url"`
+		FailedAt     time.Time `gorm:"column:failed_at"`
+		Output       string    `gorm:"column:output"`
+	}
+
+	if err := dbc.DB.Table("prow_job_run_tests pjrt").
+		Joins("JOIN prow_job_runs pjr ON pjr.id = pjrt.prow_job_run_id").
+		Joins("JOIN prow_jobs pj ON pj.id = pjr.prow_job_id").
+		Joins(`LEFT JOIN prow_job_run_test_outputs pjrto ON pjrto.prow_job_run_test_id = pjrt.id
+			AND pjrto.prow_job_run_test_release = pjrt.prow_job_run_release
+			AND pjrto.prow_job_run_test_timestamp = pjrt.prow_job_run_timestamp`).
+		Where("pjrt.test_id IN ?", testIDs).
+		Where("pjrt.status = ?", int(sippyprocessingv1.TestStatusFailure)).
+		Where("pjrt.prow_job_run_release = ?", release).
+		Where("pjrt.prow_job_run_timestamp >= ? AND pjrt.prow_job_run_timestamp < ?", periodStart, reportEnd).
+		Where("pjrt.deleted_at IS NULL").
+		Where("pjr.prow_job_release = ?", release).
+		Where("pjr.timestamp >= ? AND pjr.timestamp < ?", periodStart, reportEnd).
+		Where("pjr.deleted_at IS NULL").
+		Where("pj.deleted_at IS NULL").
+		Select(`pjrt.test_id AS test_id,
+			pjrt.suite_id AS suite_id,
+			pjr.id AS prow_job_run_id,
+			pj.name AS prow_job_name,
+			pjr.url AS prow_job_url,
+			pjr.timestamp AS failed_at,
+			COALESCE(pjrto.output, '') AS output`).
+		Scan(&outputs).Error; err != nil {
+		return nil, err
+	}
+
+	result := make(map[testSuiteKey][]apitype.RecentTestFailureOutput)
+	for _, o := range outputs {
+		key := testSuiteKey{testID: o.TestID}
+		if o.SuiteID != nil {
+			key.suiteID = *o.SuiteID
+		}
+		result[key] = append(result[key], apitype.RecentTestFailureOutput{
+			ProwJobRunID: o.ProwJobRunID,
+			ProwJobName:  o.ProwJobName,
+			ProwJobURL:   o.ProwJobURL,
+			FailedAt:     o.FailedAt,
+			Output:       o.Output,
+		})
+	}
+
+	return result, nil
 }

--- a/pkg/apis/api/recent_test_failures.go
+++ b/pkg/apis/api/recent_test_failures.go
@@ -8,6 +8,7 @@ import (
 // RecentTestFailure represents a test that failed during the queried period.
 type RecentTestFailure struct {
 	TestID        uint                      `json:"test_id"`
+	SuiteID       *uint                     `json:"suite_id,omitempty"`
 	TestName      string                    `json:"test_name"`
 	SuiteName     string                    `json:"suite_name,omitempty"`
 	JiraComponent string                    `json:"jira_component,omitempty"`
@@ -53,6 +54,11 @@ func (r RecentTestFailure) GetNumericalValue(param string) (float64, error) {
 	switch param {
 	case "test_id":
 		return float64(r.TestID), nil
+	case "suite_id":
+		if r.SuiteID != nil {
+			return float64(*r.SuiteID), nil
+		}
+		return 0, nil
 	case "failure_count":
 		return float64(r.FailureCount), nil
 	case "first_failure":


### PR DESCRIPTION
## Summary

- Rewrites the `/api/tests/recent_failures` endpoint to resolve production timeouts (>90s to ~600ms)
- Reverses join order: starts from `prow_job_run_tests` filtered by status index, defers dimension lookups (tests/suites/test_ownerships) until after aggregation
- Eliminates `prow_job_runs`/`prow_jobs` JOINs from the main query using denormalized columns
- Runs COUNT and Scan in parallel via errgroup
- Scopes follow-up queries (`findLastPass`, `fetchOutputs`) to the current page only (~5-25 rows)
- `findLastPass` slides backwards one calendar day at a time using `civil.Date` for exact partition alignment (~5ms/day, typically 3 iterations)
- All queries now correlate on both `(test_id, suite_id)` for correct per-suite behavior (NOT EXISTS, findLastPass, fetchOutputs), fixing a pre-existing gap where suite was ignored

## Test plan

- [x] `go build ./pkg/api/...` compiles clean
- [x] `make lint` passes (0 issues)
- [x] `go test ./pkg/...` passes
- [x] Benchmarked against staging DB: ~600ms warm (perPage=5 with outputs), ~1.5s (perPage=25)
- [x] `findLastPass` completes in 47-80ms with 3 iterations
- [x] Verified `last_pass` values are non-null for tests that passed within 90 days
- [x] Verify on staging deployment
- [x] Verify frontend RecentTestFailures component renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Recent test failure results now distinguish failures by both test and suite, improving accuracy when the same test runs across multiple suites.
  - Previous-failure filtering and last successful run details are now suite-aware.
  - Failure outputs now match the correct test-and-suite combination.
- **New Features**
  - Recent test failure responses now include an optional `suite_id` field.
- **Performance**
  - Improved efficiency for recent failure searches and enrichment, especially when paginating results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->