### PR TITLE
TRT-2741: Remove unused prow_ga_test_statuses_matview

### DIFF
--- a/cmd/sippy/seed_data.go
+++ b/cmd/sippy/seed_data.go
@@ -1305,8 +1305,7 @@ func seedFeatureGates(dbc *db.DB) error {
 }
 
 // seedGARawTestData populates prow_ga_raw_test_data for GA releases using
-// the same synthetic test/job definitions. This gives the
-// prow_ga_test_statuses_matview data to aggregate when refreshed.
+// the same synthetic test/job definitions.
 func seedGARawTestData(dbc *db.DB) error {
 	var gaReleases []models.ReleaseDefinition
 	if err := dbc.DB.Where("ga_date IS NOT NULL AND ga_date < CURRENT_DATE").Find(&gaReleases).Error; err != nil {

--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -28,12 +28,6 @@ var PostgresMatViews = []PostgresView{
 		IndexColumns:   []string{"release", "architecture", "stream", "prow_job_run_id", "test_id", "suite_id"},
 		ReplaceStrings: map[string]string{},
 	},
-	{
-		Name:         "prow_ga_test_statuses_matview",
-		Definition:   gaTestStatusMatView,
-		IndexColumns: []string{"release", "window_days", "test_id", "suite_id", "variant_combination_id"},
-		RefreshPhase: 1,
-	},
 }
 
 // PostgresViews are regular, non-materialized views:
@@ -267,19 +261,4 @@ WHERE
     AND pjr.id = pjrt.prow_job_run_id
     AND pj.id = pjr.prow_job_id
 ORDER BY pjrt.id DESC
-`
-
-const gaTestStatusMatView = `
-SELECT
-    raw.test_id,
-    raw.suite_id,
-    pj.variant_combination_id,
-    raw.release,
-    raw.window_days,
-    SUM(raw.runs)::int AS total_count,
-    SUM(raw.passes + raw.flakes)::int AS success_count,
-    SUM(raw.flakes)::int AS flake_count
-FROM prow_ga_raw_test_data raw
-JOIN prow_jobs pj ON pj.id = raw.prow_job_id AND pj.deleted_at IS NULL AND pj.variant_combination_id IS NOT NULL
-GROUP BY raw.test_id, raw.suite_id, pj.variant_combination_id, raw.release, raw.window_days
 `


### PR DESCRIPTION
## Summary

- Remove `prow_ga_test_statuses_matview` from the `PostgresMatViews` registry so it is no longer created or refreshed
- The CR provider queries `prow_ga_raw_test_data` directly; this matview aggregated that table but was never read
- Existing matviews in databases are left in place (no migration to drop)

## Test plan

- [x] `go vet ./pkg/...` passes
- [x] `pkg/db` tests pass
- [x] Verify no code references `prow_ga_test_statuses_matview` outside of comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed an obsolete test-status analytics view from database maintenance.
  * Updated test-data documentation comments for clarity.
  * No user-facing functionality or behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->