### PR TITLE
TRT-2848: Drop unused idx_test_daily_totals_date index

### DIFF
--- a/pkg/db/migrations/000012_drop_test_daily_totals_date_index.down.sql
+++ b/pkg/db/migrations/000012_drop_test_daily_totals_date_index.down.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_test_daily_totals_date
+    ON test_daily_totals (date);

--- a/pkg/db/migrations/000012_drop_test_daily_totals_date_index.up.sql
+++ b/pkg/db/migrations/000012_drop_test_daily_totals_date_index.up.sql
@@ -1,11 +1,7 @@
 -- idx_test_daily_totals_date exists only to make an unscoped
 -- SELECT MAX(date) FROM test_daily_totals fast across ~3,700 partitions.
--- TRT-2848 (incremental summary-table writer) removes the last two callers
--- that relied on that query (dailysummary.MaxSummaryDate and
--- cumulativesummary.MaxDailySummaryDate), so this index is now pure write
--- overhead: every insert into test_daily_totals maintains it for no reader.
---
--- Do not deploy this migration before TRT-2848 lands: MaxSummaryDate and
--- MaxDailySummaryDate are still on the hot path on main today, and without
--- this index they fall back to a full scan across every partition.
+-- Nothing queries MAX(date) without a release filter anymore
+-- (dailysummary.MaxSummaryDate and cumulativesummary.MaxDailySummaryDate
+-- were the last two callers), so this index is now pure write overhead:
+-- every insert into test_daily_totals maintains it for no reader.
 DROP INDEX IF EXISTS idx_test_daily_totals_date;

--- a/pkg/db/migrations/000012_drop_test_daily_totals_date_index.up.sql
+++ b/pkg/db/migrations/000012_drop_test_daily_totals_date_index.up.sql
@@ -1,0 +1,11 @@
+-- idx_test_daily_totals_date exists only to make an unscoped
+-- SELECT MAX(date) FROM test_daily_totals fast across ~3,700 partitions.
+-- TRT-2848 (incremental summary-table writer) removes the last two callers
+-- that relied on that query (dailysummary.MaxSummaryDate and
+-- cumulativesummary.MaxDailySummaryDate), so this index is now pure write
+-- overhead: every insert into test_daily_totals maintains it for no reader.
+--
+-- Do not deploy this migration before TRT-2848 lands: MaxSummaryDate and
+-- MaxDailySummaryDate are still on the hot path on main today, and without
+-- this index they fall back to a full scan across every partition.
+DROP INDEX IF EXISTS idx_test_daily_totals_date;

--- a/pkg/db/migrations/MANIFEST
+++ b/pkg/db/migrations/MANIFEST
@@ -18,3 +18,4 @@
 000009_add_lifecycle_to_prow_job_run_tests
 000010_drop_test_analysis_by_job_by_dates
 000011_add_lifecycle_to_summaries
+000012_drop_test_daily_totals_date_index


### PR DESCRIPTION
## Summary

- Drops `idx_test_daily_totals_date`, a single-column btree index on `test_daily_totals(date)` that existed only to make an unscoped `SELECT MAX(date) FROM test_daily_totals` fast across ~3,700 partitions.
- #3852 ([TRT-2848](https://redhat.atlassian.net/browse/TRT-2848)) removed the last two callers of that query pattern (`dailysummary.MaxSummaryDate` and `cumulativesummary.MaxDailySummaryDate`), which is why this PR was held until that one merged. With those gone, the index is pure write overhead on every insert into `test_daily_totals`, with no remaining reader.
- A full-codebase search confirmed no other query touches `date` on `test_daily_totals`/`test_cumulative_summaries` without a `release` predicate, so nothing else depends on this index.

## Test plan

- [x] `make lint` / `go build ./pkg/db/...`
- [x] `./hack/verify-migrations.sh` passes
- [x] Applied migration up/down against a fresh Postgres 16 instance seeded with the full migration history; confirmed `idx_test_daily_totals_date` is dropped on `up` and exactly recreated on `down` (verified via `\d test_daily_totals`)
- [x] Confirmed against a read-only inspection of staging that the index's current definition (`btree (date)`) matches what this migration expects to drop/recreate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migrations to remove an unnecessary index and keep the migration history in sync.
  * Added a rollback path to restore the index if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->