### PR TITLE
[WIP] TRT-2752: Add lifecycle as a dimension in summary tables

### DIFF
--- a/chat/prompts/test-analysis.yaml
+++ b/chat/prompts/test-analysis.yaml
@@ -22,13 +22,13 @@ prompt: |
     * URL encode the test name parameter
 
   ## 2. 7-Day Performance
-  Query `test_cumulative_summaries` with database tool. LEFT JOIN two rows per (test_id, prow_job_id, suite_id) at `date = CURRENT_DATE - 1` (end) and `date = CURRENT_DATE - 8` (start), filtering `release = '{{ release }}'`. Compute 7-day totals by subtracting prefix sums:
+  Query `test_cumulative_summaries` with database tool. LEFT JOIN two rows per (test_id, prow_job_id, suite_id, lifecycle) at `date = CURRENT_DATE - 1` (end) and `date = CURRENT_DATE - 8` (start), filtering `release = '{{ release }}'`. Compute 7-day totals by subtracting prefix sums:
   - Overall pass rate: SUM(end.prefix_sum_successes - COALESCE(start.prefix_sum_successes, 0)) / SUM(end.prefix_sum_runs - COALESCE(start.prefix_sum_runs, 0)) × 100
   - Total runs, failures, flakes (all as prefix_sum differences with COALESCE)
   - Trend: consistent passing/failing or intermittent
 
   ## 3. Variant Analysis
-  Query `test_cumulative_summaries` joined to `prow_jobs` (via prow_job_id) and `tests` (via test_id), grouped by `prow_jobs.variants`. LEFT JOIN two rows per key at `date = CURRENT_DATE - 1` (end) and `date = CURRENT_DATE - 8` (start), filtering `release = '{{ release }}'`. Compute 7-day totals by subtracting prefix sums:
+  Query `test_cumulative_summaries` joined to `prow_jobs` (via prow_job_id) and `tests` (via test_id), grouped by `prow_jobs.variants`. LEFT JOIN two rows per (test_id, prow_job_id, suite_id, lifecycle) at `date = CURRENT_DATE - 1` (end) and `date = CURRENT_DATE - 8` (start), filtering `release = '{{ release }}'`. Compute 7-day totals by subtracting prefix sums:
   - Calculate failure rate per variant combination: SUM(end.prefix_sum_failures - COALESCE(start.prefix_sum_failures, 0)) / SUM(end.prefix_sum_runs - COALESCE(start.prefix_sum_runs, 0)) × 100
   - Report: variant combo, pass rate, failure count vs runs
   - Order by worst performing first

--- a/chat/sippy_agent/tools/database_query.py
+++ b/chat/sippy_agent/tools/database_query.py
@@ -78,11 +78,12 @@ Key Tables:
       * `test_id`: Links to `tests.id`.
       * `prow_job_id`: Links to `prow_jobs.id`.
       * `suite_id`: Links to `suites.id`.
+      * `lifecycle`: Whether this test is `blocking` or `informing` for this execution.
       * `release`: OpenShift release version (partition key). **Required in WHERE clause.**
       * `date`: The date of the aggregation (partition key). **Required in WHERE clause.**
       * `successes`, `failures`, `flakes`, `runs`: Pre-computed daily counts.
   * **`test_cumulative_summaries`**: Running prefix sums of `test_daily_totals`. For any date range [start, end], compute: `prefix_sum(end) - prefix_sum(start - 1)`. **Partitioned by `(release, date)`**.
-      * `date`, `release`, `test_id`, `prow_job_id`, `suite_id`: Same as `test_daily_totals`.
+      * `date`, `release`, `test_id`, `prow_job_id`, `suite_id`, `lifecycle`: Same as `test_daily_totals`.
       * `prefix_sum_successes`, `prefix_sum_failures`, `prefix_sum_flakes`, `prefix_sum_runs`: Cumulative totals up to that date.
    * **`suites`**: Defines a collection or group of tests.
       * `name`: The name of the test suite (e.g., openshift-tests).
@@ -104,8 +105,8 @@ For performance, **always prefer pre-aggregated summary tables or materialized v
 
 Use the pg_matviews table to learn about the schema for materialized views.
 
-  * **`test_daily_totals`** (PREFERRED for test statistics): Pre-aggregated daily test pass/fail/flake counts per (test, job, suite, release, date). Use `SUM(successes)`, `SUM(failures)`, `SUM(flakes)`, `SUM(runs)` for aggregation. Always filter on `release` and `date`.
-    * **IMPORTANT**: Each test has multiple rows per (prow_job_id, suite_id). When providing an overall overview (e.g., "top failing tests"), aggregate by test name: `GROUP BY t.name` with `SUM(failures)` across all jobs. Only group by `prow_jobs.variants` or `prow_job_id` when the user asks for a per-variant or per-job breakdown.
+  * **`test_daily_totals`** (PREFERRED for test statistics): Pre-aggregated daily test pass/fail/flake counts per (test, job, suite, lifecycle, release, date). Use `SUM(successes)`, `SUM(failures)`, `SUM(flakes)`, `SUM(runs)` for aggregation. Always filter on `release` and `date`.
+    * **IMPORTANT**: Each test has multiple rows per (prow_job_id, suite_id, lifecycle). When providing an overall overview (e.g., "top failing tests"), aggregate by test name: `GROUP BY t.name` with `SUM(failures)` across all jobs. Only group by `prow_jobs.variants` or `prow_job_id` when the user asks for a per-variant or per-job breakdown.
 
   * **`test_cumulative_summaries`** (PREFERRED for date-range test statistics): Running prefix sums of `test_daily_totals`. To compute totals for any date range [start, end], query two dates and subtract: `prefix_sum(end) - prefix_sum(start - 1)`. Always filter on `release` and `date`.
     * **IMPORTANT**: Same multi-row structure as `test_daily_totals` — see aggregation guidance above.
@@ -349,6 +350,7 @@ LEFT JOIN
   ON  s.test_id = e.test_id
   AND s.prow_job_id = e.prow_job_id
   AND s.suite_id = e.suite_id
+  AND s.lifecycle = e.lifecycle
   AND s.release = '4.21'           -- Partition key: required on both sides
   AND s.date = CURRENT_DATE - 8   -- day before range start (start - 1)
 WHERE

