### PR TITLE
TRT-2799: Extract PR merge sync into standalone loader and fix SHA bug

### DIFF
--- a/cmd/sippy/backfill_pr_status.go
+++ b/cmd/sippy/backfill_pr_status.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/openshift/sippy/pkg/dataloader/prmergesyncloader"
+	"github.com/openshift/sippy/pkg/dataloader/prowloader/github"
+	"github.com/openshift/sippy/pkg/flags"
+)
+
+type BackfillPRStatusFlags struct {
+	DBFlags   *flags.PostgresFlags
+	BatchSize int
+	Pause     int
+	Limit     int
+}
+
+func NewBackfillPRStatusFlags() *BackfillPRStatusFlags {
+	return &BackfillPRStatusFlags{
+		DBFlags:   flags.NewPostgresDatabaseFlags(),
+		BatchSize: 50,
+		Pause:     60,
+	}
+}
+
+func (f *BackfillPRStatusFlags) BindFlags(fs *pflag.FlagSet) {
+	f.DBFlags.BindFlags(fs)
+	fs.IntVar(&f.BatchSize, "batch-size", f.BatchSize, "Number of PRs to look up per batch")
+	fs.IntVar(&f.Pause, "pause", f.Pause, "Seconds to pause between batches")
+	fs.IntVar(&f.Limit, "limit", f.Limit, "Maximum total PRs to process (0 = no limit)")
+}
+
+func NewBackfillPRStatusCommand() *cobra.Command {
+	f := NewBackfillPRStatusFlags()
+
+	cmd := &cobra.Command{
+		Use:   "backfill-pr-status",
+		Short: "Backfill merged_at on prow_pull_requests by querying GitHub for each PR",
+		Long: `Query all prow_pull_requests rows that have no merged_at set (and no sibling
+row with merged_at set), look up each PR on GitHub, and set merged_at for PRs
+that have merged. Processes in batches with pauses to stay within rate limits.
+
+Naturally resumable: each run re-queries what is still unset, so previously
+resolved PRs are skipped.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runBackfillPRStatus(f)
+		},
+	}
+
+	f.BindFlags(cmd.Flags())
+	return cmd
+}
+
+func runBackfillPRStatus(f *BackfillPRStatusFlags) error {
+	ctx := context.Background()
+
+	dbc, err := f.DBFlags.GetDBClient()
+	if err != nil {
+		return fmt.Errorf("getting db client: %w", err)
+	}
+
+	ghClient := github.New(ctx, github.OpenshiftOrg)
+	loader := prmergesyncloader.New(ctx, dbc, ghClient)
+
+	return loader.Backfill(f.BatchSize, f.Pause, f.Limit)
+}

--- a/cmd/sippy/load.go
+++ b/cmd/sippy/load.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openshift/sippy/pkg/dataloader/gateststatus"
 	"github.com/openshift/sippy/pkg/dataloader/jiraloader"
 	"github.com/openshift/sippy/pkg/dataloader/loaderwithmetrics"
+	"github.com/openshift/sippy/pkg/dataloader/prmergesyncloader"
 	"github.com/openshift/sippy/pkg/dataloader/prowloader"
 	"github.com/openshift/sippy/pkg/dataloader/prowloader/gcs"
 	"github.com/openshift/sippy/pkg/dataloader/prowloader/github"
@@ -102,7 +103,7 @@ func (f *LoadFlags) BindFlags(fs *pflag.FlagSet) {
 	f.JiraFlags.BindFlags(fs)
 
 	fs.BoolVar(&f.InitDatabase, "init-database", false, "Migrate the DB before loading")
-	fs.StringArrayVar(&f.Loaders, "loader", []string{"release-definitions", "prow", "releases", "jira", "github", "bugs", "test-mapping", "feature-gates", "ga-test-status"}, "Which data sources to use for data loading")
+	fs.StringArrayVar(&f.Loaders, "loader", []string{"release-definitions", "pr-merge-sync", "prow", "releases", "jira", "github", "bugs", "test-mapping", "feature-gates", "ga-test-status"}, "Which data sources to use for data loading")
 	fs.StringArrayVar(&f.Releases, "release", f.Releases, "Which releases to load (one per arg instance)")
 	fs.StringArrayVar(&f.Architectures, "arch", f.Architectures, "Which architectures to load (one per arg instance)")
 	fs.StringVar(&f.JobVariantsInputFile, "job-variants-input-file", "expected-job-variants.json", "JSON input file for the job-variants loader")
@@ -278,6 +279,14 @@ func NewLoadCommand() *cobra.Command {
 						return dbErr
 					}
 					loaders = append(loaders, releaseloader.New(ctx, dbc, bqc, f.Releases, f.Architectures, releaseConfigs))
+				}
+
+				if l == "pr-merge-sync" {
+					if dbErr != nil {
+						return dbErr
+					}
+					ghClient := github.New(ctx, github.OpenshiftOrg)
+					loaders = append(loaders, prmergesyncloader.New(ctx, dbc, ghClient))
 				}
 
 				// Prow Loader

--- a/cmd/sippy/main.go
+++ b/cmd/sippy/main.go
@@ -40,6 +40,7 @@ func main() {
 		NewSnapshotCommand(),
 		NewRefreshCommand(),
 		NewBackfillCommand(),
+		NewBackfillPRStatusCommand(),
 		NewComponentReadinessCommand(),
 		NewAutomateJiraCommand(),
 		NewVariantsCommand(),

--- a/pkg/dataloader/loaderwithmetrics/loaderwithmetrics.go
+++ b/pkg/dataloader/loaderwithmetrics/loaderwithmetrics.go
@@ -46,7 +46,7 @@ func New(wrappedLoaders []dataloader.DataLoader) *LoaderWithMetrics {
 	return loader
 }
 
-var loaderOrder = []string{"release-definitions", "prow", "releases", "jira", "github", "bugs", "test-mapping", "feature-gates", "regression-cache"}
+var loaderOrder = []string{"release-definitions", "pr-merge-sync", "prow", "releases", "jira", "github", "bugs", "test-mapping", "feature-gates", "regression-cache", "ga-test-status"}
 
 // sortLoaders guarantees that the loaders run in a predictable and proper order
 func (l *LoaderWithMetrics) sortLoaders() {

--- a/pkg/dataloader/prmergesyncloader/prmergesyncloader.go
+++ b/pkg/dataloader/prmergesyncloader/prmergesyncloader.go
@@ -1,0 +1,349 @@
+package prmergesyncloader
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/stdlib"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+
+	"github.com/openshift/sippy/pkg/dataloader/prowloader/github"
+	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/models"
+)
+
+type mergedPR struct {
+	org      string
+	repo     string
+	number   int
+	headSHA  string
+	mergedAt time.Time
+}
+
+type PRMergeSyncLoader struct {
+	ctx      context.Context
+	dbc      *db.DB
+	ghClient *github.Client
+	errors   []error
+}
+
+func New(ctx context.Context, dbc *db.DB, ghClient *github.Client) *PRMergeSyncLoader {
+	return &PRMergeSyncLoader{
+		ctx:      ctx,
+		dbc:      dbc,
+		ghClient: ghClient,
+	}
+}
+
+func (l *PRMergeSyncLoader) Name() string {
+	return "pr-merge-sync"
+}
+
+func (l *PRMergeSyncLoader) Errors() []error {
+	return l.errors
+}
+
+func (l *PRMergeSyncLoader) Load() {
+	if l.ghClient == nil {
+		log.Info("No GitHub client, skipping PR merge sync")
+		return
+	}
+
+	if err := l.sync(); err != nil {
+		l.errors = append(l.errors, errors.Wrap(err, "error in PR merge sync"))
+	}
+}
+
+// unmatchedPRs returns a base query scoped to prow_pull_requests rows that
+// have no merged_at set and no sibling row with merged_at set. Callers add
+// their own Select, Order, Limit, and Scan.
+func (l *PRMergeSyncLoader) unmatchedPRs() *gorm.DB {
+	return l.dbc.DB.
+		Table("prow_pull_requests p").
+		Where("p.merged_at IS NULL").
+		Where(`NOT EXISTS (
+			SELECT 1 FROM prow_pull_requests p2
+			WHERE p2.org = p.org AND p2.repo = p.repo AND p2.number = p.number
+			  AND p2.merged_at IS NOT NULL
+		)`)
+}
+
+func (l *PRMergeSyncLoader) sync() error {
+	type orgRepo struct {
+		Org  string
+		Repo string
+	}
+
+	var repos []orgRepo
+	if res := l.unmatchedPRs().
+		Select("DISTINCT p.org, p.repo").
+		Scan(&repos); res.Error != nil && !errors.Is(res.Error, gorm.ErrRecordNotFound) {
+		return errors.Wrap(res.Error, "could not fetch distinct repos from prow_pull_requests")
+	}
+
+	log.WithField("repos", len(repos)).Info("pr-merge-sync: repos with unmerged pull requests")
+
+	var merged []mergedPR
+	var rateLimitErr error
+	for _, r := range repos {
+		closedPRs, err := l.ghClient.ListRecentlyClosedPRs(r.Org, r.Repo)
+
+		// Process valid PRs before checking the error; partial pages are common
+		// when pagination hits a rate limit or transient API failure.
+		for _, pr := range closedPRs {
+			if pr.MergedAt == nil || pr.Head == nil || pr.Head.SHA == nil || pr.Number == nil {
+				continue
+			}
+			merged = append(merged, mergedPR{
+				org:      r.Org,
+				repo:     r.Repo,
+				number:   *pr.Number,
+				headSHA:  *pr.Head.SHA,
+				mergedAt: *pr.MergedAt,
+			})
+		}
+
+		if err != nil {
+			if l.ghClient.IsWithinRateLimitThreshold() {
+				rateLimitErr = err
+				break
+			}
+			log.WithError(err).WithField("org", r.Org).WithField("repo", r.Repo).Error("error fetching closed PRs")
+		}
+	}
+
+	if len(merged) == 0 {
+		log.Info("pr-merge-sync: no recently merged PRs found")
+		return rateLimitErr
+	}
+
+	log.WithField("count", len(merged)).Info("pr-merge-sync: recently merged PRs to process")
+
+	sqlDB, err := l.dbc.DB.DB()
+	if err != nil {
+		return fmt.Errorf("getting sql.DB: %w", err)
+	}
+
+	rowsUpdated, rowsDeleted, flushErr := flushMergedPRs(l.ctx, sqlDB, merged)
+	if flushErr != nil {
+		return flushErr
+	}
+	log.WithField("rows_updated", rowsUpdated).Info("pr-merge-sync: marked PR rows as merged")
+	log.WithField("rows_deleted", rowsDeleted).Info("pr-merge-sync: cleared pending risk analysis comments")
+
+	return rateLimitErr
+}
+
+// Backfill queries GitHub for each individual unmerged PR and sets merged_at
+// for those that have merged. Processes in batches with pauses between them
+// to stay within rate limits. Naturally resumable since each run re-queries
+// what is still unset.
+func (l *PRMergeSyncLoader) Backfill(batchSize, pause, limit int) error {
+	if batchSize <= 0 {
+		return fmt.Errorf("batchSize must be greater than 0")
+	}
+
+	type prKey struct {
+		Org    string
+		Repo   string
+		Number int
+	}
+
+	query := l.unmatchedPRs().
+		Select("DISTINCT p.org, p.repo, p.number").
+		Order("p.org, p.repo, p.number")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+
+	var prs []prKey
+	if err := query.Scan(&prs).Error; err != nil {
+		return fmt.Errorf("querying unmerged PRs: %w", err)
+	}
+
+	log.WithField("count", len(prs)).Info("unmerged PRs to check")
+	if len(prs) == 0 {
+		return nil
+	}
+
+	sqlDB, err := l.dbc.DB.DB()
+	if err != nil {
+		return fmt.Errorf("getting sql.DB: %w", err)
+	}
+
+	var stats struct {
+		processed int
+		merged    int
+		updated   int64
+		deleted   int64
+		notFound  int
+		errors    int
+	}
+
+	totalBatches := (len(prs) + batchSize - 1) / batchSize
+
+	for batchIdx := 0; batchIdx*batchSize < len(prs); batchIdx++ {
+		start := batchIdx * batchSize
+		end := start + batchSize
+		if end > len(prs) {
+			end = len(prs)
+		}
+		batch := prs[start:end]
+
+		var merged []mergedPR
+		rateLimited := false
+
+		for _, pr := range batch {
+			stats.processed++
+			entry, err := l.ghClient.GetPREntry(pr.Org, pr.Repo, pr.Number)
+			if err != nil {
+				if l.ghClient.IsWithinRateLimitThreshold() {
+					log.WithField("org", pr.Org).Warn("rate limit threshold reached, flushing progress")
+					rateLimited = true
+					break
+				}
+				stats.errors++
+				log.WithError(err).
+					WithField("org", pr.Org).
+					WithField("repo", pr.Repo).
+					WithField("number", pr.Number).
+					Error("error fetching PR, skipping")
+				continue
+			}
+			if entry == nil {
+				stats.notFound++
+				continue
+			}
+			if entry.MergedAt != nil && entry.SHA != "" {
+				merged = append(merged, mergedPR{
+					org:      pr.Org,
+					repo:     pr.Repo,
+					number:   pr.Number,
+					headSHA:  entry.SHA,
+					mergedAt: *entry.MergedAt,
+				})
+			}
+		}
+
+		stats.merged += len(merged)
+
+		if len(merged) > 0 {
+			rowsUpdated, rowsDeleted, flushErr := flushMergedPRs(l.ctx, sqlDB, merged)
+			if flushErr != nil {
+				return flushErr
+			}
+			stats.updated += rowsUpdated
+			stats.deleted += rowsDeleted
+		}
+
+		log.WithFields(log.Fields{
+			"batch":     fmt.Sprintf("%d/%d", batchIdx+1, totalBatches),
+			"processed": stats.processed,
+			"remaining": len(prs) - stats.processed,
+			"merged":    stats.merged,
+			"updated":   stats.updated,
+			"deleted":   stats.deleted,
+			"not_found": stats.notFound,
+			"errors":    stats.errors,
+		}).Info("batch complete")
+
+		if rateLimited {
+			log.Info("stopping due to rate limit, re-run to continue")
+			break
+		}
+
+		if end < len(prs) {
+			select {
+			case <-l.ctx.Done():
+				return l.ctx.Err()
+			case <-time.After(time.Duration(pause) * time.Second):
+			}
+		}
+	}
+
+	log.WithFields(log.Fields{
+		"processed": stats.processed,
+		"merged":    stats.merged,
+		"updated":   stats.updated,
+		"deleted":   stats.deleted,
+		"not_found": stats.notFound,
+		"errors":    stats.errors,
+	}).Info("backfill finished")
+
+	return nil
+}
+
+func flushMergedPRs(ctx context.Context, sqlDB *sql.DB, merged []mergedPR) (int64, int64, error) {
+	conn, err := stdlib.AcquireConn(sqlDB)
+	if err != nil {
+		return 0, 0, fmt.Errorf("acquiring pgx conn: %w", err)
+	}
+	defer func() {
+		if err := stdlib.ReleaseConn(sqlDB, conn); err != nil {
+			log.WithError(err).Error("releasing pgx conn")
+		}
+	}()
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			log.WithError(err).Error("rolling back transaction")
+		}
+	}()
+
+	cleanup, err := db.CopyToTempTable(ctx, tx, "tmp_merged_prs", merged,
+		[]db.TempColumn[mergedPR]{
+			{Name: "sha", Type: "text NOT NULL", Value: func(m *mergedPR) any { return m.headSHA }},
+			{Name: "org", Type: "text NOT NULL", Value: func(m *mergedPR) any { return m.org }},
+			{Name: "repo", Type: "text NOT NULL", Value: func(m *mergedPR) any { return m.repo }},
+			{Name: "number", Type: "integer NOT NULL", Value: func(m *mergedPR) any { return m.number }},
+			{Name: "merged_at", Type: "timestamptz NOT NULL", Value: func(m *mergedPR) any { return m.mergedAt }},
+		},
+	)
+	if err != nil {
+		return 0, 0, fmt.Errorf("creating temp table: %w", err)
+	}
+	defer cleanup()
+
+	updateTag, err := tx.Exec(ctx, `
+		UPDATE prow_pull_requests p
+		SET merged_at = tmp.merged_at
+		FROM tmp_merged_prs tmp
+		WHERE p.sha = tmp.sha
+		  AND p.org = tmp.org
+		  AND p.repo = tmp.repo
+		  AND p.number = tmp.number
+		  AND p.merged_at IS NULL
+	`)
+	if err != nil {
+		return 0, 0, fmt.Errorf("updating merged_at: %w", err)
+	}
+
+	deleteTag, err := tx.Exec(ctx, `
+		DELETE FROM pull_request_comments prc
+		WHERE prc.comment_type = $1
+		  AND EXISTS (
+			SELECT 1 FROM tmp_merged_prs tmp
+			WHERE prc.org = tmp.org
+			  AND prc.repo = tmp.repo
+			  AND prc.pull_number = tmp.number
+		  )
+	`, models.CommentTypeRiskAnalysis)
+	if err != nil {
+		return 0, 0, fmt.Errorf("deleting stale comments: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, 0, fmt.Errorf("committing transaction: %w", err)
+	}
+
+	return updateTag.RowsAffected(), deleteTag.RowsAffected(), nil
+}

--- a/pkg/dataloader/prowloader/github/github.go
+++ b/pkg/dataloader/prowloader/github/github.go
@@ -49,22 +49,19 @@ type Client struct {
 	ctx                 context.Context
 	cache               map[prlocator]*PREntry
 	cacheLock           sync.RWMutex
-	closedCache         map[string]map[string]map[int]*gh.PullRequest
-	closedCacheLock     sync.RWMutex
 	prFetch             func(org, repo string, number int) (*gh.PullRequest, error)
 	prCommentsFetch     func(org, repo string, number int) ([]*gh.IssueComment, error)
 	prCommentCreate     func(org, repo string, number int, comment string) (*gh.IssueComment, error)
 	prCommentDelete     func(org, repo string, updateID int64) error
 	gitHubCoreRateFetch func() (*gh.Rate, error)
-	gitHubListClosedPRs func(org, repo string) (map[int]*gh.PullRequest, error)
+	gitHubListClosedPRs func(org, repo string) ([]*gh.PullRequest, error)
 	commentMetaRegEx    *regexp.Regexp
 }
 
 func New(ctx context.Context, org GitHubOrg) *Client {
 	client := &Client{
-		ctx:         ctx,
-		cache:       make(map[prlocator]*PREntry),
-		closedCache: make(map[string]map[string]map[int]*gh.PullRequest),
+		ctx:   ctx,
+		cache: make(map[prlocator]*PREntry),
 	}
 	ghc := gh.NewClient(newGHAuthClient(client.ctx, org))
 
@@ -101,37 +98,37 @@ func New(ctx context.Context, org GitHubOrg) *Client {
 		return rateLimits.Core, nil
 	}
 
-	client.gitHubListClosedPRs = func(org, repo string) (map[int]*gh.PullRequest, error) {
+	client.gitHubListClosedPRs = func(org, repo string) ([]*gh.PullRequest, error) {
 		since := time.Now().Add(-time.Hour * 48)
-		response := make(map[int]*gh.PullRequest)
-		// larger page size fewer requests counting against our api rate
-		pageSize := 50
-		currentPage := 0
+		var response []*gh.PullRequest
+		opts := &gh.PullRequestListOptions{
+			State:       "closed",
+			Sort:        "updated",
+			Direction:   "desc",
+			ListOptions: gh.ListOptions{PerPage: 50},
+		}
 
 		for {
-
-			prs, _, err := ghc.PullRequests.List(ctx, org, repo, &gh.PullRequestListOptions{State: "closed", Sort: "updated", Direction: "desc", ListOptions: gh.ListOptions{Page: currentPage, PerPage: pageSize}})
-
+			prs, resp, err := ghc.PullRequests.List(ctx, org, repo, opts)
 			if err != nil {
 				return response, err
 			}
 
-			currentPage += len(prs)
-			lastPage := len(prs) < pageSize
-
+			pastWindow := false
 			for _, pr := range prs {
 				if pr != nil && pr.Number != nil {
-					response[*pr.Number] = pr
+					response = append(response, pr)
 
 					if pr.UpdatedAt != nil && pr.UpdatedAt.Before(since) {
-						lastPage = true
+						pastWindow = true
 					}
 				}
 			}
 
-			if lastPage {
+			if pastWindow || resp.NextPage == 0 {
 				return response, nil
 			}
+			opts.Page = resp.NextPage
 		}
 	}
 
@@ -194,30 +191,10 @@ func newAppTokenSource() oauth2.TokenSource {
 	return appTokenSource
 }
 
-func (c *Client) IsPrRecentlyMerged(org, repo string, number int) (*time.Time, *string, error) {
-	c.closedCacheLock.Lock()
-	defer c.closedCacheLock.Unlock()
-	if c.closedCache[org] == nil {
-		c.closedCache[org] = make(map[string]map[int]*gh.PullRequest)
-	}
-
-	var err error
-	if c.closedCache[org][repo] == nil {
-		c.closedCache[org][repo], err = c.gitHubListClosedPRs(org, repo)
-
-		// we expect that gitHubListClosedPRs will return a map, possibly partially filled
-		// so log the error for now and then we will return it once we check to see if we have data for this request or not
-		if err != nil {
-			log.WithError(err).Errorf("Error fetching closed PRs for %s/%s", org, repo)
-		}
-	}
-
-	pr := c.closedCache[org][repo][number]
-	if pr != nil && pr.Number != nil && *pr.Number == number {
-		return pr.MergedAt, pr.MergeCommitSHA, err
-	}
-	// we didn't find it
-	return nil, nil, err
+// ListRecentlyClosedPRs returns all PRs for the given repo that were closed
+// within the last 48 hours. The caller filters to merged-only via MergedAt.
+func (c *Client) ListRecentlyClosedPRs(org, repo string) ([]*gh.PullRequest, error) {
+	return c.gitHubListClosedPRs(org, repo)
 }
 
 func (c *Client) IsWithinRateLimitThreshold() bool {

--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -30,7 +30,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/push"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
-	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -209,11 +208,6 @@ func (pl *ProwLoader) Load() {
 	start := time.Now()
 
 	log.Infof("started loading prow jobs to DB...")
-
-	// Update unmerged PR statuses in case any have merged
-	if err := pl.syncPRStatus(); err != nil {
-		pl.errors = append(pl.errors, errors.Wrap(err, "error in syncPRStatus"))
-	}
 
 	// Grab the ProwJob definitions from prow or CI bigquery. Note that these are the Kube
 	// ProwJob CRDs, not our sippy db model ProwJob.
@@ -806,69 +800,6 @@ func (pl *ProwLoader) findNewJobRunIDs(ctx context.Context, candidateIDs []uint)
 	}
 
 	return sets.New(newIDs...), nil
-}
-
-func (pl *ProwLoader) syncPRStatus() error {
-	if pl.githubClient == nil {
-		log.Infof("No GitHub client, skipping PR sync")
-		return nil
-	}
-
-	pulls := make([]models.ProwPullRequest, 0)
-	if res := pl.dbc.DB.
-		Table("prow_pull_requests").
-		Where("merged_at IS NULL").Scan(&pulls); res.Error != nil && !errors.Is(res.Error, gorm.ErrRecordNotFound) {
-		return errors.Wrap(res.Error, "could not fetch prow_pull_requests")
-	}
-
-	for _, pr := range pulls {
-		logger := log.WithField("org", pr.Org).
-			WithField("repo", pr.Repo).
-			WithField("number", pr.Number).
-			WithField("sha", pr.SHA)
-
-		// first check to see if this pr has recently closed (indicating it may have merged)
-		recentMergedAt, mergeCommitSha, err := pl.githubClient.IsPrRecentlyMerged(pr.Org, pr.Repo, pr.Number)
-
-		// the client should have logged the error, we want
-		// to see if we are rate limited or not, if so return
-		// otherwise keep processing
-		if err != nil {
-			if pl.githubClient.IsWithinRateLimitThreshold() {
-				return err
-			}
-		}
-
-		if recentMergedAt != nil {
-			// we have the recentMergedAt but, we don't know if it is associated with this SHA so do
-			// the SHA specific verification
-			if mergeCommitSha != nil && *mergeCommitSha == pr.SHA {
-				if pr.MergedAt != recentMergedAt {
-					pr.MergedAt = recentMergedAt
-					if res := pl.dbc.DB.Save(pr); res.Error != nil {
-						logger.WithError(res.Error).Errorf("unexpected error updating pull request %s (%s)", pr.Link, pr.SHA)
-						continue
-					}
-				}
-			}
-
-			// if we see that any sha has merged for this pr then we should clear out any risk analysis pending comment records
-			// if we don't get them here we will catch them before writing the risk analysis comment
-			// but, we should clean up here if possible
-			pendingComments, err := pl.ghCommenter.QueryPRPendingComments(pr.Org, pr.Repo, pr.Number, models.CommentTypeRiskAnalysis)
-
-			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-				logger.WithError(err).Error("Unable to fetch pending comments ")
-			}
-
-			for _, pc := range pendingComments {
-				pcp := pc
-				pl.ghCommenter.ClearPendingRecord(pcp.Org, pcp.Repo, pcp.PullNumber, pcp.SHA, models.CommentTypeRiskAnalysis, &pcp)
-			}
-		}
-	}
-
-	return nil
 }
 
 func fetchJobsJSON(prowURL string) ([]byte, error) {


### PR DESCRIPTION
## Summary

- Extracts `syncPRStatus` from the prow loader into a standalone `PRMergeSyncLoader` (`pkg/dataloader/prmergesyncloader/`), eliminating code duplication between the sync and backfill paths
- Fixes the SHA mismatch bug: the old code compared `MergeCommitSHA` against the PR head SHA from prow job specs, which almost never matched. Now uses `Head.SHA`
- Fixes GitHub API pagination bug: uses `resp.NextPage` instead of incrementing by page size
- Adds `backfill-pr-status` CLI command that delegates to the new loader's `Backfill()` method
- Registers `pr-merge-sync` as a standalone loader that runs before `prow` in the load pipeline
- Wraps UPDATE + DELETE in a transaction in `flushMergedPRs` for atomicity
- Adds `ga-test-status` to `loaderOrder` (pre-existing omission)

### Verified against staging

| Metric | Value |
|---|---|
| Repos scanned | 339 |
| Recently merged PRs found | 12,088 |
| Rows updated (merged_at set) | 2,936 |
| Stale risk analysis comments deleted | 5 |
| Total time | 3m19s |
| Errors | 0 |

## Test plan

- [x] `go build ./...` passes
- [x] `make lint` passes (0 Go issues)
- [x] `go test ./...` passes (pre-existing e2e failure in `Test_FileBugAPI` unrelated)
- [x] `load --loader pr-merge-sync` tested against staging DB in cluster pod
- [x] `backfill-pr-status --batch-size 10 --limit 30` tested against staging (multi-batch, no temp table conflicts)
- [x] Independent code review run twice, all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added PR merge-status synchronization from GitHub to keep `merged_at` up to date.
  - Added the `backfill-pr-status` command to fill missing merge timestamps (configurable batch size, pause interval, and processing limit).
  - Enabled PR merge synchronization via the default data-loading workflow using the new `pr-merge-sync` loader.
  - Automatically clears stale risk-analysis comments when a PR is confirmed merged.
- **Improvements**
  - Refined “recently closed” PR fetching and improved rate-limit handling during sync and backfill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->