### PR TITLE
TRT-2821: Use prefix_max_last_failure instead of LATERAL join for CR timestamps

### DIFF
--- a/pkg/api/componentreadiness/dataprovider/postgres/cr_queries.go
+++ b/pkg/api/componentreadiness/dataprovider/postgres/cr_queries.go
@@ -15,7 +15,6 @@ import (
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crstatus"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crtest"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/reqopts"
-	sippyv1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/query"
 )
@@ -65,27 +64,6 @@ func prepareVariantQuery(
 	}, nil
 }
 
-// lastFailureLateral wraps a failure aggregation subquery with a LATERAL join
-// that finds the most recent failure timestamp for each (test_id, suite_id).
-// The LATERAL is not scoped to the variant group or includeVariants filter,
-// so the timestamp may come from a run outside the reported cell. This matches
-// the documented BQ/PG parity gap (see PR description for known gaps).
-// Parameters after the inner query args: release, rangeStart, rangeEnd.
-const lastFailureLateral = `
-        SELECT fi.test_id, fi.suite_id, fi.variant_group_id,
-               fi.total_count, fi.success_count, fi.flake_count,
-               lf.last_failure
-        FROM (%s) fi
-        LEFT JOIN LATERAL (
-            SELECT MAX(pjrt.prow_job_run_timestamp) AS last_failure
-            FROM prow_job_run_tests pjrt
-            WHERE pjrt.test_id = fi.test_id
-              AND (pjrt.suite_id = fi.suite_id OR (fi.suite_id = 0 AND pjrt.suite_id IS NULL))
-              AND pjrt.prow_job_run_release = ?
-              AND pjrt.prow_job_run_timestamp >= ? AND pjrt.prow_job_run_timestamp < ?
-              AND pjrt.status = %d
-        ) lf ON true`
-
 // drilldownFilters holds optional SQL WHERE fragments for TestID and
 // Capability filtering when drilling down to a specific test + environment.
 type drilldownFilters struct {
@@ -127,23 +105,21 @@ func buildDrilldownFilters(reqOptions reqopts.RequestOptions) drilldownFilters {
 // prefix-sum and GA query paths. The two paths differ only in their source
 // table, aggregation expressions, and date/window filter.
 type testStatusSpec struct {
-	fromTemplate string // FROM clause template with two %s for variantSubquery and groupMapping
-	preJoinArgs  []any  // args bound in the FROM clause before filterArgs (e.g. lookupStart)
-	totalExpr    string // SQL expression for total runs
-	successExpr  string // SQL expression for successes
-	flakeExpr    string // SQL expression for flakes
-	whereFilter  string // WHERE fragment like "e.release = ? AND e.date = ?"
-	whereArgs    []any  // args for whereFilter
-	release      string // for LATERAL join on prow_job_run_tests
-	dateRange    query.DateRange
+	fromTemplate    string // FROM clause template with two %s for variantSubquery and groupMapping
+	preJoinArgs     []any  // args bound in the FROM clause before filterArgs (e.g. lookupStart)
+	totalExpr       string // SQL expression for total runs
+	successExpr     string // SQL expression for successes
+	flakeExpr       string // SQL expression for flakes
+	lastFailureExpr string // SQL expression for last failure timestamp (e.g. "MAX(e.prefix_max_last_failure)" or "NULL::timestamptz")
+	whereFilter     string // WHERE fragment like "e.release = ? AND e.date = ?"
+	whereArgs       []any  // args for whereFilter
 }
 
 // queryTestStatus builds and executes the failure + placeholder query pair
 // that both queryTestStatusPrefixSum and queryBaseTestStatusGA share.
 //
 // Two queries run in parallel:
-//   - Failure query: tests with >= MinimumFailure failures (regression candidates),
-//     wrapped in a LATERAL join to find the most recent failure timestamp
+//   - Failure query: tests with >= MinimumFailure failures (regression candidates)
 //   - Placeholder query: (component, col_group_id) pairs with any runs (for grid gating)
 //
 // Grid placeholders are only injected for cells where data confirms
@@ -174,28 +150,28 @@ func (p *PostgresProvider) queryTestStatus(
 	joinArgs = append(joinArgs, setup.filterArgs...)
 	joinArgs = append(joinArgs, spec.whereArgs...)
 
-	failureAgg := fmt.Sprintf(`
+	failureInner := fmt.Sprintf(`
         SELECT
             e.test_id, e.suite_id, vg.group_id AS variant_group_id,
             SUM(%s) AS total_count,
             SUM(%s) AS success_count,
-            SUM(%s) AS flake_count
+            SUM(%s) AS flake_count,
+            %s AS last_failure
         %s
         WHERE %s`+filters.innerClause+`
         GROUP BY e.test_id, e.suite_id, vg.group_id
         HAVING SUM(%s) > 0
             AND SUM(%s) - SUM(%s) - SUM(%s) >= ?`,
 		spec.totalExpr, spec.successExpr, spec.flakeExpr,
+		spec.lastFailureExpr,
 		fromClause,
 		spec.whereFilter,
 		spec.totalExpr, spec.totalExpr, spec.successExpr, spec.flakeExpr)
 
-	failureInner := fmt.Sprintf(lastFailureLateral, failureAgg, sippyv1.TestStatusFailure)
-
 	failureArgs := make([]any, len(joinArgs))
 	copy(failureArgs, joinArgs)
 	failureArgs = append(failureArgs, filters.innerArgs...)
-	failureArgs = append(failureArgs, setup.minimumFailure, spec.release, spec.dateRange.Start, spec.dateRange.End)
+	failureArgs = append(failureArgs, setup.minimumFailure)
 
 	colMapping := buildColumnGroupMapping(setup.groupMapping.groupToVariants, reqOptions.VariantOption.ColumnGroupBy)
 
@@ -255,14 +231,13 @@ func (p *PostgresProvider) queryTestStatusPrefixSum(
         JOIN prow_jobs pj ON pj.id = e.prow_job_id AND pj.deleted_at IS NULL
             AND pj.variant_combination_id IN (%s)
         JOIN (%s) AS vg(vcid, group_id) ON vg.vcid = pj.variant_combination_id`,
-		preJoinArgs: []any{lookupStart},
-		totalExpr:   "e.prefix_sum_runs - COALESCE(s.prefix_sum_runs, 0)",
-		successExpr: "e.prefix_sum_successes - COALESCE(s.prefix_sum_successes, 0)",
-		flakeExpr:   "e.prefix_sum_flakes - COALESCE(s.prefix_sum_flakes, 0)",
-		whereFilter: "e.release = ? AND e.date = ?",
-		whereArgs:   []any{release, lookupEnd},
-		release:     release,
-		dateRange:   dateRange,
+		preJoinArgs:     []any{lookupStart},
+		totalExpr:       "e.prefix_sum_runs - COALESCE(s.prefix_sum_runs, 0)",
+		successExpr:     "e.prefix_sum_successes - COALESCE(s.prefix_sum_successes, 0)",
+		flakeExpr:       "e.prefix_sum_flakes - COALESCE(s.prefix_sum_flakes, 0)",
+		lastFailureExpr: "MAX(e.prefix_max_last_failure)",
+		whereFilter:     "e.release = ? AND e.date = ?",
+		whereArgs:       []any{release, lookupEnd},
 	})
 }
 
@@ -283,13 +258,12 @@ func (p *PostgresProvider) queryBaseTestStatusGA(
         JOIN prow_jobs pj ON pj.id = e.prow_job_id AND pj.deleted_at IS NULL
             AND pj.variant_combination_id IN (%s)
         JOIN (%s) AS vg(vcid, group_id) ON vg.vcid = pj.variant_combination_id`,
-		totalExpr:   "e.runs",
-		successExpr: "e.passes",
-		flakeExpr:   "e.flakes",
-		whereFilter: "e.release = ? AND e.window_days = ?",
-		whereArgs:   []any{release, windowDays},
-		release:     release,
-		dateRange:   baseRange,
+		totalExpr:       "e.runs",
+		successExpr:     "e.passes",
+		flakeExpr:       "e.flakes",
+		lastFailureExpr: "NULL::timestamptz",
+		whereFilter:     "e.release = ? AND e.window_days = ?",
+		whereArgs:       []any{release, windowDays},
 	})
 }
 

--- a/test/integration/component_readiness_test.go
+++ b/test/integration/component_readiness_test.go
@@ -76,17 +76,32 @@ func createTestOwnership(t *testing.T, dbc *db.DB, testID uint, suiteID *uint, u
 	return tow
 }
 
-func createCumulativeSummary(t *testing.T, dbc *db.DB, date civil.Date, release string, testID, prowJobID, suiteID uint, runs, successes, flakes int64) {
+type cumulativeSummaryOpts struct {
+	prefixMaxLastFailure *time.Time
+}
+
+type cumulativeSummaryOption func(*cumulativeSummaryOpts)
+
+func withLastFailure(t time.Time) cumulativeSummaryOption {
+	return func(o *cumulativeSummaryOpts) { o.prefixMaxLastFailure = &t }
+}
+
+func createCumulativeSummary(t *testing.T, dbc *db.DB, date civil.Date, release string, testID, prowJobID, suiteID uint, runs, successes, flakes int64, options ...cumulativeSummaryOption) {
 	t.Helper()
+	var o cumulativeSummaryOpts
+	for _, fn := range options {
+		fn(&o)
+	}
 	tcs := models.TestCumulativeSummary{
-		Date:               date,
-		Release:            release,
-		TestID:             testID,
-		ProwJobID:          prowJobID,
-		SuiteID:            suiteID,
-		PrefixSumRuns:      runs,
-		PrefixSumSuccesses: successes,
-		PrefixSumFlakes:    flakes,
+		Date:                 date,
+		Release:              release,
+		TestID:               testID,
+		ProwJobID:            prowJobID,
+		SuiteID:              suiteID,
+		PrefixSumRuns:        runs,
+		PrefixSumSuccesses:   successes,
+		PrefixSumFlakes:      flakes,
+		PrefixMaxLastFailure: o.prefixMaxLastFailure,
 	}
 	require.NoError(t, dbc.DB.Create(&tcs).Error)
 }
@@ -743,16 +758,12 @@ func TestQuerySampleTestStatus(t *testing.T) {
 		startMinus1 := civil.Date{Year: 2024, Month: 5, Day: 31}
 		endMinus1 := civil.Date{Year: 2024, Month: 6, Day: 14}
 
-		// runs=10, successes=8, flakes=1 -> failures=1
-		createCumulativeSummary(t, dbc, startMinus1, release, test.ID, job.ID, suite.ID, 100, 90, 5)
-		createCumulativeSummary(t, dbc, endMinus1, release, test.ID, job.ID, suite.ID, 110, 98, 6)
+		failTime := time.Date(2024, 6, 10, 18, 0, 0, 0, time.UTC)
 
-		failTime1 := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
-		failTime2 := time.Date(2024, 6, 10, 18, 0, 0, 0, time.UTC)
-		run1 := createProwJobRunForCR(t, dbc, job.ID, release, failTime1)
-		run2 := createProwJobRunForCR(t, dbc, job.ID, release, failTime2)
-		createProwJobRunTest(t, dbc, run1.ID, job.ID, test.ID, &suite.ID, 12, release, failTime1) // failure
-		createProwJobRunTest(t, dbc, run2.ID, job.ID, test.ID, &suite.ID, 12, release, failTime2) // later failure
+		// runs=10, successes=8, flakes=1 -> failures=1
+		// The end-of-window row carries the prefix_max_last_failure timestamp.
+		createCumulativeSummary(t, dbc, startMinus1, release, test.ID, job.ID, suite.ID, 100, 90, 5)
+		createCumulativeSummary(t, dbc, endMinus1, release, test.ID, job.ID, suite.ID, 110, 98, 6, withLastFailure(failTime))
 
 		provider := postgres.NewPostgresProvider(dbc, nil)
 		opts := defaultReqOptions(release)
@@ -768,9 +779,101 @@ func TestQuerySampleTestStatus(t *testing.T) {
 		}
 		ts, ok := result[key.Encode()]
 		require.True(t, ok, "expected result for test with failures")
-		assert.False(t, ts.LastFailure.IsZero(), "LastFailure should be populated when failures exist")
-		assert.True(t, ts.LastFailure.Equal(failTime2),
-			"LastFailure should be the most recent failure: got %v, want %v", ts.LastFailure, failTime2)
+		assert.False(t, ts.LastFailure.IsZero(), "LastFailure should be populated when prefix_max_last_failure is set")
+		assert.True(t, ts.LastFailure.Equal(failTime),
+			"LastFailure should match prefix_max_last_failure: got %v, want %v", ts.LastFailure, failTime)
+	})
+
+	t.Run("last failure picks MAX across multiple jobs in same variant group", func(t *testing.T) {
+		dbc := crTestDB(t)
+		release := "4.16"
+
+		vc1 := createVariantCombination(t, dbc, []string{"Platform:aws", "Topology:ha"})
+		vc2 := createVariantCombination(t, dbc, []string{"Platform:aws", "Topology:single"})
+		job1 := createProwJobWithVC(t, dbc, "periodic-e2e-aws-ha-lf", release, vc1)
+		job2 := createProwJobWithVC(t, dbc, "periodic-e2e-aws-single-lf", release, vc2)
+
+		test := createTest(t, dbc, "openshift-tests:[sig-storage] multi-job last failure")
+		suite := createSuite(t, dbc, "openshift-tests-mj-lf")
+		tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:mj-lf-test", "Storage", []string{"PVC"})
+
+		startMinus1 := civil.Date{Year: 2024, Month: 5, Day: 31}
+		endMinus1 := civil.Date{Year: 2024, Month: 6, Day: 14}
+
+		earlierFailure := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
+		laterFailure := time.Date(2024, 6, 12, 9, 0, 0, 0, time.UTC)
+
+		// job1: runs=6, successes=4, flakes=1 -> failures=1, earlier failure timestamp
+		createCumulativeSummary(t, dbc, startMinus1, release, test.ID, job1.ID, suite.ID, 50, 45, 2)
+		createCumulativeSummary(t, dbc, endMinus1, release, test.ID, job1.ID, suite.ID, 56, 49, 3, withLastFailure(earlierFailure))
+
+		// job2: runs=8, successes=6, flakes=1 -> failures=1, later failure timestamp
+		createCumulativeSummary(t, dbc, startMinus1, release, test.ID, job2.ID, suite.ID, 30, 25, 1)
+		createCumulativeSummary(t, dbc, endMinus1, release, test.ID, job2.ID, suite.ID, 38, 31, 2, withLastFailure(laterFailure))
+
+		provider := postgres.NewPostgresProvider(dbc, nil)
+		opts := defaultReqOptions(release)
+		opts.VariantOption.DBGroupBy = sets.New[string]("Platform")
+
+		result, errs := provider.QuerySampleTestStatus(context.Background(), opts,
+			map[string][]string{"Platform": {"aws"}},
+			opts.SampleRelease.Start, opts.SampleRelease.End)
+		require.Empty(t, errs)
+
+		key := crtest.KeyWithVariants{
+			TestID:   tow.UniqueID,
+			Variants: map[string]string{"Platform": "aws"},
+		}
+		ts, ok := result[key.Encode()]
+		require.True(t, ok, "expected collapsed group result")
+		assert.Equal(t, 14, ts.TotalCount, "runs should aggregate: 6 + 8")
+		assert.True(t, ts.LastFailure.Equal(laterFailure),
+			"LastFailure should be MAX across jobs: got %v, want %v", ts.LastFailure, laterFailure)
+	})
+
+	t.Run("last failure picks non-NULL when mixed with NULL across jobs", func(t *testing.T) {
+		dbc := crTestDB(t)
+		release := "4.16"
+
+		vc1 := createVariantCombination(t, dbc, []string{"Platform:aws", "Topology:ha"})
+		vc2 := createVariantCombination(t, dbc, []string{"Platform:aws", "Topology:single"})
+		job1 := createProwJobWithVC(t, dbc, "periodic-e2e-aws-ha-mixed", release, vc1)
+		job2 := createProwJobWithVC(t, dbc, "periodic-e2e-aws-single-mixed", release, vc2)
+
+		test := createTest(t, dbc, "openshift-tests:[sig-storage] mixed null last failure")
+		suite := createSuite(t, dbc, "openshift-tests-mix-lf")
+		tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:mix-lf-test", "Storage", []string{"PVC"})
+
+		startMinus1 := civil.Date{Year: 2024, Month: 5, Day: 31}
+		endMinus1 := civil.Date{Year: 2024, Month: 6, Day: 14}
+
+		failTime := time.Date(2024, 6, 8, 15, 0, 0, 0, time.UTC)
+
+		// job1: has a failure timestamp
+		createCumulativeSummary(t, dbc, startMinus1, release, test.ID, job1.ID, suite.ID, 50, 45, 2)
+		createCumulativeSummary(t, dbc, endMinus1, release, test.ID, job1.ID, suite.ID, 56, 49, 3, withLastFailure(failTime))
+
+		// job2: no failure timestamp (NULL prefix_max_last_failure)
+		createCumulativeSummary(t, dbc, startMinus1, release, test.ID, job2.ID, suite.ID, 30, 25, 1)
+		createCumulativeSummary(t, dbc, endMinus1, release, test.ID, job2.ID, suite.ID, 38, 31, 2)
+
+		provider := postgres.NewPostgresProvider(dbc, nil)
+		opts := defaultReqOptions(release)
+		opts.VariantOption.DBGroupBy = sets.New[string]("Platform")
+
+		result, errs := provider.QuerySampleTestStatus(context.Background(), opts,
+			map[string][]string{"Platform": {"aws"}},
+			opts.SampleRelease.Start, opts.SampleRelease.End)
+		require.Empty(t, errs)
+
+		key := crtest.KeyWithVariants{
+			TestID:   tow.UniqueID,
+			Variants: map[string]string{"Platform": "aws"},
+		}
+		ts, ok := result[key.Encode()]
+		require.True(t, ok, "expected collapsed group result")
+		assert.True(t, ts.LastFailure.Equal(failTime),
+			"LastFailure should be the non-NULL value: got %v, want %v", ts.LastFailure, failTime)
 	})
 
 	t.Run("results limited to available data when requested range exceeds it", func(t *testing.T) {
@@ -1103,6 +1206,7 @@ func TestQueryBaseTestStatus_GA(t *testing.T) {
 	assert.Equal(t, 50, ts.TotalCount)
 	assert.Equal(t, 45, ts.SuccessCount)
 	assert.Equal(t, 2, ts.FlakeCount)
+	assert.True(t, ts.LastFailure.IsZero(), "GA base path should not populate LastFailure")
 
 	t.Run("GA drill-down with TestID", func(t *testing.T) {
 		opts2 := opts


### PR DESCRIPTION
## Summary

- Replace the `lastFailureLateral` LATERAL join (which scanned `prow_job_run_tests` partitions per test) with an inline `MAX(e.prefix_max_last_failure)` from `test_cumulative_summaries`, the table already being queried for counts.
- For the GA base path, return `NULL::timestamptz` since only sample `LastFailure` is consumed downstream (by the regression tracker and component report).
- Add a `lastFailureExpr` field to `testStatusSpec` so both prefix-sum and GA paths share the same query builder.
- Add integration tests covering MAX aggregation across multiple jobs, mixed NULL/non-NULL timestamps, and GA base path behavior.

## Test plan

- [x] `go vet` and `go build` pass
- [x] Unit tests pass (`go test ./pkg/api/componentreadiness/...`)
- [x] Integration tests pass (`go test ./test/integration/...`)
- [x] Staging deployment and manual verification against staging-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component readiness results to report the most recent test failure date accurately.
  * Corrected failure-date handling when multiple jobs are grouped together.
  * Preserved available failure information when some grouped jobs have no recorded failure.
  * Ensured cumulative summaries include failures occurring within the relevant reporting window.
  * GA results no longer display an unsupported last-failure timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->