--- a/pkg/api/componentreadiness/dataprovider/postgres/cr_queries.go
+++ b/pkg/api/componentreadiness/dataprovider/postgres/cr_queries.go
@@ -105,14 +105,15 @@ func buildDrilldownFilters(reqOptions reqopts.RequestOptions) drilldownFilters {
 // prefix-sum and GA query paths. The two paths differ only in their source
 // table, aggregation expressions, and date/window filter.
 type testStatusSpec struct {
-	fromTemplate    string // FROM clause template with two %s for variantSubquery and groupMapping
-	preJoinArgs     []any  // args bound in the FROM clause before filterArgs (e.g. lookupStart)
-	totalExpr       string // SQL expression for total runs
-	successExpr     string // SQL expression for successes
-	flakeExpr       string // SQL expression for flakes
-	lastFailureExpr string // SQL expression for last failure timestamp (e.g. "MAX(e.prefix_max_last_failure)" or "NULL::timestamptz")
-	whereFilter     string // WHERE fragment like "e.release = ? AND e.date = ?"
-	whereArgs       []any  // args for whereFilter
+	fromTemplate    string   // FROM clause template with two %s for variantSubquery and groupMapping
+	preJoinArgs     []any    // args bound in the FROM clause before filterArgs (e.g. lookupStart)
+	totalExpr       string   // SQL expression for total runs
+	successExpr     string   // SQL expression for successes
+	flakeExpr       string   // SQL expression for flakes
+	lastFailureExpr string   // SQL expression for last failure timestamp (e.g. "MAX(e.prefix_max_last_failure)" or "NULL::timestamptz")
+	whereFilter     string   // WHERE fragment like "e.release = ? AND e.date = ?"
+	whereArgs       []any    // args for whereFilter
+	lifecycles      []string // when non-empty, filter e.lifecycle to these values (sample-only, matching BQ)
 }
 
 // queryTestStatus builds and executes the failure + placeholder query pair
@@ -141,6 +142,11 @@ func (p *PostgresProvider) queryTestStatus(
 	}
 	if setup == nil {
 		return map[string]crstatus.TestStatus{}, nil
+	}
+
+	if len(spec.lifecycles) > 0 {
+		spec.whereFilter += " AND e.lifecycle = ANY(?)"
+		spec.whereArgs = append(spec.whereArgs, pq.Array(spec.lifecycles))
 	}
 
 	fromClause := fmt.Sprintf(spec.fromTemplate, setup.variantSubquery, setup.groupMapping.valuesClause)
@@ -211,6 +217,7 @@ func (p *PostgresProvider) queryTestStatusPrefixSum(
 	ctx context.Context,
 	reqOptions reqopts.RequestOptions,
 	release string,
+	lifecycles []string,
 	includeVariants map[string][]string,
 	dateRange query.DateRange,
 ) (map[string]crstatus.TestStatus, []error) {
@@ -227,7 +234,7 @@ func (p *PostgresProvider) queryTestStatusPrefixSum(
         LEFT JOIN test_cumulative_summaries s
             ON s.release = e.release AND s.test_id = e.test_id
             AND s.prow_job_id = e.prow_job_id AND s.suite_id = e.suite_id
-            AND s.date = ?
+            AND s.lifecycle = e.lifecycle AND s.date = ?
         JOIN prow_jobs pj ON pj.id = e.prow_job_id AND pj.deleted_at IS NULL
             AND pj.variant_combination_id IN (%s)
         JOIN (%s) AS vg(vcid, group_id) ON vg.vcid = pj.variant_combination_id`,
@@ -238,6 +245,7 @@ func (p *PostgresProvider) queryTestStatusPrefixSum(
 		lastFailureExpr: "MAX(e.prefix_max_last_failure)",
 		whereFilter:     "e.release = ? AND e.date = ?",
 		whereArgs:       []any{release, lookupEnd},
+		lifecycles:      lifecycles,
 	})
 }
 

--- a/pkg/api/componentreadiness/dataprovider/postgres/provider.go
+++ b/pkg/api/componentreadiness/dataprovider/postgres/provider.go
@@ -266,6 +266,7 @@ func (p *PostgresProvider) QueryBaseTestStatus(ctx context.Context, reqOptions r
 	}
 	return p.queryTestStatusPrefixSum(ctx, reqOptions,
 		reqOptions.BaseRelease.Name,
+		nil,
 		reqOptions.VariantOption.IncludeVariants,
 		baseRange)
 }
@@ -294,7 +295,9 @@ func (p *PostgresProvider) QuerySampleTestStatus(ctx context.Context, reqOptions
 	includeVariants map[string][]string,
 	start, end time.Time) (map[string]crstatus.TestStatus, []error) {
 	includeVariants = mergeCompareVariants(reqOptions, includeVariants)
-	return p.queryTestStatusPrefixSum(ctx, reqOptions, reqOptions.SampleRelease.Name, includeVariants,
+	return p.queryTestStatusPrefixSum(ctx, reqOptions, reqOptions.SampleRelease.Name,
+		reqOptions.Lifecycles,
+		includeVariants,
 		query.DateRange{
 			Start: civil.DateOf(start),
 			End:   civil.DateOf(end).AddDays(1),

--- a/pkg/db/cumulativesummary/cumulative_summary.go
+++ b/pkg/db/cumulativesummary/cumulative_summary.go
@@ -6,6 +6,7 @@ import (
 
 	"cloud.google.com/go/civil"
 	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 
 	"github.com/openshift/sippy/pkg/db"
 )
@@ -131,41 +132,80 @@ func (s *pgStore) Releases() ([]string, error) {
 }
 
 func (s *pgStore) UpdateDateForRelease(date civil.Date, release string) error {
-	return s.dbc.DB.Exec(`
-		INSERT INTO test_cumulative_summaries (date, test_id, prow_job_id, suite_id, release,
-		                         prefix_sum_successes, prefix_sum_failures, prefix_sum_flakes, prefix_sum_runs,
-		                         prefix_max_last_failure, prefix_max_last_success)
-		SELECT
-			?,
-			COALESCE(prev.test_id, tds.test_id),
-			COALESCE(prev.prow_job_id, tds.prow_job_id),
-			COALESCE(prev.suite_id, tds.suite_id),
-			COALESCE(prev.release, tds.release),
-			COALESCE(prev.prefix_sum_successes, 0) + COALESCE(tds.successes, 0),
-			COALESCE(prev.prefix_sum_failures, 0) + COALESCE(tds.failures, 0),
-			COALESCE(prev.prefix_sum_flakes, 0) + COALESCE(tds.flakes, 0),
-			COALESCE(prev.prefix_sum_runs, 0) + COALESCE(tds.runs, 0),
-			GREATEST(prev.prefix_max_last_failure, tds.last_failure_timestamp),
-			GREATEST(prev.prefix_max_last_success, tds.last_success_timestamp)
-		FROM (SELECT * FROM test_cumulative_summaries WHERE date = ?::date - 1 AND release = ?) prev
-		FULL OUTER JOIN (SELECT * FROM test_daily_totals WHERE date = ? AND release = ?) tds
-			ON prev.test_id = tds.test_id
-			AND prev.prow_job_id = tds.prow_job_id
-			AND prev.suite_id = tds.suite_id
-		ON CONFLICT (date, release, test_id, prow_job_id, suite_id)
-		DO UPDATE SET
-			prefix_sum_successes = EXCLUDED.prefix_sum_successes,
-			prefix_sum_failures = EXCLUDED.prefix_sum_failures,
-			prefix_sum_flakes = EXCLUDED.prefix_sum_flakes,
-			prefix_sum_runs = EXCLUDED.prefix_sum_runs,
-			prefix_max_last_failure = EXCLUDED.prefix_max_last_failure,
-			prefix_max_last_success = EXCLUDED.prefix_max_last_success
-		WHERE (test_cumulative_summaries.prefix_sum_successes, test_cumulative_summaries.prefix_sum_failures,
-		       test_cumulative_summaries.prefix_sum_flakes, test_cumulative_summaries.prefix_sum_runs,
-		       test_cumulative_summaries.prefix_max_last_failure, test_cumulative_summaries.prefix_max_last_success)
-		   IS DISTINCT FROM
-		      (EXCLUDED.prefix_sum_successes, EXCLUDED.prefix_sum_failures,
-		       EXCLUDED.prefix_sum_flakes, EXCLUDED.prefix_sum_runs,
-		       EXCLUDED.prefix_max_last_failure, EXCLUDED.prefix_max_last_success)
-	`, date, date, release, date, release).Error
+	return s.dbc.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec(`
+			INSERT INTO test_cumulative_summaries (date, test_id, prow_job_id, suite_id, lifecycle, release,
+			                         prefix_sum_successes, prefix_sum_failures, prefix_sum_flakes, prefix_sum_runs,
+			                         prefix_max_last_failure, prefix_max_last_success)
+			SELECT
+				?,
+				COALESCE(prev.test_id, tds.test_id),
+				COALESCE(prev.prow_job_id, tds.prow_job_id),
+				COALESCE(prev.suite_id, tds.suite_id),
+				COALESCE(prev.lifecycle, tds.lifecycle),
+				COALESCE(prev.release, tds.release),
+				COALESCE(prev.prefix_sum_successes, 0) + COALESCE(tds.successes, 0),
+				COALESCE(prev.prefix_sum_failures, 0) + COALESCE(tds.failures, 0),
+				COALESCE(prev.prefix_sum_flakes, 0) + COALESCE(tds.flakes, 0),
+				COALESCE(prev.prefix_sum_runs, 0) + COALESCE(tds.runs, 0),
+				GREATEST(prev.prefix_max_last_failure, tds.last_failure_timestamp),
+				GREATEST(prev.prefix_max_last_success, tds.last_success_timestamp)
+			FROM (SELECT * FROM test_cumulative_summaries WHERE date = ?::date - 1 AND release = ?) prev
+			FULL OUTER JOIN (SELECT * FROM test_daily_totals WHERE date = ? AND release = ?) tds
+				ON prev.test_id = tds.test_id
+				AND prev.prow_job_id = tds.prow_job_id
+				AND prev.suite_id = tds.suite_id
+				AND prev.lifecycle = tds.lifecycle
+			ON CONFLICT (release, date, test_id, suite_id, lifecycle, prow_job_id)
+			DO UPDATE SET
+				prefix_sum_successes = EXCLUDED.prefix_sum_successes,
+				prefix_sum_failures = EXCLUDED.prefix_sum_failures,
+				prefix_sum_flakes = EXCLUDED.prefix_sum_flakes,
+				prefix_sum_runs = EXCLUDED.prefix_sum_runs,
+				prefix_max_last_failure = EXCLUDED.prefix_max_last_failure,
+				prefix_max_last_success = EXCLUDED.prefix_max_last_success
+			WHERE (test_cumulative_summaries.prefix_sum_successes, test_cumulative_summaries.prefix_sum_failures,
+			       test_cumulative_summaries.prefix_sum_flakes, test_cumulative_summaries.prefix_sum_runs,
+			       test_cumulative_summaries.prefix_max_last_failure, test_cumulative_summaries.prefix_max_last_success)
+			   IS DISTINCT FROM
+			      (EXCLUDED.prefix_sum_successes, EXCLUDED.prefix_sum_failures,
+			       EXCLUDED.prefix_sum_flakes, EXCLUDED.prefix_sum_runs,
+			       EXCLUDED.prefix_max_last_failure, EXCLUDED.prefix_max_last_success)
+		`, date, date, release, date, release).Error; err != nil {
+			return err
+		}
+		return tx.Exec(cleanupDeleteSQL, date, release, date, date).Error
+	})
 }
+
+// cleanupDeleteSQL removes cumulative summary rows for a (date, release)
+// that ON CONFLICT DO UPDATE can never touch: a key with neither a prior
+// day to carry forward from nor a daily total to freshly compute from.
+// This happens when the row backing it was itself removed by a redo (e.g.
+// dailysummary's own cleanup delete dropped a reclassified/reprocessed
+// key) after this date's chain had already started from nothing. Keys
+// that are simply carrying forward (a prior day's row still exists) are
+// deliberately left alone - that's the intended "chain stays unbroken"
+// behavior for tests that stop reporting under a given key.
+const cleanupDeleteSQL = `
+	DELETE FROM test_cumulative_summaries cs
+	WHERE cs.date = ?
+	  AND cs.release = ?
+	  AND NOT EXISTS (
+	      SELECT 1 FROM test_cumulative_summaries prev
+	      WHERE prev.date = ?::date - 1
+	        AND prev.release = cs.release
+	        AND prev.test_id = cs.test_id
+	        AND prev.prow_job_id = cs.prow_job_id
+	        AND prev.suite_id = cs.suite_id
+	        AND prev.lifecycle = cs.lifecycle
+	  )
+	  AND NOT EXISTS (
+	      SELECT 1 FROM test_daily_totals tds
+	      WHERE tds.date = ?
+	        AND tds.release = cs.release
+	        AND tds.test_id = cs.test_id
+	        AND tds.prow_job_id = cs.prow_job_id
+	        AND tds.suite_id = cs.suite_id
+	        AND tds.lifecycle = cs.lifecycle
+	  )`

--- a/pkg/db/dailysummary/dailysummary.go
+++ b/pkg/db/dailysummary/dailysummary.go
@@ -9,6 +9,7 @@ import (
 
 	"cloud.google.com/go/civil"
 	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 
 	"github.com/openshift/sippy/pkg/db"
 )
@@ -26,11 +27,12 @@ var valueColumns = []string{
 
 func buildInsertSQL(tableName, dateColumn string) string {
 	return fmt.Sprintf(`
-		INSERT INTO %s (test_id, prow_job_id, suite_id, release, %s, %s)
+		INSERT INTO %s (test_id, prow_job_id, suite_id, lifecycle, release, %s, %s)
 		SELECT
 			pjrt.test_id,
 			pjrt.prow_job_id,
 			COALESCE(pjrt.suite_id, 0),
+			pjrt.lifecycle,
 			pjrt.prow_job_run_release,
 			date(pjrt.prow_job_run_timestamp),
 			COUNT(*) FILTER (WHERE pjrt.status = 1),
@@ -45,7 +47,7 @@ func buildInsertSQL(tableName, dateColumn string) string {
 		WHERE pjrt.prow_job_run_timestamp >= ?::date
 		  AND pjrt.prow_job_run_timestamp < (?::date + INTERVAL '1 day')
 		  AND pjrt.prow_job_run_release = ?
-		GROUP BY pjrt.test_id, pjrt.prow_job_id, COALESCE(pjrt.suite_id, 0), pjrt.prow_job_run_release, date(pjrt.prow_job_run_timestamp)`,
+		GROUP BY pjrt.test_id, pjrt.prow_job_id, COALESCE(pjrt.suite_id, 0), pjrt.lifecycle, pjrt.prow_job_run_release, date(pjrt.prow_job_run_timestamp)`,
 		tableName, dateColumn, strings.Join(valueColumns, ", "))
 }
 
@@ -58,13 +60,39 @@ func buildOnConflictClause(tableName, dateColumn string) string {
 	}
 
 	return fmt.Sprintf(`
-		ON CONFLICT (test_id, prow_job_id, suite_id, release, %s)
+		ON CONFLICT (release, %s, test_id, suite_id, lifecycle, prow_job_id)
 		DO UPDATE SET %s
 		WHERE (%s) IS DISTINCT FROM (%s)`,
 		dateColumn,
 		strings.Join(setClauses, ", "),
 		strings.Join(oldCols, ", "),
 		strings.Join(newCols, ", "))
+}
+
+// buildCleanupDeleteSQL removes rows whose key no longer has any
+// supporting raw result. ON CONFLICT DO UPDATE can only ever touch keys
+// present in the freshly aggregated data - it can never notice that a
+// previously-valid key (e.g. a test's lifecycle was reclassified, or its
+// suite changed, or the underlying job run was reprocessed away) no
+// longer applies. This is a separate, targeted delete rather than
+// DELETE-then-INSERT so it only touches genuinely defunct rows instead of
+// unconditionally churning every row in the range on every run.
+func buildCleanupDeleteSQL(tableName, dateColumn string) string {
+	return fmt.Sprintf(`
+		DELETE FROM %[1]s dt
+		WHERE dt.release = ?
+		  AND dt.%[2]s >= ?
+		  AND dt.%[2]s <= ?
+		  AND NOT EXISTS (
+		      SELECT 1 FROM prow_job_run_tests pjrt
+		      WHERE pjrt.prow_job_run_release = dt.release
+		        AND pjrt.test_id = dt.test_id
+		        AND pjrt.prow_job_id = dt.prow_job_id
+		        AND COALESCE(pjrt.suite_id, 0) = dt.suite_id
+		        AND pjrt.lifecycle = dt.lifecycle
+		        AND date(pjrt.prow_job_run_timestamp) = dt.%[2]s
+		  )`,
+		tableName, dateColumn)
 }
 
 type summaryStore interface {
@@ -232,9 +260,19 @@ func (s *pgStore) Releases() ([]string, error) {
 }
 
 func (s *pgStore) AggregateRangeForRelease(startDate, endDate civil.Date, release string, skipConflictDetection bool) error {
-	sql := buildInsertSQL(s.tableName, s.dateColumn)
-	if !skipConflictDetection {
-		sql += buildOnConflictClause(s.tableName, s.dateColumn)
+	insertSQL := buildInsertSQL(s.tableName, s.dateColumn)
+	if skipConflictDetection {
+		// Table is known empty for this range, so there is nothing to
+		// merge with or clean up - skip both the conflict clause and the
+		// cleanup delete.
+		return s.dbc.DB.Exec(insertSQL, startDate, endDate, release).Error
 	}
-	return s.dbc.DB.Exec(sql, startDate, endDate, release).Error
+	insertSQL += buildOnConflictClause(s.tableName, s.dateColumn)
+	cleanupSQL := buildCleanupDeleteSQL(s.tableName, s.dateColumn)
+	return s.dbc.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec(insertSQL, startDate, endDate, release).Error; err != nil {
+			return err
+		}
+		return tx.Exec(cleanupSQL, release, startDate, endDate).Error
+	})
 }

--- a/pkg/db/migrations/000011_add_lifecycle_to_summaries.down.sql
+++ b/pkg/db/migrations/000011_add_lifecycle_to_summaries.down.sql
@@ -1,0 +1,15 @@
+DROP INDEX IF EXISTS idx_test_cumulative_summaries_key;
+
+DROP INDEX IF EXISTS idx_test_daily_totals_key;
+
+ALTER TABLE test_cumulative_summaries
+    DROP COLUMN IF EXISTS lifecycle;
+
+ALTER TABLE test_daily_totals
+    DROP COLUMN IF EXISTS lifecycle;
+
+ALTER TABLE test_cumulative_summaries
+    ADD PRIMARY KEY (date, release, test_id, prow_job_id, suite_id);
+
+CREATE UNIQUE INDEX idx_test_daily_totals_unique
+    ON test_daily_totals (test_id, prow_job_id, suite_id, release, date);

--- a/pkg/db/migrations/000011_add_lifecycle_to_summaries.up.sql
+++ b/pkg/db/migrations/000011_add_lifecycle_to_summaries.up.sql
@@ -1,0 +1,31 @@
+-- TRT-2752: Add lifecycle as a key column in summary tables.
+-- Separates blocking/informing test results in daily and cumulative
+-- aggregations so downstream queries (CR, test reports) can filter by
+-- lifecycle. Existing rows default to 'blocking'.
+--
+-- Index rebuilds: both tables need unique indexes that include lifecycle
+-- for ON CONFLICT upserts. On large databases, build the new indexes
+-- out-of-band first with CREATE INDEX CONCURRENTLY (outside a
+-- transaction), then this migration's IF NOT EXISTS makes them no-ops.
+
+ALTER TABLE test_daily_totals
+    ADD COLUMN IF NOT EXISTS lifecycle TEXT NOT NULL DEFAULT 'blocking';
+
+ALTER TABLE test_cumulative_summaries
+    ADD COLUMN IF NOT EXISTS lifecycle TEXT NOT NULL DEFAULT 'blocking';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_test_daily_totals_key
+    ON test_daily_totals (release, date, test_id, suite_id, lifecycle, prow_job_id)
+    INCLUDE (successes, failures, flakes, runs,
+             first_failure_timestamp, last_failure_timestamp,
+             first_success_timestamp, last_success_timestamp);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_test_cumulative_summaries_key
+    ON test_cumulative_summaries (release, date, test_id, suite_id, lifecycle, prow_job_id)
+    INCLUDE (prefix_sum_successes, prefix_sum_failures, prefix_sum_flakes, prefix_sum_runs,
+             prefix_max_last_failure, prefix_max_last_success);
+
+DROP INDEX IF EXISTS idx_test_daily_totals_unique;
+
+ALTER TABLE test_cumulative_summaries
+    DROP CONSTRAINT IF EXISTS test_cumulative_summaries_pkey;

--- a/pkg/db/migrations/MANIFEST
+++ b/pkg/db/migrations/MANIFEST
@@ -17,3 +17,4 @@
 000008_add_summary_timestamps
 000009_add_lifecycle_to_prow_job_run_tests
 000010_drop_test_analysis_by_job_by_dates
+000011_add_lifecycle_to_summaries

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -164,11 +164,12 @@ type Suite struct {
 // Table is partitioned (LIST by release, RANGE by date) -
 // schema managed by migration 000006, not AutoMigrate.
 type TestDailyTotal struct {
-	TestID                uint       `gorm:"column:test_id;not null"`
-	ProwJobID             uint       `gorm:"column:prow_job_id;not null"`
-	SuiteID               uint       `gorm:"column:suite_id;not null;default:0"`
-	Release               string     `gorm:"column:release;not null"`
-	Date                  civil.Date `gorm:"column:date;type:date;not null"`
+	Release               string     `gorm:"column:release;not null;uniqueIndex:idx_test_daily_totals_key,priority:1"`
+	Date                  civil.Date `gorm:"column:date;type:date;not null;uniqueIndex:idx_test_daily_totals_key,priority:2"`
+	TestID                uint       `gorm:"column:test_id;not null;uniqueIndex:idx_test_daily_totals_key,priority:3"`
+	SuiteID               uint       `gorm:"column:suite_id;not null;default:0;uniqueIndex:idx_test_daily_totals_key,priority:4"`
+	Lifecycle             string     `gorm:"column:lifecycle;not null;default:blocking;uniqueIndex:idx_test_daily_totals_key,priority:5"`
+	ProwJobID             uint       `gorm:"column:prow_job_id;not null;uniqueIndex:idx_test_daily_totals_key,priority:6"`
 	Successes             int32      `gorm:"column:successes;not null;default:0"`
 	Failures              int32      `gorm:"column:failures;not null;default:0"`
 	Flakes                int32      `gorm:"column:flakes;not null;default:0"`
@@ -187,11 +188,12 @@ type TestDailyTotal struct {
 // Table is partitioned (LIST by release, RANGE by date) -
 // schema managed by migration 000006, not AutoMigrate.
 type TestCumulativeSummary struct {
-	Date                 civil.Date `gorm:"column:date;type:date;not null;primaryKey;priority:1"`
-	Release              string     `gorm:"column:release;not null;primaryKey;priority:2"`
-	TestID               uint       `gorm:"column:test_id;not null;primaryKey;priority:3"`
-	ProwJobID            uint       `gorm:"column:prow_job_id;not null;primaryKey;priority:4;index:idx_test_cumulative_summaries_prow_job_id"`
-	SuiteID              uint       `gorm:"column:suite_id;not null;default:0;primaryKey;priority:5"`
+	Release              string     `gorm:"column:release;not null;uniqueIndex:idx_test_cumulative_summaries_key,priority:1"`
+	Date                 civil.Date `gorm:"column:date;type:date;not null;uniqueIndex:idx_test_cumulative_summaries_key,priority:2"`
+	TestID               uint       `gorm:"column:test_id;not null;uniqueIndex:idx_test_cumulative_summaries_key,priority:3"`
+	SuiteID              uint       `gorm:"column:suite_id;not null;default:0;uniqueIndex:idx_test_cumulative_summaries_key,priority:4"`
+	Lifecycle            string     `gorm:"column:lifecycle;not null;default:blocking;uniqueIndex:idx_test_cumulative_summaries_key,priority:5"`
+	ProwJobID            uint       `gorm:"column:prow_job_id;not null;uniqueIndex:idx_test_cumulative_summaries_key,priority:6;index:idx_test_cumulative_summaries_prow_job_id"`
 	PrefixSumSuccesses   int64      `gorm:"column:prefix_sum_successes;not null;default:0"`
 	PrefixSumFailures    int64      `gorm:"column:prefix_sum_failures;not null;default:0"`
 	PrefixSumFlakes      int64      `gorm:"column:prefix_sum_flakes;not null;default:0"`

--- a/pkg/db/query/cumulative_query.go
+++ b/pkg/db/query/cumulative_query.go
@@ -303,8 +303,8 @@ func testReportCoreJoin(dbc *db.DB, release string, sample, base DateRange, name
 			SUM(COALESCE(e.prefix_sum_failures  - COALESCE(m.prefix_sum_failures,  0), 0))::bigint AS current_failures,
 			SUM(COALESCE(e.prefix_sum_runs      - COALESCE(m.prefix_sum_runs,      0), 0))::bigint AS current_runs`).
 		Joins("JOIN prow_jobs pj ON e.prow_job_id = pj.id AND pj.variant_combination_id IS NOT NULL").
-		Joins("LEFT JOIN test_cumulative_summaries m ON m.test_id = e.test_id AND m.prow_job_id = e.prow_job_id AND m.suite_id = e.suite_id AND m.release = e.release AND m.date = ?", boundary).
-		Joins("LEFT JOIN test_cumulative_summaries s ON s.test_id = e.test_id AND s.prow_job_id = e.prow_job_id AND s.suite_id = e.suite_id AND s.release = e.release AND s.date = ?", start).
+		Joins("LEFT JOIN test_cumulative_summaries m ON m.test_id = e.test_id AND m.prow_job_id = e.prow_job_id AND m.suite_id = e.suite_id AND m.lifecycle = e.lifecycle AND m.release = e.release AND m.date = ?", boundary).
+		Joins("LEFT JOIN test_cumulative_summaries s ON s.test_id = e.test_id AND s.prow_job_id = e.prow_job_id AND s.suite_id = e.suite_id AND s.lifecycle = e.lifecycle AND s.release = e.release AND s.date = ?", start).
 		Where("e.date = ? AND e.release = ?", end, release).
 		Group("e.test_id, e.suite_id, pj.variant_combination_id, e.release")
 

--- a/pkg/db/query/feature_gates.go
+++ b/pkg/db/query/feature_gates.go
@@ -27,9 +27,10 @@ func GetFeatureGatesFromDB(dbc *db.DB, release string, filterOpts *filter.Filter
 		SELECT 1 FROM test_cumulative_summaries e
 		LEFT JOIN test_cumulative_summaries s
 			ON s.test_id = e.test_id AND s.prow_job_id = e.prow_job_id
-			AND s.suite_id = e.suite_id AND s.release = e.release
-			AND s.date = ?
+			AND s.suite_id = e.suite_id AND s.lifecycle = e.lifecycle
+			AND s.release = e.release AND s.date = ?
 		WHERE e.test_id = t.id AND e.date = ? AND e.release = ?
+			AND e.lifecycle = 'blocking'
 			AND e.prefix_sum_runs > COALESCE(s.prefix_sum_runs, 0)
 	)`
 

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -81,6 +81,7 @@ const (
                 ON s.test_id = e.test_id
                 AND s.prow_job_id = e.prow_job_id
                 AND s.suite_id = e.suite_id
+                AND s.lifecycle = e.lifecycle
                 AND s.release = e.release
                 AND s.date = (?::date - INTERVAL '1 day')::date
             WHERE e.date = (SELECT MAX(date) FROM test_cumulative_summaries WHERE release = ?)
@@ -296,8 +297,8 @@ func UncollapsedTestReportWithStats(dbc *db.DB, release string, sample, base Dat
       SUM(COALESCE(e.prefix_sum_runs      - COALESCE(m.prefix_sum_runs,      0), 0))::bigint AS current_runs
     FROM test_cumulative_summaries e
     JOIN prow_jobs pj ON e.prow_job_id = pj.id AND pj.variant_combination_id IS NOT NULL
-    LEFT JOIN test_cumulative_summaries m ON m.test_id = e.test_id AND m.prow_job_id = e.prow_job_id AND m.suite_id = e.suite_id AND m.release = e.release AND m.date = ?
-    LEFT JOIN test_cumulative_summaries s ON s.test_id = e.test_id AND s.prow_job_id = e.prow_job_id AND s.suite_id = e.suite_id AND s.release = e.release AND s.date = ?
+    LEFT JOIN test_cumulative_summaries m ON m.test_id = e.test_id AND m.prow_job_id = e.prow_job_id AND m.suite_id = e.suite_id AND m.lifecycle = e.lifecycle AND m.release = e.release AND m.date = ?
+    LEFT JOIN test_cumulative_summaries s ON s.test_id = e.test_id AND s.prow_job_id = e.prow_job_id AND s.suite_id = e.suite_id AND s.lifecycle = e.lifecycle AND s.release = e.release AND s.date = ?
 `)
 	args = append(args, boundary, start)
 
@@ -368,7 +369,7 @@ stats AS (
       SUM(e.prefix_sum_runs      - COALESCE(m.prefix_sum_runs, 0))::bigint      AS current_runs
     FROM test_cumulative_summaries e
     JOIN prow_jobs pj ON e.prow_job_id = pj.id AND pj.variant_combination_id IS NOT NULL
-    LEFT JOIN test_cumulative_summaries m ON m.test_id = e.test_id AND m.prow_job_id = e.prow_job_id AND m.suite_id = e.suite_id AND m.release = e.release AND m.date = ?
+    LEFT JOIN test_cumulative_summaries m ON m.test_id = e.test_id AND m.prow_job_id = e.prow_job_id AND m.suite_id = e.suite_id AND m.lifecycle = e.lifecycle AND m.release = e.release AND m.date = ?
     WHERE e.date = ? AND e.release = ?
       AND e.test_id IN (SELECT DISTINCT test_id FROM %s)
       AND NOT EXISTS (SELECT 1 FROM variant_combinations WHERE 'never-stable' = any(variants) AND id = pj.variant_combination_id)

--- a/test/integration/backfill_test.go
+++ b/test/integration/backfill_test.go
@@ -1,0 +1,641 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"cloud.google.com/go/civil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/cumulativesummary"
+	"github.com/openshift/sippy/pkg/db/dailysummary"
+	"github.com/openshift/sippy/pkg/db/models"
+	intutil "github.com/openshift/sippy/test/integration/util"
+)
+
+const (
+	statusSuccess = int(v1.TestStatusSuccess)
+	statusFailure = int(v1.TestStatusFailure)
+	statusFlake   = int(v1.TestStatusFlake)
+	statusRunning = int(v1.TestStatusRunning)
+)
+
+type dailyTotalOpts struct {
+	suiteID              *uint
+	lifecycle            string
+	lastFailureTimestamp *time.Time
+	lastSuccessTimestamp *time.Time
+}
+
+type dailyTotalOption func(*dailyTotalOpts)
+
+func withDailySuiteID(id uint) dailyTotalOption {
+	return func(o *dailyTotalOpts) { o.suiteID = &id }
+}
+
+func withDailyLifecycle(lifecycle string) dailyTotalOption {
+	return func(o *dailyTotalOpts) { o.lifecycle = lifecycle }
+}
+
+func withDailyLastFailure(ts time.Time) dailyTotalOption {
+	return func(o *dailyTotalOpts) { o.lastFailureTimestamp = &ts }
+}
+
+func withDailyLastSuccess(ts time.Time) dailyTotalOption {
+	return func(o *dailyTotalOpts) { o.lastSuccessTimestamp = &ts }
+}
+
+// createDailyTotal seeds a test_daily_totals row directly, bypassing
+// dailysummary.Backfill, so cumulative-summary tests can be scoped to just
+// that package's behavior.
+func createDailyTotal(t *testing.T, dbc *db.DB, date civil.Date, release string, testID, prowJobID uint, successes, failures, flakes, runs int32, options ...dailyTotalOption) {
+	t.Helper()
+	o := dailyTotalOpts{lifecycle: "blocking"}
+	for _, fn := range options {
+		fn(&o)
+	}
+	dt := models.TestDailyTotal{
+		TestID:               testID,
+		ProwJobID:            prowJobID,
+		Release:              release,
+		Date:                 date,
+		Lifecycle:            o.lifecycle,
+		Successes:            successes,
+		Failures:             failures,
+		Flakes:               flakes,
+		Runs:                 runs,
+		LastFailureTimestamp: o.lastFailureTimestamp,
+		LastSuccessTimestamp: o.lastSuccessTimestamp,
+	}
+	if o.suiteID != nil {
+		dt.SuiteID = *o.suiteID
+	}
+	require.NoError(t, dbc.DB.Create(&dt).Error, "creating TestDailyTotal")
+}
+
+// --- dailysummary.Backfill ---
+
+func TestDailyTotalsBackfill_AggregatesCountsFromRawResults(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	ts := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	run := intutil.CreateProwJobRun(t, dbc, job.ID, "4.18", ts, true, v1.JobSucceeded)
+
+	passTest := intutil.CreateTest(t, dbc, "backfill-count-pass")
+	failTest := intutil.CreateTest(t, dbc, "backfill-count-fail")
+	flakeTest := intutil.CreateTest(t, dbc, "backfill-count-flake")
+	intutil.CreateProwJobRunTest(t, dbc, run.ID, job.ID, passTest.ID, "4.18", ts, statusSuccess)
+	intutil.CreateProwJobRunTest(t, dbc, run.ID, job.ID, failTest.ID, "4.18", ts, statusFailure)
+	intutil.CreateProwJobRunTest(t, dbc, run.ID, job.ID, flakeTest.ID, "4.18", ts, statusFlake)
+
+	day := civil.Date{Year: 2026, Month: 7, Day: 20}
+	require.NoError(t, dailysummary.Backfill(dbc, day, day))
+
+	var pass models.TestDailyTotal
+	require.NoError(t, dbc.DB.Where("test_id = ?", passTest.ID).First(&pass).Error)
+	assert.Equal(t, int32(1), pass.Successes)
+	assert.Equal(t, int32(0), pass.Failures)
+	assert.Equal(t, int32(0), pass.Flakes)
+	assert.Equal(t, int32(1), pass.Runs)
+
+	var fail models.TestDailyTotal
+	require.NoError(t, dbc.DB.Where("test_id = ?", failTest.ID).First(&fail).Error)
+	assert.Equal(t, int32(0), fail.Successes)
+	assert.Equal(t, int32(1), fail.Failures)
+	assert.Equal(t, int32(0), fail.Flakes)
+	assert.Equal(t, int32(1), fail.Runs)
+
+	var flake models.TestDailyTotal
+	require.NoError(t, dbc.DB.Where("test_id = ?", flakeTest.ID).First(&flake).Error)
+	assert.Equal(t, int32(0), flake.Successes)
+	assert.Equal(t, int32(0), flake.Failures)
+	assert.Equal(t, int32(1), flake.Flakes)
+	assert.Equal(t, int32(1), flake.Runs)
+}
+
+func TestDailyTotalsBackfill_UnrecognizedStatusCountsTowardRunsOnly(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	ts := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	run := intutil.CreateProwJobRun(t, dbc, job.ID, "4.18", ts, true, v1.JobSucceeded)
+	test := intutil.CreateTest(t, dbc, "unrecognized-status-test")
+
+	// A result outside {Success, Failure, Flake} (e.g. captured mid-run)
+	// should still be counted as a run so pass-rate denominators stay
+	// accurate, without being miscategorized into any outcome bucket.
+	intutil.CreateProwJobRunTest(t, dbc, run.ID, job.ID, test.ID, "4.18", ts, statusRunning)
+
+	day := civil.Date{Year: 2026, Month: 7, Day: 20}
+	require.NoError(t, dailysummary.Backfill(dbc, day, day))
+
+	var dt models.TestDailyTotal
+	require.NoError(t, dbc.DB.Where("test_id = ?", test.ID).First(&dt).Error)
+	assert.Equal(t, int32(0), dt.Successes)
+	assert.Equal(t, int32(0), dt.Failures)
+	assert.Equal(t, int32(0), dt.Flakes)
+	assert.Equal(t, int32(1), dt.Runs, "an uncategorized result should still count toward total runs")
+}
+
+func TestDailyTotalsBackfill_ScopedBySuite(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	suiteA := intutil.CreateSuite(t, dbc, "suite-a")
+	suiteB := intutil.CreateSuite(t, dbc, "suite-b")
+	test := intutil.CreateTest(t, dbc, "suite-scoped-test")
+	ts := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	run := intutil.CreateProwJobRun(t, dbc, job.ID, "4.18", ts, true, v1.JobSucceeded)
+
+	// The same test, job, release, and day, but run as part of two
+	// different suites - each suite should get its own daily total row
+	// rather than being merged into one.
+	intutil.CreateProwJobRunTestWithSuite(t, dbc, run.ID, job.ID, test.ID, suiteA.ID, "4.18", ts, statusSuccess)
+	intutil.CreateProwJobRunTestWithSuite(t, dbc, run.ID, job.ID, test.ID, suiteB.ID, "4.18", ts, statusFailure)
+
+	day := civil.Date{Year: 2026, Month: 7, Day: 20}
+	require.NoError(t, dailysummary.Backfill(dbc, day, day))
+
+	var totals []models.TestDailyTotal
+	require.NoError(t, dbc.DB.Where("test_id = ?", test.ID).Find(&totals).Error)
+	require.Len(t, totals, 2)
+
+	bySuite := make(map[uint]models.TestDailyTotal)
+	for _, dt := range totals {
+		bySuite[dt.SuiteID] = dt
+	}
+	assert.Equal(t, int32(1), bySuite[suiteA.ID].Successes)
+	assert.Equal(t, int32(0), bySuite[suiteA.ID].Failures)
+	assert.Equal(t, int32(0), bySuite[suiteB.ID].Successes)
+	assert.Equal(t, int32(1), bySuite[suiteB.ID].Failures)
+}
+
+func TestDailyTotalsBackfill_ScopedByLifecycle(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	test := intutil.CreateTest(t, dbc, "lifecycle-scoped-test")
+	ts := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	run := intutil.CreateProwJobRun(t, dbc, job.ID, "4.18", ts, true, v1.JobSucceeded)
+
+	// The same test, job, release, and day, but one run tagged blocking
+	// and the other informing - they must not be aggregated together.
+	intutil.CreateProwJobRunTestWithLifecycle(t, dbc, run.ID, job.ID, test.ID, "4.18", ts, statusSuccess, "blocking")
+	intutil.CreateProwJobRunTestWithLifecycle(t, dbc, run.ID, job.ID, test.ID, "4.18", ts, statusFailure, "informing")
+
+	day := civil.Date{Year: 2026, Month: 7, Day: 20}
+	require.NoError(t, dailysummary.Backfill(dbc, day, day))
+
+	var totals []models.TestDailyTotal
+	require.NoError(t, dbc.DB.Where("test_id = ?", test.ID).Find(&totals).Error)
+	require.Len(t, totals, 2)
+
+	byLifecycle := make(map[string]models.TestDailyTotal)
+	for _, dt := range totals {
+		byLifecycle[dt.Lifecycle] = dt
+	}
+	assert.Equal(t, int32(1), byLifecycle["blocking"].Successes)
+	assert.Equal(t, int32(0), byLifecycle["blocking"].Failures)
+	assert.Equal(t, int32(0), byLifecycle["informing"].Successes)
+	assert.Equal(t, int32(1), byLifecycle["informing"].Failures)
+}
+
+func TestDailyTotalsBackfill_ScopedByRelease(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	intutil.CreateReleaseDefinition(t, dbc, "4.17", 4, 17)
+	job18 := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws-418", "4.18", nil)
+	job17 := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws-417", "4.17", nil)
+	ts := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	run18 := intutil.CreateProwJobRun(t, dbc, job18.ID, "4.18", ts, true, v1.JobSucceeded)
+	run17 := intutil.CreateProwJobRun(t, dbc, job17.ID, "4.17", ts, false, v1.JobTestFailure)
+	test := intutil.CreateTest(t, dbc, "release-scoped-test")
+
+	intutil.CreateProwJobRunTest(t, dbc, run18.ID, job18.ID, test.ID, "4.18", ts, statusSuccess)
+	intutil.CreateProwJobRunTest(t, dbc, run17.ID, job17.ID, test.ID, "4.17", ts, statusFailure)
+
+	day := civil.Date{Year: 2026, Month: 7, Day: 20}
+	require.NoError(t, dailysummary.Backfill(dbc, day, day))
+
+	var totals []models.TestDailyTotal
+	require.NoError(t, dbc.DB.Where("test_id = ?", test.ID).Find(&totals).Error)
+	require.Len(t, totals, 2)
+
+	byRelease := make(map[string]models.TestDailyTotal)
+	for _, dt := range totals {
+		byRelease[dt.Release] = dt
+	}
+	assert.Equal(t, int32(1), byRelease["4.18"].Successes)
+	assert.Equal(t, int32(0), byRelease["4.18"].Failures)
+	assert.Equal(t, int32(0), byRelease["4.17"].Successes)
+	assert.Equal(t, int32(1), byRelease["4.17"].Failures)
+}
+
+func TestDailyTotalsBackfill_MultiDayRangeProducesOneRowPerDay(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	test := intutil.CreateTest(t, dbc, "multi-day-test")
+
+	day1Ts := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	day2Ts := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+	run1 := intutil.CreateProwJobRun(t, dbc, job.ID, "4.18", day1Ts, true, v1.JobSucceeded)
+	run2 := intutil.CreateProwJobRun(t, dbc, job.ID, "4.18", day2Ts, false, v1.JobTestFailure)
+	intutil.CreateProwJobRunTest(t, dbc, run1.ID, job.ID, test.ID, "4.18", day1Ts, statusSuccess)
+	intutil.CreateProwJobRunTest(t, dbc, run2.ID, job.ID, test.ID, "4.18", day2Ts, statusFailure)
+
+	start := civil.Date{Year: 2026, Month: 7, Day: 20}
+	end := civil.Date{Year: 2026, Month: 7, Day: 21}
+	require.NoError(t, dailysummary.Backfill(dbc, start, end))
+
+	var totals []models.TestDailyTotal
+	require.NoError(t, dbc.DB.Where("test_id = ?", test.ID).Order("date").Find(&totals).Error)
+	require.Len(t, totals, 2)
+	assert.Equal(t, start, totals[0].Date)
+	assert.Equal(t, int32(1), totals[0].Successes)
+	assert.Equal(t, end, totals[1].Date)
+	assert.Equal(t, int32(1), totals[1].Failures)
+}
+
+func TestDailyTotalsBackfill_TracksFirstAndLastFailureTimestamps(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	test := intutil.CreateTest(t, dbc, "failure-timestamp-test")
+
+	early := time.Date(2026, 7, 20, 6, 0, 0, 0, time.UTC)
+	late := time.Date(2026, 7, 20, 18, 0, 0, 0, time.UTC)
+	run1 := intutil.CreateProwJobRun(t, dbc, job.ID, "4.18", early, false, v1.JobTestFailure)
+	run2 := intutil.CreateProwJobRun(t, dbc, job.ID, "4.18", late, false, v1.JobTestFailure)
+	intutil.CreateProwJobRunTest(t, dbc, run1.ID, job.ID, test.ID, "4.18", early, statusFailure)
+	intutil.CreateProwJobRunTest(t, dbc, run2.ID, job.ID, test.ID, "4.18", late, statusFailure)
+
+	day := civil.Date{Year: 2026, Month: 7, Day: 20}
+	require.NoError(t, dailysummary.Backfill(dbc, day, day))
+
+	var dt models.TestDailyTotal
+	require.NoError(t, dbc.DB.Where("test_id = ?", test.ID).First(&dt).Error)
+	require.NotNil(t, dt.FirstFailureTimestamp)
+	require.NotNil(t, dt.LastFailureTimestamp)
+	assert.True(t, dt.FirstFailureTimestamp.Equal(early))
+	assert.True(t, dt.LastFailureTimestamp.Equal(late))
+}
+
+func TestDailyTotalsBackfill_TracksFirstAndLastSuccessTimestamps(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	test := intutil.CreateTest(t, dbc, "success-timestamp-test")
+
+	early := time.Date(2026, 7, 20, 6, 0, 0, 0, time.UTC)
+	late := time.Date(2026, 7, 20, 18, 0, 0, 0, time.UTC)
+	run1 := intutil.CreateProwJobRun(t, dbc, job.ID, "4.18", early, true, v1.JobSucceeded)
+	run2 := intutil.CreateProwJobRun(t, dbc, job.ID, "4.18", late, true, v1.JobSucceeded)
+	intutil.CreateProwJobRunTest(t, dbc, run1.ID, job.ID, test.ID, "4.18", early, statusSuccess)
+	intutil.CreateProwJobRunTest(t, dbc, run2.ID, job.ID, test.ID, "4.18", late, statusSuccess)
+
+	day := civil.Date{Year: 2026, Month: 7, Day: 20}
+	require.NoError(t, dailysummary.Backfill(dbc, day, day))
+
+	var dt models.TestDailyTotal
+	require.NoError(t, dbc.DB.Where("test_id = ?", test.ID).First(&dt).Error)
+	require.NotNil(t, dt.FirstSuccessTimestamp)
+	require.NotNil(t, dt.LastSuccessTimestamp)
+	assert.True(t, dt.FirstSuccessTimestamp.Equal(early))
+	assert.True(t, dt.LastSuccessTimestamp.Equal(late))
+}
+
+func TestDailyTotalsBackfill_RerunAfterRawDataRemovedDropsStaleRow(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	ts := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	run := intutil.CreateProwJobRun(t, dbc, job.ID, "4.18", ts, false, v1.JobTestFailure)
+	test := intutil.CreateTest(t, dbc, "reprocessed-away-test")
+	pjrt := intutil.CreateProwJobRunTest(t, dbc, run.ID, job.ID, test.ID, "4.18", ts, statusFailure)
+
+	day := civil.Date{Year: 2026, Month: 7, Day: 20}
+	require.NoError(t, dailysummary.Backfill(dbc, day, day))
+
+	var before models.TestDailyTotal
+	require.NoError(t, dbc.DB.Where("test_id = ?", test.ID).First(&before).Error)
+	assert.Equal(t, int32(1), before.Failures)
+
+	// Simulate the underlying job run being reprocessed and removed
+	// entirely - the raw result this daily total was built from is gone.
+	// ON CONFLICT DO UPDATE alone could never notice this; the cleanup
+	// delete is what removes the now-unsupported row.
+	require.NoError(t, dbc.DB.Unscoped().Delete(&pjrt).Error)
+
+	require.NoError(t, dailysummary.Backfill(dbc, day, day))
+
+	var count int64
+	require.NoError(t, dbc.DB.Model(&models.TestDailyTotal{}).Where("test_id = ?", test.ID).Count(&count).Error)
+	assert.Equal(t, int64(0), count, "stale daily total should be removed, not left behind, once its source data is gone")
+}
+
+func TestDailyTotalsBackfill_RerunAfterLifecycleReclassificationMovesRowToNewKey(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	ts := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	run := intutil.CreateProwJobRun(t, dbc, job.ID, "4.18", ts, false, v1.JobTestFailure)
+	test := intutil.CreateTest(t, dbc, "reclassified-test")
+	pjrt := intutil.CreateProwJobRunTestWithLifecycle(t, dbc, run.ID, job.ID, test.ID, "4.18", ts, statusFailure, "blocking")
+
+	day := civil.Date{Year: 2026, Month: 7, Day: 20}
+	require.NoError(t, dailysummary.Backfill(dbc, day, day))
+
+	var blockingBefore models.TestDailyTotal
+	require.NoError(t, dbc.DB.Where("test_id = ? AND lifecycle = ?", test.ID, "blocking").First(&blockingBefore).Error)
+	assert.Equal(t, int32(1), blockingBefore.Failures)
+
+	// The test is reclassified from blocking to informing (e.g. the
+	// classification logic is refined) and the raw row is updated in
+	// place to reflect it.
+	require.NoError(t, dbc.DB.Model(&pjrt).Update("lifecycle", "informing").Error)
+
+	require.NoError(t, dailysummary.Backfill(dbc, day, day))
+
+	var blockingCount int64
+	require.NoError(t, dbc.DB.Model(&models.TestDailyTotal{}).Where("test_id = ? AND lifecycle = ?", test.ID, "blocking").Count(&blockingCount).Error)
+	assert.Equal(t, int64(0), blockingCount, "the old blocking-keyed row should be cleaned up, not left behind")
+
+	var informing models.TestDailyTotal
+	require.NoError(t, dbc.DB.Where("test_id = ? AND lifecycle = ?", test.ID, "informing").First(&informing).Error)
+	assert.Equal(t, int32(1), informing.Failures)
+}
+
+// --- cumulativesummary.Backfill ---
+
+func TestCumulativeSummariesBackfill_FirstDayEqualsThatDaysTotals(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	test := intutil.CreateTest(t, dbc, "first-day-cumulative-test")
+
+	day := civil.Date{Year: 2026, Month: 7, Day: 20}
+	createDailyTotal(t, dbc, day, "4.18", test.ID, job.ID, 3, 1, 0, 4)
+
+	require.NoError(t, cumulativesummary.Backfill(dbc, day, day))
+
+	var cs models.TestCumulativeSummary
+	require.NoError(t, dbc.DB.Where("date = ? AND test_id = ?", day, test.ID).First(&cs).Error)
+	assert.Equal(t, int64(3), cs.PrefixSumSuccesses)
+	assert.Equal(t, int64(1), cs.PrefixSumFailures)
+	assert.Equal(t, int64(4), cs.PrefixSumRuns)
+}
+
+func TestCumulativeSummariesBackfill_AccumulatesOnTopOfPreviousDay(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	test := intutil.CreateTest(t, dbc, "accumulate-test")
+
+	yesterday := civil.Date{Year: 2026, Month: 7, Day: 19}
+	today := civil.Date{Year: 2026, Month: 7, Day: 20}
+
+	createCumulativeSummary(t, dbc, yesterday, "4.18", test.ID, job.ID, 0, 10, 8, 0, withFailures(2))
+	createDailyTotal(t, dbc, today, "4.18", test.ID, job.ID, 3, 1, 0, 4)
+
+	require.NoError(t, cumulativesummary.Backfill(dbc, today, today))
+
+	var cs models.TestCumulativeSummary
+	require.NoError(t, dbc.DB.Where("date = ? AND test_id = ?", today, test.ID).First(&cs).Error)
+	assert.Equal(t, int64(11), cs.PrefixSumSuccesses)
+	assert.Equal(t, int64(3), cs.PrefixSumFailures)
+	assert.Equal(t, int64(14), cs.PrefixSumRuns)
+}
+
+func TestCumulativeSummariesBackfill_CarriesForwardWhenNoNewDataToday(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	test := intutil.CreateTest(t, dbc, "carry-forward-test")
+
+	yesterday := civil.Date{Year: 2026, Month: 7, Day: 19}
+	today := civil.Date{Year: 2026, Month: 7, Day: 20}
+	lastFailure := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+
+	createCumulativeSummary(t, dbc, yesterday, "4.18", test.ID, job.ID, 0, 6, 5, 0,
+		withFailures(1), withLastFailure(lastFailure))
+	// No daily total for `today` - the test simply didn't run today.
+
+	require.NoError(t, cumulativesummary.Backfill(dbc, today, today))
+
+	var cs models.TestCumulativeSummary
+	require.NoError(t, dbc.DB.Where("date = ? AND test_id = ?", today, test.ID).First(&cs).Error)
+	assert.Equal(t, int64(5), cs.PrefixSumSuccesses)
+	assert.Equal(t, int64(1), cs.PrefixSumFailures)
+	assert.Equal(t, int64(6), cs.PrefixSumRuns)
+	require.NotNil(t, cs.PrefixMaxLastFailure, "last-failure timestamp should carry forward along with the counts")
+	assert.True(t, cs.PrefixMaxLastFailure.Equal(lastFailure))
+}
+
+func TestCumulativeSummariesBackfill_NewTestAppearsAlongsideExistingAccumulation(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	existing := intutil.CreateTest(t, dbc, "already-running-test")
+	newTest := intutil.CreateTest(t, dbc, "newly-added-test")
+
+	yesterday := civil.Date{Year: 2026, Month: 7, Day: 19}
+	today := civil.Date{Year: 2026, Month: 7, Day: 20}
+
+	createCumulativeSummary(t, dbc, yesterday, "4.18", existing.ID, job.ID, 0, 4, 4, 0)
+	// `existing` keeps running today; `newTest` shows up for the first time.
+	createDailyTotal(t, dbc, today, "4.18", existing.ID, job.ID, 1, 0, 0, 1)
+	createDailyTotal(t, dbc, today, "4.18", newTest.ID, job.ID, 0, 1, 0, 1)
+
+	require.NoError(t, cumulativesummary.Backfill(dbc, today, today))
+
+	var summaries []models.TestCumulativeSummary
+	require.NoError(t, dbc.DB.Where("date = ?", today).Find(&summaries).Error)
+	require.Len(t, summaries, 2)
+
+	byTest := make(map[uint]models.TestCumulativeSummary)
+	for _, cs := range summaries {
+		byTest[cs.TestID] = cs
+	}
+	assert.Equal(t, int64(5), byTest[existing.ID].PrefixSumRuns, "existing test should accumulate on top of yesterday's total")
+	assert.Equal(t, int64(1), byTest[newTest.ID].PrefixSumRuns, "brand new test should start from just today's total, not inherit another test's history")
+	assert.Equal(t, int64(1), byTest[newTest.ID].PrefixSumFailures)
+}
+
+func TestCumulativeSummariesBackfill_ScopedByRelease(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	intutil.CreateReleaseDefinition(t, dbc, "4.17", 4, 17)
+	job18 := intutil.CreateProwJob(t, dbc, "job-418", "4.18", nil)
+	job17 := intutil.CreateProwJob(t, dbc, "job-417", "4.17", nil)
+	test := intutil.CreateTest(t, dbc, "release-scoped-cumulative-test")
+
+	day := civil.Date{Year: 2026, Month: 7, Day: 20}
+	createDailyTotal(t, dbc, day, "4.18", test.ID, job18.ID, 2, 0, 0, 2)
+	createDailyTotal(t, dbc, day, "4.17", test.ID, job17.ID, 0, 5, 0, 5)
+
+	require.NoError(t, cumulativesummary.Backfill(dbc, day, day))
+
+	var summaries []models.TestCumulativeSummary
+	require.NoError(t, dbc.DB.Where("test_id = ?", test.ID).Find(&summaries).Error)
+	require.Len(t, summaries, 2)
+	byRelease := make(map[string]models.TestCumulativeSummary)
+	for _, cs := range summaries {
+		byRelease[cs.Release] = cs
+	}
+	assert.Equal(t, int64(2), byRelease["4.18"].PrefixSumSuccesses)
+	assert.Equal(t, int64(0), byRelease["4.18"].PrefixSumFailures)
+	assert.Equal(t, int64(0), byRelease["4.17"].PrefixSumSuccesses)
+	assert.Equal(t, int64(5), byRelease["4.17"].PrefixSumFailures)
+}
+
+func TestCumulativeSummariesBackfill_MultiDayRangeAccumulatesInSequence(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	test := intutil.CreateTest(t, dbc, "multi-day-cumulative-test")
+
+	day1 := civil.Date{Year: 2026, Month: 7, Day: 20}
+	day2 := civil.Date{Year: 2026, Month: 7, Day: 21}
+	day3 := civil.Date{Year: 2026, Month: 7, Day: 22}
+	createDailyTotal(t, dbc, day1, "4.18", test.ID, job.ID, 1, 0, 0, 1)
+	createDailyTotal(t, dbc, day2, "4.18", test.ID, job.ID, 0, 1, 0, 1)
+	createDailyTotal(t, dbc, day3, "4.18", test.ID, job.ID, 0, 0, 1, 1)
+
+	require.NoError(t, cumulativesummary.Backfill(dbc, day1, day3))
+
+	var summaries []models.TestCumulativeSummary
+	require.NoError(t, dbc.DB.Where("test_id = ?", test.ID).Order("date").Find(&summaries).Error)
+	require.Len(t, summaries, 3)
+	assert.Equal(t, int64(1), summaries[0].PrefixSumRuns)
+	assert.Equal(t, int64(2), summaries[1].PrefixSumRuns)
+	assert.Equal(t, int64(3), summaries[2].PrefixSumRuns)
+	assert.Equal(t, int64(1), summaries[2].PrefixSumFlakes)
+}
+
+func TestCumulativeSummariesBackfill_TracksLatestFailureTimestamp(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	test := intutil.CreateTest(t, dbc, "cumulative-timestamp-test")
+
+	yesterday := civil.Date{Year: 2026, Month: 7, Day: 19}
+	today := civil.Date{Year: 2026, Month: 7, Day: 20}
+	earlierFailure := time.Date(2026, 7, 19, 8, 0, 0, 0, time.UTC)
+	laterFailure := time.Date(2026, 7, 20, 8, 0, 0, 0, time.UTC)
+
+	createCumulativeSummary(t, dbc, yesterday, "4.18", test.ID, job.ID, 0, 0, 0, 0, withLastFailure(earlierFailure))
+	createDailyTotal(t, dbc, today, "4.18", test.ID, job.ID, 0, 1, 0, 1, withDailyLastFailure(laterFailure))
+
+	require.NoError(t, cumulativesummary.Backfill(dbc, today, today))
+
+	var cs models.TestCumulativeSummary
+	require.NoError(t, dbc.DB.Where("date = ? AND test_id = ?", today, test.ID).First(&cs).Error)
+	require.NotNil(t, cs.PrefixMaxLastFailure)
+	assert.True(t, cs.PrefixMaxLastFailure.Equal(laterFailure))
+}
+
+func TestCumulativeSummariesBackfill_TracksLatestSuccessTimestamp(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	test := intutil.CreateTest(t, dbc, "cumulative-success-timestamp-test")
+
+	yesterday := civil.Date{Year: 2026, Month: 7, Day: 19}
+	today := civil.Date{Year: 2026, Month: 7, Day: 20}
+	earlierSuccess := time.Date(2026, 7, 19, 8, 0, 0, 0, time.UTC)
+	laterSuccess := time.Date(2026, 7, 20, 8, 0, 0, 0, time.UTC)
+
+	createCumulativeSummary(t, dbc, yesterday, "4.18", test.ID, job.ID, 0, 0, 0, 0, withLastSuccess(earlierSuccess))
+	createDailyTotal(t, dbc, today, "4.18", test.ID, job.ID, 1, 0, 0, 1, withDailyLastSuccess(laterSuccess))
+
+	require.NoError(t, cumulativesummary.Backfill(dbc, today, today))
+
+	var cs models.TestCumulativeSummary
+	require.NoError(t, dbc.DB.Where("date = ? AND test_id = ?", today, test.ID).First(&cs).Error)
+	require.NotNil(t, cs.PrefixMaxLastSuccess)
+	assert.True(t, cs.PrefixMaxLastSuccess.Equal(laterSuccess))
+}
+
+func TestCumulativeSummariesBackfill_SuiteChangeStartsAnIndependentChain(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	test := intutil.CreateTest(t, dbc, "suite-change-test")
+	suiteA := intutil.CreateSuite(t, dbc, "suite-a-cumulative")
+	suiteB := intutil.CreateSuite(t, dbc, "suite-b-cumulative")
+
+	day1 := civil.Date{Year: 2026, Month: 7, Day: 20}
+	day2 := civil.Date{Year: 2026, Month: 7, Day: 21}
+	// The test runs under suite A on day 1, then is reclassified under
+	// suite B on day 2 (and no longer reports under suite A). The
+	// cumulative summary is keyed by (test, job, suite, lifecycle), so
+	// suite A's chain keeps carrying forward unchanged on day 2 (same as
+	// any test that simply stopped reporting) alongside a brand new
+	// chain for suite B - they never merge into one row.
+	createDailyTotal(t, dbc, day1, "4.18", test.ID, job.ID, 1, 0, 0, 1, withDailySuiteID(suiteA.ID))
+	createDailyTotal(t, dbc, day2, "4.18", test.ID, job.ID, 0, 1, 0, 1, withDailySuiteID(suiteB.ID))
+
+	require.NoError(t, cumulativesummary.Backfill(dbc, day1, day2))
+
+	var summaries []models.TestCumulativeSummary
+	require.NoError(t, dbc.DB.Where("test_id = ?", test.ID).Order("date, suite_id").Find(&summaries).Error)
+	require.Len(t, summaries, 3, "suite A's day-1 row, its carried-forward day-2 row, and suite B's fresh day-2 row")
+
+	var day1SuiteA, day2SuiteA, day2SuiteB models.TestCumulativeSummary
+	for _, cs := range summaries {
+		switch {
+		case cs.Date == day1 && cs.SuiteID == suiteA.ID:
+			day1SuiteA = cs
+		case cs.Date == day2 && cs.SuiteID == suiteA.ID:
+			day2SuiteA = cs
+		case cs.Date == day2 && cs.SuiteID == suiteB.ID:
+			day2SuiteB = cs
+		default:
+			t.Fatalf("unexpected cumulative summary row: %+v", cs)
+		}
+	}
+	assert.Equal(t, int64(1), day1SuiteA.PrefixSumSuccesses)
+	assert.Equal(t, int64(1), day2SuiteA.PrefixSumSuccesses, "suite A's chain should carry forward unchanged, not disappear because the suite reassignment happened")
+	assert.Equal(t, int64(0), day2SuiteB.PrefixSumSuccesses, "suite B's chain should start fresh, not inherit suite A's history")
+	assert.Equal(t, int64(1), day2SuiteB.PrefixSumFailures)
+}
+
+func TestCumulativeSummariesBackfill_LifecycleReclassificationDropsOrphanedRow(t *testing.T) {
+	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", nil)
+	testA := intutil.CreateTest(t, dbc, "cumulative-lifecycle-a")
+	testB := intutil.CreateTest(t, dbc, "cumulative-lifecycle-b")
+
+	day := civil.Date{Year: 2026, Month: 7, Day: 20}
+	createDailyTotal(t, dbc, day, "4.18", testA.ID, job.ID, 1, 0, 0, 1, withDailyLifecycle("blocking"))
+	require.NoError(t, cumulativesummary.Backfill(dbc, day, day))
+
+	var countBefore int64
+	require.NoError(t, dbc.DB.Model(&models.TestCumulativeSummary{}).Where("test_id = ?", testA.ID).Count(&countBefore).Error)
+	require.Equal(t, int64(1), countBefore)
+
+	// testA's daily total on this day is reprocessed away entirely (e.g.
+	// dailysummary's own cleanup delete removed it after a reclassification
+	// with no history to carry forward from), and testB's total appears
+	// in its place. Since this cumulative row for testA has neither a
+	// prior day to carry forward from nor a daily total to support it
+	// anymore, it should be cleaned up rather than left behind forever.
+	require.NoError(t, dbc.DB.Where("test_id = ? AND release = ? AND date = ?", testA.ID, "4.18", day).Delete(&models.TestDailyTotal{}).Error)
+	createDailyTotal(t, dbc, day, "4.18", testB.ID, job.ID, 1, 0, 0, 1, withDailyLifecycle("blocking"))
+
+	require.NoError(t, cumulativesummary.Backfill(dbc, day, day))
+
+	var countA int64
+	require.NoError(t, dbc.DB.Model(&models.TestCumulativeSummary{}).Where("test_id = ?", testA.ID).Count(&countA).Error)
+	assert.Equal(t, int64(0), countA, "orphaned cumulative summary for the removed test should be gone")
+
+	var countB int64
+	require.NoError(t, dbc.DB.Model(&models.TestCumulativeSummary{}).Where("test_id = ?", testB.ID).Count(&countB).Error)
+	assert.Equal(t, int64(1), countB)
+}

--- a/test/integration/component_readiness_test.go
+++ b/test/integration/component_readiness_test.go
@@ -77,13 +77,28 @@ func createTestOwnership(t *testing.T, dbc *db.DB, testID uint, suiteID *uint, u
 }
 
 type cumulativeSummaryOpts struct {
+	prefixSumFailures    int64
 	prefixMaxLastFailure *time.Time
+	prefixMaxLastSuccess *time.Time
+	lifecycle            string
 }
 
 type cumulativeSummaryOption func(*cumulativeSummaryOpts)
 
 func withLastFailure(t time.Time) cumulativeSummaryOption {
 	return func(o *cumulativeSummaryOpts) { o.prefixMaxLastFailure = &t }
+}
+
+func withLastSuccess(t time.Time) cumulativeSummaryOption {
+	return func(o *cumulativeSummaryOpts) { o.prefixMaxLastSuccess = &t }
+}
+
+func withFailures(failures int64) cumulativeSummaryOption {
+	return func(o *cumulativeSummaryOpts) { o.prefixSumFailures = failures }
+}
+
+func withLifecycle(lifecycle string) cumulativeSummaryOption {
+	return func(o *cumulativeSummaryOpts) { o.lifecycle = lifecycle }
 }
 
 func createCumulativeSummary(t *testing.T, dbc *db.DB, date civil.Date, release string, testID, prowJobID, suiteID uint, runs, successes, flakes int64, options ...cumulativeSummaryOption) {
@@ -98,10 +113,16 @@ func createCumulativeSummary(t *testing.T, dbc *db.DB, date civil.Date, release 
 		TestID:               testID,
 		ProwJobID:            prowJobID,
 		SuiteID:              suiteID,
+		Lifecycle:            o.lifecycle,
 		PrefixSumRuns:        runs,
 		PrefixSumSuccesses:   successes,
+		PrefixSumFailures:    o.prefixSumFailures,
 		PrefixSumFlakes:      flakes,
 		PrefixMaxLastFailure: o.prefixMaxLastFailure,
+		PrefixMaxLastSuccess: o.prefixMaxLastSuccess,
+	}
+	if tcs.Lifecycle == "" {
+		tcs.Lifecycle = "blocking"
 	}
 	require.NoError(t, dbc.DB.Create(&tcs).Error)
 }
@@ -2371,6 +2392,303 @@ func TestDrillDownBySecondaryCapability(t *testing.T) {
 	for _, ts := range nonPlaceholders {
 		assert.NotEqual(t, "openshift-tests:pvc-only", ts.TestID,
 			"test with only PVC capability should not appear in IPv4 drill-down")
+	}
+}
+
+func TestMixedLifecycleRowsProduceCorrectCounts(t *testing.T) {
+	dbc := crTestDB(t)
+	release := "4.16"
+
+	vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+	job := createProwJobWithVC(t, dbc, "periodic-e2e-aws-lifecycle", release, vc)
+	test := createTest(t, dbc, "openshift-tests:[sig-storage] PVC lifecycle test")
+	suite := createSuite(t, dbc, "openshift-tests")
+	tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:lifecycle", "Storage", []string{"PersistentVolumes"})
+
+	startMinus1 := civil.Date{Year: 2024, Month: 5, Day: 31}
+	endMinus1 := civil.Date{Year: 2024, Month: 6, Day: 14}
+
+	// Blocking: runs=10, successes=8, flakes=1
+	createCumulativeSummary(t, dbc, startMinus1, release, test.ID, job.ID, suite.ID, 100, 90, 5, withLifecycle("blocking"))
+	createCumulativeSummary(t, dbc, endMinus1, release, test.ID, job.ID, suite.ID, 110, 98, 6, withLifecycle("blocking"))
+
+	// Informing: runs=20, successes=15, flakes=2
+	createCumulativeSummary(t, dbc, startMinus1, release, test.ID, job.ID, suite.ID, 50, 40, 3, withLifecycle("informing"))
+	createCumulativeSummary(t, dbc, endMinus1, release, test.ID, job.ID, suite.ID, 70, 55, 5, withLifecycle("informing"))
+
+	provider := postgres.NewPostgresProvider(dbc, nil)
+	opts := defaultReqOptions(release)
+	includeVariants := map[string][]string{
+		"Platform": {"aws"},
+		"Network":  {"ovn"},
+	}
+
+	result, errs := provider.QuerySampleTestStatus(context.Background(), opts, includeVariants,
+		opts.SampleRelease.Start, opts.SampleRelease.End)
+	require.Empty(t, errs)
+	require.NotEmpty(t, result)
+
+	key := crtest.KeyWithVariants{
+		TestID:   tow.UniqueID,
+		Variants: map[string]string{"Platform": "aws", "Network": "ovn"},
+	}
+	ts, ok := result[key.Encode()]
+	require.True(t, ok, "expected key %s in results", key.Encode())
+
+	// Correct: blocking (10) + informing (20) = 30 runs
+	// Without lifecycle join fix, cross-product would inflate to 40
+	assert.Equal(t, 30, ts.TotalCount)
+	assert.Equal(t, 23, ts.SuccessCount) // blocking 8 + informing 15
+	assert.Equal(t, 3, ts.FlakeCount)    // blocking 1 + informing 2
+}
+
+func TestLifecycleFilterExcludesInformingFromSample(t *testing.T) {
+	dbc := crTestDB(t)
+	release := "4.16"
+
+	vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+	job := createProwJobWithVC(t, dbc, "periodic-e2e-aws-lifecycle-filter", release, vc)
+	test := createTest(t, dbc, "openshift-tests:[sig-network] informing filter test")
+	suite := createSuite(t, dbc, "openshift-tests")
+	tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:lifecycle-filter", "Networking", []string{"Connectivity"})
+
+	// defaultReqOptions uses:
+	//   sample: 2024-06-01 to 2024-06-15 -> lookup dates: 2024-05-31 (start-1), 2024-06-14 (end-1)
+	//   base:   2024-05-15 to 2024-06-01 -> lookup dates: 2024-05-14 (start-1), 2024-06-01 (end+1-1)
+	// Create prefix-sum rows at all four lookup dates.
+	baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+	baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+	sampleLookupStart := civil.Date{Year: 2024, Month: 5, Day: 31}
+	sampleLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 14}
+
+	// Blocking: base period adds 5 runs (3 success, 1 flake), sample period adds 10 runs (8 success, 1 flake)
+	createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, job.ID, suite.ID, 80, 70, 4, withLifecycle("blocking"))
+	createCumulativeSummary(t, dbc, sampleLookupStart, release, test.ID, job.ID, suite.ID, 85, 73, 5, withLifecycle("blocking"))
+	createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, job.ID, suite.ID, 85, 73, 5, withLifecycle("blocking"))
+	createCumulativeSummary(t, dbc, sampleLookupEnd, release, test.ID, job.ID, suite.ID, 95, 81, 6, withLifecycle("blocking"))
+
+	// Informing: base period adds 8 runs (6 success, 1 flake), sample period adds 20 runs (15 success, 2 flakes)
+	createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, job.ID, suite.ID, 30, 24, 2, withLifecycle("informing"))
+	createCumulativeSummary(t, dbc, sampleLookupStart, release, test.ID, job.ID, suite.ID, 38, 30, 3, withLifecycle("informing"))
+	createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, job.ID, suite.ID, 38, 30, 3, withLifecycle("informing"))
+	createCumulativeSummary(t, dbc, sampleLookupEnd, release, test.ID, job.ID, suite.ID, 58, 45, 5, withLifecycle("informing"))
+
+	provider := postgres.NewPostgresProvider(dbc, nil)
+	includeVariants := map[string][]string{
+		"Platform": {"aws"},
+		"Network":  {"ovn"},
+	}
+
+	key := crtest.KeyWithVariants{
+		TestID:   tow.UniqueID,
+		Variants: map[string]string{"Platform": "aws", "Network": "ovn"},
+	}
+
+	t.Run("sample with lifecycle=blocking excludes informing", func(t *testing.T) {
+		opts := defaultReqOptions(release)
+		opts.Lifecycles = []string{"blocking"}
+
+		result, errs := provider.QuerySampleTestStatus(context.Background(), opts, includeVariants,
+			opts.SampleRelease.Start, opts.SampleRelease.End)
+		require.Empty(t, errs)
+		require.NotEmpty(t, result)
+
+		ts, ok := result[key.Encode()]
+		require.True(t, ok, "expected key %s in results", key.Encode())
+
+		// Only blocking sample counts: 10 runs, 8 successes, 1 flake
+		assert.Equal(t, 10, ts.TotalCount)
+		assert.Equal(t, 8, ts.SuccessCount)
+		assert.Equal(t, 1, ts.FlakeCount)
+	})
+
+	t.Run("base query does not filter by lifecycle", func(t *testing.T) {
+		opts := defaultReqOptions(release)
+		opts.Lifecycles = []string{"blocking"}
+
+		result, errs := provider.QueryBaseTestStatus(context.Background(), opts)
+		require.Empty(t, errs)
+		require.NotEmpty(t, result)
+
+		ts, ok := result[key.Encode()]
+		require.True(t, ok, "expected key %s in results", key.Encode())
+
+		// Base includes both blocking (5 runs) and informing (8 runs) = 13 runs
+		assert.Equal(t, 13, ts.TotalCount)
+		assert.Equal(t, 9, ts.SuccessCount) // blocking 3 + informing 6
+		assert.Equal(t, 2, ts.FlakeCount)   // blocking 1 + informing 1
+	})
+
+	t.Run("sample without lifecycle filter includes all", func(t *testing.T) {
+		opts := defaultReqOptions(release)
+
+		result, errs := provider.QuerySampleTestStatus(context.Background(), opts, includeVariants,
+			opts.SampleRelease.Start, opts.SampleRelease.End)
+		require.Empty(t, errs)
+		require.NotEmpty(t, result)
+
+		ts, ok := result[key.Encode()]
+		require.True(t, ok, "expected key %s in results", key.Encode())
+
+		// Both blocking (10) + informing (20) = 30 runs
+		assert.Equal(t, 30, ts.TotalCount)
+		assert.Equal(t, 23, ts.SuccessCount) // blocking 8 + informing 15
+		assert.Equal(t, 3, ts.FlakeCount)    // blocking 1 + informing 2
+	})
+
+	t.Run("sample with lifecycle=informing returns only informing", func(t *testing.T) {
+		opts := defaultReqOptions(release)
+		opts.Lifecycles = []string{"informing"}
+
+		result, errs := provider.QuerySampleTestStatus(context.Background(), opts, includeVariants,
+			opts.SampleRelease.Start, opts.SampleRelease.End)
+		require.Empty(t, errs)
+		require.NotEmpty(t, result)
+
+		ts, ok := result[key.Encode()]
+		require.True(t, ok, "expected key %s in results", key.Encode())
+
+		// Only informing sample counts: 20 runs, 15 successes, 2 flakes
+		assert.Equal(t, 20, ts.TotalCount)
+		assert.Equal(t, 15, ts.SuccessCount)
+		assert.Equal(t, 2, ts.FlakeCount)
+	})
+
+	t.Run("sample with both lifecycles returns all", func(t *testing.T) {
+		opts := defaultReqOptions(release)
+		opts.Lifecycles = []string{"blocking", "informing"}
+
+		result, errs := provider.QuerySampleTestStatus(context.Background(), opts, includeVariants,
+			opts.SampleRelease.Start, opts.SampleRelease.End)
+		require.Empty(t, errs)
+		require.NotEmpty(t, result)
+
+		ts, ok := result[key.Encode()]
+		require.True(t, ok, "expected key %s in results", key.Encode())
+
+		// Both blocking (10) + informing (20) = 30 runs
+		assert.Equal(t, 30, ts.TotalCount)
+		assert.Equal(t, 23, ts.SuccessCount)
+		assert.Equal(t, 3, ts.FlakeCount)
+	})
+}
+
+func TestInformingOnlyTestExcludedFromSamplePlaceholders(t *testing.T) {
+	dbc := crTestDB(t)
+	release := "4.16"
+
+	vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+	job := createProwJobWithVC(t, dbc, "periodic-e2e-aws-placeholder-lifecycle", release, vc)
+
+	testBoth := createTest(t, dbc, "openshift-tests:[sig-network] test with both lifecycles")
+	testInformingOnly := createTest(t, dbc, "openshift-tests:[sig-storage] informing-only test")
+	suite := createSuite(t, dbc, "openshift-tests")
+
+	towBoth := createTestOwnership(t, dbc, testBoth.ID, &suite.ID, "openshift-tests:both-lifecycle", "Networking", []string{"Connectivity"})
+	createTestOwnership(t, dbc, testInformingOnly.ID, &suite.ID, "openshift-tests:informing-only", "Storage", []string{"PVC"})
+
+	startMinus1 := civil.Date{Year: 2024, Month: 5, Day: 31}
+	endMinus1 := civil.Date{Year: 2024, Month: 6, Day: 14}
+
+	// testBoth: blocking data in sample period (10 runs, 8 successes, 1 flake)
+	createCumulativeSummary(t, dbc, startMinus1, release, testBoth.ID, job.ID, suite.ID, 80, 70, 4, withLifecycle("blocking"))
+	createCumulativeSummary(t, dbc, endMinus1, release, testBoth.ID, job.ID, suite.ID, 90, 78, 5, withLifecycle("blocking"))
+	// testBoth: informing data
+	createCumulativeSummary(t, dbc, startMinus1, release, testBoth.ID, job.ID, suite.ID, 30, 24, 2, withLifecycle("informing"))
+	createCumulativeSummary(t, dbc, endMinus1, release, testBoth.ID, job.ID, suite.ID, 50, 39, 4, withLifecycle("informing"))
+
+	// testInformingOnly: ONLY informing data in sample period (20 runs)
+	createCumulativeSummary(t, dbc, startMinus1, release, testInformingOnly.ID, job.ID, suite.ID, 30, 24, 2, withLifecycle("informing"))
+	createCumulativeSummary(t, dbc, endMinus1, release, testInformingOnly.ID, job.ID, suite.ID, 50, 39, 4, withLifecycle("informing"))
+
+	provider := postgres.NewPostgresProvider(dbc, nil)
+	includeVariants := map[string][]string{
+		"Platform": {"aws"},
+		"Network":  {"ovn"},
+	}
+
+	opts := defaultReqOptions(release)
+	opts.Lifecycles = []string{"blocking"}
+
+	result, errs := provider.QuerySampleTestStatus(context.Background(), opts, includeVariants,
+		opts.SampleRelease.Start, opts.SampleRelease.End)
+	require.Empty(t, errs)
+
+	keyBoth := crtest.KeyWithVariants{
+		TestID:   towBoth.UniqueID,
+		Variants: map[string]string{"Platform": "aws", "Network": "ovn"},
+	}
+	ts, ok := result[keyBoth.Encode()]
+	require.True(t, ok, "test with blocking data should be present")
+	assert.Equal(t, 10, ts.TotalCount)
+	assert.Equal(t, 8, ts.SuccessCount)
+	assert.Equal(t, 1, ts.FlakeCount)
+
+	// testInformingOnly should be absent entirely, including placeholders.
+	// With lifecycle=blocking, this test has no data, so its component (Storage)
+	// should not appear in the grid.
+	for encodedKey, ts := range result {
+		if ts.Component == "Storage" {
+			t.Errorf("informing-only test's component should not appear in results, found key %s with component Storage", encodedKey)
+		}
+	}
+}
+
+func TestCrossCompareWithLifecycleFilter(t *testing.T) {
+	dbc := crTestDB(t)
+	release := "4.16"
+
+	vcHA := createVariantCombination(t, dbc, []string{"Platform:aws", "Topology:ha"})
+	vcSingle := createVariantCombination(t, dbc, []string{"Platform:aws", "Topology:single"})
+
+	jobHA := createProwJobWithVC(t, dbc, "periodic-e2e-aws-ha-lifecycle", release, vcHA)
+	jobSingle := createProwJobWithVC(t, dbc, "periodic-e2e-aws-single-lifecycle", release, vcSingle)
+
+	test := createTest(t, dbc, "openshift-tests:[sig-storage] cross-compare lifecycle test")
+	suite := createSuite(t, dbc, "openshift-tests-ccl")
+	createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:cc-lifecycle", "Storage", []string{"PVC"})
+
+	startMinus1 := civil.Date{Year: 2024, Month: 5, Day: 31}
+	endMinus1 := civil.Date{Year: 2024, Month: 6, Day: 14}
+
+	// HA job: blocking 10 runs, informing 5 runs in sample period
+	createCumulativeSummary(t, dbc, startMinus1, release, test.ID, jobHA.ID, suite.ID, 100, 90, 5, withLifecycle("blocking"))
+	createCumulativeSummary(t, dbc, endMinus1, release, test.ID, jobHA.ID, suite.ID, 110, 98, 6, withLifecycle("blocking"))
+	createCumulativeSummary(t, dbc, startMinus1, release, test.ID, jobHA.ID, suite.ID, 40, 35, 2, withLifecycle("informing"))
+	createCumulativeSummary(t, dbc, endMinus1, release, test.ID, jobHA.ID, suite.ID, 45, 39, 3, withLifecycle("informing"))
+
+	// Single job: blocking 20 runs (15 successes, 2 flakes), informing 8 runs in sample period
+	createCumulativeSummary(t, dbc, startMinus1, release, test.ID, jobSingle.ID, suite.ID, 50, 40, 3, withLifecycle("blocking"))
+	createCumulativeSummary(t, dbc, endMinus1, release, test.ID, jobSingle.ID, suite.ID, 70, 55, 5, withLifecycle("blocking"))
+	createCumulativeSummary(t, dbc, startMinus1, release, test.ID, jobSingle.ID, suite.ID, 20, 18, 1, withLifecycle("informing"))
+	createCumulativeSummary(t, dbc, endMinus1, release, test.ID, jobSingle.ID, suite.ID, 28, 25, 2, withLifecycle("informing"))
+
+	provider := postgres.NewPostgresProvider(dbc, nil)
+	opts := defaultReqOptions(release)
+	opts.Lifecycles = []string{"blocking"}
+	opts.VariantOption.DBGroupBy = sets.New[string]("Platform", "Topology")
+	opts.VariantOption.ColumnGroupBy = sets.New[string]("Platform")
+	opts.VariantOption.VariantCrossCompare = []string{"Topology"}
+	opts.VariantOption.CompareVariants = map[string][]string{"Topology": {"single"}}
+
+	includeVariants := map[string][]string{
+		"Platform": {"aws"},
+		"Topology": {"ha"},
+	}
+
+	result, errs := provider.QuerySampleTestStatus(context.Background(), opts, includeVariants,
+		opts.SampleRelease.Start, opts.SampleRelease.End)
+	require.Empty(t, errs)
+
+	nonPlaceholders := filterPlaceholders(result)
+	require.NotEmpty(t, nonPlaceholders, "should return results for cross-compare with lifecycle filter")
+	for _, ts := range nonPlaceholders {
+		assert.Equal(t, "single", ts.Variants["Topology"],
+			"should return sample-side (single) data, not base-side (ha)")
+		// Only blocking counts from the single job: 20 runs, 15 successes, 2 flakes
+		assert.Equal(t, 20, ts.TotalCount)
+		assert.Equal(t, 15, ts.SuccessCount)
+		assert.Equal(t, 2, ts.FlakeCount)
 	}
 }
 

--- a/test/integration/util/fixtures.go
+++ b/test/integration/util/fixtures.go
@@ -87,6 +87,47 @@ func CreateProwJobRunTest(t *testing.T, dbc *db.DB, prowJobRunID, prowJobID, tes
 	return pjrt
 }
 
+func CreateProwJobRunTestWithSuite(t *testing.T, dbc *db.DB, prowJobRunID, prowJobID, testID, suiteID uint, release string, timestamp time.Time, status int) models.ProwJobRunTest {
+	t.Helper()
+	pjrt := models.ProwJobRunTest{
+		ProwJobRunID:        prowJobRunID,
+		ProwJobID:           prowJobID,
+		TestID:              testID,
+		SuiteID:             &suiteID,
+		ProwJobRunRelease:   release,
+		ProwJobRunTimestamp: timestamp,
+		Status:              status,
+	}
+	require.NoError(t, dbc.DB.Create(&pjrt).Error, "creating ProwJobRunTest")
+	return pjrt
+}
+
+func CreateProwJobRunTestWithLifecycle(t *testing.T, dbc *db.DB, prowJobRunID, prowJobID, testID uint, release string, timestamp time.Time, status int, lifecycle string) models.ProwJobRunTest {
+	t.Helper()
+	pjrt := models.ProwJobRunTest{
+		ProwJobRunID:        prowJobRunID,
+		ProwJobID:           prowJobID,
+		TestID:              testID,
+		ProwJobRunRelease:   release,
+		ProwJobRunTimestamp: timestamp,
+		Status:              status,
+		Lifecycle:           lifecycle,
+	}
+	require.NoError(t, dbc.DB.Create(&pjrt).Error, "creating ProwJobRunTest")
+	return pjrt
+}
+
+func CreateReleaseDefinition(t *testing.T, dbc *db.DB, release string, major, minor int) models.ReleaseDefinition {
+	t.Helper()
+	rd := models.ReleaseDefinition{
+		Release: release,
+		Major:   major,
+		Minor:   minor,
+	}
+	require.NoError(t, dbc.DB.Create(&rd).Error, "creating ReleaseDefinition %q", release)
+	return rd
+}
+
 func CreateBug(t *testing.T, dbc *db.DB, key, status, summary string, lastChangeTime time.Time, jobs []models.ProwJob) models.Bug {
 	t.Helper()
 	bug := models.Bug{


### PR DESCRIPTION
@coderabbitai ignore

## Summary
- Adds `lifecycle` (blocking/informing) as a key column in `test_daily_totals` and `test_cumulative_summaries` (migration 000011)
- Updates daily and cumulative summary aggregation to group by lifecycle from `prow_job_run_tests`
- Fixes all self-joins on `test_cumulative_summaries` to include `AND x.lifecycle = y.lifecycle`, preventing cross-product inflation
- Replaces old indexes with covering unique indexes (INCLUDE all value columns) to enable index-only scans on self-join lookups used by CR queries (3M+ rows per partition, 2-3 self-joins per query)
- Changes `TestCumulativeSummary` GORM model from `primaryKey` to `uniqueIndex` tags (covering unique index cannot be a PK)
- Adds integration test verifying correct counts with mixed blocking/informing rows
- Updates AI chat tool schema docs and example queries

## Index strategy

The migration creates covering unique indexes with new names (`idx_test_daily_totals_key`, `idx_test_cumulative_summaries_key`) and drops the old indexes at the end. On large databases, the indexes should be built out-of-band before deploying the migration so the `IF NOT EXISTS` makes them no-ops.

**Prod indexes are already built (2026-08-02):**

| Step | Time |
|------|------|
| Add columns | 18s |
| `idx_test_daily_totals_key` (covering) | 33m 21s |
| `idx_test_cumulative_summaries_key` (covering) | 1h 46m 20s |

The migration itself completes in ~9 seconds with pre-built indexes.

`CREATE INDEX` on partitioned tables takes a SHARE lock (blocks writes, allows reads). User-facing queries were unaffected during the build. One fetchdata cronjob's cumulative summary refresh was blocked for ~1h while the cumulative summaries index was building, then completed normally.

## Staging validation

- Deployed branch to staging, ran migration (9.1s with pre-built indexes)
- Ran prow load against staging. Confirmed daily summary and cumulative summary refresh include lifecycle in INSERT, GROUP BY, FULL OUTER JOIN, and ON CONFLICT
- Verified API endpoints return 200 with real data after the lifecycle-aware refresh:

| Endpoint | Status | Response time |
|----------|--------|---------------|
| `/api/component_readiness?view=5.0-main` (PG) | 200 | 18.0s |
| `/api/component_readiness?view=4.19-main` (PG) | 200 | 3.5s |
| `/api/component_readiness/test_details` (5.0) | 200 | 10.2s |
| `/api/component_readiness/regressions?release=5.0` | 200 | 2.4s |
| `/api/tests?release=5.0` | 200 | 10.3s |
| `/api/tests/analysis/overall` | 200 | 0.25s |
| `/api/tests/analysis/variants` | 200 | 0.06s |
| `/api/tests/analysis/jobs` | 200 | 0.07s |
| `/api/health?release=4.19` | 200 | 0.45s |
| `/api/jobs?release=4.19` | 200 | 0.24s |

## Test plan
- [x] `make lint` passes
- [x] `go test ./pkg/...` passes
- [x] `make integration` passes (including new `TestMixedLifecycleRowsProduceCorrectCounts`)
- [x] `make e2e` passes
- [x] `make verify-migrations` passes
- [x] Staging deployment and prow load verified
- [x] Prod indexes pre-built

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle-aware handling for daily and cumulative test summaries.
  * Summary data now remains distinct for blocking and informing test lifecycles.
* **Bug Fixes**
  * Improved report, performance, component readiness, and feature-gate results by matching lifecycle-specific data consistently.
  * Prevented metrics from being mixed across different test lifecycles.
* **Database Updates**
  * Added an automatic migration to support lifecycle-specific summary records while preserving existing data defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->