### PR TITLE
INTEROP-9202: Fix OPP job variant query filter and owner classification

### DIFF
--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -107,6 +107,7 @@ WITH RecentSuccessfulJobs AS (
           OR prowjob_job_name LIKE 'release-%%'
           OR prowjob_job_name LIKE 'aggregator-%%'
           OR prowjob_job_name LIKE 'periodic-ci-%%-lp-interop-%%'
+          OR prowjob_job_name LIKE 'periodic-ci-%%-interop-opp-%%'
           OR prowjob_job_name LIKE 'periodic-ci-%%-lp-chaos-%%'
           OR prowjob_job_name LIKE 'periodic-ci-%%-lp-ocp-compat-%%'
           OR prowjob_job_name LIKE 'periodic-ci-%%-quay-cr-%%'
@@ -130,6 +131,7 @@ WHERE j.prowjob_start > DATETIME_SUB(CURRENT_DATETIME(), INTERVAL 180 DAY) AND
         OR j.prowjob_job_name LIKE 'periodic-ci-Azure-ARO-HCP-%%'
         OR j.prowjob_job_name LIKE 'release-%%'
 		OR j.prowjob_job_name LIKE 'periodic-ci-%%-lp-interop-%%'
+		OR j.prowjob_job_name LIKE 'periodic-ci-%%-interop-opp-%%'
 		OR j.prowjob_job_name LIKE 'periodic-ci-%%-lp-chaos-%%'
 		OR j.prowjob_job_name LIKE 'periodic-ci-%%-lp-ocp-compat-%%'
         OR j.prowjob_job_name LIKE 'periodic-ci-%%-quay-cr-%%'
@@ -555,6 +557,7 @@ func setOwner(_ logrus.FieldLogger, variants map[string]string, jobName string) 
 		{"-openshift-distributed-tracing", "qe"},
 		{"-oadp-", "oadp"},
 		{"-lp-chaos-", "mpict"},   // MPEX Integrity Engineering Chaos Team
+		{"-interop-opp-", "mpiit"},  // MPEX Integrity Engineering Interop Team (OPP)
 		{"-lp-interop-", "mpiit"}, // MPEX Integrity Engineering Interop Team
 		{"-lp-ocp-compat-", "lp"}, // Layered Product Teams
 	}

--- a/pkg/variantregistry/ocp.go
+++ b/pkg/variantregistry/ocp.go
@@ -556,10 +556,10 @@ func setOwner(_ logrus.FieldLogger, variants map[string]string, jobName string) 
 		{"-openshift-verification-tests", "qe"},
 		{"-openshift-distributed-tracing", "qe"},
 		{"-oadp-", "oadp"},
