### PR TITLE
Preserve original prow job names in PG provider

### DIFF
--- a/pkg/api/componentreadiness/dataprovider/postgres/provider.go
+++ b/pkg/api/componentreadiness/dataprovider/postgres/provider.go
@@ -458,7 +458,7 @@ WHERE pj.release = ?
 			TestKey:         key,
 			TestKeyStr:      key.Encode(),
 			TestName:        row.TestName,
-			ProwJob:         normalizedName,
+			ProwJob:         row.ProwJobName,
 			ProwJobRunID:    row.ProwJobRunID,
 			ProwJobURL:      row.ProwJobURL,
 			StartTime:       row.ProwJobStart,

--- a/test/integration/component_readiness_test.go
+++ b/test/integration/component_readiness_test.go
@@ -2129,6 +2129,13 @@ func TestJobNameNormalizationMergesResults(t *testing.T) {
 	rows, ok := result[normalizedKey]
 	require.True(t, ok, "both job runs should merge under normalized name %q", normalizedKey)
 	assert.Len(t, rows, 2, "both runs should appear under the normalized key")
+
+	prowJobs := sets.New[string]()
+	for _, r := range rows {
+		prowJobs.Insert(r.ProwJob)
+	}
+	assert.True(t, prowJobs.Has("periodic-ci-4.16-e2e-aws"), "original job name 4.16 should be preserved")
+	assert.True(t, prowJobs.Has("periodic-ci-4.17-e2e-aws"), "original job name 4.17 should be preserved")
 }
 
 func TestTestExistsInBaseButNotSample(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixed the PG data provider overwriting the `ProwJob` field on `TestJobRunRows` with the normalized name (`X.X`) instead of preserving the original version number (e.g., `4.22`). The BQ provider already preserved the original name correctly.
- The normalized name is only needed as the map key for cross-release grouping. The `ProwJob` field flows to the test details API response (displayed on the frontend) and into `RegressionJobRun` records, so it should retain the literal version number.
- Added integration test assertions verifying that original job names are preserved in result rows even when grouped under a normalized key.

## Test plan
- [x] `gofmt -w` on modified files
- [x] `go vet` passes
- [x] Unit tests pass (`go test ./pkg/api/componentreadiness/...`)
- [x] All 133 integration tests pass (`make integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the original test job names in component readiness results while continuing to combine equivalent versioned jobs correctly.
  * Improved result details so users can distinguish the specific job runs contributing to merged results.

* **Tests**
  * Added coverage validating result merging and preservation of original job names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->