### PR TITLE
Add OSD GCP operator e2e and HyperShift CI to ROSA releases

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -81,8 +81,10 @@ releases:
       - "^periodic-ci-openshift-release-main-nightly-.*-e2e-rosa-hcp-ovn$"
       # ROSA Classic/STS conformance (all versions)
       - "^periodic-ci-openshift-release-main-nightly-.*-e2e-rosa-sts-ovn$"
-      # SRE operator e2e tests via Prow (staging)
-      - "^periodic-ci-openshift-.*-master-rosa-sts-e2e-promotion-stage$"
+      # SRE operator e2e tests via Prow (staging, STS + GCP)
+      - "^periodic-ci-openshift-.*-(master|main)-(rosa-sts|osd-gcp)-e2e-promotion-stage$"
+      # HyperShift CI sector tests (staging)
+      - "^periodic-ci-openshift-online-rosa-e2e-main-hypershift-ci-.*-staging-.*"
       # ROSA CLI e2e tests
       - "^periodic-ci-openshift-rosa-master-e2e-rosa-.*"
       # Terraform provider RHCS e2e tests
@@ -92,8 +94,10 @@ releases:
     regexp:
       # OCM FVT integration
       - "^periodic-ci-openshift-online-rosa-e2e-main-ocm-fvt-.*-integration-.*"
-      # SRE operator e2e tests via Prow (integration)
-      - "^periodic-ci-openshift-.*-master-rosa-sts-e2e-promotion-int$"
+      # SRE operator e2e tests via Prow (integration, STS + GCP)
+      - "^periodic-ci-openshift-.*-(master|main)-(rosa-sts|osd-gcp)-e2e-promotion-int$"
+      # HyperShift CI sector tests (integration)
+      - "^periodic-ci-openshift-online-rosa-e2e-main-hypershift-ci-.*-integration-.*"
   rosa-production:
     synthetic: true
     jobs:


### PR DESCRIPTION
## Summary

Update rosa-stage and rosa-integration release regexps to capture new Prow jobs:

- **OSD GCP operator e2e**: `osd-gcp-e2e-promotion-int/stage` for RMO, CAMO, MUO, OAO, SFO (5 operators)
- **AVO branch fix**: AVO uses `main` not `master`, was excluded from the `-master-` regex
- **HyperShift CI**: New sector tests for integration and staging

Changes the operator e2e regexps from:
```
^periodic-ci-openshift-.*-master-rosa-sts-e2e-promotion-(int|stage)$
```
to:
```
^periodic-ci-openshift-.*-(master|main)-(rosa-sts|osd-gcp)-e2e-promotion-(int|stage)$
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated validation coverage for ROSA staging and integration workflows.
  * Added support for SRE operator end-to-end checks across supported branches and environments.
  * Added HyperShift CI sector test coverage for staging and integration scenarios.
  * Updated existing validation patterns to reflect current test configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->