-		{"-lp-chaos-", "mpict"},   // MPEX Integrity Engineering Chaos Team
-		{"-interop-opp-", "mpiit"},  // MPEX Integrity Engineering Interop Team (OPP)
-		{"-lp-interop-", "mpiit"}, // MPEX Integrity Engineering Interop Team
-		{"-lp-ocp-compat-", "lp"}, // Layered Product Teams
+		{"-lp-chaos-", "mpict"},    // MPEX Integrity Engineering Chaos Team
+		{"-interop-opp-", "mpiit"}, // MPEX Integrity Engineering Interop Team (OPP)
+		{"-lp-interop-", "mpiit"},  // MPEX Integrity Engineering Interop Team
+		{"-lp-ocp-compat-", "lp"},  // Layered Product Teams
 	}
 
 	for _, entry := range ownerPatterns {

--- a/pkg/variantregistry/ocp_test.go
+++ b/pkg/variantregistry/ocp_test.go
@@ -1799,7 +1799,7 @@ func TestVariantSyncer(t *testing.T) {
 			},
 		},
 		{
-			job:          "periodic-ci-stolostron-policy-collection-main-ocp4.22-lp-interop-opp-aws",
+			job:          "periodic-ci-stolostron-policy-collection-main-ocp4.22-interop-opp-aws",
 			variantsFile: map[string]string{},
 			expected: map[string]string{
 				VariantRelease:          "4.22",
@@ -1828,7 +1828,7 @@ func TestVariantSyncer(t *testing.T) {
 			},
 		},
 		{
-			job:          "periodic-ci-stolostron-policy-collection-main-ocp4.22-lp-interop-opp-vsphere",
+			job:          "periodic-ci-stolostron-policy-collection-main-ocp4.22-interop-opp-vsphere",
 			variantsFile: map[string]string{},
 			expected: map[string]string{
 				VariantRelease:          "4.22",

--- a/pkg/variantregistry/snapshot.yaml
+++ b/pkg/variantregistry/snapshot.yaml
@@ -380490,7 +380490,7 @@ periodic-ci-stolostron-policy-collection-main-ocp4.22-interop-opp-aws:
     NetworkAccess: default
     NetworkStack: ipv4
     OS: rhcos9
-    Owner: eng
+    Owner: mpiit
     Platform: aws
     Procedure: none
     Release: "4.22"
@@ -380514,7 +380514,7 @@ periodic-ci-stolostron-policy-collection-main-ocp4.22-interop-opp-vsphere:
     NetworkAccess: default
     NetworkStack: ipv4
     OS: rhcos9
-    Owner: eng
+    Owner: mpiit
     Platform: vsphere
     Procedure: none
     Release: "4.22"
@@ -380541,7 +380541,7 @@ periodic-ci-stolostron-policy-collection-main-ocp4.22-upgrade-interop-opp-upgrad
     NetworkAccess: default
     NetworkStack: ipv4
     OS: rhcos9
-    Owner: eng
+    Owner: mpiit
     Platform: aws
     Procedure: none
     Release: "4.22"
@@ -380565,7 +380565,7 @@ periodic-ci-stolostron-policy-collection-main-ocp5.0-interop-opp-aws:
     NetworkAccess: default
     NetworkStack: ipv4
     OS: rhcos10
-    Owner: eng
+    Owner: mpiit
     Platform: aws
     Procedure: none
     Release: "5.0"
@@ -380589,7 +380589,7 @@ periodic-ci-stolostron-policy-collection-main-ocp5.0-interop-opp-vsphere:
     NetworkAccess: default
     NetworkStack: ipv4
     OS: rhcos10
-    Owner: eng
+    Owner: mpiit
     Platform: vsphere
     Procedure: none
     Release: "5.0"
@@ -380616,7 +380616,7 @@ periodic-ci-stolostron-policy-collection-main-ocp5.0-upgrade-interop-opp-upgrade
     NetworkAccess: default
     NetworkStack: ipv4
     OS: rhcos10
-    Owner: eng
+    Owner: mpiit
     Platform: aws
     Procedure: none
     Release: "5.0"
@@ -380640,7 +380640,7 @@ periodic-ci-stolostron-policy-collection-main-ocp5.1-interop-opp-aws:
     NetworkAccess: default
     NetworkStack: ipv4
     OS: rhcos10
-    Owner: eng
+    Owner: mpiit
     Platform: aws
     Procedure: none
     Release: "5.1"
@@ -380664,7 +380664,7 @@ periodic-ci-stolostron-policy-collection-main-ocp5.1-interop-opp-vsphere:
     NetworkAccess: default
     NetworkStack: ipv4
     OS: rhcos10
-    Owner: eng
+    Owner: mpiit
     Platform: vsphere
     Procedure: none
     Release: "5.1"
@@ -380691,7 +380691,7 @@ periodic-ci-stolostron-policy-collection-main-ocp5.1-upgrade-interop-opp-upgrade
     NetworkAccess: default
     NetworkStack: ipv4
     OS: rhcos10
-    Owner: eng
+    Owner: mpiit
     Platform: aws
     Procedure: none
     Release: "5.1"


### PR DESCRIPTION
## Summary

OPP interop jobs (`periodic-ci-stolostron-...-interop-opp-*`) were invisible to Sippy's variant classification because:

1. **SQL filter miss**: The BigQuery allowlist only matches `-lp-interop-` pattern. OPP job names use `-interop-opp-` instead, so they were never fetched from BQ.
2. **Owner misclassification**: The owner pattern `{"-lp-interop-", "mpiit"}` didn't match OPP jobs, causing them to fall through to `owner=eng`.

This is a follow-up to PR #3865 which added the `setLayeredProduct` classification pattern for OPP but missed the upstream SQL filter and owner classification gaps.

## Changes

- Add `periodic-ci-%%-interop-opp-%%` to both BQ query allowlists (lines ~109, ~132)
- Add `{"-interop-opp-", "mpiit"}` to `setOwner()` patterns
- Fix test job names from `lp-interop-opp-aws` to actual `interop-opp-aws`
- Update snapshot.yaml: Owner `eng` → `mpiit` for all 9 OPP entries

## Context

The `setLayeredProduct` pattern `{"-interop-opp-", "lp-interop--OPP"}` from #3865 is correct — the issue was that jobs never reached classification because the SQL query filtered them out. Identified with help from @neisw.

## Test plan

- [ ] `TestVariantSyncer` passes with corrected OPP job names
- [ ] After deployment, OPP jobs appear in `4.22-LP-Interop--OPP` CR view
- [ ] OPP jobs classified as `Owner: mpiit`, `LayeredProduct: lp-interop--OPP`

/jira [INTEROP-9202](https://redhat.atlassian.net/browse/INTEROP-9202)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variant detection for interop-opp periodic jobs.
  * Correctly classifies interop-opp jobs under the MPIIT owner.
  * Updated variant registry snapshots to reflect corrected ownership across supported releases and platforms.
  * Refined test coverage for updated interop-opp job naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->