### PR TITLE
Add cluster-monitoring-operator test suites to import allowlist

### DIFF
--- a/pkg/db/suites.go
+++ b/pkg/db/suites.go
@@ -59,6 +59,7 @@ var testSuites = []string{
 	"step graph",
 	"telco-verification",
 	"github.com/openshift/console-operator/test/e2e",
+	"github.com/openshift/cluster-monitoring-operator/test/e2e",
 	"prowjob-junit",
 	"OLM-Catalog-Validation",
 	"insights-operator-tests",


### PR DESCRIPTION
junits are enabled in https://github.com/openshift/cluster-monitoring-operator/pull/3054
juinit file sample https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cluster-monitoring-operator/3054/pull-ci-openshift-cluster-monitoring-operator-main-e2e-agnostic-operator/2088014628364750848/artifacts/e2e-agnostic-operator/test/artifacts/junit/junit_e2e.xml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Cluster Monitoring Operator E2E suite to the available database import options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->