### PR TITLE
Remove prow_ga_test_statuses_matview reintroduced by bad merge

### DIFF
--- a/pkg/db/views.go
+++ b/pkg/db/views.go
@@ -20,12 +20,6 @@ var PostgresMatViews = []PostgresView{
 		IndexColumns:      []string{"id"},
 		AdditionalIndexes: []string{"release, timestamp DESC"},
 	},
-	{
-		Name:         "prow_ga_test_statuses_matview",
-		Definition:   gaTestStatusMatView,
-		IndexColumns: []string{"release", "window_days", "test_id", "suite_id", "variant_combination_id"},
-		RefreshPhase: 1,
-	},
 }
 
 // PostgresViews are regular, non-materialized views:
@@ -220,19 +214,4 @@ FROM prow_job_runs
    LEFT JOIN pull_requests ON pull_requests.id = prow_job_runs.id
    JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id
 WHERE prow_job_runs."timestamp" >= |||TIMENOW||| - interval '90 days'
-`
-
-const gaTestStatusMatView = `
-SELECT
-    raw.test_id,
-    raw.suite_id,
-    pj.variant_combination_id,
-    raw.release,
-    raw.window_days,
-    SUM(raw.runs)::int AS total_count,
-    SUM(raw.passes + raw.flakes)::int AS success_count,
-    SUM(raw.flakes)::int AS flake_count
-FROM prow_ga_raw_test_data raw
-JOIN prow_jobs pj ON pj.id = raw.prow_job_id AND pj.deleted_at IS NULL AND pj.variant_combination_id IS NOT NULL
-GROUP BY raw.test_id, raw.suite_id, pj.variant_combination_id, raw.release, raw.window_days
 `


### PR DESCRIPTION
## Summary

- PR #3838 ([TRT-2814](https://redhat.atlassian.net/browse/TRT-2814)) was rebased onto main after `prow_ga_test_statuses_matview` had already been removed as unused in a prior commit (2a0a86e4).
- Instead of cleanly resolving the rebase conflict in `pkg/db/views.go`, the merge resurrected the old `prow_ga_test_statuses_matview` entry and its `gaTestStatusMatView` SQL definition, while removing `payload_test_failures_14d_matview` (the intended change).
- Net effect on `origin/main`: the matview that was already retired came back, unregistered but unused.
- This PR removes the `prow_ga_test_statuses_matview` entry and `gaTestStatusMatView` constant again, restoring the state intended by both prior PRs.

## Test plan

- [x] `go build ./pkg/db/...`
- [x] `go test ./pkg/db/...`
- [x] `golangci-lint run ./pkg/db/...` (0 issues)
- [x] Verified via `git grep` that no other file references `gaTestStatusMatView` or `prow_ga_test_statuses_matview`