### PR TITLE
[WIP] TRT-2847: Fix aggregate test details variant filter excluding valid jobs

### DIFF
--- a/pkg/api/componentreadiness/dataprovider/postgres/provider.go
+++ b/pkg/api/componentreadiness/dataprovider/postgres/provider.go
@@ -529,6 +529,7 @@ func (p *PostgresProvider) queryBaseAggregateTestDetails(ctx context.Context, re
 		includeVariants = map[string][]string{}
 	}
 	includeVariants = mergeRequestedVariants(includeVariants, reqOptions)
+	includeVariants = filterVariantsByDBGroupBy(includeVariants, reqOptions.VariantOption.DBGroupBy)
 
 	testIDs := make([]string, 0, len(reqOptions.TestIDOptions))
 	for _, tid := range reqOptions.TestIDOptions {

--- a/pkg/api/componentreadiness/dataprovider/postgres/variants.go
+++ b/pkg/api/componentreadiness/dataprovider/postgres/variants.go
@@ -168,6 +168,20 @@ func mergeRequestedVariants(includeVariants map[string][]string, reqOptions reqo
 	return merged
 }
 
+// filterVariantsByDBGroupBy returns a copy of includeVariants keeping only keys
+// present in dbGroupBy. View-level variant filters (JobTier, CGroupMode, etc.)
+// that are not in dbGroupBy can over-constrain the SQL when querying older
+// releases whose variant_combinations lack those keys.
+func filterVariantsByDBGroupBy(includeVariants map[string][]string, dbGroupBy sets.Set[string]) map[string][]string {
+	filtered := make(map[string][]string, dbGroupBy.Len())
+	for k, v := range includeVariants {
+		if dbGroupBy.Has(k) {
+			filtered[k] = v
+		}
+	}
+	return filtered
+}
+
 // columnGroupMapping maps each real group_id to a synthetic col_group_id that
 // has only columnGroupBy dimensions. Multiple group_ids that share the same
 // column-level projection get the same col_group_id. The synthetic IDs start

--- a/pkg/api/componentreadiness/dataprovider/postgres/variants_test.go
+++ b/pkg/api/componentreadiness/dataprovider/postgres/variants_test.go
@@ -168,6 +168,82 @@ func TestMergeRequestedVariants(t *testing.T) {
 	}
 }
 
