### PR TITLE
Fix filter state mutation causing 400 errors on pagination

### DIFF
--- a/sippy-ng/src/datagrid/GridToolbarFilterMenu.jsx
+++ b/sippy-ng/src/datagrid/GridToolbarFilterMenu.jsx
@@ -192,10 +192,14 @@ export default function GridToolbarFilterMenu(props) {
   }
 
   const currentItems = props.filterModel.items || []
-  let filterItems =
-    currentItems.length === 1 && currentItems[0].value === ''
-      ? 0
-      : currentItems.length
+  const filterItems = currentItems.filter(
+    (item) =>
+      !(
+        item.columnField === '' &&
+        item.operatorValue === '' &&
+        item.value === ''
+      )
+  ).length
 
   const linkOperatorForm = (
     <FormControl variant="standard">

--- a/sippy-ng/src/datagrid/GridToolbarFilterMenu.jsx
+++ b/sippy-ng/src/datagrid/GridToolbarFilterMenu.jsx
@@ -53,14 +53,21 @@ export default function GridToolbarFilterMenu(props) {
   )
 
   useEffect(() => {
-    if (props.filterModel.items !== models.items) {
-      setModels(props.filterModel.items)
+    const parentItems = props.filterModel.items || []
+    if (parentItems.length > 0) {
+      setModels([...parentItems])
+    } else {
+      setModels([
+        {
+          id: 1,
+          columnField: '',
+          operatorValue: '',
+          value: '',
+        },
+      ])
     }
-
-    if (models.length === 0) {
-      addFilter()
-    }
-  }, [props, models])
+    setLinkOperator(props.filterModel.linkOperator || 'and')
+  }, [props.filterModel])
 
   // Ensure columns are ordered alphabetically
   const orderedColumns = [...props.columns]
@@ -111,7 +118,11 @@ export default function GridToolbarFilterMenu(props) {
       }
       // else: both empty, no change needed
 
-      setModels(newModels)
+      setModels(
+        newModels.length > 0
+          ? newModels
+          : [{ id: 1, columnField: '', operatorValue: '', value: '' }]
+      )
       setAnchorEl(null)
     }
   }
