### PR TITLE
Display lifecycle indicator on Tests and Test Analysis pages

### DIFF
--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -448,7 +448,7 @@ func (spec *TestResultsSpec) buildTestsResultsPGGenerator(ctx context.Context, d
 		variantFilter, lifecycleFilter = variantsAndLifecycle.Split([]string{"variants"})
 	}
 
-	testMetadataColumns := []string{"suite_name", "name", "jira_component", "jira_component_id"}
+	testMetadataColumns := []string{"suite_name", "name", "jira_component", "jira_component_id", "lifecycles"}
 
 	var finalResults *gorm.DB
 	workMem := "4MB"

--- a/pkg/apis/api/types.go
+++ b/pkg/apis/api/types.go
@@ -467,10 +467,11 @@ func (run JobRun) GetArrayValue(param string) ([]string, error) {
 // Test contains the full accounting of a test's history. The format
 // of this struct is suitable for use in a data table.
 type Test struct {
-	Name      string         `json:"name"`
-	SuiteName string         `json:"suite_name"`
-	Variant   string         `json:"variant,omitempty"`
-	Variants  pq.StringArray `json:"variants" gorm:"type:text[]"`
+	Name       string         `json:"name"`
+	SuiteName  string         `json:"suite_name"`
+	Variant    string         `json:"variant,omitempty"`
+	Variants   pq.StringArray `json:"variants" gorm:"type:text[]"`
+	Lifecycles pq.StringArray `json:"lifecycles,omitempty" gorm:"type:text[]"`
 
 	JiraComponent   string `json:"jira_component"`
 	JiraComponentID int    `json:"jira_component_id"`
@@ -521,6 +522,8 @@ func (test Test) GetFieldType(param string) ColumnType {
 	case "variant":
 		return ColumnTypeString
 	case "variants":
+		return ColumnTypeArray
+	case "lifecycles":
 		return ColumnTypeArray
 	default:
 		return ColumnTypeNumerical
@@ -612,6 +615,8 @@ func (test Test) GetArrayValue(param string) ([]string, error) {
 		return test.Tags, nil
 	case "variants":
 		return test.Variants, nil
+	case "lifecycles":
+		return test.Lifecycles, nil
 	default:
 		return nil, fmt.Errorf("unknown array value field %s", param)
 	}
@@ -620,11 +625,12 @@ func (test Test) GetArrayValue(param string) ([]string, error) {
 // TestBQ contains the full accounting of a test's history. The format
 // of this struct is suitable for use in a data table.
 type TestBQ struct {
-	TestID    string         `json:"test_id" bigquery:"test_id"`
-	Name      string         `json:"name" bigquery:"name"`
-	SuiteName string         `json:"suite_name" bigquery:"suite_name"`
-	Variant   string         `json:"variant,omitempty" bigquery:"variant"`
-	Variants  pq.StringArray `json:"variants" gorm:"type:text[]" bigquery:"variants"`
+	TestID     string         `json:"test_id" bigquery:"test_id"`
+	Name       string         `json:"name" bigquery:"name"`
+	SuiteName  string         `json:"suite_name" bigquery:"suite_name"`
+	Variant    string         `json:"variant,omitempty" bigquery:"variant"`
+	Variants   pq.StringArray `json:"variants" gorm:"type:text[]" bigquery:"variants"`
+	Lifecycles pq.StringArray `json:"lifecycles,omitempty" gorm:"type:text[]" bigquery:"lifecycles"`
 
 	JiraComponent   string   `json:"jira_component" bigquery:"jira_component"`
 	JiraComponentID *big.Rat `json:"jira_component_id" bigquery:"jira_component_id"`
@@ -675,6 +681,8 @@ func (test TestBQ) GetFieldType(param string) ColumnType {
 	case "variant":
 		return ColumnTypeString
 	case "variants":
+		return ColumnTypeArray
+	case "lifecycles":
 		return ColumnTypeArray
 	default:
 		return ColumnTypeNumerical
@@ -766,6 +774,8 @@ func (test TestBQ) GetArrayValue(param string) ([]string, error) {
 		return test.Tags, nil
 	case "variants":
 		return test.Variants, nil
+	case "lifecycles":
+		return test.Lifecycles, nil
 	default:
 		return nil, fmt.Errorf("unknown array value field %s", param)
 	}

--- a/pkg/db/query/cumulative_query.go
+++ b/pkg/db/query/cumulative_query.go
@@ -421,7 +421,8 @@ func TestReportQueryCollapsed(dbc *db.DB, release string, sample, base DateRange
     SUM(tcs.prefix_sum_successes) AS ps_successes,
     SUM(tcs.prefix_sum_failures)  AS ps_failures,
     SUM(tcs.prefix_sum_flakes)    AS ps_flakes,
-    SUM(tcs.prefix_sum_runs)      AS ps_runs
+    SUM(tcs.prefix_sum_runs)      AS ps_runs,
+    array_agg(DISTINCT tcs.lifecycle) AS lifecycles
   FROM test_cumulative_summaries tcs
   JOIN prow_jobs pj ON tcs.prow_job_id = pj.id AND pj.variant_combination_id IS NOT NULL
 `)
@@ -450,7 +451,7 @@ func TestReportQueryCollapsed(dbc *db.DB, release string, sample, base DateRange
 	}
 
 	buf.WriteString(`SELECT t.name, su.name AS suite_name,
-  jc.name AS jira_component, jc.id AS jira_component_id, e.release,
+  jc.name AS jira_component, jc.id AS jira_component_id, e.release, e.lifecycles,
   COALESCE(e.ps_successes - COALESCE(m.ps_successes, 0), 0)::bigint AS current_successes,
   COALESCE(e.ps_failures  - COALESCE(m.ps_failures,  0), 0)::bigint AS current_failures,
   COALESCE(e.ps_flakes    - COALESCE(m.ps_flakes,    0), 0)::bigint AS current_flakes,

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -285,7 +285,7 @@ func UncollapsedTestReportWithStats(dbc *db.DB, release string, sample, base Dat
     jira_components.name AS jira_component, jira_components.id AS jira_component_id,
     pre.current_successes, pre.current_failures, pre.current_flakes, pre.current_runs,
     pre.previous_successes, pre.previous_failures, pre.previous_flakes, pre.previous_runs,
-    ob.open_bugs, vc.variants, pre.variant_combination_id, pre.release,
+    ob.open_bugs, vc.variants, pre.variant_combination_id, pre.release, pre.lifecycles,
     `)
 	buf.WriteString(QueryTestPercentages)
 	buf.WriteString(`
@@ -298,7 +298,8 @@ func UncollapsedTestReportWithStats(dbc *db.DB, release string, sample, base Dat
       SUM(COALESCE(e.prefix_sum_successes - COALESCE(m.prefix_sum_successes, 0), 0))::bigint AS current_successes,
       SUM(COALESCE(e.prefix_sum_flakes    - COALESCE(m.prefix_sum_flakes,    0), 0))::bigint AS current_flakes,
       SUM(COALESCE(e.prefix_sum_failures  - COALESCE(m.prefix_sum_failures,  0), 0))::bigint AS current_failures,
-      SUM(COALESCE(e.prefix_sum_runs      - COALESCE(m.prefix_sum_runs,      0), 0))::bigint AS current_runs
+      SUM(COALESCE(e.prefix_sum_runs      - COALESCE(m.prefix_sum_runs,      0), 0))::bigint AS current_runs,
+      array_agg(DISTINCT e.lifecycle) AS lifecycles
     FROM test_cumulative_summaries e
     JOIN prow_jobs pj ON e.prow_job_id = pj.id AND pj.variant_combination_id IS NOT NULL
     LEFT JOIN test_cumulative_summaries m ON m.test_id = e.test_id AND m.prow_job_id = e.prow_job_id AND m.suite_id = e.suite_id AND m.lifecycle = e.lifecycle AND m.release = e.release AND m.date = ?

--- a/sippy-ng/src/tests/TestAnalysis.jsx
+++ b/sippy-ng/src/tests/TestAnalysis.jsx
@@ -249,6 +249,29 @@ export function TestAnalysis(props) {
                       variant="outlined"
                     />
                   )}
+                  {test.lifecycles && test.lifecycles.includes('informing') && (
+                    <Tooltip
+                      title={
+                        test.lifecycles.length === 1
+                          ? 'Informing'
+                          : 'Contains informing'
+                      }
+                    >
+                      <Chip
+                        label={
+                          test.lifecycles.length === 1
+                            ? 'Informing'
+                            : 'Contains informing'
+                        }
+                        size="small"
+                        color="info"
+                        variant={
+                          test.lifecycles.length === 1 ? 'filled' : 'outlined'
+                        }
+                        sx={{ ml: test.jira_component ? 1 : 0 }}
+                      />
+                    </Tooltip>
+                  )}
                 </div>
                 <GridToolbarFilterMenu
                   linkOperatorDisabled={true}

--- a/sippy-ng/src/tests/TestTable.jsx
+++ b/sippy-ng/src/tests/TestTable.jsx
@@ -1,5 +1,11 @@
 import './TestTable.css'
-import { AcUnit, Error as ErrorIcon, Search } from '@mui/icons-material'
+import {
+  AcUnit,
+  Error as ErrorIcon,
+  Info,
+  InfoOutlined,
+  Search,
+} from '@mui/icons-material'
 import {
   Backdrop,
   Badge,
@@ -490,6 +496,28 @@ function TestTable(props) {
     return {}
   }
 
+  const lifecycleIcon = (lifecycles) => {
+    if (!lifecycles || lifecycles.length === 0) {
+      return null
+    }
+    const hasInforming = lifecycles.includes('informing')
+    if (!hasInforming) {
+      return null
+    }
+    const allInforming = lifecycles.length === 1
+    const label = allInforming ? 'Informing' : 'Contains informing'
+    const IconComponent = allInforming ? Info : InfoOutlined
+    return (
+      <Tooltip title={label}>
+        <IconComponent
+          fontSize="small"
+          color="info"
+          sx={{ ml: 0.5, verticalAlign: 'middle' }}
+        />
+      </Tooltip>
+    )
+  }
+
   const columns = {
     name: {
       field: 'name',
@@ -499,19 +527,22 @@ function TestTable(props) {
           return params.value
         }
         return (
-          <div align="left" className="test-name">
-            <Tooltip title={params.value}>
-              <Link
-                to={pathForExactTestAnalysisWithFilter(
-                  props.release,
-                  params.row.name,
-                  filterModel,
-                  period
-                )}
-              >
-                {params.value}
-              </Link>
-            </Tooltip>
+          <div style={{ display: 'flex', alignItems: 'center', minWidth: 0 }}>
+            <div align="left" className="test-name">
+              <Tooltip title={params.value}>
+                <Link
+                  to={pathForExactTestAnalysisWithFilter(
+                    props.release,
+                    params.row.name,
+                    filterModel,
+                    period
+                  )}
+                >
+                  {params.value}
+                </Link>
+              </Tooltip>
+            </div>
+            {lifecycleIcon(params.row.lifecycles)}
           </div>
         )
       },

--- a/test/integration/tests_report_test.go
+++ b/test/integration/tests_report_test.go
@@ -54,7 +54,7 @@ func runCollapsedReport(t *testing.T, dbc *db.DB, release string, sample, base q
 	if err != nil {
 		return nil, err
 	}
-	testMetadataColumns := []string{"suite_name", "name", "jira_component", "jira_component_id"}
+	testMetadataColumns := []string{"suite_name", "name", "jira_component", "jira_component_id", "lifecycles"}
 	collapsedColumns := slices.Concat(testMetadataColumns, []string{query.QueryTestFields})
 	rawQuery := dbc.DB.Table("(?) AS r", collapsedQuery).Select(strings.Join(collapsedColumns, ","))
 	selectColumns := slices.Concat(testMetadataColumns, []string{query.QueryTestSummarizer})
@@ -539,6 +539,60 @@ func TestTestReportQueryCollapsed_NewTestWithNoPriorHistoryReportsZeroPrevious(t
 	assert.Equal(t, 0, results[0].PreviousRuns, "previous runs should be zero when there's no earlier data at all")
 }
 
+func TestTestReportQueryCollapsed_LifecyclesFieldReflectsDistinctLifecycles(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, _, end := testsReportPeriods()
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	// blockingOnly: one variant combination with only blocking data.
+	vcA := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	jobA := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vcA))
+	blockingOnly := intutil.CreateTest(t, dbc, "sig-network blocking-only-test")
+	intutil.CreateCumulativeSummary(t, dbc, end, release, blockingOnly.ID, jobA.ID, suite.ID, 10, 10, 0)
+
+	// mixed: two variant combinations, one blocking and one informing, that collapse into
+	// a single row with both lifecycles.
+	vcB := intutil.CreateVariantCombination(t, dbc, []string{"Platform:gcp"})
+	jobB := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-gcp", release, nil, intutil.WithVariantCombination(vcB))
+	mixed := intutil.CreateTest(t, dbc, "sig-network mixed-lifecycle-test")
+	intutil.CreateCumulativeSummary(t, dbc, end, release, mixed.ID, jobA.ID, suite.ID, 10, 10, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, mixed.ID, jobB.ID, suite.ID, 5, 5, 0, intutil.WithCumulativeSummaryLifecycle("informing"))
+
+	t.Run("blocking-only test reports single lifecycle", func(t *testing.T) {
+		nameFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "name", Operator: filter.OperatorEquals, Value: "sig-network blocking-only-test"},
+		}}
+		results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nameFilter, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.ElementsMatch(t, []string{"blocking"}, results[0].Lifecycles)
+	})
+
+	t.Run("mixed-lifecycle test reports both lifecycles", func(t *testing.T) {
+		nameFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "name", Operator: filter.OperatorEquals, Value: "sig-network mixed-lifecycle-test"},
+		}}
+		results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nameFilter, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.ElementsMatch(t, []string{"blocking", "informing"}, results[0].Lifecycles)
+	})
+
+	t.Run("lifecycle filter narrows the reported lifecycles", func(t *testing.T) {
+		nameFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "name", Operator: filter.OperatorEquals, Value: "sig-network mixed-lifecycle-test"},
+		}}
+		lifecycleFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "informing"},
+		}}
+		results, err := runCollapsedReport(t, dbc, release, sample, base, nil, nameFilter, lifecycleFilter)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.ElementsMatch(t, []string{"informing"}, results[0].Lifecycles)
+	})
+}
+
 // --- UncollapsedTestReportWithStats ---
 
 func TestUncollapsedTestReportWithStats_OneRowPerVariantCombination(t *testing.T) {
@@ -864,4 +918,49 @@ func TestUncollapsedTestReportWithStats_NewVariantWithNoPriorHistoryReportsZeroP
 	require.Len(t, results, 1)
 	assert.Equal(t, 6, results[0].CurrentRuns)
 	assert.Equal(t, 0, results[0].PreviousRuns)
+}
+
+func TestUncollapsedTestReportWithStats_LifecyclesFieldReflectsDistinctLifecycles(t *testing.T) {
+	dbc := testsReportDB(t)
+	release := "4.16"
+	sample, base, _, _, end := testsReportPeriods()
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	test := intutil.CreateTest(t, dbc, "sig-network uncollapsed-lifecycle-field-test")
+
+	// VC-A: only blocking data.
+	vcA := intutil.CreateVariantCombination(t, dbc, []string{"Platform:aws"})
+	jobA := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-aws", release, nil, intutil.WithVariantCombination(vcA))
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobA.ID, suite.ID, 10, 10, 0)
+
+	// VC-B: both blocking and informing data (two prow jobs sharing a variant combination).
+	vcB := intutil.CreateVariantCombination(t, dbc, []string{"Platform:gcp"})
+	jobB1 := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-gcp-blocking", release, nil, intutil.WithVariantCombination(vcB))
+	jobB2 := intutil.CreateProwJobWithOptions(t, dbc, "periodic-e2e-gcp-informing", release, nil, intutil.WithVariantCombination(vcB))
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobB1.ID, suite.ID, 10, 10, 0)
+	intutil.CreateCumulativeSummary(t, dbc, end, release, test.ID, jobB2.ID, suite.ID, 5, 5, 0, intutil.WithCumulativeSummaryLifecycle("informing"))
+
+	t.Run("blocking-only variant reports single lifecycle", func(t *testing.T) {
+		results, _, err := runUncollapsedReport(t, dbc, release, sample, base, nil, nil, nil, nil)
+		require.NoError(t, err)
+		rowA := findVariantRow(t, results, test.Name, []string{"Platform:aws"})
+		assert.ElementsMatch(t, []string{"blocking"}, rowA.Lifecycles)
+	})
+
+	t.Run("mixed-lifecycle variant reports both lifecycles", func(t *testing.T) {
+		results, _, err := runUncollapsedReport(t, dbc, release, sample, base, nil, nil, nil, nil)
+		require.NoError(t, err)
+		rowB := findVariantRow(t, results, test.Name, []string{"Platform:gcp"})
+		assert.ElementsMatch(t, []string{"blocking", "informing"}, rowB.Lifecycles)
+	})
+
+	t.Run("lifecycle filter narrows the reported lifecycles", func(t *testing.T) {
+		lifecycleFilter := &filter.Filter{Items: []filter.FilterItem{
+			{Field: "lifecycle", Operator: filter.OperatorEquals, Value: "blocking"},
+		}}
+		results, _, err := runUncollapsedReport(t, dbc, release, sample, base, nil, nil, nil, lifecycleFilter)
+		require.NoError(t, err)
+		rowB := findVariantRow(t, results, test.Name, []string{"Platform:gcp"})
+		assert.ElementsMatch(t, []string{"blocking"}, rowB.Lifecycles)
+	})
 }