+func TestFilterVariantsByDBGroupBy(t *testing.T) {
+	tests := []struct {
+		name            string
+		includeVariants map[string][]string
+		dbGroupBy       sets.Set[string]
+		want            map[string][]string
+	}{
+		{
+			name:            "empty inputs",
+			includeVariants: map[string][]string{},
+			dbGroupBy:       sets.New[string](),
+			want:            map[string][]string{},
+		},
+		{
+			name: "keeps only dbGroupBy keys",
+			includeVariants: map[string][]string{
+				"Architecture": {"amd64"},
+				"JobTier":      {"blocking", "informing"},
+				"Platform":     {"aws"},
+				"Owner":        {"eng"},
+			},
+			dbGroupBy: sets.New[string]("Architecture", "Platform"),
+			want: map[string][]string{
+				"Architecture": {"amd64"},
+				"Platform":     {"aws"},
+			},
+		},
+		{
+			name: "all keys in dbGroupBy preserved",
+			includeVariants: map[string][]string{
+				"Architecture": {"amd64"},
+				"Network":      {"ovn"},
+			},
+			dbGroupBy: sets.New[string]("Architecture", "Network", "Platform"),
+			want: map[string][]string{
+				"Architecture": {"amd64"},
+				"Network":      {"ovn"},
+			},
+		},
+		{
+			name: "no keys in dbGroupBy",
+			includeVariants: map[string][]string{
+				"JobTier": {"blocking"},
+				"Owner":   {"eng"},
+			},
+			dbGroupBy: sets.New[string]("Architecture", "Platform"),
+			want:      map[string][]string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := filterVariantsByDBGroupBy(tc.includeVariants, tc.dbGroupBy)
+			if len(result) != len(tc.want) {
+				t.Fatalf("got %d keys, want %d", len(result), len(tc.want))
+			}
+			for k, wantVals := range tc.want {
+				gotVals, ok := result[k]
+				if !ok {
+					t.Errorf("missing key %q", k)
+					continue
+				}
+				if len(gotVals) != len(wantVals) {
+					t.Errorf("key %q: got %v, want %v", k, gotVals, wantVals)
+					continue
+				}
+				for i, wantVal := range wantVals {
+					if gotVals[i] != wantVal {
+						t.Errorf("key %q[%d] = %q, want %q", k, i, gotVals[i], wantVal)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestBuildVariantGroupMapping(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/test/integration/component_readiness_test.go
+++ b/test/integration/component_readiness_test.go
@@ -1852,6 +1852,58 @@ func TestQueryBaseJobRunTestStatus_AggregateFallback(t *testing.T) {
 		}
 	})
 
+	t.Run("non-dbGroupBy includeVariants keys do not exclude valid jobs", func(t *testing.T) {
+		dbc := crTestDB(t)
+		release := "4.16"
+
+		// Job variant_combination only has dbGroupBy keys (Platform, Network).
+		// It does NOT have JobTier, Owner, or CGroupMode.
+		vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+		job := createProwJobWithVC(t, dbc, "periodic-non-dbg-aws", release, vc)
+
+		test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] non-dbGroupBy filter test")
+		suite := intutil.CreateSuite(t, dbc, "openshift-tests-ndbg")
+		tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:non-dbg-filter", "Storage", []string{"PVC"})
+
+		baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+		baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+		createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, job.ID, suite.ID, 80, 75, 3)
+		createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, job.ID, suite.ID, 100, 90, 5)
+
+		provider := postgres.NewPostgresProvider(dbc, nil)
+		opts := defaultReqOptions(release)
+		opts.TestIDOptions = []reqopts.TestIdentification{{
+			TestID:            tow.UniqueID,
+			RequestedVariants: map[string]string{"Platform": "aws", "Network": "ovn"},
+		}}
+		// includeVariants has keys NOT in dbGroupBy (JobTier, Owner, CGroupMode).
+		// The job's variant_combination lacks these keys. Before the fix, the SQL
+		// variant filter AND-ed all keys, returning zero rows.
+		opts.VariantOption.IncludeVariants = map[string][]string{
+			"Platform":   {"aws"},
+			"Network":    {"ovn"},
+			"JobTier":    {"blocking", "informing"},
+			"Owner":      {"eng"},
+			"CGroupMode": {"v2"},
+		}
+
+		result, errs := provider.QueryBaseJobRunTestStatus(context.Background(), opts)
+		require.Empty(t, errs)
+
+		totalRows := 0
+		for _, rows := range result {
+			totalRows += len(rows)
+		}
+		require.Equal(t, 1, totalRows, "non-dbGroupBy variant keys should not exclude valid jobs")
+
+		for _, rows := range result {
+			for _, row := range rows {
+				assert.Equal(t, tow.UniqueID, row.TestKey.TestID)
+				assert.Equal(t, 20, row.Stats.Total(), "aggregate total should be prefix-sum delta")
+			}
+		}
+	})
+
 	t.Run("multiple jobs aggregated separately", func(t *testing.T) {
 		dbc := crTestDB(t)
 		release := "4.16"


### PR DESCRIPTION
@coderabbitai ignore

## Summary

- Fixes a bug where the test_details aggregate fallback returned zero base stats for older release overrides (e.g. 4.21 in the 5.0-main view)
- The SQL variant filter included non-dbGroupBy keys (JobTier, CGroupMode, ContainerRuntime, Owner) from the view's `includeVariants`, which combined to exclude all matching jobs for older releases
- Filters `includeVariants` to only dbGroupBy keys before building the SQL WHERE clause; Go-side `matchRequestedVariants` in `processAggregateRows` handles per-variant matching

## Root cause

For release 4.21, the only jobs with complete variant_combinations (including Suite, CGroupMode, LayeredProduct) had `JobTier:candidate`, which the view's `includeVariants` excludes (only `blocking`, `informing`, `standard`). Jobs with allowed JobTier values lacked the newer variant keys. The AND combination of all filter clauses excluded every job.

## Test plan

- [x] Unit test for `filterVariantsByDBGroupBy` (included)
- [x] Existing unit tests pass (`go test ./pkg/api/componentreadiness/...`)
- [x] Verify against staging DB: fixed SQL returns 2 rows for 4.21 base override (confirmed)
- [x] Deploy to staging and verify the test_details API returns non-zero base stats for the 4.21 override analysis with `dataSource=postgres`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved aggregate readiness filtering by applying only supported dimensions, preventing unsupported filters from affecting database queries.

* **Tests**
  * Added coverage for matching, non-matching, empty, and multiple variant filter scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->