@@ -120,32 +131,30 @@ export default function GridToolbarFilterMenu(props) {
   const id = open ? 'filter-popover' : undefined
 
   const addFilter = () => {
-    let currentFilters = models
-
-    currentFilters.push({
-      id: models.length + 1,
-      columnField: '',
-      operatorValue: '',
-      value: '',
-    })
-
-    setModels([...currentFilters])
-  }
-
-  const removeFilter = (index) => {
-    let currentFilters = models
-
-    if (currentFilters.length === 1) {
-      currentFilters[index] = {
+    setModels([
+      ...models,
+      {
+        id: models.length + 1,
         columnField: '',
         operatorValue: '',
         value: '',
-      }
-    } else {
-      currentFilters.splice(index, 1)
-    }
+      },
+    ])
+  }
 
-    setModels([...currentFilters])
+  const removeFilter = (index) => {
+    if (models.length === 1) {
+      setModels([
+        {
+          id: 1,
+          columnField: '',
+          operatorValue: '',
+          value: '',
+        },
+      ])
+    } else {
+      setModels(models.filter((_, i) => i !== index))
+    }
   }
 
   const updateModel = (index, v) => {
@@ -179,16 +188,14 @@ export default function GridToolbarFilterMenu(props) {
       v.errors.includes('value') || v.errors.push('value')
     }
 
-    let currentModels = models
-    currentModels[index] = v
-    setModels([...currentModels])
+    setModels(models.map((m, i) => (i === index ? v : m)))
   }
 
+  const currentItems = props.filterModel.items || []
   let filterItems =
-    props.filterModel.items.length === 1 &&
-    props.filterModel.items[0].value === ''
+    currentItems.length === 1 && currentItems[0].value === ''
       ? 0
-      : props.filterModel.items.length
+      : currentItems.length
 
   const linkOperatorForm = (
     <FormControl variant="standard">

--- a/sippy-ng/src/datagrid/GridToolbarFilterMenu.test.jsx
+++ b/sippy-ng/src/datagrid/GridToolbarFilterMenu.test.jsx
@@ -1,0 +1,210 @@
+import '@testing-library/jest-dom'
+import { createTheme, ThemeProvider } from '@mui/material/styles'
+import { render, screen } from '@testing-library/react'
+import GridToolbarFilterMenu from './GridToolbarFilterMenu'
+import React from 'react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('@mui/styles', () => ({
+  makeStyles: () => () => ({}),
+}))
+
+vi.mock('./GridToolbarFilterItem', () => ({
+  default: ({ id, filterModel, destroy }) => (
+    <div data-testid={`filter-item-${id}`}>
+      <span data-testid={`filter-column-${id}`}>{filterModel.columnField}</span>
+      <span data-testid={`filter-operator-${id}`}>
+        {filterModel.operatorValue}
+      </span>
+      <span data-testid={`filter-value-${id}`}>{filterModel.value}</span>
+      <button data-testid={`filter-destroy-${id}`} onClick={destroy}>
+        Remove
+      </button>
+    </div>
+  ),
+  operatorWithoutValue: ['is empty', 'is not empty'],
+}))
+
+vi.mock('./utils', () => ({
+  filterTooltip: () => '',
+}))
+
+const theme = createTheme()
+
+function renderMenu(props = {}) {
+  const defaults = {
+    filterModel: { items: [] },
+    setFilterModel: vi.fn(),
+    columns: [
+      { field: 'name', headerName: 'Name', type: 'string' },
+      { field: 'status', headerName: 'Status', type: 'string' },
+    ],
+  }
+  const merged = { ...defaults, ...props }
+  return {
+    ...render(
+      <ThemeProvider theme={theme}>
+        <GridToolbarFilterMenu {...merged} />
+      </ThemeProvider>
+    ),
+    setFilterModel: merged.setFilterModel,
+  }
+}
+
+describe('GridToolbarFilterMenu', () => {
+  describe('does not mutate parent filterModel', () => {
+    it('does not mutate the parent items array on mount', () => {
+      const parentItems = []
+      const filterModel = { items: parentItems }
+      renderMenu({ filterModel })
+      expect(parentItems).toHaveLength(0)
+    })
+
+    it('does not mutate the parent items array when adding a filter', async () => {
+      const parentItems = [
+        { columnField: 'name', operatorValue: 'contains', value: 'test' },
+      ]
+      const filterModel = { items: parentItems }
+      renderMenu({ filterModel })
+
+      await userEvent.click(screen.getByText('Filters'))
+      await userEvent.click(screen.getByLabelText('add'))
+
+      expect(parentItems).toHaveLength(1)
+    })
+
+    it('does not mutate the parent items array when removing a filter', async () => {
+      const parentItems = [
+        { columnField: 'name', operatorValue: 'contains', value: 'a' },
+        { columnField: 'status', operatorValue: 'equals', value: 'b' },
+      ]
+      const filterModel = { items: parentItems }
+      renderMenu({ filterModel })
+
+      await userEvent.click(screen.getByText('Filters'))
+      await userEvent.click(screen.getByTestId('filter-destroy-0'))
+
+      expect(parentItems).toHaveLength(2)
+    })
+  })
+
+  describe('external model synchronization', () => {
+    it('syncs internal state when parent filterModel changes', async () => {
+      const { rerender } = render(
+        <ThemeProvider theme={theme}>
+          <GridToolbarFilterMenu
+            filterModel={{ items: [] }}
+            setFilterModel={vi.fn()}
+            columns={[{ field: 'name', headerName: 'Name', type: 'string' }]}
+          />
+        </ThemeProvider>
+      )
+
+      rerender(
+        <ThemeProvider theme={theme}>
+          <GridToolbarFilterMenu
+            filterModel={{
+              items: [
+                {
+                  columnField: 'name',
+                  operatorValue: 'contains',
+                  value: 'synced',
+                },
+              ],
+            }}
+            setFilterModel={vi.fn()}
+            columns={[{ field: 'name', headerName: 'Name', type: 'string' }]}
+          />
+        </ThemeProvider>
+      )
+
+      await userEvent.click(screen.getByText('Filters'))
+      expect(screen.getByTestId('filter-value-0')).toHaveTextContent('synced')
+    })
+  })
+
+  describe('add and remove filters', () => {
+    it('starts with one blank filter row when items is empty', async () => {
+      renderMenu()
+      await userEvent.click(screen.getByText('Filters'))
+      expect(screen.getByTestId('filter-item-0')).toBeInTheDocument()
+    })
+
+    it('adds a new blank filter row on add click', async () => {
+      renderMenu({
+        filterModel: {
+          items: [
+            { columnField: 'name', operatorValue: 'contains', value: 'a' },
+          ],
+        },
+      })
+
+      await userEvent.click(screen.getByText('Filters'))
+      expect(screen.queryByTestId('filter-item-1')).not.toBeInTheDocument()
+
+      await userEvent.click(screen.getByLabelText('add'))
+      expect(screen.getByTestId('filter-item-1')).toBeInTheDocument()
+    })
+
+    it('resets to a blank row when removing the last filter', async () => {
+      renderMenu({
+        filterModel: {
+          items: [
+            { columnField: 'name', operatorValue: 'contains', value: 'only' },
+          ],
+        },
+      })
+
+      await userEvent.click(screen.getByText('Filters'))
+      await userEvent.click(screen.getByTestId('filter-destroy-0'))
+
+      expect(screen.getByTestId('filter-item-0')).toBeInTheDocument()
+      expect(screen.getByTestId('filter-column-0')).toHaveTextContent('')
+    })
+  })
+
+  describe('handleClose clears blank filters', () => {
+    it('does not call setFilterModel when closing with only blank filters', async () => {
+      const { setFilterModel } = renderMenu()
+
+      await userEvent.click(screen.getByText('Filters'))
+      await userEvent.click(screen.getByText('Filter'))
+
+      expect(setFilterModel).not.toHaveBeenCalled()
+    })
+
+    it('restores a blank row after closing with all-blank filters', async () => {
+      renderMenu()
+
+      await userEvent.click(screen.getByText('Filters'))
+      await userEvent.click(screen.getByText('Filter'))
+
+      await userEvent.click(screen.getByText('Filters'))
+      expect(screen.getByTestId('filter-item-0')).toBeInTheDocument()
+    })
+  })
+
+  describe('badge count', () => {
+    it('shows zero for blank filters', () => {
+      renderMenu({
+        filterModel: {
+          items: [{ columnField: '', operatorValue: '', value: '' }],
+        },
+      })
+      const badge = screen.getByText('Filters').closest('button')
+      expect(badge).toBeInTheDocument()
+    })
+
+    it('counts non-blank filters', () => {
+      renderMenu({
+        filterModel: {
+          items: [
+            { columnField: 'name', operatorValue: 'contains', value: 'a' },
+            { columnField: 'status', operatorValue: 'equals', value: 'b' },
+          ],
+        },
+      })
+      expect(screen.getByText('2')).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- **Root cause:** `GridToolbarFilterMenu` mutated shared array references (via `.push()`, `.splice()`, and index assignment) instead of creating new arrays. This corrupted the parent component's `filterModel`, causing empty filter items to leak into API requests on subsequent page changes, which the backend rejected with HTTP 400.
- Replaced all in-place mutations (`addFilter`, `removeFilter`, `updateModel`) with immutable state updates (spread, `.filter()`, `.map()`).
- Fixed the `useEffect` sync logic: narrowed dependencies from `[props, models]` (fired every render) to `[props.filterModel]`, and replaced a broken condition (`props.filterModel.items !== models.items` was always true since `models` is an array, not an object with `.items`).
- Fixed `handleClose` to restore a blank filter row when all filters are cleared, preventing an empty popover on next open.
- Added a null guard on `props.filterModel.items` for the badge count, matching the three other locations in the component that already guard against this.

## Test plan
- [x] Navigate to Job Health > All Job Runs, click next-page arrow repeatedly: no 400 errors
- [x] Add a filter, paginate: filter is retained across pages
- [x] Add multiple filters, paginate, then remove one at a time: filters stay consistent
- [x] Open filter popover, don't fill anything, click Filter, re-open: blank filter row appears
- [x] Switch link operator (and/or) with multiple filters: persists through pagination
- [x] Test filtering/pagination on another table (e.g., Jobs) to verify shared component works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter menu synchronization with the current filter settings.
  * Added a blank filter row when no filters are configured or after all filters are cleared.
  * Improved filter counting and handling when filter entries are missing.
  * Fixed filter additions and removals to preserve consistent menu state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->