### PR TITLE
SPLAT-2647: Add vcf-migration jobs to candidate tier

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -851,6 +851,9 @@ func (v *OCPVariantLoader) setJobTier(_ logrus.FieldLogger, variants map[string]
 		// vSphere hybrid-env jobs are not yet stable enough for component readiness
 		{[]string{"-hybrid-env"}, "candidate"},
 
+		// vSphere VCF migration jobs are new and not yet stable enough for component readiness
+		{[]string{"-vcf-migration"}, "candidate"},
+
 		// Nutanix upgrade job not yet stable due to CSI operator conformance failures
 		{[]string{"-e2e-nutanix-upgrade"}, "candidate"},
 


### PR DESCRIPTION
Classify new vSphere VCF migration operator CI jobs as candidate tier so they don't affect component readiness while stabilizing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * vSphere VCF migration jobs are now correctly assigned to the candidate tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->