### PR TITLE
TRT-2834: Add stored test_flakes column to prow_job_runs

### DIFF
--- a/cmd/sippy/seed_data.go
+++ b/cmd/sippy/seed_data.go
@@ -821,13 +821,19 @@ func seedRunsForJob(dbc *db.DB, suite *models.Suite, prowJob models.ProwJob, jrK
 		}
 	}
 
-	// Update test_failures count
+	// Update test_failures and test_flakes counts
 	if err := dbc.DB.Exec(`
-		UPDATE prow_job_runs SET test_failures = COALESCE((
-			SELECT COUNT(*) FROM prow_job_run_tests
-			WHERE prow_job_run_id = prow_job_runs.id AND status = 12
-		), 0) WHERE prow_job_id = ?`, prowJob.ID).Error; err != nil {
-		return 0, 0, fmt.Errorf("updating test_failures for prow job %s: %w", prowJob.Name, err)
+		UPDATE prow_job_runs SET
+			test_failures = COALESCE((
+				SELECT COUNT(*) FROM prow_job_run_tests
+				WHERE prow_job_run_id = prow_job_runs.id AND status = 12
+			), 0),
+			test_flakes = COALESCE((
+				SELECT COUNT(*) FROM prow_job_run_tests
+				WHERE prow_job_run_id = prow_job_runs.id AND status = 13
+			), 0)
+		WHERE prow_job_id = ?`, prowJob.ID).Error; err != nil {
+		return 0, 0, fmt.Errorf("updating test counts for prow job %s: %w", prowJob.Name, err)
 	}
 
 	return totalRuns, totalResults, nil

--- a/cmd/sippy/seed_data.go
+++ b/cmd/sippy/seed_data.go
@@ -826,13 +826,14 @@ func seedRunsForJob(dbc *db.DB, suite *models.Suite, prowJob models.ProwJob, jrK
 		UPDATE prow_job_runs SET
 			test_failures = COALESCE((
 				SELECT COUNT(*) FROM prow_job_run_tests
-				WHERE prow_job_run_id = prow_job_runs.id AND status = 12
+				WHERE prow_job_run_id = prow_job_runs.id AND status = ?
 			), 0),
 			test_flakes = COALESCE((
 				SELECT COUNT(*) FROM prow_job_run_tests
-				WHERE prow_job_run_id = prow_job_runs.id AND status = 13
+				WHERE prow_job_run_id = prow_job_runs.id AND status = ?
 			), 0)
-		WHERE prow_job_id = ?`, prowJob.ID).Error; err != nil {
+		WHERE prow_job_id = ?`,
+		int(v1.TestStatusFailure), int(v1.TestStatusFlake), prowJob.ID).Error; err != nil {
 		return 0, 0, fmt.Errorf("updating test counts for prow job %s: %w", prowJob.Name, err)
 	}
 

--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -1101,6 +1101,7 @@ type prowJobRunRow struct {
 	Timestamp      time.Time
 	OverallResult  sippyprocessingv1.JobOverallResult
 	TestFailures   int
+	TestFlakes     int
 	Succeeded      bool
 	Labels         []string
 }
@@ -1141,7 +1142,7 @@ type jobRunResult struct {
 }
 
 func (pl *ProwLoader) buildJobRunResult(ctx context.Context, pj *prow.ProwJob, id uint64, path string, junitMatches []string, dbProwJob *models.ProwJob) (*jobRunResult, error) {
-	tests, failures, overallResult, err := pl.prowJobRunTestsFromGCS(ctx, pj, uint(id), dbProwJob.ID, dbProwJob.Release, path, junitMatches)
+	tests, failures, flakes, overallResult, err := pl.prowJobRunTestsFromGCS(ctx, pj, uint(id), dbProwJob.ID, dbProwJob.Release, path, junitMatches)
 	if err != nil {
 		return nil, err
 	}
@@ -1187,6 +1188,7 @@ func (pl *ProwLoader) buildJobRunResult(ctx context.Context, pj *prow.ProwJob, i
 			Timestamp:      pj.Status.StartTime,
 			OverallResult:  overallResult,
 			TestFailures:   failures,
+			TestFlakes:     flakes,
 			Succeeded:      overallResult == sippyprocessingv1.JobSucceeded,
 			Labels:         []string(pl.labelsCache[pj.Status.BuildID]),
 		},
@@ -1209,6 +1211,7 @@ var (
 		{Name: "timestamp", Type: "timestamptz NOT NULL", Value: func(r *prowJobRunRow) any { return r.Timestamp }},
 		{Name: "overall_result", Type: "text NOT NULL DEFAULT ''", Value: func(r *prowJobRunRow) any { return string(r.OverallResult) }},
 		{Name: "test_failures", Type: "integer NOT NULL DEFAULT 0", Value: func(r *prowJobRunRow) any { return r.TestFailures }},
+		{Name: "test_flakes", Type: "integer NOT NULL DEFAULT 0", Value: func(r *prowJobRunRow) any { return r.TestFlakes }},
 		{Name: "succeeded", Type: "boolean NOT NULL DEFAULT false", Value: func(r *prowJobRunRow) any { return r.Succeeded }},
 		{Name: "labels", Type: "text[]", Value: func(r *prowJobRunRow) any { return r.Labels }},
 	}
@@ -1355,11 +1358,13 @@ func (pl *ProwLoader) writeJobRunBatch(ctx context.Context, batch []jobRunResult
 
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO prow_job_runs (id, cluster, duration, prow_job_id, prow_job_release,
-			url, gcs_bucket, timestamp, overall_result, test_failures, succeeded,
-			failed, infrastructure_failure, known_failure, labels, created_at, updated_at)
+			url, gcs_bucket, timestamp, overall_result, test_failures, test_flakes,
+			succeeded, failed, infrastructure_failure, known_failure, labels,
+			created_at, updated_at)
 		SELECT id, cluster, duration, prow_job_id, prow_job_release,
-			url, gcs_bucket, timestamp, overall_result, test_failures, succeeded,
-			false, false, false, labels, NOW(), NOW()
+			url, gcs_bucket, timestamp, overall_result, test_failures, test_flakes,
+			succeeded, false, false, false, labels,
+			NOW(), NOW()
 		FROM tmp_prow_job_runs
 	`); err != nil {
 		return fmt.Errorf("inserting prow_job_runs: %w", err)
@@ -1639,14 +1644,14 @@ type testCaseKey struct {
 	TestName  string
 }
 
-func (pl *ProwLoader) prowJobRunTestsFromGCS(ctx context.Context, pj *prow.ProwJob, id, prowJobID uint, prowJobRelease, path string, junitPaths []string) ([]prowJobRunTestRow, int, sippyprocessingv1.JobOverallResult, error) {
+func (pl *ProwLoader) prowJobRunTestsFromGCS(ctx context.Context, pj *prow.ProwJob, id, prowJobID uint, prowJobRelease, path string, junitPaths []string) ([]prowJobRunTestRow, int, int, sippyprocessingv1.JobOverallResult, error) {
 	bkt := pl.gcsClient.Bucket(pj.Spec.DecorationConfig.GCSConfiguration.Bucket)
 	gcsJobRun := gcs.NewGCSJobRun(bkt, path)
 	gcsJobRun.SetGCSJunitPaths(junitPaths)
 	suites, err := gcsJobRun.GetCombinedJUnitTestSuites(ctx)
 	if err != nil {
 		log.Warningf("failed to get junit test suites: %s", err.Error())
-		return nil, 0, "", err
+		return nil, 0, 0, "", err
 	}
 
 	testCases := make(map[testCaseKey]*types.TestCaseEntry)
@@ -1662,12 +1667,13 @@ func (pl *ProwLoader) prowJobRunTestsFromGCS(ctx context.Context, pj *prow.ProwJ
 	syntheticSuite, jobResult := testconversion.ConvertProwJobRunToSyntheticTests(*pj, oldTestCases, pl.syntheticTestManager)
 
 	if !db.IsSuiteImportable(syntheticSuite.Name) {
-		return nil, 0, "", fmt.Errorf("synthetic suite %q is missing from the importable list", syntheticSuite.Name)
+		return nil, 0, 0, "", fmt.Errorf("synthetic suite %q is missing from the importable list", syntheticSuite.Name)
 	}
 	extractTestCases(syntheticSuite, testCases)
 	log.Infof("synthetic suite had %d tests", syntheticSuite.NumTests)
 
 	failures := 0
+	flakes := 0
 	results := make([]prowJobRunTestRow, 0, len(testCases))
 	for _, tc := range testCases {
 		if testidentification.IsIgnoredTest(tc.TestName) {
@@ -1684,12 +1690,15 @@ func (pl *ProwLoader) prowJobRunTestsFromGCS(ctx context.Context, pj *prow.ProwJ
 			Duration:            tc.Duration,
 			Output:              tc.Output,
 		})
-		if tc.Status == int(sippyprocessingv1.TestStatusFailure) {
+		switch tc.Status {
+		case int(sippyprocessingv1.TestStatusFailure):
 			failures++
+		case int(sippyprocessingv1.TestStatusFlake):
+			flakes++
 		}
 	}
 
-	return results, failures, jobResult, nil
+	return results, failures, flakes, jobResult, nil
 }
 
 func extractTestCases(suite *junit.TestSuite, testCases map[testCaseKey]*types.TestCaseEntry) {

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -60,6 +60,7 @@ type ProwJobRun struct {
 	GCSBucket    string
 	URL          string
 	TestFailures int
+	TestFlakes   int `gorm:"not null;default:0"`
 	Tests        []ProwJobRunTest
 	PullRequests []ProwPullRequest      `gorm:"many2many:prow_job_run_prow_pull_requests;constraint:OnDelete:CASCADE;"`
 	Annotations  []ProwJobRunAnnotation `gorm:"constraint:OnDelete:CASCADE;"`


### PR DESCRIPTION
## Summary

- Adds a denormalized `test_flakes` column to `prow_job_runs`, matching the existing `test_failures` pattern
- The column is populated at insert time by the prow loader, counting tests with status 13 (`TestStatusFlake`)
- GORM AutoMigrate adds the column as `NOT NULL DEFAULT 0` (metadata-only operation in PostgreSQL 11+)
- Seed data generation also populates `test_flakes` alongside `test_failures`

This is a prerequisite for [TRT-2814](https://redhat.atlassian.net/browse/TRT-2814) (eliminating `prow_job_runs_report_matview`).

## Backfill script

After deploying, run this PL/pgSQL script to backfill `test_flakes` for existing rows. It iterates by (release, date) pairs to target single partitions, keeping each UPDATE fast (~190ms per partition).

Tested on staging: 2,337 partitions, 251,927 rows updated, ~5 min total.

```sql
DO $$
DECLARE
  rec RECORD;
  total_updated BIGINT := 0;
  partition_count INT := 0;
  batch_updated BIGINT;
BEGIN
  FOR rec IN
    SELECT DISTINCT prow_job_release AS release,
           DATE(timestamp AT TIME ZONE 'UTC') AS dt
    FROM prow_job_runs
    ORDER BY 1, 2
  LOOP
    UPDATE prow_job_runs r
    SET    test_flakes = sub.cnt,
           updated_at  = NOW()
    FROM (
      SELECT prow_job_run_id, COUNT(*) AS cnt
      FROM   prow_job_run_tests
      WHERE  prow_job_run_release = rec.release
        AND  prow_job_run_timestamp >= rec.dt::timestamp
        AND  prow_job_run_timestamp <  (rec.dt + INTERVAL '1 day')::timestamp
        AND  status = 13
      GROUP BY prow_job_run_id
    ) sub
    WHERE r.id = sub.prow_job_run_id
      AND r.prow_job_release = rec.release
      AND DATE(r.timestamp AT TIME ZONE 'UTC') = rec.dt;

    GET DIAGNOSTICS batch_updated = ROW_COUNT;
    total_updated := total_updated + batch_updated;
    partition_count := partition_count + 1;

    IF partition_count % 100 = 0 THEN
      RAISE NOTICE 'Processed % partitions, % rows updated so far',
                   partition_count, total_updated;
    END IF;
  END LOOP;

  RAISE NOTICE 'Done. % partitions, % rows updated.', partition_count, total_updated;
END $$;
```

## Test plan

- [x] `make lint` passes
- [x] Column added via GORM AutoMigrate on staging DB
- [x] Backfill script tested on staging (2,337 partitions, 251,927 rows, ~5 min)
- [x] Spot-checked stored vs computed values on sample partitions (zero mismatches)
- [ ] `make test` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking of flaky tests alongside test failures in job run results.
  * Flaky test counts are now calculated from test reports and stored with job run data.

* **Bug Fixes**
  * Ensured aggregated flaky-test counts remain accurate when job statuses are updated.
  * Added a default value for flaky-test counts when no flakes are recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->