### PR TITLE
TRT-2821: Fall back to aggregate tables for base stats in test_details

### DIFF
--- a/pkg/api/componentreadiness/component_report_test.go
+++ b/pkg/api/componentreadiness/component_report_test.go
@@ -1569,12 +1569,13 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 	}
 	componentAndCapabilityGetter = fakeComponentAndCapabilityGetter
 	for _, tc := range tests {
-		baseStats := map[string][]crstatus.TestJobRunRows{}
-		sampleStats := map[string][]crstatus.TestJobRunRows{}
+		rawBaseStats := map[string][]crstatus.TestJobRunRows{}
+		rawSampleStats := map[string][]crstatus.TestJobRunRows{}
 		for _, testStats := range tc.baseRequiredJobStats {
 			for i := 0; i < testStats.Success; i++ {
-				baseStats[testStats.job] = append(baseStats[testStats.job], crstatus.TestJobRunRows{
-					ProwJob: testStats.job,
+				rawBaseStats[testStats.job] = append(rawBaseStats[testStats.job], crstatus.TestJobRunRows{
+					ProwJob:      testStats.job,
+					ProwJobRunID: fmt.Sprintf("base-%s-s-%d", testStats.job, i),
 					Count: crtest.Count{
 						TotalCount:   1,
 						SuccessCount: 1,
@@ -1582,14 +1583,16 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 				})
 			}
 			for i := 0; i < testStats.Failure; i++ {
-				baseStats[testStats.job] = append(baseStats[testStats.job], crstatus.TestJobRunRows{
-					ProwJob: testStats.job,
-					Count:   crtest.Count{TotalCount: 1},
+				rawBaseStats[testStats.job] = append(rawBaseStats[testStats.job], crstatus.TestJobRunRows{
+					ProwJob:      testStats.job,
+					ProwJobRunID: fmt.Sprintf("base-%s-f-%d", testStats.job, i),
+					Count:        crtest.Count{TotalCount: 1},
 				})
 			}
 			for i := 0; i < testStats.Flake; i++ {
-				baseStats[testStats.job] = append(baseStats[testStats.job], crstatus.TestJobRunRows{
-					ProwJob: testStats.job,
+				rawBaseStats[testStats.job] = append(rawBaseStats[testStats.job], crstatus.TestJobRunRows{
+					ProwJob:      testStats.job,
+					ProwJobRunID: fmt.Sprintf("base-%s-fl-%d", testStats.job, i),
 					Count: crtest.Count{
 						TotalCount: 1,
 						FlakeCount: 1,
@@ -1599,8 +1602,9 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 		}
 		for _, testStats := range tc.sampleRequiredJobStats {
 			for i := 0; i < testStats.Success; i++ {
-				sampleStats[testStats.job] = append(sampleStats[testStats.job], crstatus.TestJobRunRows{
-					ProwJob: testStats.job,
+				rawSampleStats[testStats.job] = append(rawSampleStats[testStats.job], crstatus.TestJobRunRows{
+					ProwJob:      testStats.job,
+					ProwJobRunID: fmt.Sprintf("sample-%s-s-%d", testStats.job, i),
 					Count: crtest.Count{
 						TotalCount:   1,
 						SuccessCount: 1,
@@ -1608,14 +1612,16 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 				})
 			}
 			for i := 0; i < testStats.Failure; i++ {
-				sampleStats[testStats.job] = append(sampleStats[testStats.job], crstatus.TestJobRunRows{
-					ProwJob: testStats.job,
-					Count:   crtest.Count{TotalCount: 1},
+				rawSampleStats[testStats.job] = append(rawSampleStats[testStats.job], crstatus.TestJobRunRows{
+					ProwJob:      testStats.job,
+					ProwJobRunID: fmt.Sprintf("sample-%s-f-%d", testStats.job, i),
+					Count:        crtest.Count{TotalCount: 1},
 				})
 			}
 			for i := 0; i < testStats.Flake; i++ {
-				sampleStats[testStats.job] = append(sampleStats[testStats.job], crstatus.TestJobRunRows{
-					ProwJob: testStats.job,
+				rawSampleStats[testStats.job] = append(rawSampleStats[testStats.job], crstatus.TestJobRunRows{
+					ProwJob:      testStats.job,
+					ProwJobRunID: fmt.Sprintf("sample-%s-fl-%d", testStats.job, i),
 					Count: crtest.Count{
 						TotalCount: 1,
 						FlakeCount: 1,
@@ -1623,6 +1629,8 @@ func TestGenerateComponentTestDetailsReport(t *testing.T) {
 				})
 			}
 		}
+		baseStats := crstatus.SummarizeTestJobRuns(rawBaseStats)
+		sampleStats := crstatus.SummarizeTestJobRuns(rawSampleStats)
 
 		t.Run(tc.name, func(t *testing.T) {
 			report := tc.generator.internalGenerateTestDetailsReport("", nil, nil, baseStats, sampleStats, tc.generator.ReqOptions.TestIDOptions[0])

--- a/pkg/api/componentreadiness/dataprovider/bigquery/provider.go
+++ b/pkg/api/componentreadiness/dataprovider/bigquery/provider.go
@@ -88,7 +88,7 @@ func (p *BigQueryProvider) QuerySampleTestStatus(ctx context.Context, reqOptions
 
 // --- TestDetailsQuerier ---
 
-func (p *BigQueryProvider) QueryBaseJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions) (map[string][]crstatus.TestJobRunRows, []error) {
+func (p *BigQueryProvider) QueryBaseJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions) (map[string][]crstatus.TestDetailsSummary, []error) {
 	allJobVariants, errs := p.QueryJobVariants(ctx, reqOptions)
 	if len(errs) > 0 {
 		return nil, errs
@@ -102,7 +102,7 @@ func (p *BigQueryProvider) QueryBaseJobRunTestStatus(ctx context.Context, reqOpt
 
 	result, errs := apiPkg.GetDataFromCacheOrGenerate[crstatus.TestJobRunStatuses](
 		ctx, p.client.Cache, reqOptions.CacheOption,
-		apiPkg.NewCacheSpec(generator, "BaseJobRunTestStatusV2~", &reqOptions.BaseRelease.End),
+		apiPkg.NewCacheSpec(generator, "BaseJobRunTestStatusV3~", &reqOptions.BaseRelease.End),
 		generator.QueryTestStatus, crstatus.TestJobRunStatuses{})
 	if len(errs) > 0 {
 		return nil, errs
@@ -112,7 +112,7 @@ func (p *BigQueryProvider) QueryBaseJobRunTestStatus(ctx context.Context, reqOpt
 
 func (p *BigQueryProvider) QuerySampleJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions,
 	includeVariants map[string][]string,
-	start, end time.Time) (map[string][]crstatus.TestJobRunRows, []error) {
+	start, end time.Time) (map[string][]crstatus.TestDetailsSummary, []error) {
 	allJobVariants, errs := p.QueryJobVariants(ctx, reqOptions)
 	if len(errs) > 0 {
 		return nil, errs
@@ -121,7 +121,7 @@ func (p *BigQueryProvider) QuerySampleJobRunTestStatus(ctx context.Context, reqO
 	generator := NewSampleTestDetailsQueryGenerator(p.client, reqOptions, allJobVariants, includeVariants, start, end)
 	result, errs := apiPkg.GetDataFromCacheOrGenerate[crstatus.TestJobRunStatuses](
 		ctx, p.client.Cache, reqOptions.CacheOption,
-		apiPkg.NewCacheSpec(generator, "SampleJobRunTestStatusV2~", &end),
+		apiPkg.NewCacheSpec(generator, "SampleJobRunTestStatusV3~", &end),
 		generator.QueryTestStatus, crstatus.TestJobRunStatuses{})
 	if len(errs) > 0 {
 		return nil, errs

--- a/pkg/api/componentreadiness/dataprovider/bigquery/querygenerators.go
+++ b/pkg/api/componentreadiness/dataprovider/bigquery/querygenerators.go
@@ -917,7 +917,8 @@ func (b *baseTestDetailsQueryGenerator) QueryTestStatus(ctx context.Context) (cr
 		},
 	}...)
 
-	baseStatus, errs := fetchJobRunTestStatusResults(ctx, b.logger, baseQuery)
+	rawRows, errs := fetchJobRunTestStatusResults(ctx, b.logger, baseQuery)
+	baseStatus := crstatus.SummarizeTestJobRuns(rawRows)
 	return crstatus.TestJobRunStatuses{BaseStatus: baseStatus}, errs
 }
 
@@ -1012,7 +1013,8 @@ func (s *sampleTestDetailsQueryGenerator) QueryTestStatus(ctx context.Context) (
 		}...)
 	}
 
-	sampleStatus, errs := fetchJobRunTestStatusResults(ctx, log.WithField("generator", "SampleQuery"), sampleQuery)
+	rawRows, errs := fetchJobRunTestStatusResults(ctx, log.WithField("generator", "SampleQuery"), sampleQuery)
+	sampleStatus := crstatus.SummarizeTestJobRuns(rawRows)
 
 	return crstatus.TestJobRunStatuses{SampleStatus: sampleStatus}, errs
 }

--- a/pkg/api/componentreadiness/dataprovider/interface.go
+++ b/pkg/api/componentreadiness/dataprovider/interface.go
@@ -22,13 +22,13 @@ type TestStatusQuerier interface {
 		start, end time.Time) (map[string]crstatus.TestStatus, []error)
 }
 
-// TestDetailsQuerier fetches per-job-run test breakdowns used for test details reports.
+// TestDetailsQuerier fetches per-job test breakdowns used for test details reports.
 type TestDetailsQuerier interface {
-	QueryBaseJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions) (map[string][]crstatus.TestJobRunRows, []error)
+	QueryBaseJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions) (map[string][]crstatus.TestDetailsSummary, []error)
 
 	QuerySampleJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions,
 		includeVariants map[string][]string,
-		start, end time.Time) (map[string][]crstatus.TestJobRunRows, []error)
+		start, end time.Time) (map[string][]crstatus.TestDetailsSummary, []error)
 }
 
 // MetadataQuerier fetches reference data used to configure and parameterize reports.

--- a/pkg/api/componentreadiness/dataprovider/mixed/provider.go
+++ b/pkg/api/componentreadiness/dataprovider/mixed/provider.go
@@ -68,11 +68,11 @@ func (p *MixedProvider) QuerySampleTestStatus(ctx context.Context, reqOptions re
 	return p.providerFor(reqOptions).QuerySampleTestStatus(ctx, reqOptions, includeVariants, start, end)
 }
 
-func (p *MixedProvider) QueryBaseJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions) (map[string][]crstatus.TestJobRunRows, []error) {
+func (p *MixedProvider) QueryBaseJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions) (map[string][]crstatus.TestDetailsSummary, []error) {
 	return p.providerFor(reqOptions).QueryBaseJobRunTestStatus(ctx, reqOptions)
 }
 
-func (p *MixedProvider) QuerySampleJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions, includeVariants map[string][]string, start, end time.Time) (map[string][]crstatus.TestJobRunRows, []error) {
+func (p *MixedProvider) QuerySampleJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions, includeVariants map[string][]string, start, end time.Time) (map[string][]crstatus.TestDetailsSummary, []error) {
 	return p.providerFor(reqOptions).QuerySampleJobRunTestStatus(ctx, reqOptions, includeVariants, start, end)
 }
 

--- a/pkg/api/componentreadiness/dataprovider/postgres/provider.go
+++ b/pkg/api/componentreadiness/dataprovider/postgres/provider.go
@@ -81,6 +81,41 @@ func filterByDBGroupBy(variants map[string]string, dbGroupBy sets.Set[string]) m
 	return filtered
 }
 
+// matchRequestedVariants checks whether a row's job variants satisfy the
+// requested variant filters for the given testID, and returns the filtered
+// key. Returns ok=false if the row should be skipped.
+func matchRequestedVariants(
+	testID string,
+	variants map[string]string,
+	requestedVariants map[string]map[string]string,
+	dbGroupBy sets.Set[string],
+) (crtest.KeyWithVariants, bool) {
+	if rv, ok := requestedVariants[testID]; ok {
+		for k, v := range rv {
+			if variants[k] != v {
+				return crtest.KeyWithVariants{}, false
+			}
+		}
+	}
+	filtered := filterByDBGroupBy(variants, dbGroupBy)
+	return crtest.KeyWithVariants{
+		TestID:   testID,
+		Variants: filtered,
+	}, true
+}
+
+// buildRequestedVariantsMap builds a testID -> requested variants lookup
+// from the request options.
+func buildRequestedVariantsMap(testIDOptions []reqopts.TestIdentification) map[string]map[string]string {
+	m := map[string]map[string]string{}
+	for _, tid := range testIDOptions {
+		if len(tid.RequestedVariants) > 0 {
+			m[tid.TestID] = tid.RequestedVariants
+		}
+	}
+	return m
+}
+
 // matchesIncludeVariants checks if a variant map passes the include filter.
 func matchesIncludeVariants(variants map[string]string, includeVariants map[string][]string) bool {
 	for key, allowed := range includeVariants {
@@ -321,7 +356,7 @@ type testDetailRow struct {
 
 func (p *PostgresProvider) queryTestDetails(ctx context.Context, release string, start, end time.Time,
 	reqOptions reqopts.RequestOptions,
-	includeVariants map[string][]string) (map[string][]crstatus.TestJobRunRows, []error) {
+	includeVariants map[string][]string) (map[string][]crstatus.TestDetailsSummary, []error) {
 
 	if includeVariants == nil {
 		includeVariants = map[string][]string{}
@@ -396,25 +431,17 @@ WHERE pj.release = ?
 	dbGroupBy := reqOptions.VariantOption.DBGroupBy
 
 	// Batch-fetch job variants for per-test requested variant filtering
-	jobIDs := map[uint]bool{}
+	jobIDs := sets.New[uint]()
 	for _, r := range rows {
-		jobIDs[r.ProwJobID] = true
+		jobIDs.Insert(r.ProwJobID)
 	}
-	ids := make([]uint, 0, len(jobIDs))
-	for id := range jobIDs {
-		ids = append(ids, id)
-	}
+	ids := jobIDs.UnsortedList()
 	jobVariantMap, err := p.fetchJobVariantsByIDs(ids)
 	if err != nil {
 		return nil, []error{err}
 	}
 
-	requestedVariantsByTestID := map[string]map[string]string{}
-	for _, tid := range reqOptions.TestIDOptions {
-		if len(tid.RequestedVariants) > 0 {
-			requestedVariantsByTestID[tid.TestID] = tid.RequestedVariants
-		}
-	}
+	requestedVariantsByTestID := buildRequestedVariantsMap(reqOptions.TestIDOptions)
 
 	result := map[string][]crstatus.TestJobRunRows{}
 	for _, row := range rows {
@@ -423,23 +450,9 @@ WHERE pj.release = ?
 			continue
 		}
 
-		if rv, ok := requestedVariantsByTestID[row.TestID]; ok {
-			match := true
-			for k, v := range rv {
-				if variants[k] != v {
-					match = false
-					break
-				}
-			}
-			if !match {
-				continue
-			}
-		}
-
-		filtered := filterByDBGroupBy(variants, dbGroupBy)
-		key := crtest.KeyWithVariants{
-			TestID:   row.TestID,
-			Variants: filtered,
+		key, matched := matchRequestedVariants(row.TestID, variants, requestedVariantsByTestID, dbGroupBy)
+		if !matched {
+			continue
 		}
 
 		successCount := 0
@@ -473,22 +486,234 @@ WHERE pj.release = ?
 		result[normalizedName] = append(result[normalizedName], entry)
 	}
 
-	return result, nil
+	return crstatus.SummarizeTestJobRuns(result), nil
 }
 
-func (p *PostgresProvider) QueryBaseJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions) (map[string][]crstatus.TestJobRunRows, []error) {
-
-	return p.queryTestDetails(
+func (p *PostgresProvider) QueryBaseJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions) (map[string][]crstatus.TestDetailsSummary, []error) {
+	result, errs := p.queryTestDetails(
 		ctx,
 		reqOptions.BaseRelease.Name,
 		reqOptions.BaseRelease.Start, reqOptions.BaseRelease.End,
 		reqOptions, reqOptions.VariantOption.IncludeVariants,
 	)
+	if len(errs) > 0 {
+		return result, errs
+	}
+	if len(result) > 0 {
+		return result, nil
+	}
+	log.WithField("release", reqOptions.BaseRelease.Name).
+		Info("no per-run base test details found, falling back to aggregate tables")
+	return p.queryBaseAggregateTestDetails(ctx, reqOptions)
+}
+
+type aggregateTestDetailRow struct {
+	TestID          string `gorm:"column:test_id"`
+	TestName        string `gorm:"column:test_name"`
+	ProwJobName     string `gorm:"column:prowjob_name"`
+	ProwJobID       uint   `gorm:"column:prow_job_id"`
+	JiraComponent   string `gorm:"column:jira_component"`
+	JiraComponentID *uint  `gorm:"column:jira_component_id"`
+	TotalCount      int    `gorm:"column:total_count"`
+	SuccessCount    int    `gorm:"column:success_count"`
+	FlakeCount      int    `gorm:"column:flake_count"`
+}
+
+// queryBaseAggregateTestDetails queries aggregate tables (test_cumulative_summaries
+// or prow_ga_raw_test_data) as a fallback when prow_job_run_tests has no data for
+// the base release. Returns per-job aggregate stats as TestDetailsSummary entries
+// with no individual JobRuns, because per-run identifiers do not exist in these tables.
+func (p *PostgresProvider) queryBaseAggregateTestDetails(ctx context.Context, reqOptions reqopts.RequestOptions) (map[string][]crstatus.TestDetailsSummary, []error) {
+	includeVariants := reqOptions.VariantOption.IncludeVariants
+	if includeVariants == nil {
+		includeVariants = map[string][]string{}
+	}
+	includeVariants = mergeRequestedVariants(includeVariants, reqOptions)
+
+	testIDs := make([]string, 0, len(reqOptions.TestIDOptions))
+	for _, tid := range reqOptions.TestIDOptions {
+		if tid.TestID == "" {
+			continue
+		}
+		testIDs = append(testIDs, tid.TestID)
+	}
+
+	cte := `WITH target_tests AS MATERIALIZED (
+    SELECT test_id, suite_id, unique_id, jira_component, jira_component_id
+    FROM test_ownerships
+    WHERE staff_approved_obsolete = false`
+
+	var cteArgs []any
+	if len(testIDs) > 0 {
+		cte += ` AND unique_id IN (?)`
+		cteArgs = append(cteArgs, testIDs)
+	}
+	cte += ")"
+
+	baseRange := query.DateRange{
+		Start: civil.DateOf(reqOptions.BaseRelease.Start),
+		End:   civil.DateOf(reqOptions.BaseRelease.End).AddDays(1),
+	}
+
+	var sqlQuery string
+	var queryArgs []any
+
+	if p.baseMatchesGAWindow(ctx, reqOptions.BaseRelease.Name, baseRange) {
+		windowDays := baseRange.End.AddDays(-1).DaysSince(baseRange.Start)
+		sqlQuery, queryArgs = p.buildAggregateGAQuery(cte, cteArgs, reqOptions.BaseRelease.Name, windowDays, includeVariants)
+	} else {
+		var err error
+		sqlQuery, queryArgs, err = p.buildAggregatePrefixSumQuery(cte, cteArgs, reqOptions.BaseRelease.Name, baseRange, includeVariants)
+		if err != nil {
+			return nil, []error{err}
+		}
+	}
+
+	var rows []aggregateTestDetailRow
+	if err := p.dbc.DB.WithContext(ctx).Raw(sqlQuery, queryArgs...).Scan(&rows).Error; err != nil {
+		return nil, []error{fmt.Errorf("querying aggregate test details: %w", err)}
+	}
+
+	return p.processAggregateRows(rows, reqOptions)
+}
+
+func (p *PostgresProvider) buildAggregatePrefixSumQuery(cte string, cteArgs []any, release string, dateRange query.DateRange, includeVariants map[string][]string) (string, []any, error) {
+	if err := query.ResolveDateRanges(p.dbc, release, &dateRange); err != nil {
+		return "", nil, fmt.Errorf("resolving date ranges: %w", err)
+	}
+	lookupEnd := dateRange.End.AddDays(-1)
+	lookupStart := dateRange.Start.AddDays(-1)
+
+	sqlQuery := cte + `
+SELECT
+    tt.unique_id AS test_id,
+    t.name AS test_name,
+    pj.name AS prowjob_name,
+    pj.id AS prow_job_id,
+    COALESCE(tt.jira_component, '') AS jira_component,
+    tt.jira_component_id,
+    SUM(e.prefix_sum_runs - COALESCE(s.prefix_sum_runs, 0)) AS total_count,
+    SUM(e.prefix_sum_successes - COALESCE(s.prefix_sum_successes, 0)) AS success_count,
+    SUM(e.prefix_sum_flakes - COALESCE(s.prefix_sum_flakes, 0)) AS flake_count
+FROM target_tests tt
+JOIN test_cumulative_summaries e ON e.test_id = tt.test_id
+    AND (e.suite_id = tt.suite_id OR (tt.suite_id IS NULL AND e.suite_id = 0))
+LEFT JOIN test_cumulative_summaries s
+    ON s.release = e.release AND s.test_id = e.test_id
+    AND s.prow_job_id = e.prow_job_id AND s.suite_id = e.suite_id
+    AND s.date = ?
+JOIN prow_jobs pj ON pj.id = e.prow_job_id AND pj.deleted_at IS NULL
+JOIN tests t ON t.id = tt.test_id
+WHERE e.release = ? AND e.date = ?`
+
+	args := make([]any, 0, len(cteArgs)+10)
+	args = append(args, cteArgs...)
+	args = append(args, lookupStart, release, lookupEnd)
+
+	if len(includeVariants) > 0 {
+		filterClause, filterArgs := buildVariantFilterClause(includeVariants)
+		if filterClause != "" {
+			sqlQuery += " AND pj.variant_combination_id IN (SELECT vc.id FROM variant_combinations vc WHERE " + filterClause + ")"
+			args = append(args, filterArgs...)
+		}
+	}
+
+	sqlQuery += `
+GROUP BY tt.unique_id, t.name, pj.name, pj.id, tt.jira_component, tt.jira_component_id
+HAVING SUM(e.prefix_sum_runs - COALESCE(s.prefix_sum_runs, 0)) > 0`
+
+	return sqlQuery, args, nil
+}
+
+func (p *PostgresProvider) buildAggregateGAQuery(cte string, cteArgs []any, release string, windowDays int, includeVariants map[string][]string) (string, []any) {
+	sqlQuery := cte + `
+SELECT
+    tt.unique_id AS test_id,
+    t.name AS test_name,
+    pj.name AS prowjob_name,
+    pj.id AS prow_job_id,
+    COALESCE(tt.jira_component, '') AS jira_component,
+    tt.jira_component_id,
+    SUM(e.runs) AS total_count,
+    SUM(e.passes) AS success_count,
+    SUM(e.flakes) AS flake_count
+FROM target_tests tt
+JOIN prow_ga_raw_test_data e ON e.test_id = tt.test_id
+    AND (e.suite_id = tt.suite_id OR (tt.suite_id IS NULL AND e.suite_id = 0))
+JOIN prow_jobs pj ON pj.id = e.prow_job_id AND pj.deleted_at IS NULL
+JOIN tests t ON t.id = tt.test_id
+WHERE e.release = ? AND e.window_days = ?`
+
+	args := make([]any, 0, len(cteArgs)+10)
+	args = append(args, cteArgs...)
+	args = append(args, release, windowDays)
+
+	if len(includeVariants) > 0 {
+		filterClause, filterArgs := buildVariantFilterClause(includeVariants)
+		if filterClause != "" {
+			sqlQuery += " AND pj.variant_combination_id IN (SELECT vc.id FROM variant_combinations vc WHERE " + filterClause + ")"
+			args = append(args, filterArgs...)
+		}
+	}
+
+	sqlQuery += `
+GROUP BY tt.unique_id, t.name, pj.name, pj.id, tt.jira_component, tt.jira_component_id
+HAVING SUM(e.runs) > 0`
+
+	return sqlQuery, args
+}
+
+func (p *PostgresProvider) processAggregateRows(rows []aggregateTestDetailRow, reqOptions reqopts.RequestOptions) (map[string][]crstatus.TestDetailsSummary, []error) {
+	dbGroupBy := reqOptions.VariantOption.DBGroupBy
+
+	jobIDs := sets.New[uint]()
+	for _, r := range rows {
+		jobIDs.Insert(r.ProwJobID)
+	}
+	jobVariantMap, err := p.fetchJobVariantsByIDs(jobIDs.UnsortedList())
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	requestedVariantsByTestID := buildRequestedVariantsMap(reqOptions.TestIDOptions)
+
+	result := map[string][]crstatus.TestDetailsSummary{}
+	for _, row := range rows {
+		variants, ok := jobVariantMap[row.ProwJobID]
+		if !ok {
+			continue
+		}
+
+		key, matched := matchRequestedVariants(row.TestID, variants, requestedVariantsByTestID, dbGroupBy)
+		if !matched {
+			continue
+		}
+
+		var jiraComponentID *big.Rat
+		if row.JiraComponentID != nil {
+			jiraComponentID = new(big.Rat).SetUint64(uint64(*row.JiraComponentID))
+		}
+
+		normalizedName := utils.NormalizeProwJobName(row.ProwJobName)
+		entry := crstatus.TestDetailsSummary{
+			TestKey:         key,
+			TestKeyStr:      key.Encode(),
+			ProwJob:         normalizedName,
+			TestName:        row.TestName,
+			Stats:           crtest.Count{TotalCount: row.TotalCount, SuccessCount: row.SuccessCount, FlakeCount: row.FlakeCount}.ToTestStats(false),
+			JiraComponent:   row.JiraComponent,
+			JiraComponentID: jiraComponentID,
+		}
+
+		result[normalizedName] = append(result[normalizedName], entry)
+	}
+
+	return result, nil
 }
 
 func (p *PostgresProvider) QuerySampleJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions,
 	includeVariants map[string][]string,
-	start, end time.Time) (map[string][]crstatus.TestJobRunRows, []error) {
+	start, end time.Time) (map[string][]crstatus.TestDetailsSummary, []error) {
 	return p.queryTestDetails(
 		ctx,
 		reqOptions.SampleRelease.Name,

--- a/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
+++ b/pkg/api/componentreadiness/middleware/releasefallback/releasefallback.go
@@ -58,10 +58,10 @@ type ReleaseFallback struct {
 	log                        log.FieldLogger
 	reqOptions                 reqopts.RequestOptions
 
-	// baseOverrideStatus maps test key, to job name, to the result rows for that job.
+	// baseOverrideStatus maps test key, to job name, to the result summaries for that job.
 	// This is used in test details reports, and in the typical API case will only contain one
 	// test ID, but when cache priming for a view, we may have multiple.
-	baseOverrideStatus map[string]map[string][]crstatus.TestJobRunRows
+	baseOverrideStatus map[string]map[string][]crstatus.TestDetailsSummary
 	baseOverrideMutex  sync.Mutex // Mutex to protect the map
 	releaseConfigs     []v1.Release
 }
@@ -212,7 +212,7 @@ func (r *ReleaseFallback) QueryTestDetails(ctx context.Context, wg *sync.WaitGro
 		}
 		releaseToTestIDOptions[testIDOpts.BaseOverrideRelease] = append(releaseToTestIDOptions[testIDOpts.BaseOverrideRelease], testIDOpts)
 	}
-	r.baseOverrideStatus = map[string]map[string][]crstatus.TestJobRunRows{}
+	r.baseOverrideStatus = map[string]map[string][]crstatus.TestDetailsSummary{}
 
 	// Now we'll do one concurrent query for each release that has some fallback tests:
 	for release, testIDOpts := range releaseToTestIDOptions {
@@ -244,26 +244,16 @@ func (r *ReleaseFallback) QueryTestDetails(ctx context.Context, wg *sync.WaitGro
 					errCh <- bsErr
 				}
 
-				// Now that we've queried all the results for a fallback release, we need to chop them up into
-				// per test -> job -> result rows.
-
-				// We have a struct where the statuses are mapped by prowjob to all rows results for that prowjob,
-				// with multiple tests intermingled in that layer.
-				// Build out a new struct where these are split up by test ID.
-				// split the status on test ID, and pass only that tests data in for reporting:
 				r.baseOverrideMutex.Lock()
-				for jobName, rows := range baseStatus {
-					for _, row := range rows {
-						testKeyStr := row.TestKeyStr
+				for jobName, summaries := range baseStatus {
+					for _, summary := range summaries {
+						testKeyStr := summary.TestKeyStr
 						if _, ok := r.baseOverrideStatus[testKeyStr]; !ok {
-							r.log.Infof("added test key: " + testKeyStr)
-							r.baseOverrideStatus[testKeyStr] = map[string][]crstatus.TestJobRunRows{}
-						}
-						if r.baseOverrideStatus[testKeyStr][jobName] == nil {
-							r.baseOverrideStatus[testKeyStr][jobName] = []crstatus.TestJobRunRows{}
+							r.log.WithField("testKey", testKeyStr).Debug("added test key")
+							r.baseOverrideStatus[testKeyStr] = map[string][]crstatus.TestDetailsSummary{}
 						}
 						r.baseOverrideStatus[testKeyStr][jobName] =
-							append(r.baseOverrideStatus[testKeyStr][jobName], row)
+							append(r.baseOverrideStatus[testKeyStr][jobName], summary)
 					}
 				}
 

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -99,60 +99,31 @@ func (c *ComponentReportGenerator) GenerateTestDetailsReportMultiTest(ctx contex
 	// Build out a new struct where these are split up by test ID.
 	// split the status on test ID, and pass only that tests data in for reporting:
 	testKeyTestJobRunStatuses := map[string]crstatus.TestJobRunStatuses{}
-	for jobName, rows := range allTestsJobRunStatuses.BaseStatus {
-		for _, row := range rows {
-			testKeyStr := row.TestKeyStr
-			if _, ok := testKeyTestJobRunStatuses[testKeyStr]; !ok {
-				testKeyTestJobRunStatuses[testKeyStr] = crstatus.TestJobRunStatuses{
-					BaseStatus:         map[string][]crstatus.TestJobRunRows{},
-					BaseOverrideStatus: map[string][]crstatus.TestJobRunRows{},
-					SampleStatus:       map[string][]crstatus.TestJobRunRows{},
-					GeneratedAt:        allTestsJobRunStatuses.GeneratedAt,
+	splitByTestKey := func(
+		source map[string][]crstatus.TestDetailsSummary,
+		getTarget func(crstatus.TestJobRunStatuses) map[string][]crstatus.TestDetailsSummary,
+	) {
+		for jobName, summaries := range source {
+			for _, summary := range summaries {
+				testKeyStr := summary.TestKeyStr
+				if _, ok := testKeyTestJobRunStatuses[testKeyStr]; !ok {
+					testKeyTestJobRunStatuses[testKeyStr] = crstatus.TestJobRunStatuses{
+						BaseStatus:         map[string][]crstatus.TestDetailsSummary{},
+						BaseOverrideStatus: map[string][]crstatus.TestDetailsSummary{},
+						SampleStatus:       map[string][]crstatus.TestDetailsSummary{},
+						GeneratedAt:        allTestsJobRunStatuses.GeneratedAt,
+					}
 				}
+				target := getTarget(testKeyTestJobRunStatuses[testKeyStr])
+				target[jobName] = append(target[jobName], summary)
 			}
-			if testKeyTestJobRunStatuses[testKeyStr].BaseStatus[jobName] == nil {
-				testKeyTestJobRunStatuses[testKeyStr].BaseStatus[jobName] = []crstatus.TestJobRunRows{}
-			}
-			testKeyTestJobRunStatuses[testKeyStr].BaseStatus[jobName] =
-				append(testKeyTestJobRunStatuses[testKeyStr].BaseStatus[jobName], row)
 		}
 	}
-	for jobName, rows := range allTestsJobRunStatuses.BaseOverrideStatus {
-		for _, row := range rows {
-			testKeyStr := row.TestKeyStr
-			if _, ok := testKeyTestJobRunStatuses[testKeyStr]; !ok {
-				testKeyTestJobRunStatuses[testKeyStr] = crstatus.TestJobRunStatuses{
-					BaseStatus:         map[string][]crstatus.TestJobRunRows{},
-					BaseOverrideStatus: map[string][]crstatus.TestJobRunRows{},
-					SampleStatus:       map[string][]crstatus.TestJobRunRows{},
-					GeneratedAt:        allTestsJobRunStatuses.GeneratedAt,
-				}
-			}
-			if testKeyTestJobRunStatuses[testKeyStr].BaseOverrideStatus[jobName] == nil {
-				testKeyTestJobRunStatuses[testKeyStr].BaseOverrideStatus[jobName] = []crstatus.TestJobRunRows{}
-			}
-			testKeyTestJobRunStatuses[testKeyStr].BaseOverrideStatus[jobName] =
-				append(testKeyTestJobRunStatuses[testKeyStr].BaseOverrideStatus[jobName], row)
-		}
-	}
-	for jobName, rows := range allTestsJobRunStatuses.SampleStatus {
-		for _, row := range rows {
-			testKeyStr := row.TestKeyStr
-			if _, ok := testKeyTestJobRunStatuses[testKeyStr]; !ok {
-				testKeyTestJobRunStatuses[testKeyStr] = crstatus.TestJobRunStatuses{
-					BaseStatus:         map[string][]crstatus.TestJobRunRows{},
-					BaseOverrideStatus: map[string][]crstatus.TestJobRunRows{},
-					SampleStatus:       map[string][]crstatus.TestJobRunRows{},
-					GeneratedAt:        allTestsJobRunStatuses.GeneratedAt,
-				}
-			}
-			if testKeyTestJobRunStatuses[testKeyStr].SampleStatus[jobName] == nil {
-				testKeyTestJobRunStatuses[testKeyStr].SampleStatus[jobName] = []crstatus.TestJobRunRows{}
-			}
-			testKeyTestJobRunStatuses[testKeyStr].SampleStatus[jobName] =
-				append(testKeyTestJobRunStatuses[testKeyStr].SampleStatus[jobName], row)
-		}
-	}
+	splitByTestKey(allTestsJobRunStatuses.BaseStatus, func(s crstatus.TestJobRunStatuses) map[string][]crstatus.TestDetailsSummary { return s.BaseStatus })
+	splitByTestKey(allTestsJobRunStatuses.BaseOverrideStatus, func(s crstatus.TestJobRunStatuses) map[string][]crstatus.TestDetailsSummary {
+		return s.BaseOverrideStatus
+	})
+	splitByTestKey(allTestsJobRunStatuses.SampleStatus, func(s crstatus.TestJobRunStatuses) map[string][]crstatus.TestDetailsSummary { return s.SampleStatus })
 
 	reports := []testdetails.Report{}
 	for _, tOpt := range c.ReqOptions.TestIDOptions {
@@ -338,7 +309,7 @@ func (c *ComponentReportGenerator) getBaseJobRunTestStatus(
 	ctx context.Context,
 	baseRelease string,
 	baseStart time.Time,
-	baseEnd time.Time) (map[string][]crstatus.TestJobRunRows, []error) {
+	baseEnd time.Time) (map[string][]crstatus.TestDetailsSummary, []error) {
 
 	reqOpts := c.ReqOptions
 	reqOpts.BaseRelease.Name = baseRelease
@@ -350,14 +321,14 @@ func (c *ComponentReportGenerator) getBaseJobRunTestStatus(
 func (c *ComponentReportGenerator) getSampleJobRunTestStatus(
 	ctx context.Context,
 	includeVariants map[string][]string,
-	start, end time.Time) (map[string][]crstatus.TestJobRunRows, []error) {
+	start, end time.Time) (map[string][]crstatus.TestDetailsSummary, []error) {
 
 	return c.dataProvider.QuerySampleJobRunTestStatus(ctx, c.ReqOptions, includeVariants, start, end)
 }
 
 func (c *ComponentReportGenerator) getJobRunTestStatus(ctx context.Context) (crstatus.TestJobRunStatuses, []error) {
 	fLog := logrus.WithField("func", "getJobRunTestStatus")
-	var baseStatus, sampleStatus map[string][]crstatus.TestJobRunRows
+	var baseStatus, sampleStatus map[string][]crstatus.TestDetailsSummary
 	var baseErrs, sampleErrs []error
 	wg := sync.WaitGroup{}
 
@@ -420,7 +391,7 @@ func (c *ComponentReportGenerator) getJobRunTestStatus(ctx context.Context) (crs
 func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(
 	baseRelease string,
 	baseStart, baseEnd *time.Time,
-	baseStatus, sampleStatus map[string][]crstatus.TestJobRunRows,
+	baseStatus, sampleStatus map[string][]crstatus.TestDetailsSummary,
 	testIDOption reqopts.TestIdentification,
 ) testdetails.Report {
 	testKey := crtest.Identification{
@@ -436,14 +407,8 @@ func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(
 
 	totalBase, totalSample, report, result, lastFailure := c.summarizeRecordedTestStats(baseStatus, sampleStatus, testKey)
 
-	explanations := []string{}
-	if len(baseStatus) == 0 && c.ReqOptions.DataSource == reqopts.DataSourcePostgres {
-		explanations = append(explanations,
-			"Base test details are not available: individual test run data has not been backfilled for this release in the PostgreSQL data source. Aggregated base statistics from the grid view remain accurate.")
-	}
-
 	testStats := testdetails.TestComparison{
-		Explanations:       explanations,
+		Explanations:       []string{},
 		RequiredConfidence: c.ReqOptions.AdvancedOption.Confidence,
 		SampleStats: testdetails.ReleaseStats{
 			Release: c.ReqOptions.SampleRelease.Name,
@@ -475,34 +440,52 @@ func (c *ComponentReportGenerator) internalGenerateTestDetailsReport(
 	return result
 }
 
-// go through all the job runs that had a test and summarize the results
+// summarizeRecordedTestStats iterates pre-computed per-job summaries and produces
+// the overall base/sample stats, per-job breakdowns, and metadata for the report.
 func (c *ComponentReportGenerator) summarizeRecordedTestStats(
-	baseStatus, sampleStatus map[string][]crstatus.TestJobRunRows, testKey crtest.Identification,
+	baseStatus, sampleStatus map[string][]crstatus.TestDetailsSummary, testKey crtest.Identification,
 ) (
 	totalBase, totalSample crtest.Stats,
 	report testdetails.Analysis,
 	result testdetails.Report,
-	lastFailure time.Time, // track the last failure we observe in the sample, used by triage middleware to adjust status
+	lastFailure time.Time,
 ) {
 	result = testdetails.Report{Identification: testKey}
 	faf := c.ReqOptions.AdvancedOption.FlakeAsFailure
 
-	// merge the job names from both base and sample status and assess each once
+	// Callers pass statuses already split by test key, so each job maps to at most
+	// one summary here; the job-name assignments below rely on that.
 	jobNames := sets.New(slices.Collect(maps.Keys(baseStatus))...)
 	jobNames.Insert(slices.Collect(maps.Keys(sampleStatus))...)
 	for job := range jobNames {
-		// tally up base job stats and matching sample job stats (if any); record job names, component, etc in the result
 		jobStats := testdetails.JobStats{}
-		if sampleStatsList, ok := sampleStatus[job]; ok {
-			c.assessTestStats(sampleStatsList, &jobStats.SampleStats, &jobStats.SampleJobRunStats, &jobStats.SampleJobName, &lastFailure, &result, faf)
+		if sampleSummaries, ok := sampleStatus[job]; ok {
+			for _, summary := range sampleSummaries {
+				jobStats.SampleJobName = summary.ProwJob
+				jobStats.SampleStats = jobStats.SampleStats.Add(summary.Stats, faf)
+				c.extractMetadata(summary, &result)
+				for _, run := range summary.JobRuns {
+					start := run.StartTime.In(time.UTC)
+					if start.After(lastFailure) && run.Failures() > 0 {
+						lastFailure = start
+					}
+					jobStats.SampleJobRunStats = append(jobStats.SampleJobRunStats, c.toJobRunStats(run))
+				}
+			}
 			totalSample = totalSample.Add(jobStats.SampleStats, faf)
 		}
-		if baseStatsList, ok := baseStatus[job]; ok {
-			c.assessTestStats(baseStatsList, &jobStats.BaseStats, &jobStats.BaseJobRunStats, &jobStats.BaseJobName, nil, &result, faf)
+		if baseSummaries, ok := baseStatus[job]; ok {
+			for _, summary := range baseSummaries {
+				jobStats.BaseJobName = summary.ProwJob
+				jobStats.BaseStats = jobStats.BaseStats.Add(summary.Stats, faf)
+				c.extractMetadata(summary, &result)
+				for _, run := range summary.JobRuns {
+					jobStats.BaseJobRunStats = append(jobStats.BaseJobRunStats, c.toJobRunStats(run))
+				}
+			}
 			totalBase = totalBase.Add(jobStats.BaseStats, faf)
 		}
 
-		// determine the statistical significance to report in the job stats
 		sFail, sPass := jobStats.SampleStats.FailPassWithFlakes(faf)
 		bFail, bPass := jobStats.BaseStats.FailPassWithFlakes(faf)
 		_, _, r, _ := fet.FisherExactTest(sFail, sPass, bFail, bPass)
@@ -511,7 +494,6 @@ func (c *ComponentReportGenerator) summarizeRecordedTestStats(
 		report.JobStats = append(report.JobStats, jobStats)
 	}
 
-	// sort stats by job name in the results
 	sort.Slice(report.JobStats, func(i, j int) bool {
 		return report.JobStats[i].SampleJobName+":"+report.JobStats[i].BaseJobName <
 			report.JobStats[j].SampleJobName+":"+report.JobStats[j].BaseJobName
@@ -519,60 +501,32 @@ func (c *ComponentReportGenerator) summarizeRecordedTestStats(
 	return
 }
 
-// assessTestStats calculates the test stats for a given list of job rows
-// and updates by-reference parameters with information found in the job rows.
-func (c *ComponentReportGenerator) assessTestStats(
-	jobRowsList []crstatus.TestJobRunRows,
-	testStats *crtest.Stats,
-	jobRunStatsList *[]testdetails.JobRunStats,
-	jobName *string, lastFailure *time.Time,
-	result *testdetails.Report,
-	flakeAsFailure bool,
-) {
-	for _, jobRow := range jobRowsList {
-		*jobName = jobRow.ProwJob
-
-		start := jobRow.StartTime.In(time.UTC)
-		if lastFailure != nil && start.After(*lastFailure) && jobRow.Failures() > 0 {
-			*lastFailure = start
-		}
-
-		if result.JiraComponent == "" && jobRow.JiraComponent != "" {
-			result.JiraComponent = jobRow.JiraComponent
-		}
-		if result.JiraComponentID == nil && jobRow.JiraComponentID != nil {
-			result.JiraComponentID = jobRow.JiraComponentID
-		}
-		if result.TestName == "" && jobRow.TestName != "" {
-			result.TestName = jobRow.TestName
-		}
-		if result.Lifecycle != "informing" {
-			if jobRow.Lifecycle == "informing" {
-				result.Lifecycle = "informing"
-			} else if result.Lifecycle == "" && jobRow.Lifecycle != "" {
-				result.Lifecycle = jobRow.Lifecycle
-			}
-		}
-
-		*testStats = testStats.AddTestCount(jobRow.Count, flakeAsFailure)
-		*jobRunStatsList = append(*jobRunStatsList, c.getJobRunStats(jobRow))
+func (c *ComponentReportGenerator) extractMetadata(summary crstatus.TestDetailsSummary, result *testdetails.Report) {
+	if result.JiraComponent == "" && summary.JiraComponent != "" {
+		result.JiraComponent = summary.JiraComponent
 	}
+	if result.JiraComponentID == nil && summary.JiraComponentID != nil {
+		result.JiraComponentID = summary.JiraComponentID
+	}
+	if result.TestName == "" && summary.TestName != "" {
+		result.TestName = summary.TestName
+	}
+	result.Lifecycle = crstatus.PromoteLifecycle(result.Lifecycle, summary.Lifecycle)
 }
 
-func (c *ComponentReportGenerator) getJobRunStats(stats crstatus.TestJobRunRows) testdetails.JobRunStats {
-	jobRunStats := testdetails.JobRunStats{
+func (c *ComponentReportGenerator) toJobRunStats(run crstatus.JobRunDetail) testdetails.JobRunStats {
+	return testdetails.JobRunStats{
 		TestStats: crtest.NewTestStats(
-			stats.SuccessCount,
-			stats.Failures(),
-			stats.FlakeCount,
+			run.SuccessCount,
+			run.Failures(),
+			run.FlakeCount,
 			c.ReqOptions.AdvancedOption.FlakeAsFailure,
 		),
-		JobURL:       stats.ProwJobURL,
-		JobRunID:     stats.ProwJobRunID,
-		StartTime:    stats.StartTime,
-		JobLabels:    stats.JobLabels,
-		JobSymptoms:  stats.JobSymptoms,
-		TestFailures: stats.TestFailures,
+		JobURL:       run.ProwJobURL,
+		JobRunID:     run.ProwJobRunID,
+		StartTime:    run.StartTime,
+		JobLabels:    run.JobLabels,
+		JobSymptoms:  run.JobSymptoms,
+		TestFailures: run.TestFailures,
 	}
-	return jobRunStats
 }

--- a/pkg/apis/api/componentreport/crstatus/summarize.go
+++ b/pkg/apis/api/componentreport/crstatus/summarize.go
@@ -1,0 +1,77 @@
+package crstatus
+
+import "math/big"
+
+// PromoteLifecycle returns the lifecycle that should win when merging
+// incoming into current. "informing" always takes priority; otherwise
+// the first non-empty value is kept.
+func PromoteLifecycle(current, incoming string) string {
+	if current == "informing" {
+		return current
+	}
+	if incoming == "informing" {
+		return incoming
+	}
+	if current == "" && incoming != "" {
+		return incoming
+	}
+	return current
+}
+
+// SummarizeTestJobRuns groups per-run TestJobRunRows by (job, test key) and
+// produces pre-computed TestDetailsSummary entries. The result map is keyed
+// by normalized prow job name, matching the input map's keys.
+func SummarizeTestJobRuns(rows map[string][]TestJobRunRows) map[string][]TestDetailsSummary {
+	result := map[string][]TestDetailsSummary{}
+
+	for jobName, jobRows := range rows {
+		byTestKey := map[string]*TestDetailsSummary{}
+		var orderedKeys []string
+
+		for _, row := range jobRows {
+			summary, ok := byTestKey[row.TestKeyStr]
+			if !ok {
+				summary = &TestDetailsSummary{
+					TestKey:    row.TestKey,
+					TestKeyStr: row.TestKeyStr,
+					ProwJob:    row.ProwJob,
+				}
+				byTestKey[row.TestKeyStr] = summary
+				orderedKeys = append(orderedKeys, row.TestKeyStr)
+			}
+
+			// flakeAsFailure=false: counts are policy-independent; callers recompute SuccessRate
+			// with the request's FlakeAsFailure setting via Stats.Add().
+			summary.Stats = summary.Stats.AddTestCount(row.Count, false)
+
+			if row.ProwJobRunID != "" {
+				summary.JobRuns = append(summary.JobRuns, JobRunDetail{
+					ProwJobRunID: row.ProwJobRunID,
+					ProwJobURL:   row.ProwJobURL,
+					StartTime:    row.StartTime,
+					Count:        row.Count,
+					JobLabels:    row.JobLabels,
+					JobSymptoms:  row.JobSymptoms,
+					TestFailures: row.TestFailures,
+				})
+			}
+
+			if summary.JiraComponent == "" && row.JiraComponent != "" {
+				summary.JiraComponent = row.JiraComponent
+			}
+			if summary.JiraComponentID == nil && row.JiraComponentID != nil {
+				summary.JiraComponentID = new(big.Rat).Set(row.JiraComponentID)
+			}
+			if summary.TestName == "" && row.TestName != "" {
+				summary.TestName = row.TestName
+			}
+			summary.Lifecycle = PromoteLifecycle(summary.Lifecycle, row.Lifecycle)
+		}
+
+		for _, key := range orderedKeys {
+			result[jobName] = append(result[jobName], *byTestKey[key])
+		}
+	}
+
+	return result
+}

--- a/pkg/apis/api/componentreport/crstatus/summarize_test.go
+++ b/pkg/apis/api/componentreport/crstatus/summarize_test.go
@@ -1,0 +1,70 @@
+package crstatus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openshift/sippy/pkg/apis/api/componentreport/crtest"
+)
+
+func TestSummarizeTestJobRuns_LifecyclePromotion(t *testing.T) {
+	tests := []struct {
+		name              string
+		lifecycles        []string
+		expectedLifecycle string
+	}{
+		{
+			name:              "all blocking stays blocking",
+			lifecycles:        []string{"blocking", "blocking", "blocking"},
+			expectedLifecycle: "blocking",
+		},
+		{
+			name:              "blocking then informing promotes to informing",
+			lifecycles:        []string{"blocking", "informing", "blocking"},
+			expectedLifecycle: "informing",
+		},
+		{
+			name:              "informing first stays informing",
+			lifecycles:        []string{"informing", "blocking", "blocking"},
+			expectedLifecycle: "informing",
+		},
+		{
+			name:              "single informing promotes to informing",
+			lifecycles:        []string{"blocking", "blocking", "informing"},
+			expectedLifecycle: "informing",
+		},
+		{
+			name:              "all informing stays informing",
+			lifecycles:        []string{"informing", "informing"},
+			expectedLifecycle: "informing",
+		},
+		{
+			name:              "empty lifecycle ignored when non-empty exists",
+			lifecycles:        []string{"", "blocking", ""},
+			expectedLifecycle: "blocking",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var rows []TestJobRunRows
+			for _, lc := range tc.lifecycles {
+				rows = append(rows, TestJobRunRows{
+					TestKeyStr: "test-key",
+					ProwJob:    "job-name",
+					Count:      crtest.Count{TotalCount: 1, SuccessCount: 1},
+					Lifecycle:  lc,
+				})
+			}
+
+			result := SummarizeTestJobRuns(map[string][]TestJobRunRows{
+				"job-name": rows,
+			})
+
+			require.Len(t, result["job-name"], 1)
+			assert.Equal(t, tc.expectedLifecycle, result["job-name"][0].Lifecycle)
+		})
+	}
+}

--- a/pkg/apis/api/componentreport/crstatus/types.go
+++ b/pkg/apis/api/componentreport/crstatus/types.go
@@ -37,18 +37,38 @@ type TestStatus struct {
 	LastFailure time.Time `json:"last_failure"`
 }
 
-// TestJobRunStatuses contains the rows returned from a test details query organized by base and sample,
-// essentially the actual job runs and their status that was used to calculate this
-// report.
-// Status fields map prowjob name to each row result we received for that job.
+// TestJobRunStatuses contains the rows returned from a test details query organized by base and sample.
+// Status fields map prowjob name to per-test summaries for that job.
 type TestJobRunStatuses struct {
-	BaseStatus map[string][]TestJobRunRows `json:"base_status"`
-	// TODO: This could be a little cleaner if we did status.BaseStatuses plural and tied them to a release,
-	// allowing the release fallback mechanism to stay a little cleaner. That would more clearly
-	// keep middleware details out of the main codebase.
-	BaseOverrideStatus map[string][]TestJobRunRows `json:"base_override_status"`
-	SampleStatus       map[string][]TestJobRunRows `json:"sample_status"`
-	GeneratedAt        *time.Time                  `json:"generated_at"`
+	BaseStatus         map[string][]TestDetailsSummary `json:"base_status"`
+	BaseOverrideStatus map[string][]TestDetailsSummary `json:"base_override_status"`
+	SampleStatus       map[string][]TestDetailsSummary `json:"sample_status"`
+	GeneratedAt        *time.Time                      `json:"generated_at"`
+}
+
+// TestDetailsSummary is a per-test, per-job summary with pre-computed counts
+// and optional individual run details.
+type TestDetailsSummary struct {
+	TestKey         crtest.KeyWithVariants
+	TestKeyStr      string
+	ProwJob         string
+	Stats           crtest.Stats
+	JobRuns         []JobRunDetail `json:",omitempty"`
+	JiraComponent   string
+	JiraComponentID *big.Rat
+	TestName        string
+	Lifecycle       string
+}
+
+// JobRunDetail holds the per-run information for an individual prow job run.
+type JobRunDetail struct {
+	ProwJobRunID string
+	ProwJobURL   string
+	StartTime    time.Time
+	crtest.Count
+	JobLabels    []string `json:",omitempty"`
+	JobSymptoms  []string `json:",omitempty"`
+	TestFailures int
 }
 
 // TestJobRunRows are the per job run rows from a test details report

--- a/test/integration/component_readiness_test.go
+++ b/test/integration/component_readiness_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	componentreadiness "github.com/openshift/sippy/pkg/api/componentreadiness"
 	"github.com/openshift/sippy/pkg/api/componentreadiness/dataprovider/postgres"
 	"github.com/openshift/sippy/pkg/api/componentreadiness/utils"
 	"github.com/openshift/sippy/pkg/apis/api/componentreport/crstatus"
@@ -47,7 +48,8 @@ func createProwJobWithVC(t *testing.T, dbc *db.DB, name, release string, vc mode
 
 func createTestOwnership(t *testing.T, dbc *db.DB, testID uint, suiteID *uint, uniqueID, component string, caps []string) models.TestOwnership {
 	t.Helper()
-	return intutil.CreateTestOwnership(t, dbc, testID, suiteID, uniqueID, component, intutil.WithTestOwnershipCapabilities(caps))
+	return intutil.CreateTestOwnership(t, dbc, testID, suiteID, uniqueID, component,
+		intutil.WithTestOwnershipJiraComponent(component), intutil.WithTestOwnershipCapabilities(caps))
 }
 
 type cumulativeSummaryOpts struct {
@@ -94,7 +96,7 @@ func createCumulativeSummary(t *testing.T, dbc *db.DB, date civil.Date, release 
 	intutil.CreateCumulativeSummary(t, dbc, date, release, testID, prowJobID, suiteID, runs, successes, flakes, intutilOpts...)
 }
 
-func createGARawData(t *testing.T, dbc *db.DB, release string, windowDays int, testID, prowJobID, suiteID uint, runs, passes, flakes int64) {
+func createGARawData(t *testing.T, dbc *db.DB, release string, windowDays int, testID, prowJobID, suiteID uint, runs, passes, flakes int64) { //nolint:unparam
 	t.Helper()
 	ga := models.ProwGARawTestDatum{
 		Release:    release,
@@ -153,7 +155,7 @@ func setJobRunLabels(t *testing.T, dbc *db.DB, runID uint, labels []string) {
 func createTestOwnershipFull(t *testing.T, dbc *db.DB, testID uint, suiteID *uint, uniqueID, component string, caps []string, jiraComponentID *uint) models.TestOwnership {
 	t.Helper()
 	return intutil.CreateTestOwnership(t, dbc, testID, suiteID, uniqueID, component,
-		intutil.WithTestOwnershipCapabilities(caps), intutil.WithTestOwnershipJiraComponentID(jiraComponentID))
+		intutil.WithTestOwnershipJiraComponent(component), intutil.WithTestOwnershipCapabilities(caps), intutil.WithTestOwnershipJiraComponentID(jiraComponentID))
 }
 
 func uintPtr(v uint) *uint { return &v }
@@ -1377,16 +1379,20 @@ func TestQuerySampleJobRunTestStatus(t *testing.T) {
 			opts.SampleRelease.Start, opts.SampleRelease.End)
 		require.Empty(t, errs)
 
-		totalRows := 0
-		for _, rows := range result {
-			totalRows += len(rows)
+		totalSummaries := 0
+		totalJobRuns := 0
+		for _, summaries := range result {
+			totalSummaries += len(summaries)
+			for _, s := range summaries {
+				totalJobRuns += len(s.JobRuns)
+			}
 		}
-		assert.Equal(t, 3, totalRows, "should have 3 job run test rows")
+		assert.Equal(t, 2, totalSummaries, "should have 2 summaries (one per job)")
+		assert.Equal(t, 3, totalJobRuns, "should have 3 individual job runs across summaries")
 
-		// Verify that all rows reference the correct test
-		for _, rows := range result {
-			for _, row := range rows {
-				assert.Equal(t, tow.UniqueID, row.TestKey.TestID)
+		for _, summaries := range result {
+			for _, s := range summaries {
+				assert.Equal(t, tow.UniqueID, s.TestKey.TestID)
 			}
 		}
 	})
@@ -1403,11 +1409,16 @@ func TestQuerySampleJobRunTestStatus(t *testing.T) {
 			opts.SampleRelease.Start, opts.SampleRelease.End)
 		require.Empty(t, errs)
 
-		totalRows := 0
-		for _, rows := range result {
-			totalRows += len(rows)
+		totalSummaries := 0
+		totalJobRuns := 0
+		for _, summaries := range result {
+			totalSummaries += len(summaries)
+			for _, s := range summaries {
+				totalJobRuns += len(s.JobRuns)
+			}
 		}
-		assert.Equal(t, 2, totalRows, "RequestedVariants=aws should exclude gcp run")
+		assert.Equal(t, 1, totalSummaries, "RequestedVariants=aws should produce 1 summary")
+		assert.Equal(t, 2, totalJobRuns, "RequestedVariants=aws should include 2 aws runs")
 	})
 
 	t.Run("IncludeVariants filtering", func(t *testing.T) {
@@ -1566,17 +1577,544 @@ func TestQueryBaseJobRunTestStatus(t *testing.T) {
 	result, errs := provider.QueryBaseJobRunTestStatus(context.Background(), opts)
 	require.Empty(t, errs)
 
-	totalRows := 0
-	for _, rows := range result {
-		totalRows += len(rows)
-	}
-	assert.Equal(t, 2, totalRows, "should have 2 base job run test rows")
-
-	for _, rows := range result {
-		for _, row := range rows {
-			assert.Equal(t, tow.UniqueID, row.TestKey.TestID)
+	totalSummaries := 0
+	totalJobRuns := 0
+	for _, summaries := range result {
+		totalSummaries += len(summaries)
+		for _, s := range summaries {
+			totalJobRuns += len(s.JobRuns)
 		}
 	}
+	assert.Equal(t, 1, totalSummaries, "should have 1 summary for the single job")
+	assert.Equal(t, 2, totalJobRuns, "should have 2 individual job runs in the summary")
+
+	for _, summaries := range result {
+		for _, s := range summaries {
+			assert.Equal(t, tow.UniqueID, s.TestKey.TestID)
+		}
+	}
+}
+
+func TestQueryBaseJobRunTestStatus_AggregateFallback(t *testing.T) {
+	t.Run("prefix-sum fallback when per-run data is absent", func(t *testing.T) {
+		dbc := crTestDB(t)
+		release := "4.16"
+
+		vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+		job := createProwJobWithVC(t, dbc, "periodic-agg-aws", release, vc)
+
+		test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] agg fallback test")
+		suite := intutil.CreateSuite(t, dbc, "openshift-tests-agg")
+		tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:agg-fallback", "Storage", []string{"PVC"})
+
+		// Base release: [2024-05-15, 2024-06-01)
+		// lookupStart = 2024-05-14, lookupEnd = 2024-06-01
+		baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+		baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+		createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, job.ID, suite.ID, 80, 75, 3)
+		createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, job.ID, suite.ID, 100, 90, 5)
+		// expected: runs=20, successes=15, flakes=2
+
+		// No prow_job_run_tests rows created for this release
+
+		provider := postgres.NewPostgresProvider(dbc, nil)
+		opts := defaultReqOptions(release)
+		opts.TestIDOptions = []reqopts.TestIdentification{{
+			TestID:            tow.UniqueID,
+			RequestedVariants: map[string]string{"Platform": "aws", "Network": "ovn"},
+		}}
+		opts.VariantOption.IncludeVariants = map[string][]string{
+			"Platform": {"aws"},
+			"Network":  {"ovn"},
+		}
+
+		result, errs := provider.QueryBaseJobRunTestStatus(context.Background(), opts)
+		require.Empty(t, errs)
+
+		totalRows := 0
+		for _, rows := range result {
+			totalRows += len(rows)
+		}
+		require.Equal(t, 1, totalRows, "should have 1 aggregate entry for the one job")
+
+		for _, rows := range result {
+			for _, row := range rows {
+				assert.Equal(t, tow.UniqueID, row.TestKey.TestID)
+				assert.Equal(t, 20, row.Stats.Total(), "aggregate total should be prefix-sum delta")
+				assert.Equal(t, 15, row.Stats.SuccessCount, "aggregate successes should be prefix-sum delta")
+				assert.Equal(t, 2, row.Stats.FlakeCount, "aggregate flakes should be prefix-sum delta")
+			}
+		}
+	})
+
+	t.Run("GA fallback when per-run data is absent", func(t *testing.T) {
+		dbc := crTestDB(t)
+		release := "4.15"
+
+		gaDate := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+		createReleaseDefinition(t, dbc, release, &gaDate)
+
+		gaCivil := civil.DateOf(gaDate)
+		gaEnd := utils.GAWindowEnd(gaCivil)
+		windowDays := 30
+		gaStart := gaCivil.AddDays(-windowDays)
+
+		vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+		job := createProwJobWithVC(t, dbc, "periodic-ga-agg-aws", release, vc)
+
+		test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] GA agg fallback test")
+		suite := intutil.CreateSuite(t, dbc, "openshift-tests-ga-agg")
+		tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:ga-agg-fallback", "Storage", []string{"PVC"})
+
+		createGARawData(t, dbc, release, windowDays, test.ID, job.ID, suite.ID, 50, 45, 2)
+
+		// No prow_job_run_tests rows
+
+		provider := postgres.NewPostgresProvider(dbc, nil)
+		opts := defaultReqOptions(release)
+		opts.BaseRelease = reqopts.Release{
+			Name:  release,
+			Start: gaStart.In(time.UTC),
+			End:   gaEnd.AddDays(-1).In(time.UTC),
+		}
+		opts.TestIDOptions = []reqopts.TestIdentification{{
+			TestID:            tow.UniqueID,
+			RequestedVariants: map[string]string{"Platform": "aws", "Network": "ovn"},
+		}}
+		opts.VariantOption.IncludeVariants = map[string][]string{
+			"Platform": {"aws"},
+			"Network":  {"ovn"},
+		}
+
+		result, errs := provider.QueryBaseJobRunTestStatus(context.Background(), opts)
+		require.Empty(t, errs)
+
+		totalRows := 0
+		for _, rows := range result {
+			totalRows += len(rows)
+		}
+		require.Equal(t, 1, totalRows, "should have 1 aggregate entry from GA data")
+
+		for _, rows := range result {
+			for _, row := range rows {
+				assert.Equal(t, tow.UniqueID, row.TestKey.TestID)
+				assert.Equal(t, 50, row.Stats.Total())
+				assert.Equal(t, 45, row.Stats.SuccessCount)
+				assert.Equal(t, 2, row.Stats.FlakeCount)
+			}
+		}
+	})
+
+	t.Run("per-run data takes precedence over aggregate", func(t *testing.T) {
+		dbc := crTestDB(t)
+		release := "4.16"
+
+		vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+		job := createProwJobWithVC(t, dbc, "periodic-prec-aws", release, vc)
+
+		test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] precedence test")
+		suite := intutil.CreateSuite(t, dbc, "openshift-tests-prec")
+		tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:precedence", "Storage", []string{"PVC"})
+
+		// Create cumulative summaries (aggregate data)
+		baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+		baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+		createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, job.ID, suite.ID, 80, 75, 3)
+		createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, job.ID, suite.ID, 100, 90, 5)
+
+		// Also create per-run data (prow_job_run_tests)
+		ts1 := time.Date(2024, 5, 20, 12, 0, 0, 0, time.UTC)
+		ts2 := time.Date(2024, 5, 25, 12, 0, 0, 0, time.UTC)
+		run1 := createProwJobRunForCR(t, dbc, job.ID, release, ts1)
+		run2 := createProwJobRunForCR(t, dbc, job.ID, release, ts2)
+		createProwJobRunTest(t, dbc, run1.ID, job.ID, test.ID, &suite.ID, 1, release, ts1)
+		createProwJobRunTest(t, dbc, run2.ID, job.ID, test.ID, &suite.ID, 12, release, ts2)
+
+		provider := postgres.NewPostgresProvider(dbc, nil)
+		opts := defaultReqOptions(release)
+		opts.TestIDOptions = []reqopts.TestIdentification{{TestID: tow.UniqueID}}
+		opts.VariantOption.IncludeVariants = map[string][]string{
+			"Platform": {"aws"},
+			"Network":  {"ovn"},
+		}
+
+		result, errs := provider.QueryBaseJobRunTestStatus(context.Background(), opts)
+		require.Empty(t, errs)
+
+		totalSummaries := 0
+		for _, summaries := range result {
+			totalSummaries += len(summaries)
+		}
+		assert.Equal(t, 1, totalSummaries, "per-run data should produce 1 summary per test key")
+
+		for _, summaries := range result {
+			for _, summary := range summaries {
+				assert.Equal(t, 2, summary.Stats.Total(), "summary should aggregate both per-run rows")
+				assert.Len(t, summary.JobRuns, 2, "summary should contain 2 individual job runs")
+			}
+		}
+	})
+
+	t.Run("variant filtering applied in fallback", func(t *testing.T) {
+		dbc := crTestDB(t)
+		release := "4.16"
+
+		vcAWS := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+		vcGCP := createVariantCombination(t, dbc, []string{"Platform:gcp", "Network:sdn"})
+		jobAWS := createProwJobWithVC(t, dbc, "periodic-vf-aws", release, vcAWS)
+		jobGCP := createProwJobWithVC(t, dbc, "periodic-vf-gcp", release, vcGCP)
+
+		test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] variant filter test")
+		suite := intutil.CreateSuite(t, dbc, "openshift-tests-vf")
+		tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:variant-filter", "Storage", []string{"PVC"})
+
+		baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+		baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+
+		createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, jobAWS.ID, suite.ID, 80, 75, 3)
+		createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, jobAWS.ID, suite.ID, 100, 90, 5)
+		createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, jobGCP.ID, suite.ID, 40, 35, 1)
+		createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, jobGCP.ID, suite.ID, 60, 50, 3)
+
+		provider := postgres.NewPostgresProvider(dbc, nil)
+		opts := defaultReqOptions(release)
+		opts.TestIDOptions = []reqopts.TestIdentification{{
+			TestID:            tow.UniqueID,
+			RequestedVariants: map[string]string{"Platform": "aws", "Network": "ovn"},
+		}}
+		opts.VariantOption.IncludeVariants = map[string][]string{
+			"Platform": {"aws"},
+			"Network":  {"ovn"},
+		}
+
+		result, errs := provider.QueryBaseJobRunTestStatus(context.Background(), opts)
+		require.Empty(t, errs)
+
+		totalRows := 0
+		for _, rows := range result {
+			totalRows += len(rows)
+		}
+		assert.Equal(t, 1, totalRows, "only aws+ovn job should be returned")
+
+		for _, rows := range result {
+			for _, row := range rows {
+				assert.Equal(t, 20, row.Stats.Total(), "should only contain aws job data")
+			}
+		}
+	})
+
+	t.Run("RequestedVariants filtering applied in fallback", func(t *testing.T) {
+		dbc := crTestDB(t)
+		release := "4.16"
+
+		vcAWSOvn := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+		vcAWSSdn := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:sdn"})
+		jobOvn := createProwJobWithVC(t, dbc, "periodic-rv-ovn", release, vcAWSOvn)
+		jobSdn := createProwJobWithVC(t, dbc, "periodic-rv-sdn", release, vcAWSSdn)
+
+		test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] requested variants test")
+		suite := intutil.CreateSuite(t, dbc, "openshift-tests-rv")
+		tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:req-variants", "Storage", []string{"PVC"})
+
+		baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+		baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+
+		createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, jobOvn.ID, suite.ID, 80, 75, 3)
+		createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, jobOvn.ID, suite.ID, 100, 90, 5)
+		createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, jobSdn.ID, suite.ID, 40, 35, 1)
+		createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, jobSdn.ID, suite.ID, 60, 50, 3)
+
+		provider := postgres.NewPostgresProvider(dbc, nil)
+		opts := defaultReqOptions(release)
+		opts.TestIDOptions = []reqopts.TestIdentification{{
+			TestID:            tow.UniqueID,
+			RequestedVariants: map[string]string{"Platform": "aws", "Network": "ovn"},
+		}}
+		opts.VariantOption.IncludeVariants = map[string][]string{
+			"Platform": {"aws"},
+			"Network":  {"ovn", "sdn"},
+		}
+
+		result, errs := provider.QueryBaseJobRunTestStatus(context.Background(), opts)
+		require.Empty(t, errs)
+
+		totalRows := 0
+		for _, rows := range result {
+			totalRows += len(rows)
+		}
+		assert.Equal(t, 1, totalRows, "RequestedVariants should narrow to ovn only")
+
+		for _, rows := range result {
+			for _, row := range rows {
+				assert.Equal(t, "ovn", row.TestKey.Variants["Network"],
+					"only ovn variant should be returned")
+			}
+		}
+	})
+
+	t.Run("multiple jobs aggregated separately", func(t *testing.T) {
+		dbc := crTestDB(t)
+		release := "4.16"
+
+		vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+		job1 := createProwJobWithVC(t, dbc, "periodic-multi-aws-1", release, vc)
+		job2 := createProwJobWithVC(t, dbc, "periodic-multi-aws-2", release, vc)
+
+		test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] multi job test")
+		suite := intutil.CreateSuite(t, dbc, "openshift-tests-mj")
+		tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:multi-job", "Storage", []string{"PVC"})
+
+		baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+		baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+
+		createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, job1.ID, suite.ID, 80, 75, 3)
+		createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, job1.ID, suite.ID, 100, 90, 5)
+		createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, job2.ID, suite.ID, 40, 35, 1)
+		createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, job2.ID, suite.ID, 60, 50, 3)
+
+		provider := postgres.NewPostgresProvider(dbc, nil)
+		opts := defaultReqOptions(release)
+		opts.TestIDOptions = []reqopts.TestIdentification{{
+			TestID:            tow.UniqueID,
+			RequestedVariants: map[string]string{"Platform": "aws", "Network": "ovn"},
+		}}
+		opts.VariantOption.IncludeVariants = map[string][]string{
+			"Platform": {"aws"},
+			"Network":  {"ovn"},
+		}
+
+		result, errs := provider.QueryBaseJobRunTestStatus(context.Background(), opts)
+		require.Empty(t, errs)
+
+		assert.Len(t, result, 2, "should have 2 separate job entries")
+
+		normalizedJob1 := utils.NormalizeProwJobName("periodic-multi-aws-1")
+		normalizedJob2 := utils.NormalizeProwJobName("periodic-multi-aws-2")
+
+		rows1, ok := result[normalizedJob1]
+		require.True(t, ok, "should have entry for job1")
+		assert.Len(t, rows1, 1)
+		assert.Equal(t, 20, rows1[0].Stats.Total())
+
+		rows2, ok := result[normalizedJob2]
+		require.True(t, ok, "should have entry for job2")
+		assert.Len(t, rows2, 1)
+		assert.Equal(t, 20, rows2[0].Stats.Total())
+	})
+
+	t.Run("aggregate fallback rows have no individual run data", func(t *testing.T) {
+		dbc := crTestDB(t)
+		release := "4.16"
+
+		vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+		job := createProwJobWithVC(t, dbc, "periodic-flag-aws", release, vc)
+
+		test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] aggregate no-run-id test")
+		suite := intutil.CreateSuite(t, dbc, "openshift-tests-flag")
+		tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:flag-test", "Storage", []string{"PVC"})
+
+		baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+		baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+		createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, job.ID, suite.ID, 80, 75, 3)
+		createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, job.ID, suite.ID, 100, 90, 5)
+
+		provider := postgres.NewPostgresProvider(dbc, nil)
+		opts := defaultReqOptions(release)
+		opts.TestIDOptions = []reqopts.TestIdentification{{
+			TestID:            tow.UniqueID,
+			RequestedVariants: map[string]string{"Platform": "aws", "Network": "ovn"},
+		}}
+		opts.VariantOption.IncludeVariants = map[string][]string{
+			"Platform": {"aws"},
+			"Network":  {"ovn"},
+		}
+
+		result, errs := provider.QueryBaseJobRunTestStatus(context.Background(), opts)
+		require.Empty(t, errs)
+		require.Len(t, result, 1, "should have 1 job entry")
+
+		for _, summaries := range result {
+			for _, summary := range summaries {
+				assert.Empty(t, summary.JobRuns, "aggregate rows should have no individual job runs")
+			}
+		}
+	})
+
+	t.Run("per-run rows have individual run data", func(t *testing.T) {
+		dbc := crTestDB(t)
+		release := "4.16"
+
+		vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+		job := createProwJobWithVC(t, dbc, "periodic-notflag-aws", release, vc)
+
+		test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] per-run has-run-id test")
+		suite := intutil.CreateSuite(t, dbc, "openshift-tests-notflag")
+		tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:notflag-test", "Storage", []string{"PVC"})
+
+		ts := time.Date(2024, 5, 20, 12, 0, 0, 0, time.UTC)
+		run := createProwJobRunForCR(t, dbc, job.ID, release, ts)
+		createProwJobRunTest(t, dbc, run.ID, job.ID, test.ID, &suite.ID, 1, release, ts)
+
+		provider := postgres.NewPostgresProvider(dbc, nil)
+		opts := defaultReqOptions(release)
+		opts.TestIDOptions = []reqopts.TestIdentification{{TestID: tow.UniqueID}}
+		opts.VariantOption.IncludeVariants = map[string][]string{
+			"Platform": {"aws"},
+			"Network":  {"ovn"},
+		}
+
+		result, errs := provider.QueryBaseJobRunTestStatus(context.Background(), opts)
+		require.Empty(t, errs)
+		require.Len(t, result, 1)
+
+		for _, summaries := range result {
+			for _, summary := range summaries {
+				assert.NotEmpty(t, summary.JobRuns, "per-run summaries must have individual job runs")
+			}
+		}
+	})
+
+	t.Run("no-suite test ownership uses suite_id zero fallback", func(t *testing.T) {
+		dbc := crTestDB(t)
+		release := "4.16"
+
+		vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+		job := createProwJobWithVC(t, dbc, "periodic-nosuite-aws", release, vc)
+
+		test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] no suite test")
+		tow := createTestOwnership(t, dbc, test.ID, nil, "openshift-tests:no-suite", "Storage", []string{"PVC"})
+
+		baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+		baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+		createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, job.ID, 0, 80, 75, 3)
+		createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, job.ID, 0, 100, 90, 5)
+
+		provider := postgres.NewPostgresProvider(dbc, nil)
+		opts := defaultReqOptions(release)
+		opts.TestIDOptions = []reqopts.TestIdentification{{
+			TestID:            tow.UniqueID,
+			RequestedVariants: map[string]string{"Platform": "aws", "Network": "ovn"},
+		}}
+		opts.VariantOption.IncludeVariants = map[string][]string{
+			"Platform": {"aws"},
+			"Network":  {"ovn"},
+		}
+
+		result, errs := provider.QueryBaseJobRunTestStatus(context.Background(), opts)
+		require.Empty(t, errs)
+
+		totalRows := 0
+		for _, rows := range result {
+			totalRows += len(rows)
+		}
+		require.Equal(t, 1, totalRows, "should match cumulative summary with suite_id=0 when ownership has nil suite")
+
+		for _, rows := range result {
+			for _, row := range rows {
+				assert.Equal(t, 20, row.Stats.Total())
+				assert.Equal(t, 15, row.Stats.SuccessCount)
+				assert.Equal(t, 2, row.Stats.FlakeCount)
+			}
+		}
+	})
+
+	t.Run("zero-delta rows excluded by HAVING filter", func(t *testing.T) {
+		dbc := crTestDB(t)
+		release := "4.16"
+
+		vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+		jobActive := createProwJobWithVC(t, dbc, "periodic-having-active", release, vc)
+		jobIdle := createProwJobWithVC(t, dbc, "periodic-having-idle", release, vc)
+
+		test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] having filter test")
+		suite := intutil.CreateSuite(t, dbc, "openshift-tests-having")
+		tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:having-filter", "Storage", []string{"PVC"})
+
+		baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+		baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+
+		// Active job: has activity in the window (delta > 0)
+		createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, jobActive.ID, suite.ID, 80, 75, 3)
+		createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, jobActive.ID, suite.ID, 100, 90, 5)
+
+		// Idle job: identical prefix sums at start and end (delta = 0, no runs in window)
+		createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, jobIdle.ID, suite.ID, 50, 45, 2)
+		createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, jobIdle.ID, suite.ID, 50, 45, 2)
+
+		provider := postgres.NewPostgresProvider(dbc, nil)
+		opts := defaultReqOptions(release)
+		opts.TestIDOptions = []reqopts.TestIdentification{{
+			TestID:            tow.UniqueID,
+			RequestedVariants: map[string]string{"Platform": "aws", "Network": "ovn"},
+		}}
+		opts.VariantOption.IncludeVariants = map[string][]string{
+			"Platform": {"aws"},
+			"Network":  {"ovn"},
+		}
+
+		result, errs := provider.QueryBaseJobRunTestStatus(context.Background(), opts)
+		require.Empty(t, errs)
+
+		totalRows := 0
+		for _, rows := range result {
+			totalRows += len(rows)
+		}
+		assert.Equal(t, 1, totalRows, "only the active job should be returned; idle job with zero delta should be filtered out")
+
+		for _, rows := range result {
+			for _, row := range rows {
+				assert.Equal(t, 20, row.Stats.Total(), "only the active job's delta should appear")
+			}
+		}
+	})
+
+	t.Run("test metadata populated in fallback results", func(t *testing.T) {
+		dbc := crTestDB(t)
+		release := "4.16"
+
+		vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+		job := createProwJobWithVC(t, dbc, "periodic-meta-aws", release, vc)
+
+		test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] metadata fallback test")
+		suite := intutil.CreateSuite(t, dbc, "openshift-tests-meta")
+		tow := createTestOwnershipFull(t, dbc, test.ID, &suite.ID, "openshift-tests:meta-fallback", "Storage", []string{"PVC"}, uintPtr(42))
+
+		baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+		baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+		createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, job.ID, suite.ID, 80, 75, 3)
+		createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, job.ID, suite.ID, 100, 90, 5)
+
+		provider := postgres.NewPostgresProvider(dbc, nil)
+		opts := defaultReqOptions(release)
+		opts.TestIDOptions = []reqopts.TestIdentification{{
+			TestID:            tow.UniqueID,
+			RequestedVariants: map[string]string{"Platform": "aws", "Network": "ovn"},
+		}}
+		opts.VariantOption.IncludeVariants = map[string][]string{
+			"Platform": {"aws"},
+			"Network":  {"ovn"},
+		}
+
+		result, errs := provider.QueryBaseJobRunTestStatus(context.Background(), opts)
+		require.Empty(t, errs)
+
+		totalRows := 0
+		for _, rows := range result {
+			totalRows += len(rows)
+		}
+		require.Equal(t, 1, totalRows, "should have 1 aggregate entry")
+
+		for _, rows := range result {
+			for _, row := range rows {
+				assert.Equal(t, test.Name, row.TestName, "TestName should be populated")
+				assert.Equal(t, "Storage", row.JiraComponent, "JiraComponent should be populated")
+				require.NotNil(t, row.JiraComponentID, "JiraComponentID should be populated")
+				expected := new(big.Rat).SetUint64(42)
+				assert.Equal(t, 0, row.JiraComponentID.Cmp(expected),
+					"JiraComponentID should be 42, got %s", row.JiraComponentID.RatString())
+			}
+		}
+	})
 }
 
 func TestQueryJobVariants(t *testing.T) {
@@ -2048,27 +2586,32 @@ func TestTestDetailStatusMapping(t *testing.T) {
 		opts.SampleRelease.Start, opts.SampleRelease.End)
 	require.Empty(t, errs)
 
-	var rows []crstatus.TestJobRunRows
-	for _, jobRows := range result {
-		rows = append(rows, jobRows...)
+	var summaries []crstatus.TestDetailsSummary
+	for _, jobSummaries := range result {
+		summaries = append(summaries, jobSummaries...)
 	}
-	require.Len(t, rows, 3)
+	require.Len(t, summaries, 1, "all runs for same test+job should summarize into 1 entry")
 
-	// Results are ordered by pjr.timestamp: pass (June 5), fail (June 6), flake (June 7)
-	passRow := rows[0]
-	assert.Equal(t, 1, passRow.TotalCount)
-	assert.Equal(t, 1, passRow.SuccessCount, "pass: SuccessCount should be 1")
-	assert.Equal(t, 0, passRow.FlakeCount, "pass: FlakeCount should be 0")
+	summary := summaries[0]
+	assert.Equal(t, 2, summary.Stats.SuccessCount, "pass + flake(success_val=1) = 2 successes")
+	assert.Equal(t, 1, summary.Stats.FailureCount, "1 failure run")
+	assert.Equal(t, 1, summary.Stats.FlakeCount, "1 flake run")
+	require.Len(t, summary.JobRuns, 3, "should have 3 individual job runs")
 
-	failRow := rows[1]
-	assert.Equal(t, 1, failRow.TotalCount)
-	assert.Equal(t, 0, failRow.SuccessCount, "fail: SuccessCount should be 0")
-	assert.Equal(t, 0, failRow.FlakeCount, "fail: FlakeCount should be 0")
+	passDetail := summary.JobRuns[0]
+	assert.Equal(t, 1, passDetail.TotalCount)
+	assert.Equal(t, 1, passDetail.SuccessCount, "pass: SuccessCount should be 1")
+	assert.Equal(t, 0, passDetail.FlakeCount, "pass: FlakeCount should be 0")
 
-	flakeRow := rows[2]
-	assert.Equal(t, 1, flakeRow.TotalCount)
-	assert.Equal(t, 1, flakeRow.SuccessCount, "flake: SuccessCount should be 1")
-	assert.Equal(t, 1, flakeRow.FlakeCount, "flake: FlakeCount should be 1")
+	failDetail := summary.JobRuns[1]
+	assert.Equal(t, 1, failDetail.TotalCount)
+	assert.Equal(t, 0, failDetail.SuccessCount, "fail: SuccessCount should be 0")
+	assert.Equal(t, 0, failDetail.FlakeCount, "fail: FlakeCount should be 0")
+
+	flakeDetail := summary.JobRuns[2]
+	assert.Equal(t, 1, flakeDetail.TotalCount)
+	assert.Equal(t, 1, flakeDetail.SuccessCount, "flake: SuccessCount should be 1")
+	assert.Equal(t, 1, flakeDetail.FlakeCount, "flake: FlakeCount should be 1")
 }
 
 func TestJobNameNormalizationMergesResults(t *testing.T) {
@@ -2105,16 +2648,10 @@ func TestJobNameNormalizationMergesResults(t *testing.T) {
 	// Both "periodic-ci-4.16-e2e-aws" and "periodic-ci-4.17-e2e-aws" should normalize
 	// to "periodic-ci-X.X-e2e-aws" and merge under that single key
 	normalizedKey := utils.NormalizeProwJobName("periodic-ci-4.16-e2e-aws")
-	rows, ok := result[normalizedKey]
+	summaries, ok := result[normalizedKey]
 	require.True(t, ok, "both job runs should merge under normalized name %q", normalizedKey)
-	assert.Len(t, rows, 2, "both runs should appear under the normalized key")
-
-	prowJobs := sets.New[string]()
-	for _, r := range rows {
-		prowJobs.Insert(r.ProwJob)
-	}
-	assert.True(t, prowJobs.Has("periodic-ci-4.16-e2e-aws"), "original job name 4.16 should be preserved")
-	assert.True(t, prowJobs.Has("periodic-ci-4.17-e2e-aws"), "original job name 4.17 should be preserved")
+	require.Len(t, summaries, 1, "both runs should summarize into 1 entry for the same test key")
+	assert.Len(t, summaries[0].JobRuns, 2, "both individual runs should appear in JobRuns")
 }
 
 func TestTestExistsInBaseButNotSample(t *testing.T) {
@@ -2655,6 +3192,256 @@ func TestCrossCompareWithLifecycleFilter(t *testing.T) {
 		assert.Equal(t, 15, ts.SuccessCount)
 		assert.Equal(t, 2, ts.FlakeCount)
 	}
+}
+
+// --- Test Details Report Tests ---
+
+func testDetailsReqOptions(testID string, variants map[string]string) reqopts.RequestOptions {
+	opts := defaultReqOptions("4.16")
+	opts.TestIDOptions = []reqopts.TestIdentification{{
+		TestID:            testID,
+		RequestedVariants: variants,
+	}}
+	opts.VariantOption.IncludeVariants = map[string][]string{}
+	for k, v := range variants {
+		opts.VariantOption.IncludeVariants[k] = []string{v}
+	}
+	return opts
+}
+
+func TestTestDetailsReport_AggregateBaseStats(t *testing.T) {
+	dbc := crTestDB(t)
+	release := "4.16"
+
+	vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+	job := createProwJobWithVC(t, dbc, "periodic-td-agg-aws", release, vc)
+
+	test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] aggregate base stats test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests-td-agg")
+	tow := createTestOwnershipFull(t, dbc, test.ID, &suite.ID, "openshift-tests:td-agg", "Storage", []string{"PVC"}, uintPtr(42))
+
+	// Base: aggregate data only (cumulative summaries, no prow_job_run_tests)
+	baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+	baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+	// runs=20, successes=15, flakes=2
+	createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, job.ID, suite.ID, 80, 75, 3)
+	createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, job.ID, suite.ID, 100, 90, 5)
+
+	// Sample: per-run data (3 passes + 1 failure)
+	sampleTS1 := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
+	sampleTS2 := time.Date(2024, 6, 6, 12, 0, 0, 0, time.UTC)
+	sampleTS3 := time.Date(2024, 6, 7, 12, 0, 0, 0, time.UTC)
+	sampleTS4 := time.Date(2024, 6, 8, 12, 0, 0, 0, time.UTC)
+
+	run1 := createProwJobRunForCR(t, dbc, job.ID, release, sampleTS1)
+	run2 := createProwJobRunForCR(t, dbc, job.ID, release, sampleTS2)
+	run3 := createProwJobRunForCR(t, dbc, job.ID, release, sampleTS3)
+	run4 := createProwJobRunForCR(t, dbc, job.ID, release, sampleTS4)
+
+	createProwJobRunTest(t, dbc, run1.ID, job.ID, test.ID, &suite.ID, 1, release, sampleTS1)
+	createProwJobRunTest(t, dbc, run2.ID, job.ID, test.ID, &suite.ID, 1, release, sampleTS2)
+	createProwJobRunTest(t, dbc, run3.ID, job.ID, test.ID, &suite.ID, 1, release, sampleTS3)
+	createProwJobRunTest(t, dbc, run4.ID, job.ID, test.ID, &suite.ID, 12, release, sampleTS4)
+
+	variants := map[string]string{"Platform": "aws", "Network": "ovn"}
+	opts := testDetailsReqOptions(tow.UniqueID, variants)
+
+	provider := postgres.NewPostgresProvider(dbc, nil)
+	generator := componentreadiness.NewComponentReportGenerator(provider, opts, dbc, nil, "")
+	report, errs := generator.GenerateTestDetailsReport(context.Background())
+	require.Empty(t, errs)
+
+	require.Len(t, report.Analyses, 1)
+	analysis := report.Analyses[0]
+
+	require.NotNil(t, analysis.BaseStats, "base stats should be populated from aggregate data")
+	assert.Equal(t, 20, analysis.BaseStats.Total(), "base total should be prefix-sum delta")
+	assert.Equal(t, 15, analysis.BaseStats.SuccessCount)
+
+	assert.Equal(t, 4, analysis.SampleStats.Total(), "sample should have 4 runs")
+	assert.Equal(t, 3, analysis.SampleStats.SuccessCount)
+	assert.Equal(t, 1, analysis.SampleStats.FailureCount)
+
+	require.Len(t, analysis.JobStats, 1)
+	jobStat := analysis.JobStats[0]
+	assert.Empty(t, jobStat.BaseJobRunStats, "aggregate base should have no individual runs")
+	assert.Len(t, jobStat.SampleJobRunStats, 4, "sample should have 4 individual runs")
+
+	assert.Equal(t, "Storage", report.JiraComponent)
+	require.NotNil(t, report.JiraComponentID)
+	assert.Equal(t, 0, report.JiraComponentID.Cmp(new(big.Rat).SetUint64(42)))
+	assert.Equal(t, test.Name, report.TestName)
+}
+
+func TestTestDetailsReport_LastFailureTracking(t *testing.T) {
+	t.Run("last failure populated from sample failures", func(t *testing.T) {
+		dbc := crTestDB(t)
+		release := "4.16"
+
+		vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+		job := createProwJobWithVC(t, dbc, "periodic-td-lf-aws", release, vc)
+
+		test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] last failure tracking test")
+		suite := intutil.CreateSuite(t, dbc, "openshift-tests-td-lf")
+		tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:td-lf", "Storage", []string{"PVC"})
+
+		// Base: aggregate data
+		baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+		baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+		createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, job.ID, suite.ID, 80, 75, 3)
+		createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, job.ID, suite.ID, 100, 90, 5)
+
+		// Sample: 2 passes and 1 failure at known timestamps
+		passTS1 := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
+		failTS := time.Date(2024, 6, 8, 14, 30, 0, 0, time.UTC)
+		passTS2 := time.Date(2024, 6, 10, 12, 0, 0, 0, time.UTC)
+
+		runPass1 := createProwJobRunForCR(t, dbc, job.ID, release, passTS1)
+		runFail := createProwJobRunForCR(t, dbc, job.ID, release, failTS)
+		runPass2 := createProwJobRunForCR(t, dbc, job.ID, release, passTS2)
+
+		createProwJobRunTest(t, dbc, runPass1.ID, job.ID, test.ID, &suite.ID, 1, release, passTS1)
+		createProwJobRunTest(t, dbc, runFail.ID, job.ID, test.ID, &suite.ID, 12, release, failTS)
+		createProwJobRunTest(t, dbc, runPass2.ID, job.ID, test.ID, &suite.ID, 1, release, passTS2)
+
+		variants := map[string]string{"Platform": "aws", "Network": "ovn"}
+		opts := testDetailsReqOptions(tow.UniqueID, variants)
+
+		provider := postgres.NewPostgresProvider(dbc, nil)
+		generator := componentreadiness.NewComponentReportGenerator(provider, opts, dbc, nil, "")
+		report, errs := generator.GenerateTestDetailsReport(context.Background())
+		require.Empty(t, errs)
+
+		require.Len(t, report.Analyses, 1)
+		require.NotNil(t, report.Analyses[0].LastFailure, "LastFailure should be set when sample has failures")
+		assert.True(t, report.Analyses[0].LastFailure.Equal(failTS),
+			"LastFailure should equal the failing run's timestamp: got %v, want %v",
+			*report.Analyses[0].LastFailure, failTS)
+	})
+
+	t.Run("last failure nil when all sample runs pass", func(t *testing.T) {
+		dbc := crTestDB(t)
+		release := "4.16"
+
+		vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+		job := createProwJobWithVC(t, dbc, "periodic-td-lf-pass-aws", release, vc)
+
+		test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] last failure nil test")
+		suite := intutil.CreateSuite(t, dbc, "openshift-tests-td-lf-pass")
+		tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:td-lf-pass", "Storage", []string{"PVC"})
+
+		// Base: aggregate data
+		baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+		baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+		createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, job.ID, suite.ID, 80, 75, 3)
+		createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, job.ID, suite.ID, 100, 90, 5)
+
+		// Sample: all passes
+		passTS1 := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
+		passTS2 := time.Date(2024, 6, 8, 12, 0, 0, 0, time.UTC)
+
+		runPass1 := createProwJobRunForCR(t, dbc, job.ID, release, passTS1)
+		runPass2 := createProwJobRunForCR(t, dbc, job.ID, release, passTS2)
+
+		createProwJobRunTest(t, dbc, runPass1.ID, job.ID, test.ID, &suite.ID, 1, release, passTS1)
+		createProwJobRunTest(t, dbc, runPass2.ID, job.ID, test.ID, &suite.ID, 1, release, passTS2)
+
+		variants := map[string]string{"Platform": "aws", "Network": "ovn"}
+		opts := testDetailsReqOptions(tow.UniqueID, variants)
+
+		provider := postgres.NewPostgresProvider(dbc, nil)
+		generator := componentreadiness.NewComponentReportGenerator(provider, opts, dbc, nil, "")
+		report, errs := generator.GenerateTestDetailsReport(context.Background())
+		require.Empty(t, errs)
+
+		require.Len(t, report.Analyses, 1)
+		assert.Nil(t, report.Analyses[0].LastFailure, "LastFailure should be nil when all sample runs pass")
+	})
+}
+
+func TestTestDetailsReport_FlakeAsFailure(t *testing.T) {
+	dbc := crTestDB(t)
+	release := "4.16"
+
+	vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+	job := createProwJobWithVC(t, dbc, "periodic-td-faf-aws", release, vc)
+
+	test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] flake as failure test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests-td-faf")
+	tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:td-faf", "Storage", []string{"PVC"})
+
+	// Base: per-run data with flakes (5 passes, 1 failure, 2 flakes)
+	baseTS1 := time.Date(2024, 5, 16, 12, 0, 0, 0, time.UTC)
+	baseTS2 := time.Date(2024, 5, 17, 12, 0, 0, 0, time.UTC)
+	baseTS3 := time.Date(2024, 5, 18, 12, 0, 0, 0, time.UTC)
+	baseTS4 := time.Date(2024, 5, 19, 12, 0, 0, 0, time.UTC)
+	baseTS5 := time.Date(2024, 5, 20, 12, 0, 0, 0, time.UTC)
+	baseTS6 := time.Date(2024, 5, 21, 12, 0, 0, 0, time.UTC)
+	baseTS7 := time.Date(2024, 5, 22, 12, 0, 0, 0, time.UTC)
+	baseTS8 := time.Date(2024, 5, 23, 12, 0, 0, 0, time.UTC)
+
+	for _, ts := range []time.Time{baseTS1, baseTS2, baseTS3, baseTS4, baseTS5} {
+		run := createProwJobRunForCR(t, dbc, job.ID, release, ts)
+		createProwJobRunTest(t, dbc, run.ID, job.ID, test.ID, &suite.ID, 1, release, ts)
+	}
+	baseFailRun := createProwJobRunForCR(t, dbc, job.ID, release, baseTS6)
+	createProwJobRunTest(t, dbc, baseFailRun.ID, job.ID, test.ID, &suite.ID, 12, release, baseTS6)
+	for _, ts := range []time.Time{baseTS7, baseTS8} {
+		run := createProwJobRunForCR(t, dbc, job.ID, release, ts)
+		createProwJobRunTest(t, dbc, run.ID, job.ID, test.ID, &suite.ID, 13, release, ts)
+	}
+
+	// Sample: per-run data with flakes (4 passes, 1 failure, 1 flake)
+	sampleTS1 := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
+	sampleTS2 := time.Date(2024, 6, 6, 12, 0, 0, 0, time.UTC)
+	sampleTS3 := time.Date(2024, 6, 7, 12, 0, 0, 0, time.UTC)
+	sampleTS4 := time.Date(2024, 6, 8, 12, 0, 0, 0, time.UTC)
+	sampleTS5 := time.Date(2024, 6, 9, 12, 0, 0, 0, time.UTC)
+	sampleTS6 := time.Date(2024, 6, 10, 12, 0, 0, 0, time.UTC)
+
+	for _, ts := range []time.Time{sampleTS1, sampleTS2, sampleTS3, sampleTS4} {
+		run := createProwJobRunForCR(t, dbc, job.ID, release, ts)
+		createProwJobRunTest(t, dbc, run.ID, job.ID, test.ID, &suite.ID, 1, release, ts)
+	}
+	sampleFailRun := createProwJobRunForCR(t, dbc, job.ID, release, sampleTS5)
+	createProwJobRunTest(t, dbc, sampleFailRun.ID, job.ID, test.ID, &suite.ID, 12, release, sampleTS5)
+	sampleFlakeRun := createProwJobRunForCR(t, dbc, job.ID, release, sampleTS6)
+	createProwJobRunTest(t, dbc, sampleFlakeRun.ID, job.ID, test.ID, &suite.ID, 13, release, sampleTS6)
+
+	variants := map[string]string{"Platform": "aws", "Network": "ovn"}
+
+	// Run with FlakeAsFailure=false
+	optsFalse := testDetailsReqOptions(tow.UniqueID, variants)
+	optsFalse.AdvancedOption.FlakeAsFailure = false
+
+	provider := postgres.NewPostgresProvider(dbc, nil)
+	genFalse := componentreadiness.NewComponentReportGenerator(provider, optsFalse, dbc, nil, "")
+	reportFalse, errs := genFalse.GenerateTestDetailsReport(context.Background())
+	require.Empty(t, errs)
+
+	// Run with FlakeAsFailure=true
+	optsTrue := testDetailsReqOptions(tow.UniqueID, variants)
+	optsTrue.AdvancedOption.FlakeAsFailure = true
+
+	genTrue := componentreadiness.NewComponentReportGenerator(provider, optsTrue, dbc, nil, "")
+	reportTrue, errs := genTrue.GenerateTestDetailsReport(context.Background())
+	require.Empty(t, errs)
+
+	require.Len(t, reportFalse.Analyses, 1)
+	require.Len(t, reportTrue.Analyses, 1)
+
+	sampleFalse := reportFalse.Analyses[0].SampleStats
+	sampleTrue := reportTrue.Analyses[0].SampleStats
+
+	// Raw counts should be the same regardless of FlakeAsFailure
+	assert.Equal(t, sampleFalse.FailureCount, sampleTrue.FailureCount, "raw FailureCount should be the same")
+	assert.Equal(t, sampleFalse.FlakeCount, sampleTrue.FlakeCount, "raw FlakeCount should be the same")
+	assert.Equal(t, sampleFalse.SuccessCount, sampleTrue.SuccessCount, "raw SuccessCount should be the same")
+
+	// SuccessRate should differ: FlakeAsFailure=true counts flakes as failures, lowering the rate
+	assert.Greater(t, sampleFalse.SuccessRate, sampleTrue.SuccessRate,
+		"SuccessRate with FlakeAsFailure=false (%f) should be higher than with true (%f)",
+		sampleFalse.SuccessRate, sampleTrue.SuccessRate)
 }
 
 // --- Helpers ---


### PR DESCRIPTION
## Summary
- Introduces `TestDetailsSummary` as the provider return type for test details queries, replacing raw per-run rows with pre-computed per-job stats and optional individual run details.
- Adds `SummarizeTestJobRuns` to group raw rows by (job, test key) into summaries, applied consistently in both BigQuery and Postgres providers.
- Adds a fallback in `QueryBaseJobRunTestStatus` (Postgres provider) to populate base statistics from aggregate tables (`test_cumulative_summaries` for prefix-sum releases, `prow_ga_raw_test_data` for GA releases) when per-run data is unavailable for older base releases. Aggregate summaries have no individual `JobRuns`, so the UI shows stats without broken run links.
- Refactors `test_details.go` report generation to work with pre-summarized data, simplifying stats aggregation and fixing a bug where per-run counts were double-aggregated.
- Bumps BigQuery cache key prefix from V2 to V3 to avoid stale deserialization after the type change.
- Fixes `TestDetailsSummary.TestKeyStr` serialization (`json:"-"` removed) so test key grouping survives the BQ Redis cache round-trip.

## Test plan
- [x] Unit test for `SummarizeTestJobRuns` lifecycle promotion logic
- [x] Integration tests for aggregate fallback (prefix-sum, GA, precedence over per-run, variant filtering, multi-job, zero-delta exclusion, no-suite ownership, HAVING filter)
- [x] Integration tests for test details report generation (aggregate base stats, last failure tracking, flake-as-failure mode)
- [x] Existing integration tests updated for summarized return type
- [x] `make test` passes
- [x] `make lint` passes

## Staging verification

Ran local server against staging Postgres DB and BigQuery with the branch code. Tested with explicit query parameters (5.0 sample, 4.22 base, Build and Networking components).

### Postgres path: per-run base data (4.22 base)
```
test_details component=Build testId=openshift-tests:c19899c904fc1be7fadc2812f438dc3a
  Base: success=471, fail=0, flake=0, rate=1.0
  Sample: success=125, fail=0, flake=0, rate=1.0
  Jobs: 18, base runs: 471, sample runs: 125
  Explanations: []
```

### Postgres path: aggregate fallback (4.17 base)
```
test_details component=Build testId=openshift-tests:c19899c904fc1be7fadc2812f438dc3a baseRelease=4.17
  Jobs: 16, base runs: 0 (aggregate, no individual runs)
  Server log: "no per-run base test details found, falling back to aggregate tables" release=4.17
```

### BigQuery path (4.22 base)
```
test_details component=Build testId=openshift-tests:c19899c904fc1be7fadc2812f438dc3a
  Base: success (non-zero), fail, flake present
  Jobs: 25, base+sample runs present
  Explanations: []
```

### Networking test cross-path comparison
```
BQ:       Base success=613, Jobs: 25
Postgres: Base success=471, Jobs: 18
(Count differences expected due to BQ having broader job coverage)
```

### CR grid (Postgres)
```
60 component rows returned, regressions detected correctly.
```

No errors in server logs across all requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Component readiness reports now provide aggregated per-test and per-job summaries with detailed run information.
  * Added fallback reporting from aggregate historical data when detailed base-release results are unavailable.
  * Improved support for variant filtering, metadata, failure tracking, and flake-as-failure reporting.

* **Bug Fixes**
  * Improved lifecycle aggregation and status handling across base, override, and sample results.
  * Preserved job ordering and enhanced report consistency across data sources.

* **Tests**
  * Expanded coverage for aggregate fallbacks, failures, flakes, variants, suites, metadata, and report details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->