### PR TITLE
Add lifecycle filter to the Tests page

### DIFF
--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -466,6 +466,14 @@ Endpoint: `/api/tests`
 | sort     | asc / desc     | Sort type, ascending or descending                                                        | "asc" or "desc"                                     |
 | limit    | Integer        | The maximum amount of results to return                                                   | N/A                                                 |
 
+`filter` supports a `lifecycle` field (`equals` or `!=` operators only; other operators return a
+400) to restrict results to a test lifecycle (`blocking` or `informing`). It narrows which
+underlying test runs are aggregated; it is not returned as a field on results, and
+blocking/informing runs for the same test are combined into a single row when no lifecycle filter
+is applied. This filter is only supported against the Postgres-backed report (`/api/tests`); using
+it against `/api/tests/v2` (BigQuery) returns a 400, since the underlying BigQuery comparison
+tables don't carry a lifecycle column.
+
 <details>
 <summary>Example response</summary>
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -9,6 +9,8 @@ import (
 	"github.com/jackc/pgconn"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/googleapi"
+
+	"github.com/openshift/sippy/pkg/filter"
 )
 
 func RespondWithJSON(statusCode int, w http.ResponseWriter, data interface{}) {
@@ -66,6 +68,9 @@ func IsBadRequestError(err error) bool {
 	var apiErr *googleapi.Error
 	if errors.As(err, &apiErr) && apiErr.Code == http.StatusBadRequest &&
 		len(apiErr.Errors) > 0 && apiErr.Errors[0].Reason == bqInvalidQuery {
+		return true
+	}
+	if errors.Is(err, filter.ErrUnsupportedOperator) {
 		return true
 	}
 	return false

--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -439,11 +439,13 @@ func (spec *TestResultsSpec) buildTestsResultsFromPostgres(ctx context.Context, 
 func (spec *TestResultsSpec) buildTestsResultsPGGenerator(ctx context.Context, dbc *db.DB, sample, base query.DateRange) (result testResults, errs []error) {
 	now := time.Now()
 
-	var nameFilter, variantFilter, processedFilter *filter.Filter
+	var nameFilter, variantFilter, processedFilter, lifecycleFilter *filter.Filter
 	if spec.Filter != nil {
-		var rawFilter *filter.Filter
-		rawFilter, processedFilter = spec.Filter.Split([]string{"name", "variants"})
-		nameFilter, variantFilter = rawFilter.Split([]string{"name"})
+		var nameVariantsAndLifecycle *filter.Filter
+		nameVariantsAndLifecycle, processedFilter = spec.Filter.Split([]string{"name", "variants", "lifecycle"})
+		var variantsAndLifecycle *filter.Filter
+		nameFilter, variantsAndLifecycle = nameVariantsAndLifecycle.Split([]string{"name"})
+		variantFilter, lifecycleFilter = variantsAndLifecycle.Split([]string{"variants"})
 	}
 
 	testMetadataColumns := []string{"suite_name", "name", "jira_component", "jira_component_id"}
@@ -453,7 +455,7 @@ func (spec *TestResultsSpec) buildTestsResultsPGGenerator(ctx context.Context, d
 	if spec.Collapse {
 		workMem = "16MB"
 
-		collapsedQuery, err := query.TestReportQueryCollapsed(dbc, spec.Release, sample, base, variantFilter, nameFilter)
+		collapsedQuery, err := query.TestReportQueryCollapsed(dbc, spec.Release, sample, base, variantFilter, nameFilter, lifecycleFilter)
 		if err != nil {
 			errs = append(errs, err)
 			return
@@ -471,7 +473,7 @@ func (spec *TestResultsSpec) buildTestsResultsPGGenerator(ctx context.Context, d
 			Where("current_runs > 0 or previous_runs > 0")
 		finalResults = dbc.DB.Table("(?) as final_results", processedResults)
 	} else {
-		rawQuery, remainingFilter, err := query.UncollapsedTestReportWithStats(dbc, spec.Release, sample, base, nameFilter, variantFilter, processedFilter)
+		rawQuery, remainingFilter, err := query.UncollapsedTestReportWithStats(dbc, spec.Release, sample, base, nameFilter, variantFilter, processedFilter, lifecycleFilter)
 		if err != nil {
 			errs = append(errs, err)
 			return
@@ -588,7 +590,17 @@ func (spec *TestResultsSpec) buildTestsResultsBQGenerator(ctx context.Context, b
 	// assembled our final temporary table.
 	var rawFilter, processedFilter *filter.Filter
 	if spec.Filter != nil {
-		rawFilter, processedFilter = spec.Filter.Split([]string{"name", "variants"})
+		var lifecycleFilter *filter.Filter
+		lifecycleFilter, processedFilter = spec.Filter.Split([]string{"lifecycle"})
+		if len(lifecycleFilter.Items) > 0 {
+			// junit_7day_comparison/junit_2day_comparison are materialized BigQuery tables
+			// populated outside this repo and have no lifecycle column, unlike the Postgres
+			// cumulative summary tables. Fail clearly rather than silently ignoring the filter.
+			return testResultsBQ{}, []error{&ValidationError{
+				Message: "lifecycle filter is not supported for the BigQuery-backed tests report",
+			}}
+		}
+		rawFilter, processedFilter = processedFilter.Split([]string{"name", "variants"})
 	}
 	table := "junit_7day_comparison"
 	if spec.Period == "twoDay" {

--- a/pkg/api/tests_test.go
+++ b/pkg/api/tests_test.go
@@ -1,9 +1,13 @@
 package api
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
+	"github.com/openshift/sippy/pkg/filter"
 )
 
 func TestComputeOverallTest(t *testing.T) {
@@ -148,5 +152,50 @@ func assertFloat(t *testing.T, name string, got, want float64) {
 	t.Helper()
 	if got != want {
 		t.Errorf("%s = %f, want %f", name, got, want)
+	}
+}
+
+// TestBuildTestsResultsBQGenerator_RejectsLifecycleFilter guards the /api/tests/v2
+// (BigQuery-backed) 400 response: the underlying junit_7day_comparison/
+// junit_2day_comparison tables have no lifecycle column, so a lifecycle filter must be
+// rejected explicitly rather than silently ignored. This never reaches bqc, so passing
+// nil is safe.
+func TestBuildTestsResultsBQGenerator_RejectsLifecycleFilter(t *testing.T) {
+	spec := &TestResultsSpec{
+		Release: "4.16",
+		Filter: &filter.Filter{Items: []filter.FilterItem{
+			{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "blocking"},
+		}},
+	}
+
+	_, errs := spec.buildTestsResultsBQGenerator(context.Background(), nil)
+	if len(errs) != 1 {
+		t.Fatalf("errs = %v, want exactly one error", errs)
+	}
+	var validationErr *ValidationError
+	if !errors.As(errs[0], &validationErr) {
+		t.Fatalf("errs[0] = %v (%T), want *ValidationError so it surfaces as HTTP 400", errs[0], errs[0])
+	}
+	if !strings.Contains(validationErr.Message, "lifecycle") {
+		t.Errorf("validation message = %q, want it to mention lifecycle", validationErr.Message)
+	}
+}
+
+func TestBuildTestsResultsBQGenerator_RejectsLifecycleFilterAlongsideOtherFilters(t *testing.T) {
+	spec := &TestResultsSpec{
+		Release: "4.16",
+		Filter: &filter.Filter{Items: []filter.FilterItem{
+			{Field: "name", Operator: filter.OperatorContains, Value: "network"},
+			{Field: "lifecycle", Operator: filter.OperatorArithmeticNotEquals, Value: "informing"},
+		}},
+	}
+
+	_, errs := spec.buildTestsResultsBQGenerator(context.Background(), nil)
+	if len(errs) != 1 {
+		t.Fatalf("errs = %v, want exactly one error", errs)
+	}
+	var validationErr *ValidationError
+	if !errors.As(errs[0], &validationErr) {
+		t.Fatalf("errs[0] = %v (%T), want *ValidationError", errs[0], errs[0])
 	}
 }

--- a/pkg/db/query/cumulative_query.go
+++ b/pkg/db/query/cumulative_query.go
@@ -205,6 +205,57 @@ func variantFilterConditions(variantFilter *filter.Filter) (conditions []string,
 	return conditions, args
 }
 
+// lifecycleWhereClause returns a single ready-to-AND-in SQL fragment (e.g. "e.lifecycle = ?",
+// or for multiple items a parenthesized "(e.lifecycle = ? OR e.lifecycle <> ?)") applying
+// lifecycleFilter against columnRef (a qualified reference to the "lifecycle" column on
+// test_cumulative_summaries, e.g. "e.lifecycle" or "tcs.lifecycle"). A qualifier is required
+// because test_cumulative_summaries is self-joined (aliased e/m/s) in the uncollapsed path,
+// where an unqualified "lifecycle" would be ambiguous. Unlike variant filters, this clause
+// must be applied before aggregation: lifecycle is not part of the GROUP BY in
+// TestReportQueryCollapsed/UncollapsedTestReportWithStats, so it is summed away once rows
+// reach the outer query. Returns an empty string when there's nothing to filter.
+//
+// Multiple items are joined per lifecycleFilter.LinkOperator (OR when explicitly "or", AND
+// otherwise): naively ANDing regardless of LinkOperator would make an OR-linked filter like
+// "blocking OR informing" into an unsatisfiable "lifecycle = 'blocking' AND lifecycle =
+// 'informing'", since a row has exactly one lifecycle value, silently returning zero rows.
+//
+// Only equals/not-equals are supported, matching the fixed dropdown of known values
+// (blocking/informing) the frontend restricts this filter to. Any other operator is
+// rejected rather than silently ignored, since a filter that appears to apply but
+// doesn't would return unfiltered results without any indication of the problem.
+func lifecycleWhereClause(lifecycleFilter *filter.Filter, columnRef string) (clause string, args []any, err error) {
+	if lifecycleFilter == nil || len(lifecycleFilter.Items) == 0 {
+		return "", nil, nil
+	}
+	var conditions []string
+	for _, item := range lifecycleFilter.Items {
+		var op string
+		switch item.Operator {
+		case filter.OperatorEquals, filter.OperatorArithmeticEquals:
+			op = "="
+		case filter.OperatorArithmeticNotEquals:
+			op = "<>"
+		default:
+			return "", nil, fmt.Errorf("%w: lifecycle filter only supports equals/not-equals, got %q", filter.ErrUnsupportedOperator, item.Operator)
+		}
+		cond := fmt.Sprintf("%s %s ?", columnRef, op)
+		if item.Not {
+			cond = negateConditions([]string{cond})[0]
+		}
+		conditions = append(conditions, cond)
+		args = append(args, item.Value)
+	}
+	if len(conditions) == 1 {
+		return conditions[0], args, nil
+	}
+	joiner := " AND "
+	if lifecycleFilter.LinkOperator == filter.LinkOperatorOr {
+		joiner = " OR "
+	}
+	return "(" + strings.Join(conditions, joiner) + ")", args, nil
+}
+
 // pushdownSafeFields lists columns available in the filtered CTE (before the
 // stats join). Only these fields can be pushed into post_filtered; stats-derived
 // fields like working_average and delta_from_* exist only after the final SELECT
@@ -346,13 +397,17 @@ func testReportPreAgg(dbc *db.DB, release string, sample, base DateRange, nameMa
 // It aggregates prefix sums per date partition separately (~16K groups each), then joins
 // the three small results to compute period counts. This avoids the expensive 3-way
 // self-join on all ~1.8M per-prow_job rows that the uncollapsed path requires.
-func TestReportQueryCollapsed(dbc *db.DB, release string, sample, base DateRange, variantFilter, nameFilter *filter.Filter) (*gorm.DB, error) {
+func TestReportQueryCollapsed(dbc *db.DB, release string, sample, base DateRange, variantFilter, nameFilter, lifecycleFilter *filter.Filter) (*gorm.DB, error) {
 	end, boundary, start, err := resolvePrefixSumDates(dbc, release, &sample, &base)
 	if err != nil {
 		return nil, err
 	}
 	nameConds, nameArgs := nameFilterConditions(nameFilter)
 	variantConds, variantArgs := variantFilterConditions(variantFilter)
+	lifecycleClause, lifecycleArgs, err := lifecycleWhereClause(lifecycleFilter, "tcs.lifecycle")
+	if err != nil {
+		return nil, err
+	}
 
 	var nameJoinClause string
 	var nameJoinArgs []any
@@ -391,6 +446,12 @@ func TestReportQueryCollapsed(dbc *db.DB, release string, sample, base DateRange
 			buf.WriteString(cond)
 		}
 		args = append(args, variantArgs...)
+
+		if lifecycleClause != "" {
+			buf.WriteString("\n    AND ")
+			buf.WriteString(lifecycleClause)
+		}
+		args = append(args, lifecycleArgs...)
 
 		fmt.Fprintf(&buf, "\n  GROUP BY tcs.test_id, tcs.suite_id, tcs.release\n) AS %s", alias)
 	}

--- a/pkg/db/query/cumulative_query_test.go
+++ b/pkg/db/query/cumulative_query_test.go
@@ -1,6 +1,8 @@
 package query
 
 import (
+	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -179,6 +181,146 @@ func TestNameFilterConditions(t *testing.T) {
 				if got, ok := args[0].(string); !ok || got != tc.wantFirstArg {
 					t.Errorf("args[0] = %v, want %q", args[0], tc.wantFirstArg)
 				}
+			}
+		})
+	}
+}
+
+func TestLifecycleWhereClause(t *testing.T) {
+	tests := []struct {
+		name       string
+		filter     *filter.Filter
+		wantClause string
+		wantArgs   []any
+		wantErr    bool
+	}{
+		{
+			name:       "nil filter",
+			filter:     nil,
+			wantClause: "",
+		},
+		{
+			name:       "empty items",
+			filter:     &filter.Filter{Items: []filter.FilterItem{}},
+			wantClause: "",
+		},
+		{
+			name: "equals",
+			filter: &filter.Filter{Items: []filter.FilterItem{
+				{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "blocking"},
+			}},
+			wantClause: "e.lifecycle = ?",
+			wantArgs:   []any{"blocking"},
+		},
+		{
+			name: "arithmetic equals",
+			filter: &filter.Filter{Items: []filter.FilterItem{
+				{Field: "lifecycle", Operator: filter.OperatorArithmeticEquals, Value: "informing"},
+			}},
+			wantClause: "e.lifecycle = ?",
+			wantArgs:   []any{"informing"},
+		},
+		{
+			name: "negative equals",
+			filter: &filter.Filter{Items: []filter.FilterItem{
+				{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "informing", Not: true},
+			}},
+			wantClause: "NOT(e.lifecycle = ?)",
+			wantArgs:   []any{"informing"},
+		},
+		{
+			name: "not equals",
+			filter: &filter.Filter{Items: []filter.FilterItem{
+				{Field: "lifecycle", Operator: filter.OperatorArithmeticNotEquals, Value: "blocking"},
+			}},
+			wantClause: "e.lifecycle <> ?",
+			wantArgs:   []any{"blocking"},
+		},
+		{
+			name: "negated not equals",
+			filter: &filter.Filter{Items: []filter.FilterItem{
+				{Field: "lifecycle", Operator: filter.OperatorArithmeticNotEquals, Value: "informing", Not: true},
+			}},
+			wantClause: "NOT(e.lifecycle <> ?)",
+			wantArgs:   []any{"informing"},
+		},
+		{
+			name: "multiple items default to AND",
+			filter: &filter.Filter{Items: []filter.FilterItem{
+				{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "blocking"},
+				{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "informing"},
+			}},
+			wantClause: "(e.lifecycle = ? AND e.lifecycle = ?)",
+			wantArgs:   []any{"blocking", "informing"},
+		},
+		{
+			name: "multiple items with explicit AND",
+			filter: &filter.Filter{
+				LinkOperator: filter.LinkOperatorAnd,
+				Items: []filter.FilterItem{
+					{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "blocking"},
+					{Field: "lifecycle", Operator: filter.OperatorArithmeticNotEquals, Value: "informing"},
+				},
+			},
+			wantClause: "(e.lifecycle = ? AND e.lifecycle <> ?)",
+			wantArgs:   []any{"blocking", "informing"},
+		},
+		{
+			// This is the case the OR-linked bug affected: selecting both lifecycles via
+			// two "equals" items must produce a union, not an unsatisfiable AND.
+			name: "multiple items with OR",
+			filter: &filter.Filter{
+				LinkOperator: filter.LinkOperatorOr,
+				Items: []filter.FilterItem{
+					{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "blocking"},
+					{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "informing"},
+				},
+			},
+			wantClause: "(e.lifecycle = ? OR e.lifecycle = ?)",
+			wantArgs:   []any{"blocking", "informing"},
+		},
+		{
+			name: "starts with is rejected",
+			filter: &filter.Filter{Items: []filter.FilterItem{
+				{Field: "lifecycle", Operator: filter.OperatorStartsWith, Value: "block"},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "contains is rejected",
+			filter: &filter.Filter{Items: []filter.FilterItem{
+				{Field: "lifecycle", Operator: filter.OperatorContains, Value: "lock"},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "ends with is rejected",
+			filter: &filter.Filter{Items: []filter.FilterItem{
+				{Field: "lifecycle", Operator: filter.OperatorEndsWith, Value: "ing"},
+			}},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clause, args, err := lifecycleWhereClause(tc.filter, "e.lifecycle")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+				if !errors.Is(err, filter.ErrUnsupportedOperator) {
+					t.Errorf("err = %v, want wrapped filter.ErrUnsupportedOperator", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if clause != tc.wantClause {
+				t.Errorf("clause = %q, want %q", clause, tc.wantClause)
+			}
+			if !slices.Equal(args, tc.wantArgs) {
+				t.Errorf("args = %v, want %v", args, tc.wantArgs)
 			}
 		})
 	}

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -252,7 +252,7 @@ func LoadBugsForTest(dbc *db.DB, testName string, filterClosed bool) ([]models.B
 //
 // Any processedFilter items with unsupported operators (ILIKE, array membership) are
 // returned as remainingFilter for the caller to apply via GORM on the outer query.
-func UncollapsedTestReportWithStats(dbc *db.DB, release string, sample, base DateRange, nameFilter, variantFilter, processedFilter *filter.Filter) (*gorm.DB, *filter.Filter, error) {
+func UncollapsedTestReportWithStats(dbc *db.DB, release string, sample, base DateRange, nameFilter, variantFilter, processedFilter, lifecycleFilter *filter.Filter) (*gorm.DB, *filter.Filter, error) {
 	end, boundary, start, err := resolvePrefixSumDates(dbc, release, &sample, &base)
 	if err != nil {
 		return nil, nil, err
@@ -273,6 +273,10 @@ func UncollapsedTestReportWithStats(dbc *db.DB, release string, sample, base Dat
 	}
 
 	variantConds, variantArgs := variantFilterConditions(variantFilter)
+	lifecycleClause, lifecycleArgs, err := lifecycleWhereClause(lifecycleFilter, "e.lifecycle")
+	if err != nil {
+		return nil, nil, err
+	}
 	pfConds, pfArgs, remainingFilter := processedFilterConditions(processedFilter)
 
 	// === filtered CTE: per-variant test report with percentages ===
@@ -309,7 +313,16 @@ func UncollapsedTestReportWithStats(dbc *db.DB, release string, sample, base Dat
 		args = append(args, nameJoinArgs...)
 	}
 
-	buf.WriteString(`    WHERE e.date = ? AND e.release = ?
+	buf.WriteString(`    WHERE e.date = ? AND e.release = ?`)
+	args = append(args, end, release)
+
+	if lifecycleClause != "" {
+		buf.WriteString("\n    AND ")
+		buf.WriteString(lifecycleClause)
+	}
+	args = append(args, lifecycleArgs...)
+
+	buf.WriteString(`
     GROUP BY e.test_id, e.suite_id, pj.variant_combination_id, e.release
   ) AS pre
   JOIN tests ON tests.id = pre.test_id
@@ -322,7 +335,6 @@ func UncollapsedTestReportWithStats(dbc *db.DB, release string, sample, base Dat
   ) AS ob ON tests.id = ob.test_id
   WHERE NOT EXISTS (SELECT 1 FROM variant_combinations WHERE 'never-stable' = any(variants) AND id = variant_combination_id)
     AND (current_runs > 0 OR previous_runs > 0)`)
-	args = append(args, end, release)
 
 	for _, cond := range variantConds {
 		buf.WriteString("\n    AND ")
@@ -349,6 +361,18 @@ post_filtered AS MATERIALIZED (
 		args = append(args, pfArgs...)
 	}
 
+	// Re-apply the lifecycle filter here: without it, stats would average in
+	// rows from lifecycles the caller excluded from the filtered/post_filtered CTE,
+	// since only test_id (not lifecycle) scopes this subquery to that CTE's contents.
+	// Reusing lifecycleClause verbatim (built above against "e.lifecycle") is only valid
+	// because this stats subquery also aliases test_cumulative_summaries as "e" (see the
+	// FROM clause a few lines down) -- if that alias ever changes independently of the
+	// "pre" subquery's, this reused clause must be rebuilt against the new alias too.
+	statsLifecycleClause := ""
+	if lifecycleClause != "" {
+		statsLifecycleClause = "AND " + lifecycleClause
+	}
+
 	// === stats CTE: AVG/STDDEV across all variant combinations per (test_id, suite_id),
 	// scoped to test_ids from the filtered/post_filtered CTE. Uses a 2-way prefix sum
 	// join (current period only) since base-period counts are not needed for
@@ -373,11 +397,13 @@ stats AS (
     WHERE e.date = ? AND e.release = ?
       AND e.test_id IN (SELECT DISTINCT test_id FROM %s)
       AND NOT EXISTS (SELECT 1 FROM variant_combinations WHERE 'never-stable' = any(variants) AND id = pj.variant_combination_id)
+      %s
     GROUP BY e.test_id, e.suite_id, pj.variant_combination_id
   ) c
   GROUP BY c.test_id, c.suite_id
-)`, statsSource)
+)`, statsSource, statsLifecycleClause)
 	args = append(args, boundary, end, release)
+	args = append(args, lifecycleArgs...)
 
 	// === Final SELECT: join filtered/post_filtered rows with their cross-variant statistics ===
 	fmt.Fprintf(&buf, `

--- a/pkg/filter/filterable.go
+++ b/pkg/filter/filterable.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -47,6 +48,13 @@ const (
 	OperatorArithmeticLessThan            Operator = "<"
 	OperatorArithmeticLessThanOrEquals    Operator = "<="
 )
+
+// ErrUnsupportedOperator indicates a filter item used an operator that isn't valid for its
+// field. Callers building hand-rolled SQL for a specific field (rather than going through
+// Filter.ToSQL's Filterable-driven dispatch) can wrap this with field-specific context via
+// fmt.Errorf("%w: ...", ErrUnsupportedOperator) so API handlers can classify it as a client
+// error (400) rather than an internal failure.
+var ErrUnsupportedOperator = errors.New("unsupported filter operator")
 
 // Filter is a collection of FilterItem, with a link operator. It is used to chain
 // filters together, for example: where name contains aws and runs > 10.

--- a/sippy-ng/src/datagrid/GridToolbarFilterItem.jsx
+++ b/sippy-ng/src/datagrid/GridToolbarFilterItem.jsx
@@ -53,6 +53,7 @@ export default function GridToolbarFilterItem(props) {
   let release = ''
   let disabled = false
   let valueGetter = null
+  let values = null
   props.columns.forEach((col) => {
     if (col.field === props.filterModel.columnField) {
       columnType = col.type || 'string'
@@ -60,8 +61,14 @@ export default function GridToolbarFilterItem(props) {
       release = col.release || ''
       disabled = col.disabled || false
       valueGetter = col.valueGetter || null
+      values = col.values || null
     }
   })
+
+  // Columns with a fixed set of "values" are rendered as a strict dropdown
+  // instead of a free-text/autocomplete field, and only support equals/not-equals
+  // since there's nothing meaningful to contain/start with/end with.
+  const operators = values ? ['equals', '!='] : operatorValues[columnType]
 
   const updateColumnField = (e) => {
     props.setFilterModel({
@@ -85,6 +92,40 @@ export default function GridToolbarFilterItem(props) {
       props.filterModel.operatorValue === 'is not empty'
     ) {
       return ''
+    }
+
+    if (values) {
+      return (
+        <Fragment>
+          <InputLabel id={`valueLabel-${props.id}`}>Value</InputLabel>
+          <Select
+            variant="standard"
+            disabled={disabled}
+            inputProps={{ 'data-testid': `value-${props.id}` }}
+            error={valueError}
+            value={props.filterModel.value}
+            onChange={(e) =>
+              props.setFilterModel({
+                columnField: props.filterModel.columnField,
+                not: props.filterModel.not,
+                operatorValue: props.filterModel.operatorValue,
+                value: e.target.value,
+              })
+            }
+            className={classes.selector}
+            labelId={`valueLabel-${props.id}`}
+            id={`value-${props.id}`}
+            autoWidth
+          >
+            {values.map((value) => (
+              <MenuItem key={value} value={value}>
+                {value}
+              </MenuItem>
+            ))}
+          </Select>
+          <FormHelperText error={valueError}>Required</FormHelperText>
+        </Fragment>
+      )
     }
 
     switch (columnType) {
@@ -275,7 +316,7 @@ export default function GridToolbarFilterItem(props) {
           id={`operatorValue-${props.id}`}
           autoWidth
         >
-          {operatorValues[columnType].map((operator, index) => (
+          {operators.map((operator, index) => (
             <MenuItem key={'operator-' + index} value={operator}>
               {operator}
             </MenuItem>
@@ -307,6 +348,7 @@ GridToolbarFilterItem.propTypes = {
       autocomplete: PropTypes.string,
       release: PropTypes.string,
       disabled: PropTypes.bool,
+      values: PropTypes.arrayOf(PropTypes.string),
     }).isRequired
   ),
   autocompleteData: PropTypes.array,

--- a/sippy-ng/src/datagrid/GridToolbarFilterItem.test.jsx
+++ b/sippy-ng/src/datagrid/GridToolbarFilterItem.test.jsx
@@ -1,0 +1,73 @@
+import '@testing-library/jest-dom'
+import { createTheme, ThemeProvider } from '@mui/material/styles'
+import { render, screen } from '@testing-library/react'
+import GridToolbarFilterItem from './GridToolbarFilterItem'
+import React from 'react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('./GridToolbarAutocomplete', () => ({ default: () => null }))
+vi.mock('./GridToolbarClientAutocomplete', () => ({ default: () => null }))
+
+const theme = createTheme()
+
+const lifecycleColumn = {
+  field: 'lifecycle',
+  headerName: 'Lifecycle',
+  values: ['blocking', 'informing'],
+}
+
+function renderItem(props = {}) {
+  const defaults = {
+    id: 0,
+    columns: [lifecycleColumn],
+    filterModel: {
+      columnField: 'lifecycle',
+      operatorValue: 'equals',
+      value: '',
+      not: false,
+    },
+    setFilterModel: vi.fn(),
+    destroy: vi.fn(),
+  }
+  return render(
+    <ThemeProvider theme={theme}>
+      <GridToolbarFilterItem {...defaults} {...props} />
+    </ThemeProvider>
+  )
+}
+
+describe('GridToolbarFilterItem values-restricted column', () => {
+  it('restricts the operator dropdown to equals/not-equals', async () => {
+    renderItem()
+    await userEvent.click(screen.getByLabelText('Operator'))
+    const options = screen.getAllByRole('option')
+    expect(options.map((o) => o.textContent)).toEqual(['equals', '!='])
+  })
+
+  it('renders a fixed dropdown of the configured values', async () => {
+    renderItem()
+    await userEvent.click(screen.getByLabelText('Value'))
+    const options = screen.getAllByRole('option')
+    expect(options.map((o) => o.textContent)).toEqual(['blocking', 'informing'])
+  })
+
+  it('propagates the Not checkbox alongside the != operator', async () => {
+    const setFilterModel = vi.fn()
+    renderItem({
+      filterModel: {
+        columnField: 'lifecycle',
+        operatorValue: '!=',
+        value: 'blocking',
+        not: false,
+      },
+      setFilterModel,
+    })
+    await userEvent.click(screen.getByTestId('not-0'))
+    expect(setFilterModel).toHaveBeenCalledWith({
+      columnField: 'lifecycle',
+      not: true,
+      operatorValue: '!=',
+      value: 'blocking',
+    })
+  })
+})

--- a/sippy-ng/src/tests/TestTable.jsx
+++ b/sippy-ng/src/tests/TestTable.jsx
@@ -844,6 +844,11 @@ function TestTable(props) {
       },
     },
     // These are here just to allow filtering
+    lifecycle: {
+      field: 'lifecycle',
+      headerName: 'Lifecycle',
+      values: ['blocking', 'informing'],
+    },
     current_runs: {
       field: 'current_runs',
       headerName: 'Current runs',

--- a/test/integration/component_readiness_test.go
+++ b/test/integration/component_readiness_test.go
@@ -29,37 +29,25 @@ func crTestDB(t *testing.T) *db.DB {
 	return intutil.NewTestDB(t, pgContainer)
 }
 
+// createVariantCombination, createProwJobWithVC, createTestOwnership, and
+// createCumulativeSummary below are thin delegates to the shared intutil fixture helpers,
+// kept as file-local wrappers (same names/signatures as before) so the ~250 call sites in
+// this file didn't need to change. The actual row-creation logic lives once in
+// test/integration/util/fixtures.go, shared with test/integration/tests_report_test.go.
+
 func createVariantCombination(t *testing.T, dbc *db.DB, variants []string) models.VariantCombination {
 	t.Helper()
-	vc := models.VariantCombination{Variants: pq.StringArray(variants)}
-	require.NoError(t, dbc.DB.Create(&vc).Error)
-	return vc
+	return intutil.CreateVariantCombination(t, dbc, variants)
 }
 
 func createProwJobWithVC(t *testing.T, dbc *db.DB, name, release string, vc models.VariantCombination) models.ProwJob {
 	t.Helper()
-	job := models.ProwJob{
-		Name:                 name,
-		Release:              release,
-		Variants:             vc.Variants,
-		VariantCombinationID: &vc.ID,
-	}
-	require.NoError(t, dbc.DB.Create(&job).Error)
-	return job
+	return intutil.CreateProwJobWithOptions(t, dbc, name, release, nil, intutil.WithVariantCombination(vc))
 }
 
 func createTestOwnership(t *testing.T, dbc *db.DB, testID uint, suiteID *uint, uniqueID, component string, caps []string) models.TestOwnership {
 	t.Helper()
-	tow := models.TestOwnership{
-		TestID:       testID,
-		SuiteID:      suiteID,
-		UniqueID:     uniqueID,
-		Name:         uniqueID,
-		Component:    component,
-		Capabilities: pq.StringArray(caps),
-	}
-	require.NoError(t, dbc.DB.Create(&tow).Error)
-	return tow
+	return intutil.CreateTestOwnership(t, dbc, testID, suiteID, uniqueID, component, intutil.WithTestOwnershipCapabilities(caps))
 }
 
 type cumulativeSummaryOpts struct {
@@ -93,24 +81,17 @@ func createCumulativeSummary(t *testing.T, dbc *db.DB, date civil.Date, release 
 	for _, fn := range options {
 		fn(&o)
 	}
-	tcs := models.TestCumulativeSummary{
-		Date:                 date,
-		Release:              release,
-		TestID:               testID,
-		ProwJobID:            prowJobID,
-		SuiteID:              suiteID,
-		Lifecycle:            o.lifecycle,
-		PrefixSumRuns:        runs,
-		PrefixSumSuccesses:   successes,
-		PrefixSumFailures:    o.prefixSumFailures,
-		PrefixSumFlakes:      flakes,
-		PrefixMaxLastFailure: o.prefixMaxLastFailure,
-		PrefixMaxLastSuccess: o.prefixMaxLastSuccess,
+	intutilOpts := []intutil.CumulativeSummaryOption{intutil.WithCumulativeSummaryFailures(o.prefixSumFailures)}
+	if o.lifecycle != "" {
+		intutilOpts = append(intutilOpts, intutil.WithCumulativeSummaryLifecycle(o.lifecycle))
 	}
-	if tcs.Lifecycle == "" {
-		tcs.Lifecycle = "blocking"
+	if o.prefixMaxLastFailure != nil {
+		intutilOpts = append(intutilOpts, intutil.WithCumulativeSummaryLastFailure(*o.prefixMaxLastFailure))
 	}
-	require.NoError(t, dbc.DB.Create(&tcs).Error)
+	if o.prefixMaxLastSuccess != nil {
+		intutilOpts = append(intutilOpts, intutil.WithCumulativeSummaryLastSuccess(*o.prefixMaxLastSuccess))
+	}
+	intutil.CreateCumulativeSummary(t, dbc, date, release, testID, prowJobID, suiteID, runs, successes, flakes, intutilOpts...)
 }
 
 func createGARawData(t *testing.T, dbc *db.DB, release string, windowDays int, testID, prowJobID, suiteID uint, runs, passes, flakes int64) {
@@ -171,17 +152,8 @@ func setJobRunLabels(t *testing.T, dbc *db.DB, runID uint, labels []string) {
 
 func createTestOwnershipFull(t *testing.T, dbc *db.DB, testID uint, suiteID *uint, uniqueID, component string, caps []string, jiraComponentID *uint) models.TestOwnership {
 	t.Helper()
-	tow := models.TestOwnership{
-		TestID:          testID,
-		SuiteID:         suiteID,
-		UniqueID:        uniqueID,
-		Name:            uniqueID,
-		Component:       component,
-		Capabilities:    pq.StringArray(caps),
-		JiraComponentID: jiraComponentID,
-	}
-	require.NoError(t, dbc.DB.Create(&tow).Error)
-	return tow
+	return intutil.CreateTestOwnership(t, dbc, testID, suiteID, uniqueID, component,
+		intutil.WithTestOwnershipCapabilities(caps), intutil.WithTestOwnershipJiraComponentID(jiraComponentID))
 }
 
 func uintPtr(v uint) *uint { return &v }

--- a/test/integration/tests_report_test.go
+++ b/test/integration/tests_report_test.go
@@ -1,0 +1,867 @@
+package integration
+
+import (
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/civil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	apitype "github.com/openshift/sippy/pkg/apis/api"
+	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/openshift/sippy/pkg/db/query"
+	"github.com/openshift/sippy/pkg/filter"
+	intutil "github.com/openshift/sippy/test/integration/util"
+)
+
+// testsReportDB returns a fresh test database for a Tests-report integration test.
+func testsReportDB(t *testing.T) *db.DB {
+	t.Helper()
+	return intutil.NewTestDB(t, pgContainer)
+}
+
+// testsReportPeriods returns fixed sample/base DateRanges for Tests-report tests, along
+// with the three prefix-sum lookup dates (start, boundary, end) a test_cumulative_summaries
+// row must be seeded at to be visible to the query at that point in the period:
+//
+//	previous period = (start, boundary], current period = (boundary, end]
+//	(resolvePrefixSumDates: end = sample.End-1, boundary = sample.Start-1 = base.End-1, start = base.Start-1)
+//
+// A row with no prior row at an earlier lookup date is treated as having a baseline of
+// zero as of that date (see TestTestReportQueryCollapsed_NewTestWithNoPriorHistoryReportsZeroPrevious),
+// so tests that don't care about the previous period may omit the start/boundary rows entirely.
+func testsReportPeriods() (sample, base query.DateRange, start, boundary, end civil.Date) {
+	sample = query.DateRange{Start: civil.Date{Year: 2024, Month: 6, Day: 8}, End: civil.Date{Year: 2024, Month: 6, Day: 15}}
+	base = query.DateRange{Start: civil.Date{Year: 2024, Month: 6, Day: 1}, End: civil.Date{Year: 2024, Month: 6, Day: 8}}
+	return sample, base,
+		civil.Date{Year: 2024, Month: 5, Day: 31},
+		civil.Date{Year: 2024, Month: 6, Day: 7},
+		civil.Date{Year: 2024, Month: 6, Day: 14}
+}
+
+// runCollapsedReport reproduces the wrapping buildTestsResultsPGGenerator (pkg/api/tests.go,
+// unexported) applies around TestReportQueryCollapsed in production: computing percentages
+// via QueryTestSummarizer and dropping zero-run rows, neither of which TestReportQueryCollapsed
+// does on its own.
+func runCollapsedReport(t *testing.T, dbc *db.DB, release string, sample, base query.DateRange, variantFilter, nameFilter, lifecycleFilter *filter.Filter) ([]apitype.Test, error) {
+	t.Helper()
+	collapsedQuery, err := query.TestReportQueryCollapsed(dbc, release, sample, base, variantFilter, nameFilter, lifecycleFilter)
+	if err != nil {
+		return nil, err
+	}
+	testMetadataColumns := []string{"suite_name", "name", "jira_component", "jira_component_id"}
+	collapsedColumns := slices.Concat(testMetadataColumns, []string{query.QueryTestFields})
+	rawQuery := dbc.DB.Table("(?) AS r", collapsedQuery).Select(strings.Join(collapsedColumns, ","))
+	selectColumns := slices.Concat(testMetadataColumns, []string{query.QueryTestSummarizer})
+	processedResults := dbc.DB.Table("(?) as results", rawQuery).
+		Select(strings.Join(selectColumns, ",")).
+		Where("current_runs > 0 or previous_runs > 0")
+
+	var results []apitype.Test
+	r := dbc.DB.Table("(?) as final_results", processedResults).Scan(&results)
+	return results, r.Error
+}
+
+// runUncollapsedReport calls UncollapsedTestReportWithStats and scans the result; unlike
+// the collapsed path, percentages and cross-variant stats are computed inside the query
+// itself, so no further wrapping is needed to match production output.
+func runUncollapsedReport(t *testing.T, dbc *db.DB, release string, sample, base query.DateRange, nameFilter, variantFilter, processedFilter, lifecycleFilter *filter.Filter) ([]apitype.Test, *filter.Filter, error) {
+	t.Helper()
+	rawQuery, remainingFilter, err := query.UncollapsedTestReportWithStats(dbc, release, sample, base, nameFilter, variantFilter, processedFilter, lifecycleFilter)
+	if err != nil {
+		return nil, nil, err
+	}
+	var results []apitype.Test
+	r := dbc.DB.Table("(?) as final_results", rawQuery).Scan(&results)
+	return results, remainingFilter, r.Error
+}
+
+// findTestRow returns the row matching name (and, if suiteName is non-empty, suite) from
+// results, failing the test if there's no such row.
+func findTestRow(t *testing.T, results []apitype.Test, name, suiteName string) apitype.Test {
+	t.Helper()
+	for _, r := range results {
+		if r.Name == name && (suiteName == "" || r.SuiteName == suiteName) {
+			return r
+		}
+	}
+	t.Fatalf("no row found for test %q suite %q among %d results", name, suiteName, len(results))
+	return apitype.Test{}
+}
+
+// findVariantRow returns the row whose Variants slice matches exactly the given variants
+// (order-independent), failing the test if there's no such row. Used to distinguish
+// per-variant-combination rows from the uncollapsed report.
+func findVariantRow(t *testing.T, results []apitype.Test, name string, variants []string) apitype.Test {
+	t.Helper()
+	want := sets.New[string](variants...)
+	for _, r := range results {
+		if r.Name != name {
+			continue
+		}
+		if sets.New[string](r.Variants...).Equal(want) {
+			return r
+		}
+	}
+	t.Fatalf("no row found for test %q with variants %v among %d results", name, variants, len(results))
+	return apitype.Test{}
+}
+
+// --- TestReportQueryCollapsed ---
+
+func TestTestReportQueryCollapsed_AggregatesCurrentAndPreviousPeriods(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, start, boundary, end := testsReportPeriods()
+
+	vc := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+	job := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws-ovn", release, nil, intutil.WithVariantCombination(vc))
+	test := intutil.CreateTest(t, dbc, "sig-network test-a")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	// previous = boundary - start: runs=8, successes=6, failures=1, flakes=1
+	intutil.CreateCumulativeSummary(t, dbc, start, release, test.ID, job.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, job.ID, suite.ID, 8, 6, 1, intutil.WithCumulativeSummaryFailures(1))
+	// current = end - boundary: runs=12, successes=8, failures=3, flakes=1
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, job.ID, suite.ID, 20, 14, 2, intutil.WithCumulativeSummaryFailures(4))
+
+	results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	row := results[0]
+	assert.Equal(t, "sig-network test-a", row.Name)
+	assert.Equal(t, "openshift-tests", row.SuiteName)
+
+	assert.Equal(t, 12, row.CurrentRuns, "current runs")
+	assert.Equal(t, 8, row.CurrentSuccesses, "current successes")
+	assert.Equal(t, 3, row.CurrentFailures, "current failures")
+	assert.Equal(t, 1, row.CurrentFlakes, "current flakes")
+	assert.InDelta(t, 66.667, row.CurrentPassPercentage, 0.01, "current pass percentage")
+	assert.InDelta(t, 8.333, row.CurrentFlakePercentage, 0.01, "current flake percentage")
+	assert.InDelta(t, 25.0, row.CurrentFailurePercentage, 0.01, "current failure percentage")
+	assert.InDelta(t, 75.0, row.CurrentWorkingPercentage, 0.01, "current working percentage")
+
+	assert.Equal(t, 8, row.PreviousRuns, "previous runs")
+	assert.Equal(t, 6, row.PreviousSuccesses, "previous successes")
+	assert.Equal(t, 1, row.PreviousFailures, "previous failures")
+	assert.Equal(t, 1, row.PreviousFlakes, "previous flakes")
+	assert.InDelta(t, 75.0, row.PreviousPassPercentage, 0.01, "previous pass percentage")
+	assert.InDelta(t, 12.5, row.PreviousFlakePercentage, 0.01, "previous flake percentage")
+	assert.InDelta(t, 12.5, row.PreviousFailurePercentage, 0.01, "previous failure percentage")
+	assert.InDelta(t, 87.5, row.PreviousWorkingPercentage, 0.01, "previous working percentage")
+
+	assert.InDelta(t, -8.333, row.NetImprovement, 0.01, "net pass-rate improvement")
+}
+
+func TestTestReportQueryCollapsed_CollapsesAcrossVariantCombinations(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, boundary, end := testsReportPeriods()
+
+	test := intutil.CreateTest(t, dbc, "sig-storage test-a")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	vcAWS := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	jobAWS := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vcAWS))
+	// current = 9-5 = 4
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, jobAWS.ID, suite.ID, 5, 5, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobAWS.ID, suite.ID, 9, 9, 0)
+
+	vcGCP := intutil.CreateVariantCombination(t, dbc, []string{"Platform:gcp"})
+	jobGCP := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-gcp", release, nil, intutil.WithVariantCombination(vcGCP))
+	// current = 8-3 = 5
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, jobGCP.ID, suite.ID, 3, 3, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobGCP.ID, suite.ID, 8, 8, 0)
+
+	results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "collapsed report should merge both variant combinations into one row")
+
+	row := results[0]
+	assert.Equal(t, 9, row.CurrentRuns, "current runs should sum across both variant combinations (4+5)")
+	assert.Equal(t, 9, row.CurrentSuccesses)
+}
+
+func TestTestReportQueryCollapsed_KeepsDifferentSuitesSeparate(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, boundary, end := testsReportPeriods()
+
+	vc := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	job := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vc))
+	test := intutil.CreateTest(t, dbc, "sig-network shared-test-name")
+
+	suiteX := intutil.CreateSuite(t, dbc, "suite-x")
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, job.ID, suiteX.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, job.ID, suiteX.ID, 5, 5, 0)
+
+	suiteY := intutil.CreateSuite(t, dbc, "suite-y")
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, job.ID, suiteY.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, job.ID, suiteY.ID, 7, 7, 0)
+
+	results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 2, "same test name in two suites should produce two separate rows")
+
+	rowX := findTestRow(t, results, "sig-network shared-test-name", "suite-x")
+	assert.Equal(t, 5, rowX.CurrentRuns)
+	rowY := findTestRow(t, results, "sig-network shared-test-name", "suite-y")
+	assert.Equal(t, 7, rowY.CurrentRuns)
+}
+
+func TestTestReportQueryCollapsed_FiltersByName(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, boundary, end := testsReportPeriods()
+
+	vc := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	job := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vc))
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	testNetwork := intutil.CreateTest(t, dbc, "sig-network aws connectivity test")
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, testNetwork.ID, job.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, testNetwork.ID, job.ID, suite.ID, 5, 5, 0)
+
+	testStorage := intutil.CreateTest(t, dbc, "sig-storage gcp volume test")
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, testStorage.ID, job.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, testStorage.ID, job.ID, suite.ID, 6, 6, 0)
+
+	t.Run("equals matches exact name only", func(t *testing.T) {
+		nameFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "name", Operator: filter.OperatorEquals, Value: "sig-network aws connectivity test"},
+		}}
+		results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nameFilter, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "sig-network aws connectivity test", results[0].Name)
+	})
+
+	t.Run("starts with matches prefix", func(t *testing.T) {
+		nameFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "name", Operator: filter.OperatorStartsWith, Value: "sig-network"},
+		}}
+		results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nameFilter, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "sig-network aws connectivity test", results[0].Name)
+	})
+
+	t.Run("contains matches substring case-insensitively", func(t *testing.T) {
+		nameFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "name", Operator: filter.OperatorContains, Value: "VOLUME"},
+		}}
+		results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nameFilter, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "sig-storage gcp volume test", results[0].Name)
+	})
+
+	t.Run("negated contains excludes matches", func(t *testing.T) {
+		nameFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "name", Operator: filter.OperatorContains, Value: "storage", Not: true},
+		}}
+		results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nameFilter, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "sig-network aws connectivity test", results[0].Name)
+	})
+}
+
+func TestTestReportQueryCollapsed_FiltersByVariant(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, boundary, end := testsReportPeriods()
+
+	test := intutil.CreateTest(t, dbc, "sig-network variant-filter-test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	vcAWS := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+	jobAWS := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws-ovn", release, nil, intutil.WithVariantCombination(vcAWS))
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, jobAWS.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobAWS.ID, suite.ID, 4, 4, 0)
+
+	vcGCP := intutil.CreateVariantCombination(t, dbc, []string{"Platform:gcp", "Network:ovn"})
+	jobGCP := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-gcp-ovn", release, nil, intutil.WithVariantCombination(vcGCP))
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, jobGCP.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobGCP.ID, suite.ID, 6, 6, 0)
+
+	t.Run("has entry narrows to matching variant combination", func(t *testing.T) {
+		variantFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "variants", Operator: filter.OperatorHasEntry, Value: "Platform:aws"},
+		}}
+		results, err := runCollapsedReport(t, dbc, release, sample, base, variantFilter, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, 4, results[0].CurrentRuns)
+	})
+
+	t.Run("has entry containing matches substring within a variant", func(t *testing.T) {
+		variantFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "variants", Operator: filter.OperatorHasEntryContaining, Value: "gcp"},
+		}}
+		results, err := runCollapsedReport(t, dbc, release, sample, base, variantFilter, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, 6, results[0].CurrentRuns)
+	})
+
+	t.Run("negated has entry excludes matching variant combination", func(t *testing.T) {
+		variantFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "variants", Operator: filter.OperatorHasEntry, Value: "Platform:aws", Not: true},
+		}}
+		results, err := runCollapsedReport(t, dbc, release, sample, base, variantFilter, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, 6, results[0].CurrentRuns, "should only include the gcp variant combination")
+	})
+}
+
+func TestTestReportQueryCollapsed_LifecycleFilter(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, boundary, end := testsReportPeriods()
+
+	vc := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	job := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vc))
+	test := intutil.CreateTest(t, dbc, "sig-network lifecycle-test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	// blocking: current = 15-5 = 10
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, job.ID, suite.ID, 5, 5, 0, intutil.WithCumulativeSummaryLifecycle("blocking"))
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, job.ID, suite.ID, 15, 15, 0, intutil.WithCumulativeSummaryLifecycle("blocking"))
+	// informing: current = 8-2 = 6
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, job.ID, suite.ID, 2, 2, 0, intutil.WithCumulativeSummaryLifecycle("informing"))
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, job.ID, suite.ID, 8, 8, 0, intutil.WithCumulativeSummaryLifecycle("informing"))
+
+	t.Run("no filter combines blocking and informing", func(t *testing.T) {
+		results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, 16, results[0].CurrentRuns, "10 blocking + 6 informing")
+	})
+
+	t.Run("equals blocking narrows to blocking only", func(t *testing.T) {
+		lifecycleFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "blocking"},
+		}}
+		results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nil, lifecycleFilter)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, 10, results[0].CurrentRuns)
+	})
+
+	t.Run("equals informing narrows to informing only", func(t *testing.T) {
+		lifecycleFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "informing"},
+		}}
+		results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nil, lifecycleFilter)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, 6, results[0].CurrentRuns)
+	})
+
+	t.Run("not-equals blocking returns only informing", func(t *testing.T) {
+		lifecycleFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "lifecycle", Operator: filter.OperatorArithmeticNotEquals, Value: "blocking"},
+		}}
+		results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nil, lifecycleFilter)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, 6, results[0].CurrentRuns)
+	})
+
+	t.Run("negated equals blocking is equivalent to not-equals", func(t *testing.T) {
+		lifecycleFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "blocking", Not: true},
+		}}
+		results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nil, lifecycleFilter)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, 6, results[0].CurrentRuns)
+	})
+
+	// Regression test: selecting both lifecycles via two OR-linked "equals" items must
+	// produce their union (16), not an unsatisfiable "lifecycle = 'blocking' AND
+	// lifecycle = 'informing'" that silently returns zero rows.
+	t.Run("OR-linked equals blocking or informing returns the union", func(t *testing.T) {
+		lifecycleFilter := &filter.Filter{
+			LinkOperator: filter.LinkOperatorOr,
+			Items: []filter.FilterItem{
+				{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "blocking"},
+				{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "informing"},
+			},
+		}
+		results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nil, lifecycleFilter)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, 16, results[0].CurrentRuns, "10 blocking + 6 informing")
+	})
+}
+
+func TestTestReportQueryCollapsed_LifecycleFilterUnsupportedOperatorReturnsError(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, _, _ := testsReportPeriods()
+
+	lifecycleFilter := &filter.Filter{Items: []filter.FilterItem{
+		{Field: "lifecycle", Operator: filter.OperatorContains, Value: "block"},
+	}}
+	_, err := runCollapsedReport(t, dbc, release, sample, base, nil, nil, lifecycleFilter)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, filter.ErrUnsupportedOperator)
+}
+
+// TestTestReportQueryCollapsed_NeverStableVariantRequiresExplicitFilter documents an
+// intentional asymmetry with UncollapsedTestReportWithStats: unlike the uncollapsed path
+// (which always excludes never-stable variant combinations, hardcoded into the query),
+// the collapsed path applies no such exclusion on its own -- it relies entirely on the
+// caller supplying a variant filter for it, exactly as the frontend does by default via
+// DEFAULT_TEST_FILTERS (sippy-ng/src/constants.jsx) applied from the sidebar "Tests" link
+// (sippy-ng/src/components/Sidebar.jsx).
+func TestTestReportQueryCollapsed_NeverStableVariantRequiresExplicitFilter(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, boundary, end := testsReportPeriods()
+
+	vc := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws", "never-stable"})
+	job := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws-never-stable", release, nil, intutil.WithVariantCombination(vc))
+	test := intutil.CreateTest(t, dbc, "sig-network never-stable-test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, job.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, job.ID, suite.ID, 10, 10, 0)
+
+	t.Run("without a variant filter, never-stable data is included", func(t *testing.T) {
+		results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, 10, results[0].CurrentRuns)
+	})
+
+	t.Run("excluding never-stable via a variant filter narrows it out, as the frontend does by default", func(t *testing.T) {
+		variantFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "variants", Operator: filter.OperatorHasEntry, Value: "never-stable", Not: true},
+		}}
+		results, err := runCollapsedReport(t, dbc, release, sample, base, variantFilter, nil, nil)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+func TestTestReportQueryCollapsed_ExcludesJobsWithNilVariantCombinationID(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, boundary, end := testsReportPeriods()
+
+	// A plain ProwJob has no VariantCombinationID set.
+	job := intutil.CreateProwJob(t, dbc, "periodic-e2e-unclassified", release, nil)
+	test := intutil.CreateTest(t, dbc, "sig-network unclassified-job-test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, job.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, job.ID, suite.ID, 10, 10, 0)
+
+	results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Empty(t, results, "a job with no variant_combination_id should not contribute to the report")
+}
+
+func TestTestReportQueryCollapsed_OpenBugsCountsDistinctOpenExcludesClosedCaseInsensitive(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, boundary, end := testsReportPeriods()
+
+	vc := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	job := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vc))
+	test := intutil.CreateTest(t, dbc, "sig-network bugged-test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, job.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, job.ID, suite.ID, 5, 5, 0)
+
+	lastChangeTime := time.Date(2024, 6, 10, 12, 0, 0, 0, time.UTC)
+	intutil.CreateBugForTests(t, dbc, "BUG-1", "NEW", "still open", lastChangeTime, []models.Test{test})
+	intutil.CreateBugForTests(t, dbc, "BUG-2", "POST", "also open", lastChangeTime, []models.Test{test})
+	intutil.CreateBugForTests(t, dbc, "BUG-3", "Closed", "should be excluded", lastChangeTime, []models.Test{test})
+
+	results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, 2, results[0].OpenBugs, "only the two non-closed bugs should count, case-insensitively")
+}
+
+func TestTestReportQueryCollapsed_ResolvesJiraComponentViaTestOwnershipAndSuite(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, boundary, end := testsReportPeriods()
+
+	vc := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	job := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vc))
+	test := intutil.CreateTest(t, dbc, "sig-network owned-test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, job.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, job.ID, suite.ID, 5, 5, 0)
+
+	jc := intutil.CreateJiraComponent(t, dbc, "Networking")
+	intutil.CreateTestOwnership(t, dbc, test.ID, &suite.ID, "sig-network owned-test", "Networking-team", intutil.WithTestOwnershipJiraComponent(jc.Name))
+
+	results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "openshift-tests", results[0].SuiteName)
+	assert.Equal(t, "Networking", results[0].JiraComponent)
+	assert.Equal(t, int(jc.ID), results[0].JiraComponentID) //nolint:gosec
+}
+
+func TestTestReportQueryCollapsed_NewTestWithNoPriorHistoryReportsZeroPrevious(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, _, end := testsReportPeriods()
+
+	vc := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	job := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vc))
+	test := intutil.CreateTest(t, dbc, "sig-network brand-new-test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	// Only a row at "end" -- no row at "start" or "boundary" at all, simulating a test
+	// that started running partway through the current period.
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, job.ID, suite.ID, 6, 5, 0, intutil.WithCumulativeSummaryFailures(1))
+
+	results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, 6, results[0].CurrentRuns, "current runs should be the full cumulative total since the missing boundary row is treated as a zero baseline")
+	assert.Equal(t, 0, results[0].PreviousRuns, "previous runs should be zero when there's no earlier data at all")
+}
+
+// --- UncollapsedTestReportWithStats ---
+
+func TestUncollapsedTestReportWithStats_OneRowPerVariantCombination(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, boundary, end := testsReportPeriods()
+
+	test := intutil.CreateTest(t, dbc, "sig-storage per-variant-test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	vcAWS := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	jobAWS := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vcAWS))
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, jobAWS.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobAWS.ID, suite.ID, 4, 4, 0)
+
+	vcGCP := intutil.CreateVariantCombination(t, dbc, []string{"Platform:gcp"})
+	jobGCP := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-gcp", release, nil, intutil.WithVariantCombination(vcGCP))
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, jobGCP.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobGCP.ID, suite.ID, 6, 6, 0)
+
+	results, _, err := runUncollapsedReport(t, dbc, release, sample, base, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 2, "uncollapsed report should keep each variant combination as its own row")
+
+	rowAWS := findVariantRow(t, results, "sig-storage per-variant-test", []string{"Platform:aws"})
+	assert.Equal(t, 4, rowAWS.CurrentRuns)
+	rowGCP := findVariantRow(t, results, "sig-storage per-variant-test", []string{"Platform:gcp"})
+	assert.Equal(t, 6, rowGCP.CurrentRuns)
+}
+
+func TestUncollapsedTestReportWithStats_ComputesCrossVariantStatsAndDeltas(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, boundary, end := testsReportPeriods()
+
+	test := intutil.CreateTest(t, dbc, "sig-network cross-variant-stats-test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	// Three variant combinations at 100%, 80%, and 60% current pass rates.
+	// working average = (100+80+60)/3 = 80.
+	type combo struct {
+		platform         string
+		runs, successes  int64
+		wantWorkingDelta float64
+		wantPassingAvg   float64
+	}
+	combos := []combo{
+		{"aws", 10, 10, 20, 80},
+		{"gcp", 10, 8, 0, 80},
+		{"azure", 10, 6, -20, 80},
+	}
+	for _, c := range combos {
+		vc := intutil.CreateVariantCombination(t, dbc, []string{"Platform:" + c.platform})
+		job := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-"+c.platform, release, nil, intutil.WithVariantCombination(vc))
+		intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, job.ID, suite.ID, 0, 0, 0)
+		intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, job.ID, suite.ID, c.runs, c.successes, 0)
+	}
+
+	results, _, err := runUncollapsedReport(t, dbc, release, sample, base, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+
+	for _, c := range combos {
+		row := findVariantRow(t, results, "sig-network cross-variant-stats-test", []string{"Platform:" + c.platform})
+		assert.InDelta(t, 80.0, row.WorkingAverage, 0.5, "platform %s working average", c.platform)
+		assert.InDelta(t, c.wantWorkingDelta, row.DeltaFromWorkingAverage, 0.5, "platform %s delta from working average", c.platform)
+		assert.InDelta(t, c.wantPassingAvg, row.PassingAverage, 0.5, "platform %s passing average", c.platform)
+	}
+}
+
+// TestUncollapsedTestReportWithStats_LifecycleFilterAppliesToStatsToo is a regression
+// test: the stats CTE scopes its input by test_id membership in the filtered/post_filtered
+// CTE, not by lifecycle directly, so it must re-apply the lifecycle filter itself or it
+// will silently blend in data from lifecycles the caller asked to exclude.
+func TestUncollapsedTestReportWithStats_LifecycleFilterAppliesToStatsToo(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, _, end := testsReportPeriods()
+
+	test := intutil.CreateTest(t, dbc, "sig-network lifecycle-stats-test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	// VC-A: blocking 90%, informing 10%. VC-B: blocking 50%, informing 10%.
+	// If lifecycle correctly scopes the stats calculation, filtering to blocking alone
+	// should yield a cross-variant average of (90+50)/2 = 70, giving VC-A a delta of
+	// +20 and VC-B a delta of -20. If the informing rows leak into the stats average
+	// (the bug this test guards against), the blended rows would each show a combined
+	// (blocking+informing) rate of 50%/30%, averaging to 40 -- giving deltas of +50/+10
+	// instead, even though the filtered rows themselves correctly show 90%/50%.
+	vcA := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	jobA := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vcA))
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobA.ID, suite.ID, 10, 9, 0, intutil.WithCumulativeSummaryLifecycle("blocking"), intutil.WithCumulativeSummaryFailures(1))
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobA.ID, suite.ID, 10, 1, 0, intutil.WithCumulativeSummaryLifecycle("informing"), intutil.WithCumulativeSummaryFailures(9))
+
+	vcB := intutil.CreateVariantCombination(t, dbc, []string{"Platform:gcp"})
+	jobB := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-gcp", release, nil, intutil.WithVariantCombination(vcB))
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobB.ID, suite.ID, 10, 5, 0, intutil.WithCumulativeSummaryLifecycle("blocking"), intutil.WithCumulativeSummaryFailures(5))
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobB.ID, suite.ID, 10, 1, 0, intutil.WithCumulativeSummaryLifecycle("informing"), intutil.WithCumulativeSummaryFailures(9))
+
+	lifecycleFilter := &filter.Filter{Items: []filter.FilterItem{
+		{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "blocking"},
+	}}
+	results, _, err := runUncollapsedReport(t, dbc, release, sample, base, nil, nil, nil, lifecycleFilter)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	rowA := findVariantRow(t, results, "sig-network lifecycle-stats-test", []string{"Platform:aws"})
+	assert.Equal(t, 10, rowA.CurrentRuns, "filtered rows themselves should only reflect blocking data")
+	assert.InDelta(t, 90.0, rowA.CurrentPassPercentage, 0.01)
+	assert.InDelta(t, 70.0, rowA.WorkingAverage, 0.5, "stats average must be computed from blocking-only data (90+50)/2=70, not the blended (50+30)/2=40")
+	assert.InDelta(t, 20.0, rowA.DeltaFromWorkingAverage, 0.5)
+
+	rowB := findVariantRow(t, results, "sig-network lifecycle-stats-test", []string{"Platform:gcp"})
+	assert.Equal(t, 10, rowB.CurrentRuns)
+	assert.InDelta(t, 50.0, rowB.CurrentPassPercentage, 0.01)
+	assert.InDelta(t, 70.0, rowB.WorkingAverage, 0.5)
+	assert.InDelta(t, -20.0, rowB.DeltaFromWorkingAverage, 0.5)
+}
+
+func TestUncollapsedTestReportWithStats_LifecycleFilterEqualsAndNotEquals(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, boundary, end := testsReportPeriods()
+
+	vc := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	job := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vc))
+	test := intutil.CreateTest(t, dbc, "sig-network uncollapsed-lifecycle-test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, job.ID, suite.ID, 5, 5, 0, intutil.WithCumulativeSummaryLifecycle("blocking"))
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, job.ID, suite.ID, 15, 15, 0, intutil.WithCumulativeSummaryLifecycle("blocking"))
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, job.ID, suite.ID, 2, 2, 0, intutil.WithCumulativeSummaryLifecycle("informing"))
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, job.ID, suite.ID, 8, 8, 0, intutil.WithCumulativeSummaryLifecycle("informing"))
+
+	t.Run("equals blocking", func(t *testing.T) {
+		lifecycleFilter := &filter.Filter{Items: []filter.FilterItem{{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "blocking"}}}
+		results, _, err := runUncollapsedReport(t, dbc, release, sample, base, nil, nil, nil, lifecycleFilter)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, 10, results[0].CurrentRuns)
+	})
+
+	t.Run("not-equals blocking", func(t *testing.T) {
+		lifecycleFilter := &filter.Filter{Items: []filter.FilterItem{{Field: "lifecycle", Operator: filter.OperatorArithmeticNotEquals, Value: "blocking"}}}
+		results, _, err := runUncollapsedReport(t, dbc, release, sample, base, nil, nil, nil, lifecycleFilter)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, 6, results[0].CurrentRuns)
+	})
+
+	// Regression test: an OR-linked filter selecting both lifecycles must return their
+	// union (16), not an unsatisfiable AND that silently returns zero rows. This also
+	// exercises the stats CTE's re-application of the same clause.
+	t.Run("OR-linked equals blocking or informing returns the union", func(t *testing.T) {
+		lifecycleFilter := &filter.Filter{
+			LinkOperator: filter.LinkOperatorOr,
+			Items: []filter.FilterItem{
+				{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "blocking"},
+				{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "informing"},
+			},
+		}
+		results, _, err := runUncollapsedReport(t, dbc, release, sample, base, nil, nil, nil, lifecycleFilter)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, 16, results[0].CurrentRuns, "10 blocking + 6 informing")
+	})
+}
+
+func TestUncollapsedTestReportWithStats_LifecycleFilterUnsupportedOperatorReturnsError(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, _, _ := testsReportPeriods()
+
+	lifecycleFilter := &filter.Filter{Items: []filter.FilterItem{
+		{Field: "lifecycle", Operator: filter.OperatorStartsWith, Value: "block"},
+	}}
+	_, _, err := runUncollapsedReport(t, dbc, release, sample, base, nil, nil, nil, lifecycleFilter)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, filter.ErrUnsupportedOperator)
+}
+
+func TestUncollapsedTestReportWithStats_FiltersByNameAndVariant(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, boundary, end := testsReportPeriods()
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	vcAWS := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	jobAWS := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vcAWS))
+	vcGCP := intutil.CreateVariantCombination(t, dbc, []string{"Platform:gcp"})
+	jobGCP := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-gcp", release, nil, intutil.WithVariantCombination(vcGCP))
+
+	testNetwork := intutil.CreateTest(t, dbc, "sig-network uncollapsed-name-test")
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, testNetwork.ID, jobAWS.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, testNetwork.ID, jobAWS.ID, suite.ID, 3, 3, 0)
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, testNetwork.ID, jobGCP.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, testNetwork.ID, jobGCP.ID, suite.ID, 4, 4, 0)
+
+	testStorage := intutil.CreateTest(t, dbc, "sig-storage uncollapsed-name-test")
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, testStorage.ID, jobAWS.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, testStorage.ID, jobAWS.ID, suite.ID, 5, 5, 0)
+
+	t.Run("name filter narrows across all variant combinations", func(t *testing.T) {
+		nameFilter := &filter.Filter{Items: []filter.FilterItem{{Field: "name", Operator: filter.OperatorContains, Value: "sig-network"}}}
+		results, _, err := runUncollapsedReport(t, dbc, release, sample, base, nameFilter, nil, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 2, "sig-network test has two variant combination rows")
+	})
+
+	t.Run("variant filter narrows to one combination across tests", func(t *testing.T) {
+		variantFilter := &filter.Filter{Items: []filter.FilterItem{{Field: "variants", Operator: filter.OperatorHasEntry, Value: "Platform:gcp"}}}
+		results, _, err := runUncollapsedReport(t, dbc, release, sample, base, nil, variantFilter, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1, "only sig-network runs under the gcp variant combination")
+		assert.Equal(t, "sig-network uncollapsed-name-test", results[0].Name)
+	})
+}
+
+func TestUncollapsedTestReportWithStats_ExcludesNeverStableVariantFromResultsAndStats(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, boundary, end := testsReportPeriods()
+
+	test := intutil.CreateTest(t, dbc, "sig-network mixed-stability-test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	vcStable := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	jobStable := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vcStable))
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, jobStable.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobStable.ID, suite.ID, 10, 9, 0, intutil.WithCumulativeSummaryFailures(1))
+
+	vcNeverStable := intutil.CreateVariantCombination(t, dbc, []string{"Platform:gcp", "never-stable"})
+	jobNeverStable := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-gcp-never-stable", release, nil, intutil.WithVariantCombination(vcNeverStable))
+	// If this leaked into the stats average, working_average would be pulled toward 10%.
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, jobNeverStable.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobNeverStable.ID, suite.ID, 10, 1, 0, intutil.WithCumulativeSummaryFailures(9))
+
+	results, _, err := runUncollapsedReport(t, dbc, release, sample, base, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "the never-stable variant combination should not appear as a row")
+
+	row := results[0]
+	assert.Equal(t, "Platform:aws", row.Variants[0])
+	assert.InDelta(t, 90.0, row.WorkingAverage, 0.5, "the never-stable combination's data should not skew the stats average")
+	assert.InDelta(t, 0.0, row.DeltaFromWorkingAverage, 0.5)
+}
+
+func TestUncollapsedTestReportWithStats_ProcessedFilterPushesDownAndReturnsRemainingFilter(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, boundary, end := testsReportPeriods()
+
+	test := intutil.CreateTest(t, dbc, "sig-network processed-filter-test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	vcLowRuns := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	jobLowRuns := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vcLowRuns))
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, jobLowRuns.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobLowRuns.ID, suite.ID, 3, 3, 0)
+
+	vcHighRuns := intutil.CreateVariantCombination(t, dbc, []string{"Platform:gcp"})
+	jobHighRuns := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-gcp", release, nil, intutil.WithVariantCombination(vcHighRuns))
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, jobHighRuns.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobHighRuns.ID, suite.ID, 10, 10, 0)
+
+	processedFilter := &filter.Filter{
+		LinkOperator: filter.LinkOperatorAnd,
+		Items: []filter.FilterItem{
+			{Field: "current_runs", Operator: filter.OperatorArithmeticGreaterThanOrEquals, Value: "5"},
+			{Field: "suite_name", Operator: filter.OperatorContains, Value: "openshift"},
+		},
+	}
+	results, remaining, err := runUncollapsedReport(t, dbc, release, sample, base, nil, nil, processedFilter, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "current_runs >= 5 should be pushed down and exclude the low-runs variant")
+	assert.Equal(t, "Platform:gcp", results[0].Variants[0])
+
+	require.NotNil(t, remaining, "the suite_name filter isn't pushdown-safe and must be returned for the caller to apply")
+	require.Len(t, remaining.Items, 1)
+	assert.Equal(t, "suite_name", remaining.Items[0].Field)
+}
+
+func TestUncollapsedTestReportWithStats_OpenBugsAndJiraComponent(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, boundary, end := testsReportPeriods()
+
+	vc := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	job := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vc))
+	test := intutil.CreateTest(t, dbc, "sig-network uncollapsed-bugged-test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+	intutil.CreateCumulativeSummary(t, dbc, boundary, release, test.ID, job.ID, suite.ID, 0, 0, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, job.ID, suite.ID, 5, 5, 0)
+
+	jc := intutil.CreateJiraComponent(t, dbc, "Networking")
+	intutil.CreateTestOwnership(t, dbc, test.ID, &suite.ID, "sig-network uncollapsed-bugged-test", "Networking-team", intutil.WithTestOwnershipJiraComponent(jc.Name))
+	lastChangeTime := time.Date(2024, 6, 10, 12, 0, 0, 0, time.UTC)
+	intutil.CreateBugForTests(t, dbc, "BUG-100", "NEW", "still open", lastChangeTime, []models.Test{test})
+	intutil.CreateBugForTests(t, dbc, "BUG-101", "CLOSED", "should be excluded", lastChangeTime, []models.Test{test})
+
+	results, _, err := runUncollapsedReport(t, dbc, release, sample, base, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, 1, results[0].OpenBugs)
+	assert.Equal(t, "Networking", results[0].JiraComponent)
+	assert.Equal(t, int(jc.ID), results[0].JiraComponentID) //nolint:gosec
+}
+
+func TestUncollapsedTestReportWithStats_NewVariantWithNoPriorHistoryReportsZeroPrevious(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, _, end := testsReportPeriods()
+
+	vc := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	job := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vc))
+	test := intutil.CreateTest(t, dbc, "sig-network uncollapsed-brand-new-test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, job.ID, suite.ID, 6, 5, 0, intutil.WithCumulativeSummaryFailures(1))
+
+	results, _, err := runUncollapsedReport(t, dbc, release, sample, base, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, 6, results[0].CurrentRuns)
+	assert.Equal(t, 0, results[0].PreviousRuns)
+}

