### PR TITLE
TRT-2821: Add timestamp columns to summary tables

### DIFF
--- a/pkg/db/cumulativesummary/cumulative_summary.go
+++ b/pkg/db/cumulativesummary/cumulative_summary.go
@@ -133,7 +133,8 @@ func (s *pgStore) Releases() ([]string, error) {
 func (s *pgStore) UpdateDateForRelease(date civil.Date, release string) error {
 	return s.dbc.DB.Exec(`
 		INSERT INTO test_cumulative_summaries (date, test_id, prow_job_id, suite_id, release,
-		                         prefix_sum_successes, prefix_sum_failures, prefix_sum_flakes, prefix_sum_runs)
+		                         prefix_sum_successes, prefix_sum_failures, prefix_sum_flakes, prefix_sum_runs,
+		                         prefix_max_last_failure, prefix_max_last_success)
 		SELECT
 			?,
 			COALESCE(prev.test_id, tds.test_id),
@@ -143,7 +144,9 @@ func (s *pgStore) UpdateDateForRelease(date civil.Date, release string) error {
 			COALESCE(prev.prefix_sum_successes, 0) + COALESCE(tds.successes, 0),
 			COALESCE(prev.prefix_sum_failures, 0) + COALESCE(tds.failures, 0),
 			COALESCE(prev.prefix_sum_flakes, 0) + COALESCE(tds.flakes, 0),
-			COALESCE(prev.prefix_sum_runs, 0) + COALESCE(tds.runs, 0)
+			COALESCE(prev.prefix_sum_runs, 0) + COALESCE(tds.runs, 0),
+			GREATEST(prev.prefix_max_last_failure, tds.last_failure_timestamp),
+			GREATEST(prev.prefix_max_last_success, tds.last_success_timestamp)
 		FROM (SELECT * FROM test_cumulative_summaries WHERE date = ?::date - 1 AND release = ?) prev
 		FULL OUTER JOIN (SELECT * FROM test_daily_totals WHERE date = ? AND release = ?) tds
 			ON prev.test_id = tds.test_id
@@ -154,11 +157,15 @@ func (s *pgStore) UpdateDateForRelease(date civil.Date, release string) error {
 			prefix_sum_successes = EXCLUDED.prefix_sum_successes,
 			prefix_sum_failures = EXCLUDED.prefix_sum_failures,
 			prefix_sum_flakes = EXCLUDED.prefix_sum_flakes,
-			prefix_sum_runs = EXCLUDED.prefix_sum_runs
+			prefix_sum_runs = EXCLUDED.prefix_sum_runs,
+			prefix_max_last_failure = EXCLUDED.prefix_max_last_failure,
+			prefix_max_last_success = EXCLUDED.prefix_max_last_success
 		WHERE (test_cumulative_summaries.prefix_sum_successes, test_cumulative_summaries.prefix_sum_failures,
-		       test_cumulative_summaries.prefix_sum_flakes, test_cumulative_summaries.prefix_sum_runs)
+		       test_cumulative_summaries.prefix_sum_flakes, test_cumulative_summaries.prefix_sum_runs,
+		       test_cumulative_summaries.prefix_max_last_failure, test_cumulative_summaries.prefix_max_last_success)
 		   IS DISTINCT FROM
 		      (EXCLUDED.prefix_sum_successes, EXCLUDED.prefix_sum_failures,
-		       EXCLUDED.prefix_sum_flakes, EXCLUDED.prefix_sum_runs)
+		       EXCLUDED.prefix_sum_flakes, EXCLUDED.prefix_sum_runs,
+		       EXCLUDED.prefix_max_last_failure, EXCLUDED.prefix_max_last_success)
 	`, date, date, release, date, release).Error
 }

--- a/pkg/db/dailysummary/dailysummary.go
+++ b/pkg/db/dailysummary/dailysummary.go
@@ -18,7 +18,11 @@ const (
 	parallelWorkers     = 4
 )
 
-var valueColumns = []string{"successes", "failures", "flakes", "runs"}
+var valueColumns = []string{
+	"successes", "failures", "flakes", "runs",
+	"first_failure_timestamp", "last_failure_timestamp",
+	"first_success_timestamp", "last_success_timestamp",
+}
 
 func buildInsertSQL(tableName, dateColumn string) string {
 	return fmt.Sprintf(`
@@ -32,7 +36,11 @@ func buildInsertSQL(tableName, dateColumn string) string {
 			COUNT(*) FILTER (WHERE pjrt.status = 1),
 			COUNT(*) FILTER (WHERE pjrt.status = 12),
 			COUNT(*) FILTER (WHERE pjrt.status = 13),
-			COUNT(*)
+			COUNT(*),
+			MIN(pjrt.prow_job_run_timestamp) FILTER (WHERE pjrt.status = 12),
+			MAX(pjrt.prow_job_run_timestamp) FILTER (WHERE pjrt.status = 12),
+			MIN(pjrt.prow_job_run_timestamp) FILTER (WHERE pjrt.status = 1),
+			MAX(pjrt.prow_job_run_timestamp) FILTER (WHERE pjrt.status = 1)
 		FROM prow_job_run_tests pjrt
 		WHERE pjrt.prow_job_run_timestamp >= ?::date
 		  AND pjrt.prow_job_run_timestamp < (?::date + INTERVAL '1 day')

--- a/pkg/db/migrations/000008_add_summary_timestamps.down.sql
+++ b/pkg/db/migrations/000008_add_summary_timestamps.down.sql
@@ -1,0 +1,9 @@
+ALTER TABLE test_cumulative_summaries
+  DROP COLUMN IF EXISTS prefix_max_last_failure,
+  DROP COLUMN IF EXISTS prefix_max_last_success;
+
+ALTER TABLE test_daily_totals
+  DROP COLUMN IF EXISTS first_failure_timestamp,
+  DROP COLUMN IF EXISTS last_failure_timestamp,
+  DROP COLUMN IF EXISTS first_success_timestamp,
+  DROP COLUMN IF EXISTS last_success_timestamp;

--- a/pkg/db/migrations/000008_add_summary_timestamps.up.sql
+++ b/pkg/db/migrations/000008_add_summary_timestamps.up.sql
@@ -1,0 +1,17 @@
+-- TRT-2821: Add timestamp columns to summary tables
+--
+-- Adds MIN/MAX timestamp columns to test_daily_totals for tracking when
+-- failures and successes occurred within each day. Adds running-maximum
+-- columns to test_cumulative_summaries for efficient lookback queries.
+--
+-- ALTER TABLE on a partitioned parent propagates to all existing partitions.
+
+ALTER TABLE test_daily_totals
+  ADD COLUMN IF NOT EXISTS first_failure_timestamp TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS last_failure_timestamp TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS first_success_timestamp TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS last_success_timestamp TIMESTAMPTZ;
+
+ALTER TABLE test_cumulative_summaries
+  ADD COLUMN IF NOT EXISTS prefix_max_last_failure TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS prefix_max_last_success TIMESTAMPTZ;

--- a/pkg/db/migrations/MANIFEST
+++ b/pkg/db/migrations/MANIFEST
@@ -14,3 +14,4 @@
 000005_drop_daily_summary_variant_combination
 000006_partition_cumulative_tables
 000007_drop_test_daily_summaries
+000008_add_summary_timestamps

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -174,15 +174,19 @@ type TestAnalysisByJobByDate struct {
 // Table is partitioned (LIST by release, RANGE by date) -
 // schema managed by migration 000006, not AutoMigrate.
 type TestDailyTotal struct {
-	TestID    uint       `gorm:"column:test_id;not null"`
-	ProwJobID uint       `gorm:"column:prow_job_id;not null"`
-	SuiteID   uint       `gorm:"column:suite_id;not null;default:0"`
-	Release   string     `gorm:"column:release;not null"`
-	Date      civil.Date `gorm:"column:date;type:date;not null"`
-	Successes int32      `gorm:"column:successes;not null;default:0"`
-	Failures  int32      `gorm:"column:failures;not null;default:0"`
-	Flakes    int32      `gorm:"column:flakes;not null;default:0"`
-	Runs      int32      `gorm:"column:runs;not null;default:0"`
+	TestID                uint       `gorm:"column:test_id;not null"`
+	ProwJobID             uint       `gorm:"column:prow_job_id;not null"`
+	SuiteID               uint       `gorm:"column:suite_id;not null;default:0"`
+	Release               string     `gorm:"column:release;not null"`
+	Date                  civil.Date `gorm:"column:date;type:date;not null"`
+	Successes             int32      `gorm:"column:successes;not null;default:0"`
+	Failures              int32      `gorm:"column:failures;not null;default:0"`
+	Flakes                int32      `gorm:"column:flakes;not null;default:0"`
+	Runs                  int32      `gorm:"column:runs;not null;default:0"`
+	FirstFailureTimestamp *time.Time `gorm:"column:first_failure_timestamp"`
+	LastFailureTimestamp  *time.Time `gorm:"column:last_failure_timestamp"`
+	FirstSuccessTimestamp *time.Time `gorm:"column:first_success_timestamp"`
+	LastSuccessTimestamp  *time.Time `gorm:"column:last_success_timestamp"`
 }
 
 // TestCumulativeSummary stores running totals of test_daily_totals values,
@@ -193,15 +197,17 @@ type TestDailyTotal struct {
 // Table is partitioned (LIST by release, RANGE by date) -
 // schema managed by migration 000006, not AutoMigrate.
 type TestCumulativeSummary struct {
-	Date               civil.Date `gorm:"column:date;type:date;not null;primaryKey;priority:1"`
-	Release            string     `gorm:"column:release;not null;primaryKey;priority:2"`
-	TestID             uint       `gorm:"column:test_id;not null;primaryKey;priority:3"`
-	ProwJobID          uint       `gorm:"column:prow_job_id;not null;primaryKey;priority:4;index:idx_test_cumulative_summaries_prow_job_id"`
-	SuiteID            uint       `gorm:"column:suite_id;not null;default:0;primaryKey;priority:5"`
-	PrefixSumSuccesses int64      `gorm:"column:prefix_sum_successes;not null;default:0"`
-	PrefixSumFailures  int64      `gorm:"column:prefix_sum_failures;not null;default:0"`
-	PrefixSumFlakes    int64      `gorm:"column:prefix_sum_flakes;not null;default:0"`
-	PrefixSumRuns      int64      `gorm:"column:prefix_sum_runs;not null;default:0"`
+	Date                 civil.Date `gorm:"column:date;type:date;not null;primaryKey;priority:1"`
+	Release              string     `gorm:"column:release;not null;primaryKey;priority:2"`
+	TestID               uint       `gorm:"column:test_id;not null;primaryKey;priority:3"`
+	ProwJobID            uint       `gorm:"column:prow_job_id;not null;primaryKey;priority:4;index:idx_test_cumulative_summaries_prow_job_id"`
+	SuiteID              uint       `gorm:"column:suite_id;not null;default:0;primaryKey;priority:5"`
+	PrefixSumSuccesses   int64      `gorm:"column:prefix_sum_successes;not null;default:0"`
+	PrefixSumFailures    int64      `gorm:"column:prefix_sum_failures;not null;default:0"`
+	PrefixSumFlakes      int64      `gorm:"column:prefix_sum_flakes;not null;default:0"`
+	PrefixSumRuns        int64      `gorm:"column:prefix_sum_runs;not null;default:0"`
+	PrefixMaxLastFailure *time.Time `gorm:"column:prefix_max_last_failure"`
+	PrefixMaxLastSuccess *time.Time `gorm:"column:prefix_max_last_success"`
 }
 
 // ProwGARawTestDatum stores raw BigQuery test results for GA release windows.


### PR DESCRIPTION
## Summary

- Adds `first_failure_timestamp`, `last_failure_timestamp`, `first_success_timestamp`, `last_success_timestamp` columns to `test_daily_totals`
- Adds `prefix_max_last_failure`, `prefix_max_last_success` running-maximum columns to `test_cumulative_summaries`
- Updates daily summary refresh to populate timestamps via `MIN/MAX ... FILTER (WHERE status = ...)` aggregates
- Updates cumulative summary refresh to propagate running maximums via `GREATEST()`
- Includes migration 000008 (ALTER TABLE on partitioned parents propagates to all partitions)

This enables downstream queries (recent failures, test reports, component readiness) to read timestamps from summary tables instead of scanning raw `prow_job_run_tests` partitions. Consumer query changes will follow in a separate PR.

## Production backfill

After merging and deploying, the new columns will be NULL for existing rows. Before merging the follow-up consumer query PR, backfill production data:

1. `sippy backfill --table daily-totals --start-date <earliest-date>` (~65 min on staging-2)
2. `sippy backfill --table cumulative-summaries --start-date <earliest-date>` (~7h on staging-2)

Both commands are safe to restart (ON CONFLICT upserts, IS DISTINCT FROM guards avoid write amplification).

## Test plan

- [x] `make lint` passes (0 Go errors, 0 JS errors)
- [x] Migration tested on staging-2 (partitioned tables)
- [x] Daily totals backfill verified: 416M rows, 1.6M with failure timestamps, 404M with success timestamps
- [x] Cumulative timestamps backfill verified: running-max property holds (`prefix_max >= daily value`)
- [x] Independent code review: no correctness bugs found

🤖 Generated with [Claude Code](https://claude.com/claude-code)