### PR TITLE
wip: add support for parsing JUnit testcase lifecycle

### DIFF
--- a/pkg/apis/junit/types.go
+++ b/pkg/apis/junit/types.go
@@ -68,6 +68,9 @@ type TestCase struct {
 	// Duration is the time taken in seconds to run the test
 	Duration float64 `xml:"time,attr"`
 
+	// Lifecycle is the lifecycle of this test case
+	Lifecycle string `xml:"lifecycle,attr"`
+
 	// SkipMessage holds the reason why the test was skipped
 	SkipMessage *SkipMessage `xml:"skipped"`
 

--- a/pkg/dataloader/prowloader/extract_test_cases_test.go
+++ b/pkg/dataloader/prowloader/extract_test_cases_test.go
@@ -144,6 +144,43 @@ func TestExtractTestCases(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "passing test with lifecycle",
+			suite: &junit.TestSuite{
+				Name: "openshift-tests",
+				TestCases: []*junit.TestCase{
+					{Name: "test-a", Duration: 1.5, Lifecycle: "informing"},
+				},
+			},
+			expected: map[testCaseKey]*types.TestCaseEntry{
+				{SuiteName: "openshift-tests", TestName: "test-a"}: {
+					TestName:  "test-a",
+					SuiteName: "openshift-tests",
+					Status:    int(sippyprocessingv1.TestStatusSuccess),
+					Duration:  1.5,
+					Lifecycle: "informing",
+				},
+			},
+		},
+		{
+			name: "failing test with output and lifecycle",
+			suite: &junit.TestSuite{
+				Name: "openshift-tests",
+				TestCases: []*junit.TestCase{
+					{Name: "test-a", Duration: 2.0, FailureOutput: &junit.FailureOutput{Output: failMsg}, Lifecycle: "blocking"},
+				},
+			},
+			expected: map[testCaseKey]*types.TestCaseEntry{
+				{SuiteName: "openshift-tests", TestName: "test-a"}: {
+					TestName:  "test-a",
+					SuiteName: "openshift-tests",
+					Status:    int(sippyprocessingv1.TestStatusFailure),
+					Duration:  2.0,
+					Output:    &failMsg,
+					Lifecycle: "blocking",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -1717,6 +1717,7 @@ func extractTestCases(suite *junit.TestSuite, testCases map[testCaseKey]*types.T
 				Status:    int(status),
 				Duration:  tc.Duration,
 				Output:    output,
+				Lifecycle: tc.Lifecycle,
 			}
 		} else if (existing.Status == int(sippyprocessingv1.TestStatusFailure) && status == sippyprocessingv1.TestStatusSuccess) ||
 			(existing.Status == int(sippyprocessingv1.TestStatusSuccess) && status == sippyprocessingv1.TestStatusFailure) {

--- a/pkg/dataloader/prowloader/types/types.go
+++ b/pkg/dataloader/prowloader/types/types.go
@@ -6,4 +6,5 @@ type TestCaseEntry struct {
 	Status    int
 	Duration  float64
 	Output    *string
+	Lifecycle string
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JUnit test results now include lifecycle metadata for each test case.
  * Lifecycle information is preserved when test cases are processed, alongside status, duration, and failure details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->