--- a/test/integration/util/fixtures.go
+++ b/test/integration/util/fixtures.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/civil"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 
@@ -29,6 +30,27 @@ func WithKind(kind models.ProwKind) ProwJobOption {
 	return func(j *models.ProwJob) {
 		j.Kind = kind
 	}
+}
+
+// WithVariantCombination sets both Variants and VariantCombinationID from an existing
+// VariantCombination. In production, VariantCombinationID is populated by a database
+// trigger; the integration schema intentionally skips triggers (see SetupIntegrationSchema),
+// so tests must set it explicitly via this option.
+func WithVariantCombination(vc models.VariantCombination) ProwJobOption {
+	return func(j *models.ProwJob) {
+		j.Variants = vc.Variants
+		j.VariantCombinationID = &vc.ID
+	}
+}
+
+// CreateVariantCombination creates a variant_combinations row. Pass the result to
+// WithVariantCombination when creating a ProwJob so cumulative-summary-based reports
+// (which join through prow_jobs.variant_combination_id) can find it.
+func CreateVariantCombination(t *testing.T, dbc *db.DB, variants []string) models.VariantCombination {
+	t.Helper()
+	vc := models.VariantCombination{Variants: pq.StringArray(variants)}
+	require.NoError(t, dbc.DB.Create(&vc).Error, "creating VariantCombination %v", variants)
+	return vc
 }
 
 func CreateProwJobWithOptions(t *testing.T, dbc *db.DB, name, release string, variants []string, opts ...ProwJobOption) models.ProwJob {
@@ -71,6 +93,57 @@ func CreateSuite(t *testing.T, dbc *db.DB, name string) models.Suite {
 	suite := models.Suite{Name: name}
 	require.NoError(t, dbc.DB.Create(&suite).Error, "creating Suite %q", name)
 	return suite
+}
+
+// CreateJiraComponent creates a jira_components row. Test report queries resolve
+// TestOwnership.JiraComponent (a plain string) against JiraComponent.Name to populate
+// jira_component_id, so the two must match for that join to succeed.
+func CreateJiraComponent(t *testing.T, dbc *db.DB, name string) models.JiraComponent {
+	t.Helper()
+	jc := models.JiraComponent{Name: name}
+	require.NoError(t, dbc.DB.Create(&jc).Error, "creating JiraComponent %q", name)
+	return jc
+}
+
+type TestOwnershipOption func(*models.TestOwnership)
+
+// WithTestOwnershipJiraComponent sets the string joined against JiraComponent.Name.
+// Note this is distinct from TestOwnership.JiraComponentID, which test report queries
+// don't use for the jira_components join.
+func WithTestOwnershipJiraComponent(name string) TestOwnershipOption {
+	return func(to *models.TestOwnership) {
+		to.JiraComponent = name
+	}
+}
+
+func WithTestOwnershipJiraComponentID(id *uint) TestOwnershipOption {
+	return func(to *models.TestOwnership) {
+		to.JiraComponentID = id
+	}
+}
+
+func WithTestOwnershipCapabilities(caps []string) TestOwnershipOption {
+	return func(to *models.TestOwnership) {
+		to.Capabilities = pq.StringArray(caps)
+	}
+}
+
+// CreateTestOwnership creates a test_ownerships row scoped to a specific suite. Pass
+// suiteID as nil for a suite-agnostic ownership row.
+func CreateTestOwnership(t *testing.T, dbc *db.DB, testID uint, suiteID *uint, uniqueID, component string, opts ...TestOwnershipOption) models.TestOwnership {
+	t.Helper()
+	to := models.TestOwnership{
+		TestID:    testID,
+		SuiteID:   suiteID,
+		UniqueID:  uniqueID,
+		Name:      uniqueID,
+		Component: component,
+	}
+	for _, opt := range opts {
+		opt(&to)
+	}
+	require.NoError(t, dbc.DB.Create(&to).Error, "creating TestOwnership for test %d", testID)
+	return to
 }
 
 type ProwJobRunTestOption func(*models.ProwJobRunTest)
@@ -126,4 +199,71 @@ func CreateBug(t *testing.T, dbc *db.DB, key, status, summary string, lastChange
 	}
 	require.NoError(t, dbc.DB.Create(&bug).Error, "creating Bug %q", key)
 	return bug
+}
+
+// CreateBugForTests creates a bug associated with tests via the bug_tests join table
+// (as opposed to CreateBug, which associates via bug_jobs). Test report queries
+// (openBugsSubquery) count open bugs through this association.
+func CreateBugForTests(t *testing.T, dbc *db.DB, key, status, summary string, lastChangeTime time.Time, tests []models.Test) models.Bug {
+	t.Helper()
+	bug := models.Bug{
+		Key:            key,
+		Status:         status,
+		Summary:        summary,
+		LastChangeTime: lastChangeTime,
+		Tests:          tests,
+	}
+	require.NoError(t, dbc.DB.Create(&bug).Error, "creating Bug %q", key)
+	return bug
+}
+
+type CumulativeSummaryOption func(*models.TestCumulativeSummary)
+
+func WithCumulativeSummaryLifecycle(lifecycle string) CumulativeSummaryOption {
+	return func(tcs *models.TestCumulativeSummary) {
+		tcs.Lifecycle = lifecycle
+	}
+}
+
+func WithCumulativeSummaryFailures(failures int64) CumulativeSummaryOption {
+	return func(tcs *models.TestCumulativeSummary) {
+		tcs.PrefixSumFailures = failures
+	}
+}
+
+func WithCumulativeSummaryLastFailure(t time.Time) CumulativeSummaryOption {
+	return func(tcs *models.TestCumulativeSummary) {
+		tcs.PrefixMaxLastFailure = &t
+	}
+}
+
+func WithCumulativeSummaryLastSuccess(t time.Time) CumulativeSummaryOption {
+	return func(tcs *models.TestCumulativeSummary) {
+		tcs.PrefixMaxLastSuccess = &t
+	}
+}
+
+// CreateCumulativeSummary creates a test_cumulative_summaries row directly with the given
+// prefix sums, rather than deriving them from raw run data. Prefix sums are cumulative
+// totals as of Date: callers computing a period count from two rows (e.g. for dates end
+// and boundary) get period_count = end.PrefixSumX - boundary.PrefixSumX. Lifecycle
+// defaults to "blocking" (matching the column's DB default) unless overridden.
+func CreateCumulativeSummary(t *testing.T, dbc *db.DB, date civil.Date, release string, testID, prowJobID, suiteID uint, runs, successes, flakes int64, opts ...CumulativeSummaryOption) models.TestCumulativeSummary {
+	t.Helper()
+	tcs := models.TestCumulativeSummary{
+		Date:               date,
+		Release:            release,
+		TestID:             testID,
+		ProwJobID:          prowJobID,
+		SuiteID:            suiteID,
+		Lifecycle:          "blocking",
+		PrefixSumRuns:      runs,
+		PrefixSumSuccesses: successes,
+		PrefixSumFlakes:    flakes,
+	}
+	for _, opt := range opts {
+		opt(&tcs)
+	}
+	require.NoError(t, dbc.DB.Create(&tcs).Error, "creating TestCumulativeSummary for test %d on %s", testID, date)
+	return tcs
 }


