### PR TITLE
SPLAT-2814: Set Nutanix upgrade job to candidate tier

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -851,6 +851,9 @@ func (v *OCPVariantLoader) setJobTier(_ logrus.FieldLogger, variants map[string]
 		// vSphere hybrid-env jobs are not yet stable enough for component readiness
 		{[]string{"-hybrid-env"}, "candidate"},
 
+		// Nutanix upgrade job not yet stable due to CSI operator conformance failures
+		{[]string{"-e2e-nutanix-upgrade"}, "candidate"},
+
 		// All 4.19/4.20 MCO jobs default to candidate
 		{[]string{"machine-config-operator-release-4.19"}, "candidate"},
 		{[]string{"machine-config-operator-release-4.20"}, "candidate"},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nutanix end-to-end upgrade jobs are now correctly classified as candidate-tier jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->