### PR TITLE
TRT-2821: Optimize GetJobRunTestsCountByLookback using cumulative summaries

### DIFF
--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -12,10 +12,13 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
 	pkgerrors "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/iterator"
 	"gorm.io/gorm"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/apis/cache"
@@ -374,37 +377,102 @@ func PrintTestsJSONFromBigQuery(release string, w http.ResponseWriter, req *http
 }
 
 func GetJobRunTestsCountByLookback(dbc *db.DB, lookbackDays int) (int64, int64, error) {
+	return GetJobRunTestsCountByLookbackAt(dbc, lookbackDays, civil.DateOf(time.Now().UTC()))
+}
+
+func GetJobRunTestsCountByLookbackAt(dbc *db.DB, lookbackDays int, today civil.Date) (int64, int64, error) {
+	if dbc == nil {
+		return -1, -1, errors.New("database connection is required")
+	}
 	if lookbackDays < 1 {
 		return -1, -1, errors.New("lookback days must be greater than zero")
 	}
-	// Calculate the truncated time
-	now := time.Now().UTC()
-	truncatedTime := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, -lookbackDays)
 
-	type counts = struct {
-		JobRunsCount int64 `json:"job_runs_count"`
-		TestIDsCount int64 `json:"test_ids_count"`
+	startMinusOne := today.AddDays(-lookbackDays - 1)
+
+	timeStart := time.Now()
+	log.WithField("lookbackDays", lookbackDays).Info("starting lookback count queries")
+
+	// Count job runs from prow_job_runs (one row per run, much smaller than prow_job_run_tests).
+	var jobRunsCount int64
+	err := dbc.DB.Table("prow_job_runs").
+		Where("timestamp > ? AND deleted_at IS NULL", today.AddDays(-lookbackDays).In(time.UTC)).
+		Count(&jobRunsCount).
+		Error
+	if err != nil {
+		return -1, -1, fmt.Errorf("counting job runs: %w", err)
 	}
 
-	queryCounts := counts{}
-	timeStart := time.Now()
+	// Count distinct tests using cumulative summaries. Query per-release so
+	// Postgres can prune to a single date sub-partition per release for each
+	// side of the join, avoiding the full cross-partition scan that makes a
+	// global self-join slow.
 
-	log.Infof("Starting tests count query for lookback: %d", lookbackDays)
-
-	err := dbc.DB.Table("prow_job_run_tests").
-		Select("count(distinct prow_job_run_id) as job_runs_count, count(distinct test_id) as test_ids_count").
-		Where("prow_job_run_timestamp > ?", truncatedTime).
-		Scan(&queryCounts).
+	var releases []string
+	err = dbc.DB.Table("release_definitions").
+		Pluck("release", &releases).
 		Error
-
-	timeFinish := time.Now()
-	log.Infof("Finished tests count query for lookback: %d, duration: %s", lookbackDays, timeFinish.Sub(timeStart).String())
-
 	if err != nil {
+		return -1, -1, fmt.Errorf("listing releases: %w", err)
+	}
+
+	ch := make(chan []int64, len(releases))
+	testIDs := sets.New[int64]()
+	done := make(chan struct{})
+	go func() {
+		for ids := range ch {
+			testIDs.Insert(ids...)
+		}
+		close(done)
+	}()
+
+	g := new(errgroup.Group)
+	g.SetLimit(4)
+	for _, release := range releases {
+		g.Go(func() error {
+			var releaseTestIDs []int64
+			queryErr := dbc.DB.Raw(`
+				WITH end_sums AS (
+				  SELECT test_id, SUM(prefix_sum_runs) AS total_runs
+				  FROM test_cumulative_summaries
+				  WHERE release = ? AND date = ?
+				  GROUP BY test_id
+				),
+				start_sums AS (
+				  SELECT test_id, SUM(prefix_sum_runs) AS total_runs
+				  FROM test_cumulative_summaries
+				  WHERE release = ? AND date = ?
+				  GROUP BY test_id
+				)
+				SELECT e.test_id
+				FROM end_sums e
+				LEFT JOIN start_sums s ON s.test_id = e.test_id
+				WHERE (e.total_runs - COALESCE(s.total_runs, 0)) > 0`,
+				release, today, release, startMinusOne).
+				Scan(&releaseTestIDs).
+				Error
+			if queryErr != nil {
+				return fmt.Errorf("counting test IDs for release %s: %w", release, queryErr)
+			}
+			ch <- releaseTestIDs
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
 		return -1, -1, err
 	}
+	close(ch)
+	<-done
+	testIDsCount := int64(testIDs.Len())
 
-	return queryCounts.JobRunsCount, queryCounts.TestIDsCount, nil
+	log.WithFields(log.Fields{
+		"lookbackDays": lookbackDays,
+		"jobRunsCount": jobRunsCount,
+		"testIDsCount": testIDsCount,
+		"duration":     time.Since(timeStart),
+	}).Info("finished lookback count queries")
+
+	return jobRunsCount, testIDsCount, nil
 }
 
 type TestResultsSpec struct {

--- a/test/integration/lookback_count_test.go
+++ b/test/integration/lookback_count_test.go
@@ -1,0 +1,184 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"cloud.google.com/go/civil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openshift/sippy/pkg/api"
+	v1 "github.com/openshift/sippy/pkg/apis/sippyprocessing/v1"
+	"github.com/openshift/sippy/pkg/db"
+	intutil "github.com/openshift/sippy/test/integration/util"
+)
+
+var lookbackDate = civil.Date{Year: 2024, Month: 7, Day: 15}
+
+func lookbackCountDB(t *testing.T) *db.DB {
+	t.Helper()
+	return intutil.NewTestDB(t, pgContainer)
+}
+
+type lookbackFixtures struct {
+	jobA, jobB                     uint
+	suiteA                         uint
+	testAlpha, testBeta, testGamma uint
+}
+
+func seedLookbackFixtures(t *testing.T, dbc *db.DB) lookbackFixtures {
+	t.Helper()
+
+	intutil.CreateReleaseDefinition(t, dbc, "4.18", 4, 18)
+	intutil.CreateReleaseDefinition(t, dbc, "4.19", 4, 19)
+
+	jobA := intutil.CreateProwJob(t, dbc, "periodic-e2e-aws", "4.18", []string{"aws"})
+	jobB := intutil.CreateProwJob(t, dbc, "periodic-e2e-gcp", "4.19", []string{"gcp"})
+
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests")
+
+	testAlpha := intutil.CreateTest(t, dbc, "alpha-test")
+	testBeta := intutil.CreateTest(t, dbc, "beta-test")
+	testGamma := intutil.CreateTest(t, dbc, "gamma-test")
+
+	return lookbackFixtures{
+		jobA:      jobA.ID,
+		jobB:      jobB.ID,
+		suiteA:    suite.ID,
+		testAlpha: testAlpha.ID,
+		testBeta:  testBeta.ID,
+		testGamma: testGamma.ID,
+	}
+}
+
+func TestLookbackCount_DeduplicatesTestIDsAcrossReleases(t *testing.T) {
+	dbc := lookbackCountDB(t)
+	f := seedLookbackFixtures(t, dbc)
+
+	today := lookbackDate
+	startMinusOne := today.AddDays(-15)
+
+	// testAlpha appears in both releases with runs in the window.
+	// It should be counted once, not twice.
+	intutil.CreateCumulativeSummary(t, dbc, today, "4.18", f.testAlpha, f.jobA, f.suiteA, 100, 90, 5)
+	intutil.CreateCumulativeSummary(t, dbc, startMinusOne, "4.18", f.testAlpha, f.jobA, f.suiteA, 80, 70, 3)
+
+	intutil.CreateCumulativeSummary(t, dbc, today, "4.19", f.testAlpha, f.jobB, f.suiteA, 50, 45, 2)
+	intutil.CreateCumulativeSummary(t, dbc, startMinusOne, "4.19", f.testAlpha, f.jobB, f.suiteA, 30, 25, 1)
+
+	// testBeta only in 4.18.
+	intutil.CreateCumulativeSummary(t, dbc, today, "4.18", f.testBeta, f.jobA, f.suiteA, 60, 55, 3)
+	intutil.CreateCumulativeSummary(t, dbc, startMinusOne, "4.18", f.testBeta, f.jobA, f.suiteA, 40, 35, 2)
+
+	_, testIDsCount, err := api.GetJobRunTestsCountByLookbackAt(dbc, 14, lookbackDate)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), testIDsCount, "testAlpha should be deduplicated across releases")
+}
+
+func TestLookbackCount_ZeroAndNegativeDeltaExcluded(t *testing.T) {
+	dbc := lookbackCountDB(t)
+	f := seedLookbackFixtures(t, dbc)
+
+	today := lookbackDate
+	startMinusOne := today.AddDays(-15)
+
+	// testAlpha has runs in the window (delta > 0).
+	intutil.CreateCumulativeSummary(t, dbc, today, "4.18", f.testAlpha, f.jobA, f.suiteA, 100, 90, 5)
+	intutil.CreateCumulativeSummary(t, dbc, startMinusOne, "4.18", f.testAlpha, f.jobA, f.suiteA, 80, 70, 3)
+
+	// testBeta has zero delta (same prefix sum at both dates).
+	intutil.CreateCumulativeSummary(t, dbc, today, "4.18", f.testBeta, f.jobA, f.suiteA, 50, 45, 2)
+	intutil.CreateCumulativeSummary(t, dbc, startMinusOne, "4.18", f.testBeta, f.jobA, f.suiteA, 50, 45, 2)
+
+	// testGamma has negative delta (end prefix sum < start prefix sum).
+	intutil.CreateCumulativeSummary(t, dbc, today, "4.18", f.testGamma, f.jobA, f.suiteA, 30, 25, 1)
+	intutil.CreateCumulativeSummary(t, dbc, startMinusOne, "4.18", f.testGamma, f.jobA, f.suiteA, 40, 35, 2)
+
+	_, testIDsCount, err := api.GetJobRunTestsCountByLookbackAt(dbc, 14, lookbackDate)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), testIDsCount, "only testAlpha (positive delta) should be counted")
+}
+
+func TestLookbackCount_NewTestWithNoPriorRow(t *testing.T) {
+	dbc := lookbackCountDB(t)
+	f := seedLookbackFixtures(t, dbc)
+
+	today := lookbackDate
+
+	// testAlpha has a row at today but no row at startMinusOne.
+	// COALESCE treats the missing start row as zero, so the delta
+	// equals the full end prefix sum and should be counted.
+	intutil.CreateCumulativeSummary(t, dbc, today, "4.18", f.testAlpha, f.jobA, f.suiteA, 10, 8, 1)
+
+	_, testIDsCount, err := api.GetJobRunTestsCountByLookbackAt(dbc, 14, lookbackDate)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), testIDsCount, "test with no prior row should be counted")
+}
+
+func TestLookbackCount_JobRunsCountExcludesDeleted(t *testing.T) {
+	dbc := lookbackCountDB(t)
+	seedLookbackFixtures(t, dbc)
+
+	withinWindow := lookbackDate.AddDays(-1).In(time.UTC)
+	outsideWindow := lookbackDate.AddDays(-15).In(time.UTC)
+
+	// Two runs within the 14-day window.
+	intutil.CreateProwJobRun(t, dbc, 1, "4.18", withinWindow, true, v1.JobSucceeded)
+	intutil.CreateProwJobRun(t, dbc, 1, "4.18", withinWindow.Add(-time.Hour), false, v1.JobTestFailure)
+
+	// One run outside the window.
+	intutil.CreateProwJobRun(t, dbc, 1, "4.18", outsideWindow, true, v1.JobSucceeded)
+
+	// One soft-deleted run within the window.
+	deletedRun := intutil.CreateProwJobRun(t, dbc, 1, "4.18", withinWindow.Add(-2*time.Hour), true, v1.JobSucceeded)
+	require.NoError(t, dbc.DB.Delete(&deletedRun).Error)
+
+	jobRunsCount, _, err := api.GetJobRunTestsCountByLookbackAt(dbc, 14, lookbackDate)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), jobRunsCount, "should count only non-deleted runs within the window")
+}
+
+func TestLookbackCount_MultipleJobsPerTestAggregated(t *testing.T) {
+	dbc := lookbackCountDB(t)
+	f := seedLookbackFixtures(t, dbc)
+
+	today := lookbackDate
+	startMinusOne := today.AddDays(-15)
+
+	// testAlpha has zero delta in jobA but positive delta in jobB,
+	// both in the same release. The SUM across jobs should yield a
+	// positive total, so testAlpha is counted.
+	intutil.CreateCumulativeSummary(t, dbc, today, "4.18", f.testAlpha, f.jobA, f.suiteA, 50, 45, 2)
+	intutil.CreateCumulativeSummary(t, dbc, startMinusOne, "4.18", f.testAlpha, f.jobA, f.suiteA, 50, 45, 2)
+
+	intutil.CreateCumulativeSummary(t, dbc, today, "4.18", f.testAlpha, f.jobB, f.suiteA, 30, 25, 1)
+	intutil.CreateCumulativeSummary(t, dbc, startMinusOne, "4.18", f.testAlpha, f.jobB, f.suiteA, 20, 18, 0)
+
+	_, testIDsCount, err := api.GetJobRunTestsCountByLookbackAt(dbc, 14, lookbackDate)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), testIDsCount, "test with positive aggregate delta across jobs should be counted")
+}
+
+func TestLookbackCount_NoReleasesReturnsZeroTests(t *testing.T) {
+	dbc := lookbackCountDB(t)
+
+	_, testIDsCount, err := api.GetJobRunTestsCountByLookbackAt(dbc, 14, lookbackDate)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), testIDsCount)
+}
+
+func TestLookbackCount_InvalidLookbackDays(t *testing.T) {
+	dbc := lookbackCountDB(t)
+
+	_, _, err := api.GetJobRunTestsCountByLookbackAt(dbc, 0, lookbackDate)
+	assert.Error(t, err)
+
+	_, _, err = api.GetJobRunTestsCountByLookbackAt(dbc, -1, lookbackDate)
+	assert.Error(t, err)
+}
+
+func TestLookbackCount_NilDatabase(t *testing.T) {
+	_, _, err := api.GetJobRunTestsCountByLookbackAt(nil, 14, lookbackDate)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

- Replace the single `COUNT(DISTINCT)` query against `prow_job_run_tests` (the largest table, ~70M rows in a 14-day window) with two targeted queries:
  - **Job run count** from `prow_job_runs` directly (one row per run, indexed on timestamp): ~50ms
  - **Test ID count** using per-release cumulative summary self-joins run concurrently via errgroup (4 workers): ~2s
- Total wall-clock drops from ~3 minutes to ~2 seconds on staging

## Benchmark results (staging, 3 iterations)

| Query | Before (prod) | After (staging) |
|---|---|---|
| 14-day lookback | 219s | **~2s** |
| 9-day lookback | 160s | **~2s** |

## Approach

The old query scanned `prow_job_run_tests` with two `COUNT(DISTINCT)` aggregates (no release filter, hitting all partitions). The new approach:

1. Counts job runs from `prow_job_runs` (much smaller table, indexed timestamp)
2. Gets the release list from `release_definitions`
3. For each release, queries `test_cumulative_summaries` with a self-join on two dates (window end vs window start minus one day), pre-aggregating by test_id with `GROUP BY` + `SUM` before joining, so only ~14K aggregated rows join instead of ~2M raw rows
4. Merges distinct test IDs across releases in Go via a channel and `sets.New[int64]()`

Pinning each query to a single release is critical: without it, the Postgres planner spends 4+ seconds just evaluating ~3,600 sub-partitions (36 releases x ~100 date ranges). A single global query takes ~7s (4.4s planning + 2.7s execution), while per-release queries run concurrently in ~2s total.

## Test plan

- [x] `gofmt -w` and `go vet` pass
- [x] Benchmarked on staging via `Test_BenchmarkIndividual/TestCountsByLookback` (3 iterations each)
- [x] Benchmarked individual per-release queries via psql on prod
- [x] Verified result counts match between old and new implementations
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving test counts over a lookback period.
  * Ensured accurate deduplication across releases and multiple jobs.
  * Excluded deleted, out-of-window, and zero-change runs from counts.
  * Added validation for invalid lookback periods and unavailable database connections.

* **Performance**
  * Release data lookups can now run concurrently, improving response times.

* **Monitoring**
  * Added structured operation logging and duration metrics for improved visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->