### PR DESCRIPTION
## Summary

- Expose lifecycle (blocking/informing) as a filter-only column on the Tests page, both collapsed and per-variant views.
- `lifecycleWhereClause` applies equals/not-equals before aggregation, honoring `LinkOperator` so OR-linked filters return a union instead of an unsatisfiable AND.
- BigQuery-backed `/api/tests/v2` returns HTTP 400 for lifecycle filters (tables lack the column).
- Frontend: `GridToolbarFilterItem` gains generic values-restricted dropdown support (fixed choices, equals/!= only).
- Integration tests: new `tests_report_test.go` with end-to-end coverage for both query paths; shared fixtures extracted to `util/fixtures.go`.

## Staging verification

Tested against `sippy-staging` (build `sippy-staging-148`, release 4.22).
Release 4.22 has both lifecycle values: 177M blocking rows, 1M informing rows.

### Collapsed path (`/api/tests?collapse=true`)

| Filter | Result |
|--------|--------|
| No filter | 18,289 tests |
| `lifecycle = blocking` | 18,186 |
| `lifecycle = informing` | 106 |
| `lifecycle != blocking` | 106 (matches informing) |
| `lifecycle != informing` | 18,186 (matches blocking) |
| `lifecycle = blocking OR lifecycle = informing` | 18,289 (matches no-filter total) |
| Combined: `lifecycle = informing AND name contains 'network'` | 52 |
| Unsupported operator (`contains`) | HTTP 400 |