### PR DESCRIPTION
## Summary
- Add `lifecycles` field to the test API response using `array_agg(DISTINCT lifecycle)` in both collapsed and uncollapsed queries
- Display an informing indicator on the Tests page: filled icon for fully-informing tests, outlined icon for mixed-lifecycle tests
- Show a chip with matching label and variant (filled/outlined) on the Test Analysis page
- Add integration tests covering the new field for both query paths

## Screenshots

#### Test with all runs informing
<img width="1512" height="982" alt="Screenshot 2026-08-04 at 10 02 19 PM" src="https://github.com/user-attachments/assets/cc62e953-9348-45e3-85f5-2f880bdf9fbc" />

#### Test with some but not all runs informing
<img width="1512" height="982" alt="Screenshot 2026-08-04 at 10 02 13 PM" src="https://github.com/user-attachments/assets/080bd0e4-5545-4bdc-978c-f869bad4f8c6" />

#### Test Analysis for test with all runs informing
<img width="1244" height="408" alt="Screenshot 2026-08-04 at 10 09 31 PM" src="https://github.com/user-attachments/assets/4fd84fc0-46df-4024-8f09-4c9a6185c46c" />

#### Test Analysis for test with some but not all runs informing
<img width="1244" height="408" alt="Screenshot 2026-08-04 at 10 09 02 PM" src="https://github.com/user-attachments/assets/c51e6b42-0931-4baa-83b4-caf3e4221be7" />

#### Badge in table in Test Analysis page
<img width="1186" height="479" alt="Screenshot 2026-08-04 at 10 09 13 PM" src="https://github.com/user-attachments/assets/159c52dd-4525-4730-b495-9574668a6e6f" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test reports now display lifecycle information, including “Informing” and “Contains informing” indicators.
  * Lifecycle details are available in test analysis, test tables, JSON responses, and BigQuery data.
  * Collapsed and uncollapsed reports now preserve and aggregate lifecycle values.

* **Bug Fixes**
  * Improved lifecycle filtering and reporting across test variants and jobs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->