### PR TITLE
TRT-2865: Add nested-podman integration test image for CI

### DIFF
--- a/Dockerfile.integration
+++ b/Dockerfile.integration
@@ -1,0 +1,22 @@
+# Extends the build root with nested-podman support for integration tests.
+# ci-operator replaces this FROM with the "src" image (build root + source).
+# For local builds: podman build --from sippy-buildroot -f Dockerfile.integration .
+FROM replaced-by-ci-operator
+
+RUN dnf install -y podman fuse-overlayfs shadow-utils && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+COPY scripts/nested-podman-entrypoint.sh /nested-podman-entrypoint.sh
+ENV BUILDAH_ISOLATION=chroot
+RUN chmod +rx /nested-podman-entrypoint.sh && \
+    chown 0:0 /etc/passwd /etc/group && \
+    chmod g=u /etc/passwd /etc/group && \
+    setcap cap_setuid+ep /usr/bin/newuidmap && \
+    setcap cap_setgid+ep /usr/bin/newgidmap && \
+    touch /etc/subgid /etc/subuid && \
+    chown 0:0 /etc/subgid /etc/subuid && \
+    chmod -R g=u /etc/subuid /etc/subgid
+
+ENTRYPOINT ["/usr/libexec/podman/catatonit", "--", "/nested-podman-entrypoint.sh"]
+CMD ["make", "integration"]

--- a/scripts/nested-podman-entrypoint.sh
+++ b/scripts/nested-podman-entrypoint.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -d "${HOME}" ]; then
+    mkdir -p "${HOME}"
+fi
+
+mkdir -p "${HOME}/.config/containers"
+
+if [ ! -f "${HOME}/.config/containers/registries.conf" ]; then
+    cat > "${HOME}/.config/containers/registries.conf" <<'REGISTRIES'
+unqualified-search-registries = [
+  "registry.access.redhat.com",
+  "registry.redhat.io",
+  "docker.io"
+]
+short-name-mode = "permissive"
+REGISTRIES
+fi
+
+if [ ! -f "${HOME}/.config/containers/storage.conf" ]; then
+    if [ -c "/dev/fuse" ] && [ -f "/usr/bin/fuse-overlayfs" ]; then
+        cat > "${HOME}/.config/containers/storage.conf" <<'STORAGE'
+[storage]
+driver = "overlay"
+graphroot = "/tmp/graphroot"
+[storage.options.overlay]
+mount_program = "/usr/bin/fuse-overlayfs"
+STORAGE
+    else
+        cat > "${HOME}/.config/containers/storage.conf" <<'STORAGE'
+[storage]
+driver = "vfs"
+STORAGE
+    fi
+fi
+
+# Handle OpenShift's random UID (add /etc/passwd entry if unmapped)
+if ! whoami &> /dev/null; then
+    if [ -w /etc/passwd ]; then
+        echo "${USER_NAME:-user}:x:$(id -u):0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
+        echo "${USER_NAME:-user}:x:$(id -u):" >> /etc/group
+    fi
+fi
+
+# Configure subuid/subgid for rootless podman user namespaces.
+# ci-operator pods with hostUsers:false map only 65536 UIDs (0-65535).
+# The default rootless range (100000:65536) falls outside that, so
+# newuidmap/newgidmap fail with EPERM. Compute a range that fits.
+USER_NAME="$(whoami)"
+SUBID_START_DEFAULT=$(( $(id -u) + 1 ))
+SUBID_COUNT_DEFAULT=$(( 65536 - SUBID_START_DEFAULT ))
+if (( SUBID_COUNT_DEFAULT <= 0 )); then
+    SUBID_START_DEFAULT=100000
+    SUBID_COUNT_DEFAULT=65536
+fi
+SUBID_START="${SUBID_START:-$SUBID_START_DEFAULT}"
+SUBID_COUNT="${SUBID_COUNT:-$SUBID_COUNT_DEFAULT}"
+echo "${USER_NAME}:${SUBID_START}:${SUBID_COUNT}" > /etc/subuid
+echo "${USER_NAME}:${SUBID_START}:${SUBID_COUNT}" > /etc/subgid
+
+# Start the podman API socket service. testcontainers-go communicates
+# via the Docker HTTP API over a unix socket. Rootless podman does not
+# listen on a socket by default.
+PODMAN_SOCKET_DIR="${XDG_RUNTIME_DIR:-/tmp}/podman"
+mkdir -p "${PODMAN_SOCKET_DIR}"
+PODMAN_SOCKET="${PODMAN_SOCKET_DIR}/podman.sock"
+podman system service "unix://${PODMAN_SOCKET}" --time=0 &
+
+for _ in $(seq 1 30); do
+    if [ -S "${PODMAN_SOCKET}" ]; then
+        break
+    fi
+    sleep 0.1
+done
+
+if [ ! -S "${PODMAN_SOCKET}" ]; then
+    echo "ERROR: podman socket did not appear at ${PODMAN_SOCKET}" >&2
+    exit 1
+fi
+
+export DOCKER_HOST="unix://${PODMAN_SOCKET}"
+export TESTCONTAINERS_RYUK_DISABLED=true
+
+exec "$@"


### PR DESCRIPTION
## Summary

- Adds `Dockerfile.integration` that layers podman, fuse-overlayfs, and shadow-utils on top of the build root for running integration tests in CI with nested podman
- Adds `scripts/nested-podman-entrypoint.sh` that configures rootless podman (storage, registries, subuid/subgid, OpenShift random UID handling) and starts the podman API socket service so testcontainers-go can connect
- No changes to integration test code; testcontainers-go works as-is once `DOCKER_HOST` points at the podman socket

The corresponding ci-operator config change (in openshift/release) will reference this Dockerfile with `from: src` and add an integration test job with `capabilities: [nested-podman]` and `nested_podman: true`.

## Test plan

- [x] Built buildroot image locally (`podman build -f Dockerfile.buildroot`)
- [x] Built integration image on top (`podman build --from sippy-buildroot -f Dockerfile.integration`)
- [x] Verified `make integration` starts successfully inside the container with `--privileged`
- [ ] CI rehearsal in openshift/release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a containerized integration-test environment with nested rootless container support.
  * Improved integration test startup and configuration, including Podman API readiness and Docker-compatible test settings.
  * Added support for dynamic user and group mappings in hosted CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->