### Uncollapsed path (`/api/tests?collapse=false`)

Scoped to `name contains 'NetworkSegmentation'` to keep result sets manageable.

| Filter | Result |
|--------|--------|
| No filter | 12,632 rows |
| `lifecycle = blocking` | 6,640 |
| `lifecycle = informing` | 5,994 |
| `lifecycle != blocking` | 5,994 (matches informing) |
| `lifecycle != informing` | 6,640 (matches blocking) |

### BigQuery path (`/api/tests/v2`)

| Filter | Result |
|--------|--------|
| `lifecycle = blocking` | HTTP 400 (expected) |

### Observations

- Equals/not-equals pairs are symmetric across both paths.
- OR-linked filter (`blocking OR informing`) returns the same count as unfiltered, confirming the LinkOperator fix works correctly.
- Combined lifecycle + name filters narrow results as expected.
- Unsupported operators return HTTP 400 (not silently ignored).

## Test plan

- [x] `make lint` clean
- [x] `make test` passes (unit + Vitest)
- [x] `make integration` passes (204/204)
- [x] Staging verification: collapsed path (8 scenarios)
- [x] Staging verification: uncollapsed path (5 scenarios)
- [x] Staging verification: BigQuery rejection
- [ ] Manual UI verification of filter dropdown behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lifecycle filtering to Tests reports, supporting “blocking” and “informing” values.
  * Added a Lifecycle filter dropdown with supported equality and inequality options.
  * Lifecycle filters now apply consistently to collapsed, uncollapsed, and statistical report results.

* **Bug Fixes**
  * Invalid filter operators now return a clear HTTP 400 error.
  * The BigQuery-backed Tests endpoint now clearly rejects unsupported Lifecycle filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->