### PR TITLE
Trt 2709 partitioning phase2 query partitioning

### DIFF
--- a/cmd/sippy/seed_data.go
+++ b/cmd/sippy/seed_data.go
@@ -862,7 +862,8 @@ func seedRunsForJob(dbc *db.DB, suite *models.Suite, prowJob models.ProwJob, jrK
 			updates["labels"] = pq.StringArray{"InfraFailure"}
 		}
 
-		if err := dbc.DB.Model(&models.ProwJobRun{}).Where("id = ?", runID).
+		if err := dbc.DB.Model(&models.ProwJobRun{}).
+			Where("id = ? AND prow_job_release = ?", runID, prowJob.Release).
 			Updates(updates).Error; err != nil {
 			return 0, 0, fmt.Errorf("failed to update ProwJobRun result: %w", err)
 		}
@@ -873,14 +874,18 @@ func seedRunsForJob(dbc *db.DB, suite *models.Suite, prowJob models.ProwJob, jrK
 		UPDATE prow_job_runs SET
 			test_failures = COALESCE((
 				SELECT COUNT(*) FROM prow_job_run_tests
-				WHERE prow_job_run_id = prow_job_runs.id AND status = ?
+				WHERE prow_job_run_id = prow_job_runs.id
+				AND prow_job_run_release = prow_job_runs.prow_job_release
+				AND status = ?
 			), 0),
 			test_flakes = COALESCE((
 				SELECT COUNT(*) FROM prow_job_run_tests
-				WHERE prow_job_run_id = prow_job_runs.id AND status = ?
+				WHERE prow_job_run_id = prow_job_runs.id
+				AND prow_job_run_release = prow_job_runs.prow_job_release
+				AND status = ?
 			), 0)
-		WHERE prow_job_id = ?`,
-		int(v1.TestStatusFailure), int(v1.TestStatusFlake), prowJob.ID).Error; err != nil {
+		WHERE prow_job_id = ? AND prow_job_release = ?`,
+		int(v1.TestStatusFailure), int(v1.TestStatusFlake), prowJob.ID, prowJob.Release).Error; err != nil {
 		return 0, 0, fmt.Errorf("updating test counts for prow job %s: %w", prowJob.Name, err)
 	}
 

--- a/docs/plans/trt-2709-golden-file-validation.md
+++ b/docs/plans/trt-2709-golden-file-validation.md
@@ -1,0 +1,82 @@
+# Golden File Validation for Partition Migration Queries
+
+## Context
+
+We've modified multiple query functions to add partition pruning filters (`prow_job_release`, `prow_job_run_release`, timestamp bounds) as part of TRT-2709 (phase 4b partitioning). These filters should be logically redundant with existing JOIN/WHERE conditions, meaning results must not change. We need to validate that the pre-migration codebase on an unpartitioned DB produces identical results to the post-migration codebase on a partitioned DB.
+
+**Workflow:**
+1. Commit current changes on `trt-2709-partitioning-phase2`
+2. Switch to `master`, add golden file test, run `Test_GenerateGoldenFile` against unmodified staging DB
+3. Switch back to `trt-2709-partitioning-phase2`, cherry-pick the golden file test
+4. Update any validation cases that call renamed functions (e.g. `ProwJobRunIDs` -> `ProwJobRunCount`)
+5. Run `Test_ValidateGoldenFile` against post-migration DB restored from the same backup
+
+## New file
+
+`pkg/flags/postgres_validation_test.go` (single file, same package as benchmarks)
+
+## Data structures
+
+```go
+type validationSnapshot struct {
+    RowCount   int               `json:"row_count"`
+    SpotChecks map[string]string `json:"spot_checks,omitempty"`
+}
+
+type goldenFile struct {
+    Metadata struct {
+        AsOf      time.Time `json:"as_of"`
+        Release   string    `json:"release"`
+        Generated time.Time `json:"generated_at"`
+    } `json:"metadata"`
+    Results map[string]validationSnapshot `json:"results"`
+}
+
+type validationCase struct {
+    name string
+    fn   func(dbc *db.DB, asOf time.Time) (validationSnapshot, error)
+}
+```
+
+## Validation cases
+
+One `getValidationCases(asOf)` function returning `[]validationCase`, mirroring all cases from `getBenchmarkCases` + `getIndividualBenchmarkCases`. Each calls the same query function but captures a `validationSnapshot` with `RowCount` and a few `SpotChecks`.
+
+**Spot check strategy per result type:**
+- **Slice results** (JobReports, VariantReports, etc.): `row_count` + first element's identifying field (name/ID) after sorting
+- **Scalar counts** (JobRunTestCount, ProwJobHistoricalTestCounts): value stored as `row_count`
+- **PaginationResult** (JobsRunsReport, RecentTestFailures): `total_rows` as `row_count`
+- **Map results** (TestAnalysisOverall, TestAnalysisByJob): number of keys as `row_count`, sorted key list as spot check
+- **Special** (IsNewTestQuery): `found` bool, org/repo if found
+
+Cases use the same constants (`benchmarkRelease`, `benchmarkJobName`, `benchmarkTestName`) and the same query parameters as benchmark cases. Uses the same `getBenchmarkDBClient` helper.
+
+## Test functions
+
+### `Test_GenerateGoldenFile`
+- Env vars: `db_benchmarking_dsn` (existing), `golden_file_path` (required, path to write JSON)
+- Records `asOf = time.Now().UTC()` and stores in golden file metadata
+- Runs all validation cases, collects snapshots
+- Writes `goldenFile` as indented JSON to `golden_file_path`
+
+### `Test_ValidateGoldenFile`
+- Env vars: `db_benchmarking_dsn`, `golden_file_path` (required, path to read JSON)
+- Reads the golden file, extracts `asOf` from metadata to reuse the same time anchor
+- Runs all validation cases with the stored `asOf`
+- For each case, compares `RowCount` (exact match) and `SpotChecks` (exact string match per key)
+- Reports all mismatches as test failures with clear diff output (expected vs got)
+- Does NOT fail-fast: reports all mismatches before failing
+
+## Time-sensitive queries
+
+Some cases use `current_date` in raw SQL (TestCountsByLookback*, TestOutputs, TestDurations). Since both DBs are restored from the same backup, running both generate and validate on the same day keeps these consistent. The `asOf` parameter (used by Go-level date math like `PeriodToDates`) is stored and reused from the golden file.
+
+## Cross-branch compatibility
+
+On `master`, the validation case for job run counting calls `query.ProwJobRunIDs` and stores `len(ids)` as `row_count`. After cherry-picking to `trt-2709-partitioning-phase2`, update that one case to call `query.ProwJobRunCount` and store the count directly. The golden file format is identical either way, so comparison works.
+
+## Verification
+
+1. On `master`: `db_benchmarking_dsn=<staging_ro> golden_file_path=/tmp/golden.json go test -v -run Test_GenerateGoldenFile -count=1 ./pkg/flags/`
+2. On `trt-2709-partitioning-phase2`: `db_benchmarking_dsn=<staging_ro> golden_file_path=/tmp/golden.json go test -v -run Test_ValidateGoldenFile -count=1 ./pkg/flags/`
+3. All cases should pass with matching row counts and spot checks

--- a/pkg/api/autocomplete.go
+++ b/pkg/api/autocomplete.go
@@ -83,6 +83,9 @@ func PrintAutocompleteFromDB(w http.ResponseWriter, req *http.Request, dbc *db.D
 			clusterRelease, err = query.CurrentActiveRelease(dbc)
 			if err != nil {
 				log.WithError(err).Warn("could not determine current development release for cluster autocomplete")
+				// do not return error for autocomplete, default to empty results
+				RespondWithJSON(200, w, result)
+				return
 			}
 		}
 		q = q.Table("prow_job_runs").

--- a/pkg/api/autocomplete.go
+++ b/pkg/api/autocomplete.go
@@ -5,7 +5,10 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/openshift/sippy/pkg/db"
+	"github.com/openshift/sippy/pkg/db/query"
 )
 
 // LabelOption represents a label with ID and title for autocomplete
@@ -74,9 +77,19 @@ func PrintAutocompleteFromDB(w http.ResponseWriter, req *http.Request, dbc *db.D
 			Select("DISTINCT(author) as name").
 			Order("name")
 	case "cluster":
+		clusterRelease := release
+		if clusterRelease == "" {
+			var err error
+			clusterRelease, err = query.CurrentActiveRelease(dbc)
+			if err != nil {
+				log.WithError(err).Warn("could not determine current development release for cluster autocomplete")
+			}
+		}
 		q = q.Table("prow_job_runs").
 			Select("DISTINCT(cluster) as name").
 			Where("cluster IS NOT NULL").
+			Where("prow_job_release = ?", clusterRelease).
+			Where("timestamp > NOW() - INTERVAL '14 days'").
 			Order("name")
 	case "suites":
 		q = q.Table("suites").
@@ -98,7 +111,7 @@ func PrintAutocompleteFromDB(w http.ResponseWriter, req *http.Request, dbc *db.D
 		RespondWithJSON(404, w, map[string]string{"message": "Autocomplete field not found."})
 	}
 
-	if release != "" {
+	if release != "" && field != "cluster" {
 		q = q.Where("release = ?", release)
 	}
 

--- a/pkg/api/build_clusters.go
+++ b/pkg/api/build_clusters.go
@@ -8,15 +8,15 @@ import (
 	"github.com/openshift/sippy/pkg/db/query"
 )
 
-func GetBuildClusterHealthReport(dbc *db.DB, start, boundary, end time.Time) ([]apitype.BuildClusterHealth, error) {
-	results, err := query.BuildClusterHealth(dbc, start, boundary, end)
+func GetBuildClusterHealthReport(dbc *db.DB, release string, start, boundary, end time.Time) ([]apitype.BuildClusterHealth, error) {
+	results, err := query.BuildClusterHealth(dbc, release, start, boundary, end)
 	return results, err
 }
 
-func GetBuildClusterHealthAnalysis(dbc *db.DB, period string) (map[string]apitype.BuildClusterHealthAnalysis, error) {
+func GetBuildClusterHealthAnalysis(dbc *db.DB, release, period string) (map[string]apitype.BuildClusterHealthAnalysis, error) {
 	results := make(map[string]apitype.BuildClusterHealthAnalysis)
 
-	health, err := query.BuildClusterAnalysis(dbc, period)
+	health, err := query.BuildClusterAnalysis(dbc, release, period)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -84,9 +84,9 @@ func PrintOverallReleaseHealthFromDB(w http.ResponseWriter, dbc *db.DB, release 
 		indicators["tests"] = testsIndicator
 	}
 
-	var lastUpdated time.Time
-	if r := dbc.DB.Raw("SELECT MAX(created_at) FROM prow_job_runs").Scan(&lastUpdated); r.Error != nil {
-		log.WithError(r.Error).Error("error querying last update time")
+	lastUpdated, err := GetLastUpdateTime(dbc)
+	if err != nil {
+		log.WithError(err).Error("error querying last update time")
 		return
 	}
 	log.WithField("lastUpdated", lastUpdated).Info("ran the last update query")

--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -55,11 +55,7 @@ func JobsRunsReportFromDB(dbc *db.DB, filterOpts *filter.FilterOptions, release 
 	}
 
 	if len(release) == 0 {
-		var err error
-		release, err = query.CurrentActiveRelease(dbc)
-		if err != nil {
-			return nil, fmt.Errorf("determining current release: %w", err)
-		}
+		return nil, &ValidationError{Message: "release is required; use useCurrentRelease=true to resolve automatically"}
 	}
 
 	jobsResult := make([]apitype.JobRun, 0)
@@ -453,7 +449,13 @@ func FetchJobRun(dbc *db.DB, jobRunID int64, onlyNewTests bool, preloads []strin
 		q = q.Preload(preload)
 	}
 
-	res := q.Order("timestamp DESC").First(jobRun, jobRunID)
+	partKeys, err := query.LookupProwJobRunPartitionKeys(dbc, jobRunID)
+	if err != nil {
+		return nil, fmt.Errorf("looking up partition keys for job run %d: %w", jobRunID, err)
+	}
+
+	res := q.Where("prow_job_release = ? AND timestamp = ?", partKeys.ProwJobRelease, partKeys.Timestamp).
+		Take(jobRun, jobRunID)
 	if res.Error != nil {
 		return nil, res.Error
 	}

--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -71,6 +71,11 @@ func JobsRunsReportFromDB(dbc *db.DB, filterOpts *filter.FilterOptions, release 
 		Joins("JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id")
 
 	addPRJoin := func(q *gorm.DB) *gorm.DB {
+		if len(release) > 0 {
+			return q.
+				Joins(`LEFT JOIN (SELECT DISTINCT ON(prow_job_run_id) prow_job_run_id, prow_pull_request_id FROM prow_job_run_prow_pull_requests WHERE prow_job_run_release = ? ORDER BY prow_job_run_id, prow_pull_request_id DESC) jrpp ON jrpp.prow_job_run_id = prow_job_runs.id`, release).
+				Joins("LEFT JOIN prow_pull_requests pp ON pp.id = jrpp.prow_pull_request_id")
+		}
 		return q.
 			Joins(`LEFT JOIN (SELECT DISTINCT ON(prow_job_run_id) prow_job_run_id, prow_pull_request_id FROM prow_job_run_prow_pull_requests ORDER BY prow_job_run_id, prow_pull_request_id DESC) jrpp ON jrpp.prow_job_run_id = prow_job_runs.id`).
 			Joins("LEFT JOIN prow_pull_requests pp ON pp.id = jrpp.prow_pull_request_id")
@@ -87,6 +92,7 @@ func JobsRunsReportFromDB(dbc *db.DB, filterOpts *filter.FilterOptions, release 
 
 	if len(release) > 0 {
 		q = q.Where("prow_jobs.release = ?", release)
+		q = q.Where("prow_job_runs.prow_job_release = ?", release)
 	}
 	q = q.Where(`prow_job_runs."timestamp" < ?`, reportEnd)
 	q = q.Where(`prow_job_runs."timestamp" >= ?`, lookback)
@@ -132,7 +138,7 @@ func JobsRunsReportFromDB(dbc *db.DB, filterOpts *filter.FilterOptions, release 
 
 		if !needs.needsPRJoin() {
 			g.Go(func() error {
-				return enrichJobRunsWithPRData(dbc, jobsResult, ids)
+				return enrichJobRunsWithPRData(dbc, jobsResult, ids, release)
 			})
 		}
 
@@ -358,7 +364,7 @@ func enrichJobRunsWithTestNames(dbc *db.DB, results []apitype.JobRun, ids []int,
 	return nil
 }
 
-func enrichJobRunsWithPRData(dbc *db.DB, results []apitype.JobRun, ids []int) error {
+func enrichJobRunsWithPRData(dbc *db.DB, results []apitype.JobRun, ids []int, release string) error {
 	type prResult struct {
 		ID                int    `gorm:"column:id"`
 		PullRequestLink   string `gorm:"column:pull_request_link"`
@@ -368,18 +374,21 @@ func enrichJobRunsWithPRData(dbc *db.DB, results []apitype.JobRun, ids []int) er
 		PullRequestAuthor string `gorm:"column:pull_request_author"`
 	}
 	var prResults []prResult
-	if err := dbc.DB.Raw(`
-		SELECT DISTINCT ON(jrpp.prow_job_run_id)
+	q := dbc.DB.Table("prow_job_run_prow_pull_requests jrpp").
+		Select(`DISTINCT ON(jrpp.prow_job_run_id)
 			jrpp.prow_job_run_id AS id,
 			pp.link AS pull_request_link,
 			pp.sha AS pull_request_sha,
 			pp.org AS pull_request_org,
 			pp.author AS pull_request_author,
-			pp.repo AS pull_request_repo
-		FROM prow_job_run_prow_pull_requests jrpp
-			INNER JOIN prow_pull_requests pp ON pp.id = jrpp.prow_pull_request_id
-		WHERE jrpp.prow_job_run_id IN ?
-		ORDER BY jrpp.prow_job_run_id, jrpp.prow_pull_request_id DESC`, ids).Scan(&prResults).Error; err != nil {
+			pp.repo AS pull_request_repo`).
+		Joins("INNER JOIN prow_pull_requests pp ON pp.id = jrpp.prow_pull_request_id").
+		Where("jrpp.prow_job_run_id IN ?", ids).
+		Order("jrpp.prow_job_run_id, jrpp.prow_pull_request_id DESC")
+	if len(release) > 0 {
+		q = q.Where("jrpp.prow_job_run_release = ?", release)
+	}
+	if err := q.Scan(&prResults).Error; err != nil {
 		return err
 	}
 	prMap := make(map[int]*prResult, len(prResults))
@@ -463,7 +472,7 @@ func FetchJobRun(dbc *db.DB, jobRunID int64, onlyNewTests bool, preloads []strin
 			Where("NOT EXISTS (SELECT 1 FROM test_ownerships tow WHERE tow.test_id = prow_job_run_tests.test_id)").
 			Where(`NOT EXISTS (
 				SELECT 1 FROM prow_job_run_tests t2
-				INNER JOIN prow_job_run_prow_pull_requests prmap ON prmap.prow_job_run_id = t2.prow_job_run_id
+				INNER JOIN prow_job_run_prow_pull_requests prmap ON prmap.prow_job_run_id = t2.prow_job_run_id AND prmap.prow_job_run_release = t2.prow_job_run_release
 				INNER JOIN prow_pull_requests prs ON prs.id = prmap.prow_pull_request_id
 				WHERE t2.test_id = prow_job_run_tests.test_id
 				  AND t2.prow_job_run_release = prow_job_run_tests.prow_job_run_release

--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -583,7 +583,7 @@ func findReleaseMatchJobNames(dbc *db.DB, jobRun *models.ProwJobRun, compareRele
 					gosort.Strings(job.Variants)
 					if stringSlicesEqual(variants, job.Variants) {
 
-						runCount, err := query.ProwJobRunCount(dbc, job.ID, compareRelease)
+						runCount, err := query.ProwJobRunCount(dbc, job.ID, compareRelease, time.Now().Add(-14*24*time.Hour))
 						if err != nil {
 							logger.WithError(err).Errorf("Failed to query job run count for %d", job.ID)
 							continue

--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -453,15 +453,7 @@ func FetchJobRun(dbc *db.DB, jobRunID int64, onlyNewTests bool, preloads []strin
 		q = q.Preload(preload)
 	}
 
-	// Two-step load: first fetch partition keys (lightweight cross-partition
-	// scan), then load the full row with partition pruning.
-	partKeys, err := query.LookupProwJobRunPartitionKeys(dbc, jobRunID)
-	if err != nil {
-		return nil, fmt.Errorf("looking up partition keys for job run %d: %w", jobRunID, err)
-	}
-
-	res := q.Where("prow_job_release = ? AND timestamp = ?", partKeys.ProwJobRelease, partKeys.Timestamp).
-		First(jobRun, jobRunID)
+	res := q.Order("timestamp DESC").First(jobRun, jobRunID)
 	if res.Error != nil {
 		return nil, res.Error
 	}

--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -568,14 +568,12 @@ func findReleaseMatchJobNames(dbc *db.DB, jobRun *models.ProwJobRun, compareRele
 					gosort.Strings(job.Variants)
 					if stringSlicesEqual(variants, job.Variants) {
 
-						jobIDs, err := query.ProwJobRunIDs(dbc, job.ID)
-
+						runCount, err := query.ProwJobRunCount(dbc, job.ID, compareRelease)
 						if err != nil {
-							logger.WithError(err).Errorf("Failed to query job run ids for %d", job.ID)
+							logger.WithError(err).Errorf("Failed to query job run count for %d", job.ID)
 							continue
 						}
-
-						totalJobRunsCount += len(jobIDs)
+						totalJobRunsCount += runCount
 						allJobNames = append(allJobNames, job.Name)
 					}
 				}

--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -54,6 +54,14 @@ func JobsRunsReportFromDB(dbc *db.DB, filterOpts *filter.FilterOptions, release 
 		return nil, &ValidationError{Message: fmt.Sprintf("sorting by %s is not supported", filterOpts.SortField)}
 	}
 
+	if len(release) == 0 {
+		var err error
+		release, err = query.CurrentActiveRelease(dbc)
+		if err != nil {
+			return nil, fmt.Errorf("determining current release: %w", err)
+		}
+	}
+
 	jobsResult := make([]apitype.JobRun, 0)
 	lookback := reportEnd.Add(-90 * 24 * time.Hour)
 
@@ -71,13 +79,8 @@ func JobsRunsReportFromDB(dbc *db.DB, filterOpts *filter.FilterOptions, release 
 		Joins("JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id")
 
 	addPRJoin := func(q *gorm.DB) *gorm.DB {
-		if len(release) > 0 {
-			return q.
-				Joins(`LEFT JOIN (SELECT DISTINCT ON(prow_job_run_id) prow_job_run_id, prow_pull_request_id FROM prow_job_run_prow_pull_requests WHERE prow_job_run_release = ? ORDER BY prow_job_run_id, prow_pull_request_id DESC) jrpp ON jrpp.prow_job_run_id = prow_job_runs.id`, release).
-				Joins("LEFT JOIN prow_pull_requests pp ON pp.id = jrpp.prow_pull_request_id")
-		}
 		return q.
-			Joins(`LEFT JOIN (SELECT DISTINCT ON(prow_job_run_id) prow_job_run_id, prow_pull_request_id FROM prow_job_run_prow_pull_requests ORDER BY prow_job_run_id, prow_pull_request_id DESC) jrpp ON jrpp.prow_job_run_id = prow_job_runs.id`).
+			Joins(`LEFT JOIN (SELECT DISTINCT ON(prow_job_run_id) prow_job_run_id, prow_pull_request_id FROM prow_job_run_prow_pull_requests WHERE prow_job_run_release = ? ORDER BY prow_job_run_id, prow_pull_request_id DESC) jrpp ON jrpp.prow_job_run_id = prow_job_runs.id`, release).
 			Joins("LEFT JOIN prow_pull_requests pp ON pp.id = jrpp.prow_pull_request_id")
 	}
 
@@ -90,10 +93,8 @@ func JobsRunsReportFromDB(dbc *db.DB, filterOpts *filter.FilterOptions, release 
 		return nil, err
 	}
 
-	if len(release) > 0 {
-		q = q.Where("prow_jobs.release = ?", release)
-		q = q.Where("prow_job_runs.prow_job_release = ?", release)
-	}
+	q = q.Where("prow_jobs.release = ?", release)
+	q = q.Where("prow_job_runs.prow_job_release = ?", release)
 	q = q.Where(`prow_job_runs."timestamp" < ?`, reportEnd)
 	q = q.Where(`prow_job_runs."timestamp" >= ?`, lookback)
 
@@ -452,10 +453,15 @@ func FetchJobRun(dbc *db.DB, jobRunID int64, onlyNewTests bool, preloads []strin
 		q = q.Preload(preload)
 	}
 
-	// Load the job run first, then query tests separately with partition
-	// pruning keys for performance on the heavily partitioned
-	// prow_job_run_tests table (~3,500 partitions).
-	res := q.First(jobRun, jobRunID)
+	// Two-step load: first fetch partition keys (lightweight cross-partition
+	// scan), then load the full row with partition pruning.
+	partKeys, err := query.LookupProwJobRunPartitionKeys(dbc, jobRunID)
+	if err != nil {
+		return nil, fmt.Errorf("looking up partition keys for job run %d: %w", jobRunID, err)
+	}
+
+	res := q.Where("prow_job_release = ? AND timestamp = ?", partKeys.ProwJobRelease, partKeys.Timestamp).
+		First(jobRun, jobRunID)
 	if res.Error != nil {
 		return nil, res.Error
 	}

--- a/pkg/api/jobartifacts/query.go
+++ b/pkg/api/jobartifacts/query.go
@@ -15,7 +15,6 @@ import (
 	"github.com/openshift/sippy/pkg/apis/cache"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
-	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
@@ -102,15 +101,9 @@ func (q *JobArtifactQuery) getJobRun(jobRunID int64) (JobRun, error) {
 		ID:      strconv.FormatInt(jobRunID, 10),
 		IsFinal: true, // even errors are final - only if we timed out getting answers might a retry get more
 	}
-	// Two-step load: first fetch partition keys for pruning, then load full row.
-	partKeys, err := query.LookupProwJobRunPartitionKeys(q.DbClient, jobRunID)
-	if err != nil {
-		return jobRunResponse, fmt.Errorf("looking up partition keys for job run %d: %w", jobRunID, err)
-	}
-
 	jobRunModel := new(models.ProwJobRun)
 	res := q.DbClient.DB.Preload("ProwJob").
-		Where("prow_job_release = ? AND timestamp = ?", partKeys.ProwJobRelease, partKeys.Timestamp).
+		Order("timestamp DESC").
 		First(jobRunModel, jobRunID)
 	if res.Error != nil {
 		return jobRunResponse, res.Error

--- a/pkg/api/jobartifacts/query.go
+++ b/pkg/api/jobartifacts/query.go
@@ -142,14 +142,14 @@ func (q *JobArtifactQuery) getJobRunFiles(jobRunPath string) ([]*storage.ObjectA
 	truncated := false
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
-	query := &storage.Query{
+	gcsQuery := &storage.Query{
 		Prefix:     jobRunPath,
 		Projection: storage.ProjectionNoACL,
 	}
 	if q.PathGlob != "" {
-		query.MatchGlob = jobRunPath + q.PathGlob
+		gcsQuery.MatchGlob = jobRunPath + q.PathGlob
 	}
-	iter := q.GcsBucket.Objects(ctx, query)
+	iter := q.GcsBucket.Objects(ctx, gcsQuery)
 	for {
 		attrs, err := iter.Next()
 		if err != nil {

--- a/pkg/api/jobartifacts/query.go
+++ b/pkg/api/jobartifacts/query.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/sippy/pkg/apis/cache"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
@@ -101,10 +102,15 @@ func (q *JobArtifactQuery) getJobRun(jobRunID int64) (JobRun, error) {
 		ID:      strconv.FormatInt(jobRunID, 10),
 		IsFinal: true, // even errors are final - only if we timed out getting answers might a retry get more
 	}
+	partKeys, err := query.LookupProwJobRunPartitionKeys(q.DbClient, jobRunID)
+	if err != nil {
+		return jobRunResponse, fmt.Errorf("looking up partition keys for job run %d: %w", jobRunID, err)
+	}
+
 	jobRunModel := new(models.ProwJobRun)
 	res := q.DbClient.DB.Preload("ProwJob").
-		Order("timestamp DESC").
-		First(jobRunModel, jobRunID)
+		Where("prow_job_release = ? AND timestamp = ?", partKeys.ProwJobRelease, partKeys.Timestamp).
+		Take(jobRunModel, jobRunID)
 	if res.Error != nil {
 		return jobRunResponse, res.Error
 	}

--- a/pkg/api/jobartifacts/query.go
+++ b/pkg/api/jobartifacts/query.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/sippy/pkg/apis/cache"
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
+	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
@@ -101,8 +102,16 @@ func (q *JobArtifactQuery) getJobRun(jobRunID int64) (JobRun, error) {
 		ID:      strconv.FormatInt(jobRunID, 10),
 		IsFinal: true, // even errors are final - only if we timed out getting answers might a retry get more
 	}
+	// Two-step load: first fetch partition keys for pruning, then load full row.
+	partKeys, err := query.LookupProwJobRunPartitionKeys(q.DbClient, jobRunID)
+	if err != nil {
+		return jobRunResponse, fmt.Errorf("looking up partition keys for job run %d: %w", jobRunID, err)
+	}
+
 	jobRunModel := new(models.ProwJobRun)
-	res := q.DbClient.DB.Preload("ProwJob").First(jobRunModel, jobRunID)
+	res := q.DbClient.DB.Preload("ProwJob").
+		Where("prow_job_release = ? AND timestamp = ?", partKeys.ProwJobRelease, partKeys.Timestamp).
+		First(jobRunModel, jobRunID)
 	if res.Error != nil {
 		return jobRunResponse, res.Error
 	}

--- a/pkg/api/jobrunscan/reevaluate.go
+++ b/pkg/api/jobrunscan/reevaluate.go
@@ -23,7 +23,6 @@ import (
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/models/jobrunscan"
-	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
@@ -177,17 +176,8 @@ func (r *ReEvaluator) reEvaluateOne(ctx context.Context, buildID string, symptom
 		return result
 	}
 
-	// Two-step load: first fetch partition keys for pruning, then load full row.
-	partKeys, err := query.LookupProwJobRunPartitionKeys(r.db, jobRunID)
-	if err != nil {
-		result.Status = ReEvalEvalError
-		result.Error = fmt.Sprintf("looking up partition keys for job run %s: %v", buildID, err)
-		return result
-	}
-
 	jobRunModel := new(models.ProwJobRun)
-	res := r.db.DB.Where("prow_job_release = ? AND timestamp = ?", partKeys.ProwJobRelease, partKeys.Timestamp).
-		First(jobRunModel, jobRunID)
+	res := r.db.DB.Order("timestamp DESC").First(jobRunModel, jobRunID)
 	if res.Error != nil {
 		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
 			result.Status = ReEvalMissingError

--- a/pkg/api/jobrunscan/reevaluate.go
+++ b/pkg/api/jobrunscan/reevaluate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/models/jobrunscan"
+	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
@@ -176,9 +177,17 @@ func (r *ReEvaluator) reEvaluateOne(ctx context.Context, buildID string, symptom
 		return result
 	}
 
-	// Look up the job run to get metadata
+	// Two-step load: first fetch partition keys for pruning, then load full row.
+	partKeys, err := query.LookupProwJobRunPartitionKeys(r.db, jobRunID)
+	if err != nil {
+		result.Status = ReEvalEvalError
+		result.Error = fmt.Sprintf("looking up partition keys for job run %s: %v", buildID, err)
+		return result
+	}
+
 	jobRunModel := new(models.ProwJobRun)
-	res := r.db.DB.First(jobRunModel, jobRunID)
+	res := r.db.DB.Where("prow_job_release = ? AND timestamp = ?", partKeys.ProwJobRelease, partKeys.Timestamp).
+		First(jobRunModel, jobRunID)
 	if res.Error != nil {
 		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
 			result.Status = ReEvalMissingError
@@ -496,7 +505,8 @@ func (r *ReEvaluator) updatePostgresLabels(ctx context.Context, buildID string, 
 	merged := pq.StringArray(mergeLabels(manualLabels, newBQLabels))
 
 	// Update prow_job_runs
-	if err := r.db.DB.Model(&models.ProwJobRun{}).Where("id = ?", jobRun.ID).
+	if err := r.db.DB.Model(&models.ProwJobRun{}).
+		Where("id = ? AND prow_job_release = ? AND timestamp = ?", jobRun.ID, jobRun.ProwJobRelease, jobRun.Timestamp).
 		Update("labels", merged).Error; err != nil {
 		return fmt.Errorf("updating prow_job_runs.labels: %w", err)
 	}

--- a/pkg/api/jobrunscan/reevaluate.go
+++ b/pkg/api/jobrunscan/reevaluate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/sippy/pkg/db"
 	"github.com/openshift/sippy/pkg/db/models"
 	"github.com/openshift/sippy/pkg/db/models/jobrunscan"
+	"github.com/openshift/sippy/pkg/db/query"
 	"github.com/openshift/sippy/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
@@ -176,8 +177,16 @@ func (r *ReEvaluator) reEvaluateOne(ctx context.Context, buildID string, symptom
 		return result
 	}
 
+	partKeys, err := query.LookupProwJobRunPartitionKeys(r.db, jobRunID)
+	if err != nil {
+		result.Status = ReEvalEvalError
+		result.Error = fmt.Sprintf("looking up partition keys for job run %s: %v", buildID, err)
+		return result
+	}
+
 	jobRunModel := new(models.ProwJobRun)
-	res := r.db.DB.Order("timestamp DESC").First(jobRunModel, jobRunID)
+	res := r.db.DB.Where("prow_job_release = ? AND timestamp = ?", partKeys.ProwJobRelease, partKeys.Timestamp).
+		Take(jobRunModel, jobRunID)
 	if res.Error != nil {
 		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
 			result.Status = ReEvalMissingError

--- a/pkg/api/jobs.go
+++ b/pkg/api/jobs.go
@@ -258,6 +258,7 @@ func JobDetailsReport(dbc *db.DB, release, jobSearchStr string, reportEnd time.T
 	prowJobRuns := make([]*models.ProwJobRun, 0)
 	res := dbc.DB.Joins("ProwJob").
 		Where("name LIKE ?", "%"+jobSearchStr+"%").
+		Where("prow_job_release = ?", release).
 		Where("timestamp > ?", since).
 		Where("release = ?", release).
 		Preload("Tests", "status = ? AND prow_job_run_release = ? AND prow_job_run_timestamp > ?", 12, release, since).

--- a/pkg/api/prtestresults.go
+++ b/pkg/api/prtestresults.go
@@ -70,7 +70,7 @@ func GetPRTestResults(dbc *db.DB, org, repo string, prNumber int, latestSHAOnly 
 			pjrt.status,
 			COALESCE(pjrto.output, '') AS output`).
 		Joins("JOIN prow_job_run_prow_pull_requests jrpr ON jrpr.prow_pull_request_id = pp.id AND jrpr.prow_job_run_release = ? AND jrpr.prow_job_run_timestamp >= ? AND jrpr.prow_job_run_timestamp < ?", models.ReleasePresubmits, startDate, endDate).
-		Joins("JOIN prow_job_runs pjr ON pjr.id = jrpr.prow_job_run_id").
+		Joins("JOIN prow_job_runs pjr ON pjr.id = jrpr.prow_job_run_id AND pjr.prow_job_release = ?", models.ReleasePresubmits).
 		Joins("JOIN prow_jobs pj ON pj.id = pjr.prow_job_id AND pj.release = ?", models.ReleasePresubmits).
 		Joins("JOIN prow_job_run_tests pjrt ON pjrt.prow_job_run_id = pjr.id AND pjrt.prow_job_run_release = ? AND pjrt.prow_job_run_timestamp >= ? AND pjrt.prow_job_run_timestamp < ?", models.ReleasePresubmits, startDate, endDate).
 		Joins("JOIN tests t ON t.id = pjrt.test_id").
@@ -81,7 +81,7 @@ func GetPRTestResults(dbc *db.DB, org, repo string, prNumber int, latestSHAOnly 
 		Where("pjr.timestamp >= ? AND pjr.timestamp < ?", startDate, endDate)
 
 	if latestSHAOnly {
-		query = query.Where("pp.sha = (SELECT pp2.sha FROM prow_pull_requests pp2 JOIN prow_job_run_prow_pull_requests jrpr2 ON jrpr2.prow_pull_request_id = pp2.id JOIN prow_job_runs pjr2 ON pjr2.id = jrpr2.prow_job_run_id WHERE pp2.org = ? AND pp2.repo = ? AND pp2.number = ? ORDER BY pjr2.timestamp DESC LIMIT 1)", org, repo, prNumber)
+		query = query.Where("pp.sha = (SELECT pp2.sha FROM prow_pull_requests pp2 JOIN prow_job_run_prow_pull_requests jrpr2 ON jrpr2.prow_pull_request_id = pp2.id AND jrpr2.prow_job_run_release = ? JOIN prow_job_runs pjr2 ON pjr2.id = jrpr2.prow_job_run_id AND pjr2.prow_job_release = ? WHERE pp2.org = ? AND pp2.repo = ? AND pp2.number = ? ORDER BY pjr2.timestamp DESC LIMIT 1)", models.ReleasePresubmits, models.ReleasePresubmits, org, repo, prNumber)
 	}
 
 	// By default only return failures (no flakes, no successes).

--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -673,12 +673,14 @@ func BuildReleasesResponse(releases []sippyv1.Release, lastUpdated time.Time) ap
 func GetLastUpdateTime(dbc *db.DB) (time.Time, error) {
 	rel, err := query.CurrentActiveRelease(dbc)
 	if err != nil {
-		return time.Time{}, err
+		return time.Time{}, fmt.Errorf("get current active release: %w", err)
 	}
 	var lastUpdated time.Time
-	err = dbc.DB.Raw("SELECT COALESCE(MAX(created_at), '0001-01-01') FROM prow_job_runs WHERE prow_job_release = ? AND timestamp > NOW() - INTERVAL '14 days'", rel).
-		Scan(&lastUpdated).Error
-	return lastUpdated, err
+	if err := dbc.DB.Raw("SELECT COALESCE(MAX(created_at), '0001-01-01') FROM prow_job_runs WHERE prow_job_release = ? AND timestamp > NOW() - INTERVAL '14 days'", rel).
+		Scan(&lastUpdated).Error; err != nil {
+		return time.Time{}, fmt.Errorf("query last update time: %w", err)
+	}
+	return lastUpdated, nil
 }
 
 // PayloadForJobRun returns the payload release tag that was used for a given job run.

--- a/pkg/api/releases.go
+++ b/pkg/api/releases.go
@@ -666,6 +666,21 @@ func BuildReleasesResponse(releases []sippyv1.Release, lastUpdated time.Time) ap
 	return response
 }
 
+// GetLastUpdateTime returns the most recent prow_job_runs created_at for the
+// current active release. It uses query.CurrentActiveRelease to identify the
+// release, then queries the most recent created_at scoped to the last 14 days
+// for partition pruning.
+func GetLastUpdateTime(dbc *db.DB) (time.Time, error) {
+	rel, err := query.CurrentActiveRelease(dbc)
+	if err != nil {
+		return time.Time{}, err
+	}
+	var lastUpdated time.Time
+	err = dbc.DB.Raw("SELECT COALESCE(MAX(created_at), '0001-01-01') FROM prow_job_runs WHERE prow_job_release = ? AND timestamp > NOW() - INTERVAL '14 days'", rel).
+		Scan(&lastUpdated).Error
+	return lastUpdated, err
+}
+
 // PayloadForJobRun returns the payload release tag that was used for a given job run.
 func PayloadForJobRun(dbClient *db.DB, jobRunID string) ([]apitype.JobPayload, error) {
 	var results []apitype.JobPayload

--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -412,8 +412,13 @@ func GetJobRunTestsCountByLookbackAt(dbc *db.DB, lookbackDays int, today civil.D
 	log.WithField("lookbackDays", lookbackDays).Info("starting lookback count queries")
 
 	// Count job runs from prow_job_runs (one row per run, much smaller than prow_job_run_tests).
+	release, err := query.CurrentActiveRelease(dbc)
+	if err != nil {
+		return -1, -1, fmt.Errorf("determining current release: %w", err)
+	}
 	var jobRunsCount int64
-	err := dbc.DB.Table("prow_job_runs").
+	err = dbc.DB.Table("prow_job_runs").
+		Where("prow_job_release = ?", release).
 		Where("timestamp > ? AND deleted_at IS NULL", today.AddDays(-lookbackDays).In(time.UTC)).
 		Count(&jobRunsCount).
 		Error

--- a/pkg/api/tests.go
+++ b/pkg/api/tests.go
@@ -15,10 +15,8 @@ import (
 	"cloud.google.com/go/civil"
 	pkgerrors "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/iterator"
 	"gorm.io/gorm"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/apis/cache"
@@ -426,67 +424,32 @@ func GetJobRunTestsCountByLookbackAt(dbc *db.DB, lookbackDays int, today civil.D
 		return -1, -1, fmt.Errorf("counting job runs: %w", err)
 	}
 
-	// Count distinct tests using cumulative summaries. Query per-release so
-	// Postgres can prune to a single date sub-partition per release for each
-	// side of the join, avoiding the full cross-partition scan that makes a
-	// global self-join slow.
-
-	var releases []string
-	err = dbc.DB.Table("release_definitions").
-		Pluck("release", &releases).
+	// Count distinct tests using cumulative summaries for the active release.
+	var testIDs []int64
+	err = dbc.DB.Raw(`
+		WITH end_sums AS (
+		  SELECT test_id, SUM(prefix_sum_runs) AS total_runs
+		  FROM test_cumulative_summaries
+		  WHERE release = ? AND date = ?
+		  GROUP BY test_id
+		),
+		start_sums AS (
+		  SELECT test_id, SUM(prefix_sum_runs) AS total_runs
+		  FROM test_cumulative_summaries
+		  WHERE release = ? AND date = ?
+		  GROUP BY test_id
+		)
+		SELECT e.test_id
+		FROM end_sums e
+		LEFT JOIN start_sums s ON s.test_id = e.test_id
+		WHERE (e.total_runs - COALESCE(s.total_runs, 0)) > 0`,
+		release, today, release, startMinusOne).
+		Scan(&testIDs).
 		Error
 	if err != nil {
-		return -1, -1, fmt.Errorf("listing releases: %w", err)
+		return -1, -1, fmt.Errorf("counting test IDs for release %s: %w", release, err)
 	}
-
-	ch := make(chan []int64, len(releases))
-	testIDs := sets.New[int64]()
-	done := make(chan struct{})
-	go func() {
-		for ids := range ch {
-			testIDs.Insert(ids...)
-		}
-		close(done)
-	}()
-
-	g := new(errgroup.Group)
-	g.SetLimit(4)
-	for _, release := range releases {
-		g.Go(func() error {
-			var releaseTestIDs []int64
-			queryErr := dbc.DB.Raw(`
-				WITH end_sums AS (
-				  SELECT test_id, SUM(prefix_sum_runs) AS total_runs
-				  FROM test_cumulative_summaries
-				  WHERE release = ? AND date = ?
-				  GROUP BY test_id
-				),
-				start_sums AS (
-				  SELECT test_id, SUM(prefix_sum_runs) AS total_runs
-				  FROM test_cumulative_summaries
-				  WHERE release = ? AND date = ?
-				  GROUP BY test_id
-				)
-				SELECT e.test_id
-				FROM end_sums e
-				LEFT JOIN start_sums s ON s.test_id = e.test_id
-				WHERE (e.total_runs - COALESCE(s.total_runs, 0)) > 0`,
-				release, today, release, startMinusOne).
-				Scan(&releaseTestIDs).
-				Error
-			if queryErr != nil {
-				return fmt.Errorf("counting test IDs for release %s: %w", release, queryErr)
-			}
-			ch <- releaseTestIDs
-			return nil
-		})
-	}
-	if err := g.Wait(); err != nil {
-		return -1, -1, err
-	}
-	close(ch)
-	<-done
-	testIDsCount := int64(testIDs.Len())
+	testIDsCount := int64(len(testIDs))
 
 	log.WithFields(log.Fields{
 		"lookbackDays": lookbackDays,

--- a/pkg/dataloader/prowloader/bigqueryjobs.go
+++ b/pkg/dataloader/prowloader/bigqueryjobs.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/api/iterator"
 
 	"github.com/openshift/sippy/pkg/apis/prow"
+	"github.com/openshift/sippy/pkg/db/query"
 )
 
 func (pl *ProwLoader) fetchProwJobsFromOpenShiftBigQuery() ([]prow.ProwJob, []error) {
@@ -24,7 +25,10 @@ func (pl *ProwLoader) fetchProwJobsFromOpenShiftBigQuery() ([]prow.ProwJob, []er
 		lastProwJobRun = *pl.loadSince
 		log.Infof("Using manually specified load-since time: %s", lastProwJobRun.UTC().Format(time.RFC3339))
 	} else {
-		row := pl.dbc.DB.Table("prow_job_runs").Select("max(timestamp)").Row()
+		release, _ := query.CurrentActiveRelease(pl.dbc)
+		row := pl.dbc.DB.Table("prow_job_runs").Select("max(timestamp)").
+			Where("prow_job_release = ?", release).
+			Where("timestamp > NOW() - INTERVAL '14 days'").Row()
 		err := row.Scan(&lastProwJobRun)
 		if err != nil || lastProwJobRun.IsZero() {
 			log.WithError(err).Warnf("no last prow job run found (new database?), importing previous %d days", DefaultLookbackDays)

--- a/pkg/dataloader/prowloader/bigqueryjobs.go
+++ b/pkg/dataloader/prowloader/bigqueryjobs.go
@@ -25,20 +25,25 @@ func (pl *ProwLoader) fetchProwJobsFromOpenShiftBigQuery() ([]prow.ProwJob, []er
 		lastProwJobRun = *pl.loadSince
 		log.Infof("Using manually specified load-since time: %s", lastProwJobRun.UTC().Format(time.RFC3339))
 	} else {
-		release, _ := query.CurrentActiveRelease(pl.dbc)
-		row := pl.dbc.DB.Table("prow_job_runs").Select("max(timestamp)").
-			Where("prow_job_release = ?", release).
-			Where("timestamp > NOW() - INTERVAL '14 days'").Row()
-		err := row.Scan(&lastProwJobRun)
-		if err != nil || lastProwJobRun.IsZero() {
-			log.WithError(err).Warnf("no last prow job run found (new database?), importing previous %d days", DefaultLookbackDays)
+		release, err := query.CurrentActiveRelease(pl.dbc)
+		if err != nil {
+			log.WithError(err).Warnf("could not determine active release, importing previous %d days", DefaultLookbackDays)
 			lastProwJobRun = time.Now().AddDate(0, 0, -DefaultLookbackDays)
 		} else {
-			// adjust the last job run time, we're querying all jobs that have completed since our last recorded
-			// job START time, but we need to subtract our max job runtime in-case a job ended early and was our last
-			// imported start time, while others that started before it hadn't completed yet.
-			// 12 hours should safely cover our max timeout.
-			lastProwJobRun = lastProwJobRun.Add(-12 * time.Hour)
+			row := pl.dbc.DB.Table("prow_job_runs").Select("max(timestamp)").
+				Where("prow_job_release = ?", release).
+				Where("timestamp > NOW() - INTERVAL '14 days'").Row()
+			err = row.Scan(&lastProwJobRun)
+			if err != nil || lastProwJobRun.IsZero() {
+				log.WithError(err).Warnf("no last prow job run found (new database?), importing previous %d days", DefaultLookbackDays)
+				lastProwJobRun = time.Now().AddDate(0, 0, -DefaultLookbackDays)
+			} else {
+				// adjust the last job run time, we're querying all jobs that have completed since our last recorded
+				// job START time, but we need to subtract our max job runtime in-case a job ended early and was our last
+				// imported start time, while others that started before it hadn't completed yet.
+				// 12 hours should safely cover our max timeout.
+				lastProwJobRun = lastProwJobRun.Add(-12 * time.Hour)
+			}
 		}
 
 		// we need to know how far back we are looking for partitioning
@@ -49,7 +54,7 @@ func (pl *ProwLoader) fetchProwJobsFromOpenShiftBigQuery() ([]prow.ProwJob, []er
 	// NOTE: casting a couple datetime columns to timestamps, it does appear they go in as UTC, and thus come out
 	// as the default UTC correctly.
 	// Annotations and labels can be queried here if we need them.
-	query := pl.bigQueryClient.Query(pl.ctx, bqlabel.ProwLoaderProwJobs, `
+	bqQuery := pl.bigQueryClient.Query(pl.ctx, bqlabel.ProwLoaderProwJobs, `
         SELECT
 			prowjob_job_name,
 			prowjob_state,
@@ -71,13 +76,13 @@ func (pl *ProwLoader) fetchProwJobsFromOpenShiftBigQuery() ([]prow.ProwJob, []er
 	       AND prowjob_url IS NOT NULL
 	       AND prowjob_state NOT IN ('pending', 'triggered')
 	       ORDER BY prowjob_start_ts`)
-	query.Parameters = []bigquery.QueryParameter{
+	bqQuery.Parameters = []bigquery.QueryParameter{
 		{
 			Name:  "queryFrom",
 			Value: lastProwJobRun,
 		},
 	}
-	it, err := query.Read(pl.ctx)
+	it, err := bqQuery.Read(pl.ctx)
 	if err != nil {
 		errs = append(errs, err)
 		log.WithError(err).Error("error querying jobs from bigquery")

--- a/pkg/db/functions.go
+++ b/pkg/db/functions.go
@@ -75,108 +75,114 @@ $_$;
 `
 
 const jobResultFunction = `
-CREATE FUNCTION public.job_results(release text, start timestamp without time zone, boundary timestamp without time zone, endstamp timestamp without time zone) RETURNS TABLE(pj_name text, pj_variants text[], org text, repo text, average_retests_to_merge double precision, previous_passes bigint, previous_fails bigint, previous_runs bigint, previous_infra_fails bigint, current_passes bigint, current_fails bigint, current_runs bigint, current_infra_fails bigint, id bigint, created_at timestamp without time zone, updated_at timestamp without time zone, deleted_at timestamp without time zone, name text, release text, variants text[], test_grid_url text, kind text, brief_name text, current_pass_percentage real, current_projected_pass_percentage real, current_failure_percentage real, previous_pass_percentage real, previous_projected_pass_percentage real, previous_failure_percentage real, net_improvement real, open_bugs int, last_pass timestamp, current_average_duration_minutes int, previous_average_duration_minutes int)
-    LANGUAGE sql
-    AS $_$
-WITH repo_org_jobs AS (
-    SELECT org, repo, prow_jobs.id
-    FROM prow_job_runs
-         INNER JOIN prow_job_run_prow_pull_requests on prow_job_run_prow_pull_requests.prow_job_run_id = prow_job_runs.id
-         INNER JOIN prow_pull_requests on prow_pull_requests.id = prow_job_run_prow_pull_requests.prow_pull_request_id
-         INNER JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id
-    WHERE prow_job_runs.prow_job_release = $1
-      AND prow_job_runs.timestamp BETWEEN $2 AND $4
-      AND prow_job_run_prow_pull_requests.prow_job_run_release = $1
-      AND prow_job_run_prow_pull_requests.prow_job_run_timestamp BETWEEN $2 AND $4
-    GROUP BY prow_pull_requests.org, prow_pull_requests.repo, prow_jobs.id
-),
-merged_prs AS
-    (SELECT prow_jobs.id as prow_job_id, prow_pull_requests.link, COUNT(*) as total_runs
-    FROM prow_job_runs
-         INNER JOIN prow_job_run_prow_pull_requests on prow_job_run_prow_pull_requests.prow_job_run_id = prow_job_runs.id
-         INNER JOIN prow_pull_requests on prow_pull_requests.id = prow_job_run_prow_pull_requests.prow_pull_request_id
-         INNER JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id
-	WHERE prow_pull_requests.merged_at BETWEEN $2::timestamp AND $4::timestamp
-	AND prow_job_runs.timestamp BETWEEN $2 AND $4
-	AND prow_job_runs.prow_job_release = $1
-	AND prow_job_run_prow_pull_requests.prow_job_run_release = $1
-	AND prow_job_run_prow_pull_requests.prow_job_run_timestamp BETWEEN $2 AND $4
-	AND prow_job_runs.overall_result != 'S'
-	AND prow_job_runs.overall_result != 'A'
-    GROUP BY prow_jobs.id, prow_pull_requests.id, prow_pull_requests.link),
-retests AS
-    (SELECT prow_job_id, AVG(total_runs) as average_retests_to_merge FROM merged_prs GROUP BY prow_job_id),
-job_bugs AS (
-        SELECT prow_jobs.id AS prow_job_id,
-               COUNT(DISTINCT bugs.id) AS open_bugs
-        FROM prow_jobs
-        LEFT JOIN bug_jobs ON prow_jobs.id = bug_jobs.prow_job_id
-        LEFT JOIN bugs ON bugs.id = bug_jobs.bug_id AND lower(bugs.status) NOT IN ('verified', 'modified', 'closed', 'on_qa')
-        WHERE prow_jobs.release = $1
-        GROUP BY prow_jobs.id
+CREATE FUNCTION public.job_results(p_release text, p_start timestamp without time zone, p_boundary timestamp without time zone, p_endstamp timestamp without time zone) RETURNS TABLE(pj_name text, pj_variants text[], org text, repo text, average_retests_to_merge double precision, previous_passes bigint, previous_fails bigint, previous_runs bigint, previous_infra_fails bigint, current_passes bigint, current_fails bigint, current_runs bigint, current_infra_fails bigint, id bigint, created_at timestamp without time zone, updated_at timestamp without time zone, deleted_at timestamp without time zone, name text, release text, variants text[], test_grid_url text, kind text, brief_name text, current_pass_percentage real, current_projected_pass_percentage real, current_failure_percentage real, previous_pass_percentage real, previous_projected_pass_percentage real, previous_failure_percentage real, net_improvement real, open_bugs int, last_pass timestamp, current_average_duration_minutes int, previous_average_duration_minutes int)
+    LANGUAGE plpgsql
+    AS $fn$
+BEGIN
+RETURN QUERY
+WITH retests AS (
+    SELECT sub.id as prow_job_id, AVG(sub.cnt)::double precision as average_retests_to_merge
+    FROM (
+        SELECT prow_jobs.id, COUNT(*) as cnt
+        FROM prow_job_runs
+             INNER JOIN prow_job_run_prow_pull_requests on prow_job_run_prow_pull_requests.prow_job_run_id = prow_job_runs.id
+             INNER JOIN prow_pull_requests on prow_pull_requests.id = prow_job_run_prow_pull_requests.prow_pull_request_id
+             INNER JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id
+        WHERE prow_pull_requests.merged_at BETWEEN p_start AND p_endstamp
+        AND prow_job_runs.timestamp BETWEEN p_start AND p_endstamp
+        AND prow_job_runs.prow_job_release = p_release
+        AND prow_job_run_prow_pull_requests.prow_job_run_release = p_release
+        AND prow_job_run_prow_pull_requests.prow_job_run_timestamp BETWEEN p_start AND p_endstamp
+        AND prow_job_runs.overall_result != 'S'
+        AND prow_job_runs.overall_result != 'A'
+        GROUP BY prow_jobs.id, prow_pull_requests.id, prow_pull_requests.link
+    ) sub
+    GROUP BY sub.id
 ),
 results AS (
         select prow_jobs.name as pj_name, prow_jobs.variants as pj_variants,
-                coalesce(count(case when succeeded = true AND timestamp >= $2 AND timestamp < $3 then 1 end), 0) as previous_passes,
-                coalesce(count(case when succeeded = false AND timestamp >= $2 AND timestamp < $3 then 1 end), 0) as previous_fails,
-                coalesce(count(case when timestamp >= $2 AND timestamp < $3 then 1 end), 0) as previous_runs,
-                coalesce(count(case when infrastructure_failure = true AND timestamp >= $2 AND timestamp < $3 then 1 end), 0) as previous_infra_fails,
-                coalesce(count(case when succeeded = true AND timestamp BETWEEN $3 AND $4 then 1 end), 0) as current_passes,
-                coalesce(count(case when succeeded = false AND timestamp BETWEEN $3 AND $4 then 1 end), 0) as current_fails,
-                coalesce(count(case when timestamp BETWEEN $3 AND $4 then 1 end), 0) as current_runs,
-                coalesce(count(case when infrastructure_failure = true AND timestamp BETWEEN $3 AND $4 then 1 end), 0) as current_infra_fails,
-                ROUND(coalesce(AVG(case when timestamp BETWEEN $3 AND $4 then prow_job_runs.duration end) / 60000000000.0, 0))::int as current_average_duration_minutes,
-                ROUND(coalesce(AVG(case when timestamp >= $2 AND timestamp < $3 then prow_job_runs.duration end) / 60000000000.0, 0))::int as previous_average_duration_minutes
+                coalesce(count(case when succeeded = true AND prow_job_runs.timestamp >= p_start AND prow_job_runs.timestamp < p_boundary then 1 end), 0) as previous_passes,
+                coalesce(count(case when succeeded = false AND prow_job_runs.timestamp >= p_start AND prow_job_runs.timestamp < p_boundary then 1 end), 0) as previous_fails,
+                coalesce(count(case when prow_job_runs.timestamp >= p_start AND prow_job_runs.timestamp < p_boundary then 1 end), 0) as previous_runs,
+                coalesce(count(case when infrastructure_failure = true AND prow_job_runs.timestamp >= p_start AND prow_job_runs.timestamp < p_boundary then 1 end), 0) as previous_infra_fails,
+                coalesce(count(case when succeeded = true AND prow_job_runs.timestamp BETWEEN p_boundary AND p_endstamp then 1 end), 0) as current_passes,
+                coalesce(count(case when succeeded = false AND prow_job_runs.timestamp BETWEEN p_boundary AND p_endstamp then 1 end), 0) as current_fails,
+                coalesce(count(case when prow_job_runs.timestamp BETWEEN p_boundary AND p_endstamp then 1 end), 0) as current_runs,
+                coalesce(count(case when infrastructure_failure = true AND prow_job_runs.timestamp BETWEEN p_boundary AND p_endstamp then 1 end), 0) as current_infra_fails,
+                ROUND(coalesce(AVG(case when prow_job_runs.timestamp BETWEEN p_boundary AND p_endstamp then prow_job_runs.duration end) / 60000000000.0, 0))::int as current_average_duration_minutes,
+                ROUND(coalesce(AVG(case when prow_job_runs.timestamp >= p_start AND prow_job_runs.timestamp < p_boundary then prow_job_runs.duration end) / 60000000000.0, 0))::int as previous_average_duration_minutes
         FROM prow_job_runs
         JOIN prow_jobs
                 ON prow_jobs.id = prow_job_runs.prow_job_id
-                                AND prow_jobs.release = $1
-                AND timestamp BETWEEN $2 AND $4
-        WHERE prow_job_runs.prow_job_release = $1
+                AND prow_jobs.release = p_release
+        WHERE prow_job_runs.prow_job_release = p_release
+          AND prow_job_runs.timestamp BETWEEN p_start AND p_endstamp
         group by prow_jobs.name, prow_jobs.variants
 ),
-last_pass AS (
-	SELECT prow_job_id, max(timestamp) as last_pass from prow_job_runs where overall_result = 'S' AND prow_job_release = $1 group by prow_job_id
+lp AS (
+    SELECT prow_job_runs.prow_job_id, max(prow_job_runs.timestamp)::timestamp without time zone as last_pass
+    FROM prow_job_runs
+    WHERE overall_result = 'S' AND prow_job_release = p_release AND prow_job_runs.timestamp >= p_start
+    GROUP BY prow_job_runs.prow_job_id
 )
-SELECT pj_name,
-       pj_variants,
-       repo_org_jobs.org,
-       repo_org_jobs.repo,
-	   average_retests_to_merge,
-       previous_passes,
-       previous_fails,
-       previous_runs,
-       previous_infra_fails,
-       current_passes,
-       current_fails,
-       current_runs,
-       current_infra_fails,
+SELECT results.pj_name,
+       results.pj_variants,
+       roj.org,
+       roj.repo,
+       retests.average_retests_to_merge,
+       results.previous_passes,
+       results.previous_fails,
+       results.previous_runs,
+       results.previous_infra_fails,
+       results.current_passes,
+       results.current_fails,
+       results.current_runs,
+       results.current_infra_fails,
        prow_jobs.id,
-       prow_jobs.created_at,
-       prow_jobs.updated_at,
-       prow_jobs.deleted_at,
-       name,
-       release,
-       variants,
-       test_grid_url,
-       kind,
+       prow_jobs.created_at::timestamp without time zone,
+       prow_jobs.updated_at::timestamp without time zone,
+       prow_jobs.deleted_at::timestamp without time zone,
+       prow_jobs.name,
+       prow_jobs.release,
+       prow_jobs.variants,
+       prow_jobs.test_grid_url,
+       prow_jobs.kind,
        REGEXP_REPLACE(results.pj_name, 'periodic-ci-openshift-(multiarch|release)-(master|main)-(ci|nightly)-[0-9]+.[0-9]+-', '') as brief_name,
-       current_passes * 100.0 / NULLIF(current_runs, 0) AS current_pass_percentage,
-       (current_passes + current_infra_fails) * 100.0 / NULLIF(current_runs, 0) AS current_projected_pass_percentage,
-       current_fails * 100.0 / NULLIF(current_runs, 0) AS current_failure_percentage,
-       previous_passes * 100.0 / NULLIF(previous_runs, 0) AS previous_pass_percentage,
-       (previous_passes + previous_infra_fails) * 100.0 / NULLIF(previous_runs, 0) AS previous_projected_pass_percentage,
-       previous_fails * 100.0 / NULLIF(previous_runs, 0) AS previous_failure_percentage,
-       (current_passes * 100.0 / NULLIF(current_runs, 0)) - (previous_passes * 100.0 / NULLIF(previous_runs, 0)) AS net_improvement,
-       COALESCE(job_bugs.open_bugs, 0) AS open_bugs,
-       last_pass.last_pass,
-       current_average_duration_minutes,
-       previous_average_duration_minutes
+       (results.current_passes * 100.0 / NULLIF(results.current_runs, 0))::real AS current_pass_percentage,
+       ((results.current_passes + results.current_infra_fails) * 100.0 / NULLIF(results.current_runs, 0))::real AS current_projected_pass_percentage,
+       (results.current_fails * 100.0 / NULLIF(results.current_runs, 0))::real AS current_failure_percentage,
+       (results.previous_passes * 100.0 / NULLIF(results.previous_runs, 0))::real AS previous_pass_percentage,
+       ((results.previous_passes + results.previous_infra_fails) * 100.0 / NULLIF(results.previous_runs, 0))::real AS previous_projected_pass_percentage,
+       (results.previous_fails * 100.0 / NULLIF(results.previous_runs, 0))::real AS previous_failure_percentage,
+       ((results.current_passes * 100.0 / NULLIF(results.current_runs, 0)) - (results.previous_passes * 100.0 / NULLIF(results.previous_runs, 0)))::real AS net_improvement,
+       COALESCE(jb.open_bugs, 0)::int AS open_bugs,
+       lp.last_pass,
+       results.current_average_duration_minutes,
+       results.previous_average_duration_minutes
 FROM results
          JOIN prow_jobs ON prow_jobs.name = results.pj_name
-         LEFT JOIN repo_org_jobs ON prow_jobs.id = repo_org_jobs.id
-		 LEFT JOIN retests ON prow_jobs.id = retests.prow_job_id
-		 LEFT JOIN last_pass ON prow_jobs.id = last_pass.prow_job_id
-		 LEFT JOIN job_bugs ON prow_jobs.id = job_bugs.prow_job_id
-    $_$;
+         LEFT JOIN (
+             SELECT prow_pull_requests.org, prow_pull_requests.repo, prow_jobs.id
+             FROM prow_job_runs
+                  INNER JOIN prow_job_run_prow_pull_requests on prow_job_run_prow_pull_requests.prow_job_run_id = prow_job_runs.id
+                  INNER JOIN prow_pull_requests on prow_pull_requests.id = prow_job_run_prow_pull_requests.prow_pull_request_id
+                  INNER JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id
+             WHERE prow_job_runs.prow_job_release = p_release
+               AND prow_job_runs.timestamp BETWEEN p_start AND p_endstamp
+               AND prow_job_run_prow_pull_requests.prow_job_run_release = p_release
+               AND prow_job_run_prow_pull_requests.prow_job_run_timestamp BETWEEN p_start AND p_endstamp
+             GROUP BY prow_pull_requests.org, prow_pull_requests.repo, prow_jobs.id
+         ) roj ON prow_jobs.id = roj.id
+         LEFT JOIN retests ON prow_jobs.id = retests.prow_job_id
+         LEFT JOIN lp ON prow_jobs.id = lp.prow_job_id
+         LEFT JOIN (
+             SELECT prow_jobs.id AS prow_job_id, COUNT(DISTINCT bugs.id)::int AS open_bugs
+             FROM prow_jobs
+             LEFT JOIN bug_jobs ON prow_jobs.id = bug_jobs.prow_job_id
+             LEFT JOIN bugs ON bugs.id = bug_jobs.bug_id AND lower(bugs.status) NOT IN ('verified', 'modified', 'closed', 'on_qa')
+             WHERE prow_jobs.release = p_release
+             GROUP BY prow_jobs.id
+         ) jb ON prow_jobs.id = jb.prow_job_id;
+END;
+    $fn$;
 `

--- a/pkg/db/functions.go
+++ b/pkg/db/functions.go
@@ -122,7 +122,8 @@ results AS (
 lp AS (
     SELECT prow_job_runs.prow_job_id, max(prow_job_runs.timestamp)::timestamp without time zone as last_pass
     FROM prow_job_runs
-    WHERE overall_result = 'S' AND prow_job_release = p_release AND prow_job_runs.timestamp >= p_start
+    WHERE overall_result = 'S' AND prow_job_release = p_release
+      AND prow_job_runs.timestamp BETWEEN p_start AND p_endstamp
     GROUP BY prow_job_runs.prow_job_id
 )
 SELECT results.pj_name,

--- a/pkg/db/functions.go
+++ b/pkg/db/functions.go
@@ -123,7 +123,8 @@ lp AS (
     SELECT prow_job_runs.prow_job_id, max(prow_job_runs.timestamp)::timestamp without time zone as last_pass
     FROM prow_job_runs
     WHERE overall_result = 'S' AND prow_job_release = p_release
-      AND prow_job_runs.timestamp BETWEEN p_start AND p_endstamp
+      AND prow_job_runs.timestamp >= p_endstamp - INTERVAL '90 days'
+      AND prow_job_runs.timestamp <= p_endstamp
     GROUP BY prow_job_runs.prow_job_id
 )
 SELECT results.pj_name,

--- a/pkg/db/functions.go
+++ b/pkg/db/functions.go
@@ -162,6 +162,7 @@ SELECT results.pj_name,
        results.previous_average_duration_minutes
 FROM results
          JOIN prow_jobs ON prow_jobs.name = results.pj_name
+                      AND prow_jobs.release = p_release
          LEFT JOIN (
              SELECT prow_pull_requests.org, prow_pull_requests.repo, prow_jobs.id
              FROM prow_job_runs

--- a/pkg/db/query/build_clusters.go
+++ b/pkg/db/query/build_clusters.go
@@ -9,12 +9,12 @@ import (
 	"github.com/openshift/sippy/pkg/db/models"
 )
 
-func HasBuildClusterData(dbc *db.DB, release string) (bool, error) {
+func HasBuildClusterData(dbc *db.DB, release string, since time.Time) (bool, error) {
 	count := int64(0)
 	res := dbc.DB.Table("prow_job_runs").
 		Where(`cluster != '' AND cluster IS NOT NULL`).
 		Where("prow_job_release = ?", release).
-		Where("timestamp > NOW() - INTERVAL '14 days'").
+		Where("timestamp > ?", since).
 		Count(&count)
 	return count > 0, res.Error
 }

--- a/pkg/db/query/build_clusters.go
+++ b/pkg/db/query/build_clusters.go
@@ -9,13 +9,17 @@ import (
 	"github.com/openshift/sippy/pkg/db/models"
 )
 
-func HasBuildClusterData(dbc *db.DB) (bool, error) {
+func HasBuildClusterData(dbc *db.DB, release string) (bool, error) {
 	count := int64(0)
-	res := dbc.DB.Table("prow_job_runs").Where(`cluster != '' AND cluster IS NOT NULL`).Count(&count)
+	res := dbc.DB.Table("prow_job_runs").
+		Where(`cluster != '' AND cluster IS NOT NULL`).
+		Where("prow_job_release = ?", release).
+		Where("timestamp > NOW() - INTERVAL '14 days'").
+		Count(&count)
 	return count > 0, res.Error
 }
 
-func BuildClusterHealth(dbc *db.DB, start, boundary, end time.Time) ([]models.BuildClusterHealthReport, error) {
+func BuildClusterHealth(dbc *db.DB, release string, start, boundary, end time.Time) ([]models.BuildClusterHealthReport, error) {
 	results := make([]models.BuildClusterHealthReport, 0)
 
 	rawResults := dbc.DB.Select(`
@@ -32,6 +36,7 @@ func BuildClusterHealth(dbc *db.DB, start, boundary, end time.Time) ([]models.Bu
 		Joins("JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id").
 		Where(`cluster != '' AND cluster IS NOT NULL`).
 		Where("prow_jobs.kind = 'periodic'").
+		Where("prow_job_runs.prow_job_release = ?", release).
 		Where("prow_job_runs.timestamp BETWEEN @start AND @end", sql.Named("start", start), sql.Named("end", end)).
 		Group("cluster")
 
@@ -45,7 +50,7 @@ func BuildClusterHealth(dbc *db.DB, start, boundary, end time.Time) ([]models.Bu
 	return results, q.Error
 }
 
-func BuildClusterAnalysis(dbc *db.DB, period string) ([]models.BuildClusterHealth, error) {
+func BuildClusterAnalysis(dbc *db.DB, release, period string) ([]models.BuildClusterHealth, error) {
 	results := make([]models.BuildClusterHealth, 0)
 
 	q := dbc.DB.Raw(fmt.Sprintf(`
@@ -65,10 +70,12 @@ WHERE
 AND
 	prow_jobs.kind = 'periodic'
 AND
+    prow_job_runs.prow_job_release = @release
+AND
     cluster != ''
 AND
     timestamp > NOW() - INTERVAL '14 DAY'
 GROUP BY cluster, period
-`, period)).Scan(&results)
+`, period), sql.Named("release", release)).Scan(&results)
 	return results, q.Error
 }

--- a/pkg/db/query/job_queries.go
+++ b/pkg/db/query/job_queries.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"gorm.io/gorm"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/db"
@@ -26,17 +25,11 @@ type ProwJobRunPartitionKeys struct {
 // the caller then uses these keys to load the full row with partition pruning.
 func LookupProwJobRunPartitionKeys(dbc *db.DB, jobRunID int64) (ProwJobRunPartitionKeys, error) {
 	var keys ProwJobRunPartitionKeys
-	res := dbc.DB.Table("prow_job_runs").
+	err := dbc.DB.Table("prow_job_runs").
 		Select("prow_job_release, timestamp").
 		Where("id = ?", jobRunID).
-		Scan(&keys)
-	if res.Error != nil {
-		return keys, res.Error
-	}
-	if res.RowsAffected == 0 {
-		return keys, gorm.ErrRecordNotFound
-	}
-	return keys, nil
+		Take(&keys).Error
+	return keys, err
 }
 
 func JobRunTestCount(dbc *db.DB, jobRunID int64, release string, timestamp time.Time) (int, error) {

--- a/pkg/db/query/job_queries.go
+++ b/pkg/db/query/job_queries.go
@@ -12,6 +12,27 @@ import (
 	"github.com/openshift/sippy/pkg/filter"
 )
 
+// ProwJobRunPartitionKeys holds the partition key columns for prow_job_runs.
+// Used for two-step lookups: fetch these lightweight keys first, then load the
+// full row with partition pruning. This will be replaced by a mapping table in
+// a future iteration.
+type ProwJobRunPartitionKeys struct {
+	ProwJobRelease string    `gorm:"column:prow_job_release"`
+	Timestamp      time.Time `gorm:"column:timestamp"`
+}
+
+// LookupProwJobRunPartitionKeys fetches the partition keys for a prow_job_run
+// by ID. This is intended as the first step of a two-step lookup pattern where
+// the caller then uses these keys to load the full row with partition pruning.
+func LookupProwJobRunPartitionKeys(dbc *db.DB, jobRunID int64) (ProwJobRunPartitionKeys, error) {
+	var keys ProwJobRunPartitionKeys
+	err := dbc.DB.Table("prow_job_runs").
+		Select("prow_job_release, timestamp").
+		Where("id = ?", jobRunID).
+		Take(&keys).Error
+	return keys, err
+}
+
 func JobRunTestCount(dbc *db.DB, jobRunID int64, release string, timestamp time.Time) (int, error) {
 	var prowJobRunTestCount int64
 

--- a/pkg/db/query/job_queries.go
+++ b/pkg/db/query/job_queries.go
@@ -73,12 +73,12 @@ func ProwJobSimilarName(dbc *db.DB, rootName, release string) ([]models.ProwJob,
 	return jobs, nil
 }
 
-func ProwJobRunCount(dbc *db.DB, prowJobID uint, release string) (int, error) {
+func ProwJobRunCount(dbc *db.DB, prowJobID uint, release string, since time.Time) (int, error) {
 	var count int64
 	q := dbc.DB.Table("prow_job_runs").
 		Where("prow_job_id = ?", prowJobID).
 		Where("prow_job_release = ?", release).
-		Where("timestamp > NOW() - INTERVAL '14 days'")
+		Where("timestamp > ?", since)
 	if err := q.Count(&count).Error; err != nil {
 		return 0, err
 	}

--- a/pkg/db/query/job_queries.go
+++ b/pkg/db/query/job_queries.go
@@ -12,26 +12,6 @@ import (
 	"github.com/openshift/sippy/pkg/filter"
 )
 
-// ProwJobRunPartitionKeys holds the partition key columns for prow_job_runs.
-// Used for two-step lookups: fetch these lightweight keys first, then load the
-// full row with partition pruning.
-type ProwJobRunPartitionKeys struct {
-	ProwJobRelease string    `gorm:"column:prow_job_release"`
-	Timestamp      time.Time `gorm:"column:timestamp"`
-}
-
-// LookupProwJobRunPartitionKeys fetches the partition keys for a prow_job_run
-// by ID. This is intended as the first step of a two-step lookup pattern where
-// the caller then uses these keys to load the full row with partition pruning.
-func LookupProwJobRunPartitionKeys(dbc *db.DB, jobRunID int64) (ProwJobRunPartitionKeys, error) {
-	var keys ProwJobRunPartitionKeys
-	err := dbc.DB.Table("prow_job_runs").
-		Select("prow_job_release, timestamp").
-		Where("id = ?", jobRunID).
-		Take(&keys).Error
-	return keys, err
-}
-
 func JobRunTestCount(dbc *db.DB, jobRunID int64, release string, timestamp time.Time) (int, error) {
 	var prowJobRunTestCount int64
 

--- a/pkg/db/query/job_queries.go
+++ b/pkg/db/query/job_queries.go
@@ -12,6 +12,26 @@ import (
 	"github.com/openshift/sippy/pkg/filter"
 )
 
+// ProwJobRunPartitionKeys holds the partition key columns for prow_job_runs.
+// Used for two-step lookups: fetch these lightweight keys first, then load the
+// full row with partition pruning.
+type ProwJobRunPartitionKeys struct {
+	ProwJobRelease string    `gorm:"column:prow_job_release"`
+	Timestamp      time.Time `gorm:"column:timestamp"`
+}
+
+// LookupProwJobRunPartitionKeys fetches the partition keys for a prow_job_run
+// by ID. This is intended as the first step of a two-step lookup pattern where
+// the caller then uses these keys to load the full row with partition pruning.
+func LookupProwJobRunPartitionKeys(dbc *db.DB, jobRunID int64) (ProwJobRunPartitionKeys, error) {
+	var keys ProwJobRunPartitionKeys
+	err := dbc.DB.Table("prow_job_runs").
+		Select("prow_job_release, timestamp").
+		Where("id = ?", jobRunID).
+		Scan(&keys).Error
+	return keys, err
+}
+
 func JobRunTestCount(dbc *db.DB, jobRunID int64, release string, timestamp time.Time) (int, error) {
 	var prowJobRunTestCount int64
 
@@ -50,7 +70,8 @@ func ProwJobRunCount(dbc *db.DB, prowJobID uint, release string) (int, error) {
 	var count int64
 	q := dbc.DB.Table("prow_job_runs").
 		Where("prow_job_id = ?", prowJobID).
-		Where("prow_job_release = ?", release)
+		Where("prow_job_release = ?", release).
+		Where("timestamp > NOW() - INTERVAL '14 days'")
 	if err := q.Count(&count).Error; err != nil {
 		return 0, err
 	}

--- a/pkg/db/query/job_queries.go
+++ b/pkg/db/query/job_queries.go
@@ -46,18 +46,15 @@ func ProwJobSimilarName(dbc *db.DB, rootName, release string) ([]models.ProwJob,
 	return jobs, nil
 }
 
-func ProwJobRunIDs(dbc *db.DB, prowJobID uint) ([]uint, error) {
-	jobIDs := make([]uint, 0)
-	q := dbc.DB.Raw(`SELECT id 
-	FROM prow_job_runs WHERE prow_job_id = ?`, prowJobID)
-	if q.Error != nil {
-		return nil, q.Error
+func ProwJobRunCount(dbc *db.DB, prowJobID uint, release string) (int, error) {
+	var count int64
+	q := dbc.DB.Table("prow_job_runs").
+		Where("prow_job_id = ?", prowJobID).
+		Where("prow_job_release = ?", release)
+	if err := q.Count(&count).Error; err != nil {
+		return 0, err
 	}
-	if err := q.Scan(&jobIDs).Error; err != nil {
-		return nil, err
-	}
-
-	return jobIDs, nil
+	return int(count), nil
 }
 
 func ProwJobHistoricalTestCounts(dbc *db.DB, prowJobID uint, release string) (int, error) {

--- a/pkg/db/query/job_queries.go
+++ b/pkg/db/query/job_queries.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/db"
@@ -25,11 +26,17 @@ type ProwJobRunPartitionKeys struct {
 // the caller then uses these keys to load the full row with partition pruning.
 func LookupProwJobRunPartitionKeys(dbc *db.DB, jobRunID int64) (ProwJobRunPartitionKeys, error) {
 	var keys ProwJobRunPartitionKeys
-	err := dbc.DB.Table("prow_job_runs").
+	res := dbc.DB.Table("prow_job_runs").
 		Select("prow_job_release, timestamp").
 		Where("id = ?", jobRunID).
-		Scan(&keys).Error
-	return keys, err
+		Scan(&keys)
+	if res.Error != nil {
+		return keys, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return keys, gorm.ErrRecordNotFound
+	}
+	return keys, nil
 }
 
 func JobRunTestCount(dbc *db.DB, jobRunID int64, release string, timestamp time.Time) (int, error) {

--- a/pkg/db/query/pull_request_queries.go
+++ b/pkg/db/query/pull_request_queries.go
@@ -43,23 +43,31 @@ func PullRequestReport(dbc *db.DB, filterOpts *filter.FilterOptions, release str
 	return results, nil
 }
 
-func PullRequestAveragePremergeFailures(dbc *db.DB, start, end *time.Time) *gorm.DB {
+func PullRequestAveragePremergeFailures(dbc *db.DB, release string, start, end *time.Time) *gorm.DB {
 	premergeFailures := dbc.DB.Table("prow_job_runs").
 		Select("prow_jobs.id as prow_job_id, prow_jobs.name as prow_job_name, prow_pull_requests.org, prow_pull_requests.repo, prow_pull_requests.link, COUNT(*) as total_runs").
-		Joins("INNER JOIN prow_job_run_prow_pull_requests on prow_job_run_prow_pull_requests.prow_job_run_id = prow_job_runs.id").
+		Joins("INNER JOIN prow_job_run_prow_pull_requests on prow_job_run_prow_pull_requests.prow_job_run_id = prow_job_runs.id AND prow_job_run_prow_pull_requests.prow_job_run_release = prow_job_runs.prow_job_release").
 		Joins("INNER JOIN prow_pull_requests on prow_pull_requests.id = prow_job_run_prow_pull_requests.prow_pull_request_id").
 		Joins("INNER JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id").
+		Where("prow_job_runs.prow_job_release = ?", release).
+		Where("prow_job_run_prow_pull_requests.prow_job_run_release = ?", release).
 		Where("prow_job_runs.overall_result != 'S'").
 		Where("prow_job_runs.overall_result != 'A'").
 		Where("prow_pull_requests.merged_at IS NOT NULL").
 		Group("prow_jobs.id, prow_jobs.name, prow_pull_requests.org, prow_pull_requests.repo, prow_pull_requests.id, prow_pull_requests.link")
 
 	if start != nil {
-		premergeFailures = premergeFailures.Where("prow_pull_requests.merged_at >= ?", start)
+		premergeFailures = premergeFailures.
+			Where("prow_pull_requests.merged_at >= ?", start).
+			Where("prow_job_runs.timestamp >= ?", start).
+			Where("prow_job_run_prow_pull_requests.prow_job_run_timestamp >= ?", start)
 	}
 
 	if end != nil {
-		premergeFailures = premergeFailures.Where("prow_pull_requests.merged_at <= ?", end)
+		premergeFailures = premergeFailures.
+			Where("prow_pull_requests.merged_at <= ?", end).
+			Where("prow_job_runs.timestamp <= ?", end).
+			Where("prow_job_run_prow_pull_requests.prow_job_run_timestamp <= ?", end)
 	}
 
 	return dbc.DB.Table("(?) as premerge_failures", premergeFailures).

--- a/pkg/db/query/pull_request_queries.go
+++ b/pkg/db/query/pull_request_queries.go
@@ -19,6 +19,7 @@ func PullRequestReport(dbc *db.DB, filterOpts *filter.FilterOptions, release str
 		Joins("INNER JOIN release_tags ON release_tags.id = release_tag_pull_requests.release_tag_id").
 		Group("url, release_tags.stream, release_tags.architecture, release_tags.release_tag, release_tags.phase, release_tags.release")
 
+	lookback14d := time.Now().UTC().Add(-14 * 24 * time.Hour)
 	prs := dbc.DB.Table("prow_pull_requests").
 		Joins("LEFT JOIN (?) ci ON ci.url = prow_pull_requests.link",
 			dbc.DB.Table("(?) as ci", firstPayloadsByStreamAndArch).Where("ci.stream = 'ci' AND architecture = 'amd64'")).
@@ -29,7 +30,9 @@ func PullRequestReport(dbc *db.DB, filterOpts *filter.FilterOptions, release str
 		Joins("INNER JOIN prow_jobs on prow_job_runs.prow_job_id = prow_jobs.id").
 		Where("prow_jobs.release = ?", release).
 		Where("prow_job_runs.prow_job_release = ?", release).
+		Where("prow_job_runs.timestamp > ?", lookback14d).
 		Where("prow_job_run_prow_pull_requests.prow_job_run_release = ?", release).
+		Where("prow_job_run_prow_pull_requests.prow_job_run_timestamp > ?", lookback14d).
 		Select("DISTINCT ON(prow_pull_requests.link) prow_pull_requests.*, ci.release_tag AS first_ci_payload, ci.phase AS first_ci_payload_phase, ci.release as first_ci_payload_release, nightly.release_tag as first_nightly_payload, nightly.phase as first_nightly_payload_phase, nightly.release as first_nightly_payload_release")
 
 	results := make([]api.PullRequest, 0)

--- a/pkg/db/query/pull_request_queries.go
+++ b/pkg/db/query/pull_request_queries.go
@@ -19,7 +19,7 @@ func PullRequestReport(dbc *db.DB, filterOpts *filter.FilterOptions, release str
 		Joins("INNER JOIN release_tags ON release_tags.id = release_tag_pull_requests.release_tag_id").
 		Group("url, release_tags.stream, release_tags.architecture, release_tags.release_tag, release_tags.phase, release_tags.release")
 
-	lookback14d := time.Now().UTC().Add(-14 * 24 * time.Hour)
+	lookback90d := time.Now().UTC().Add(-90 * 24 * time.Hour)
 	prs := dbc.DB.Table("prow_pull_requests").
 		Joins("LEFT JOIN (?) ci ON ci.url = prow_pull_requests.link",
 			dbc.DB.Table("(?) as ci", firstPayloadsByStreamAndArch).Where("ci.stream = 'ci' AND architecture = 'amd64'")).
@@ -30,9 +30,9 @@ func PullRequestReport(dbc *db.DB, filterOpts *filter.FilterOptions, release str
 		Joins("INNER JOIN prow_jobs on prow_job_runs.prow_job_id = prow_jobs.id").
 		Where("prow_jobs.release = ?", release).
 		Where("prow_job_runs.prow_job_release = ?", release).
-		Where("prow_job_runs.timestamp > ?", lookback14d).
+		Where("prow_job_runs.timestamp > ?", lookback90d).
 		Where("prow_job_run_prow_pull_requests.prow_job_run_release = ?", release).
-		Where("prow_job_run_prow_pull_requests.prow_job_run_timestamp > ?", lookback14d).
+		Where("prow_job_run_prow_pull_requests.prow_job_run_timestamp > ?", lookback90d).
 		Select("DISTINCT ON(prow_pull_requests.link) prow_pull_requests.*, ci.release_tag AS first_ci_payload, ci.phase AS first_ci_payload_phase, ci.release as first_ci_payload_release, nightly.release_tag as first_nightly_payload, nightly.phase as first_nightly_payload_phase, nightly.release as first_nightly_payload_release")
 
 	results := make([]api.PullRequest, 0)

--- a/pkg/db/query/release_queries.go
+++ b/pkg/db/query/release_queries.go
@@ -15,6 +15,7 @@ func CurrentActiveRelease(dbc *db.DB) (string, error) {
 	var release string
 	err := dbc.DB.Table("release_definitions").
 		Where("ga_date IS NULL").
+		Where("product = ?", "OCP").
 		Order("development_start_date ASC").
 		Limit(1).
 		Pluck("release", &release).Error
@@ -25,6 +26,7 @@ func CurrentActiveRelease(dbc *db.DB) (string, error) {
 		return release, nil
 	}
 	err = dbc.DB.Table("release_definitions").
+		Where("product = ?", "OCP").
 		Order("ga_date DESC").
 		Limit(1).
 		Pluck("release", &release).Error

--- a/pkg/db/query/release_queries.go
+++ b/pkg/db/query/release_queries.go
@@ -1,6 +1,10 @@
 package query
 
-import "github.com/openshift/sippy/pkg/db"
+import (
+	"fmt"
+
+	"github.com/openshift/sippy/pkg/db"
+)
 
 // CurrentActiveRelease returns the most relevant active release. It prefers the
 // in-development release with the oldest development_start_date (most mature).
@@ -15,7 +19,7 @@ func CurrentActiveRelease(dbc *db.DB) (string, error) {
 		Limit(1).
 		Pluck("release", &release).Error
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("query in-development release: %w", err)
 	}
 	if release != "" {
 		return release, nil
@@ -24,5 +28,8 @@ func CurrentActiveRelease(dbc *db.DB) (string, error) {
 		Order("ga_date DESC").
 		Limit(1).
 		Pluck("release", &release).Error
-	return release, err
+	if err != nil {
+		return "", fmt.Errorf("query latest GA release: %w", err)
+	}
+	return release, nil
 }

--- a/pkg/db/query/release_queries.go
+++ b/pkg/db/query/release_queries.go
@@ -36,5 +36,8 @@ func CurrentActiveRelease(dbc *db.DB) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("query latest GA release: %w", err)
 	}
+	if release == "" {
+		return "", fmt.Errorf("no OCP release found in release_definitions")
+	}
 	return release, nil
 }

--- a/pkg/db/query/release_queries.go
+++ b/pkg/db/query/release_queries.go
@@ -1,0 +1,28 @@
+package query
+
+import "github.com/openshift/sippy/pkg/db"
+
+// CurrentActiveRelease returns the most relevant active release. It prefers the
+// in-development release with the oldest development_start_date (most mature).
+// If no in-development release exists (all have a GA date), it falls back to
+// the release with the most recent GA date. Used as a fallback for
+// partition-scoped queries when no specific release is available from the caller.
+func CurrentActiveRelease(dbc *db.DB) (string, error) {
+	var release string
+	err := dbc.DB.Table("release_definitions").
+		Where("ga_date IS NULL").
+		Order("development_start_date ASC").
+		Limit(1).
+		Pluck("release", &release).Error
+	if err != nil {
+		return "", err
+	}
+	if release != "" {
+		return release, nil
+	}
+	err = dbc.DB.Table("release_definitions").
+		Order("ga_date DESC").
+		Limit(1).
+		Pluck("release", &release).Error
+	return release, err
+}

--- a/pkg/db/query/release_queries.go
+++ b/pkg/db/query/release_queries.go
@@ -16,6 +16,7 @@ func CurrentActiveRelease(dbc *db.DB) (string, error) {
 	err := dbc.DB.Table("release_definitions").
 		Where("ga_date IS NULL").
 		Where("product = ?", "OCP").
+		Where("release ~ ?", `^\d+\.\d+$`).
 		Order("development_start_date ASC").
 		Limit(1).
 		Pluck("release", &release).Error
@@ -26,7 +27,9 @@ func CurrentActiveRelease(dbc *db.DB) (string, error) {
 		return release, nil
 	}
 	err = dbc.DB.Table("release_definitions").
+		Where("ga_date IS NOT NULL").
 		Where("product = ?", "OCP").
+		Where("release ~ ?", `^\d+\.\d+$`).
 		Order("ga_date DESC").
 		Limit(1).
 		Pluck("release", &release).Error

--- a/pkg/db/query/repository_queries.go
+++ b/pkg/db/query/repository_queries.go
@@ -27,7 +27,9 @@ func RepositoryReport(dbc *db.DB, filterOpts *filter.FilterOptions, release stri
 		Joins("LEFT JOIN (?) premerge_failures ON premerge_failures.prow_job_ID = prow_jobs.id", averageByJob).
 		Where("prow_jobs.release = ?", release).
 		Where("prow_job_runs.prow_job_release = ?", release).
+		Where("prow_job_runs.timestamp >= ? AND prow_job_runs.timestamp < ?", premergeFailureStart, reportEnd).
 		Where("prow_job_run_prow_pull_requests.prow_job_run_release = ?", release).
+		Where("prow_job_run_prow_pull_requests.prow_job_run_timestamp >= ? AND prow_job_run_prow_pull_requests.prow_job_run_timestamp < ?", premergeFailureStart, reportEnd).
 		Group("prow_pull_requests.org, prow_pull_requests.repo").
 		Select("ROW_NUMBER() OVER() as id, prow_pull_requests.org, prow_pull_requests.repo, max(revert_count) as revert_count, coalesce(max(average_premerge_job_failures), 0) as worst_premerge_job_failures, count(distinct(prow_jobs.id)) as job_count")
 

--- a/pkg/db/query/repository_queries.go
+++ b/pkg/db/query/repository_queries.go
@@ -13,11 +13,9 @@ import (
 func RepositoryReport(dbc *db.DB, filterOpts *filter.FilterOptions, release string, reportEnd time.Time) ([]api.Repository, error) {
 	end := reportEnd
 
-	premergeFailureStart := reportEnd.Add(-14 * 24 * time.Hour)
-	averageByJob := PullRequestAveragePremergeFailures(dbc, release, &premergeFailureStart, &end)
-
-	revertCountStart := reportEnd.Add(-90 * 24 * time.Hour)
-	revertCount := RepositoryRevertCount(dbc, &revertCountStart, &end)
+	lookback90d := reportEnd.Add(-90 * 24 * time.Hour)
+	averageByJob := PullRequestAveragePremergeFailures(dbc, release, &lookback90d, &end)
+	revertCount := RepositoryRevertCount(dbc, &lookback90d, &end)
 
 	repos := dbc.DB.Table("prow_pull_requests").
 		Joins("INNER JOIN prow_job_run_prow_pull_requests ON prow_job_run_prow_pull_requests.prow_pull_request_id = prow_pull_requests.id").
@@ -27,9 +25,9 @@ func RepositoryReport(dbc *db.DB, filterOpts *filter.FilterOptions, release stri
 		Joins("LEFT JOIN (?) premerge_failures ON premerge_failures.prow_job_ID = prow_jobs.id", averageByJob).
 		Where("prow_jobs.release = ?", release).
 		Where("prow_job_runs.prow_job_release = ?", release).
-		Where("prow_job_runs.timestamp >= ? AND prow_job_runs.timestamp < ?", premergeFailureStart, reportEnd).
+		Where("prow_job_runs.timestamp >= ? AND prow_job_runs.timestamp < ?", lookback90d, reportEnd).
 		Where("prow_job_run_prow_pull_requests.prow_job_run_release = ?", release).
-		Where("prow_job_run_prow_pull_requests.prow_job_run_timestamp >= ? AND prow_job_run_prow_pull_requests.prow_job_run_timestamp < ?", premergeFailureStart, reportEnd).
+		Where("prow_job_run_prow_pull_requests.prow_job_run_timestamp >= ? AND prow_job_run_prow_pull_requests.prow_job_run_timestamp < ?", lookback90d, reportEnd).
 		Group("prow_pull_requests.org, prow_pull_requests.repo").
 		Select("ROW_NUMBER() OVER() as id, prow_pull_requests.org, prow_pull_requests.repo, max(revert_count) as revert_count, coalesce(max(average_premerge_job_failures), 0) as worst_premerge_job_failures, count(distinct(prow_jobs.id)) as job_count")
 

--- a/pkg/db/query/repository_queries.go
+++ b/pkg/db/query/repository_queries.go
@@ -14,7 +14,7 @@ func RepositoryReport(dbc *db.DB, filterOpts *filter.FilterOptions, release stri
 	end := reportEnd
 
 	premergeFailureStart := reportEnd.Add(-14 * 24 * time.Hour)
-	averageByJob := PullRequestAveragePremergeFailures(dbc, &premergeFailureStart, &end)
+	averageByJob := PullRequestAveragePremergeFailures(dbc, release, &premergeFailureStart, &end)
 
 	revertCountStart := reportEnd.Add(-90 * 24 * time.Hour)
 	revertCount := RepositoryRevertCount(dbc, &revertCountStart, &end)

--- a/pkg/db/query/repository_queries.go
+++ b/pkg/db/query/repository_queries.go
@@ -13,9 +13,11 @@ import (
 func RepositoryReport(dbc *db.DB, filterOpts *filter.FilterOptions, release string, reportEnd time.Time) ([]api.Repository, error) {
 	end := reportEnd
 
-	lookback90d := reportEnd.Add(-90 * 24 * time.Hour)
-	averageByJob := PullRequestAveragePremergeFailures(dbc, release, &lookback90d, &end)
-	revertCount := RepositoryRevertCount(dbc, &lookback90d, &end)
+	premergeFailureStart := reportEnd.Add(-14 * 24 * time.Hour)
+	averageByJob := PullRequestAveragePremergeFailures(dbc, release, &premergeFailureStart, &end)
+
+	revertCountStart := reportEnd.Add(-90 * 24 * time.Hour)
+	revertCount := RepositoryRevertCount(dbc, &revertCountStart, &end)
 
 	repos := dbc.DB.Table("prow_pull_requests").
 		Joins("INNER JOIN prow_job_run_prow_pull_requests ON prow_job_run_prow_pull_requests.prow_pull_request_id = prow_pull_requests.id").
@@ -25,9 +27,9 @@ func RepositoryReport(dbc *db.DB, filterOpts *filter.FilterOptions, release stri
 		Joins("LEFT JOIN (?) premerge_failures ON premerge_failures.prow_job_ID = prow_jobs.id", averageByJob).
 		Where("prow_jobs.release = ?", release).
 		Where("prow_job_runs.prow_job_release = ?", release).
-		Where("prow_job_runs.timestamp >= ? AND prow_job_runs.timestamp < ?", lookback90d, reportEnd).
+		Where("prow_job_runs.timestamp >= ? AND prow_job_runs.timestamp < ?", revertCountStart, reportEnd).
 		Where("prow_job_run_prow_pull_requests.prow_job_run_release = ?", release).
-		Where("prow_job_run_prow_pull_requests.prow_job_run_timestamp >= ? AND prow_job_run_prow_pull_requests.prow_job_run_timestamp < ?", lookback90d, reportEnd).
+		Where("prow_job_run_prow_pull_requests.prow_job_run_timestamp >= ? AND prow_job_run_prow_pull_requests.prow_job_run_timestamp < ?", revertCountStart, reportEnd).
 		Group("prow_pull_requests.org, prow_pull_requests.repo").
 		Select("ROW_NUMBER() OVER() as id, prow_pull_requests.org, prow_pull_requests.repo, max(revert_count) as revert_count, coalesce(max(average_premerge_job_failures), 0) as worst_premerge_job_failures, count(distinct(prow_jobs.id)) as job_count")
 

--- a/pkg/db/query/test_queries.go
+++ b/pkg/db/query/test_queries.go
@@ -430,14 +430,16 @@ func TestOutputs(dbc *db.DB, release, test string, includedVariants, excludedVar
 	testQuery := dbc.DB.Table("tests").Where("name = ?", test).Select("id")
 	q := dbc.DB.Table("prow_job_run_tests").
 		Joins("JOIN prow_job_run_test_outputs ON prow_job_run_test_outputs.prow_job_run_test_id = prow_job_run_tests.id AND prow_job_run_test_outputs.prow_job_run_test_timestamp = prow_job_run_tests.prow_job_run_timestamp").
-		Joins("JOIN prow_job_runs ON prow_job_run_tests.prow_job_run_id = prow_job_runs.id").
+		Joins("JOIN prow_job_runs ON prow_job_run_tests.prow_job_run_id = prow_job_runs.id AND prow_job_runs.prow_job_release = prow_job_run_tests.prow_job_run_release").
 		Joins("JOIN prow_jobs ON prow_job_runs.prow_job_id = prow_jobs.id").
 		Where("prow_job_run_tests.test_id = (?)", testQuery).
 		Where("prow_job_run_tests.status IN ?", []int{int(v1.TestStatusFailure), int(v1.TestStatusFlake)}).
 		Where("prow_job_run_tests.prow_job_run_timestamp > current_date - interval '14' day").
 		Where("prow_job_run_tests.prow_job_run_release = ?", release).
 		Where("prow_job_run_test_outputs.prow_job_run_test_timestamp > current_date - interval '14' day").
-		Where("prow_job_run_test_outputs.prow_job_run_test_release = ?", release)
+		Where("prow_job_run_test_outputs.prow_job_run_test_release = ?", release).
+		Where("prow_job_runs.prow_job_release = ?", release).
+		Where("prow_job_runs.timestamp > current_date - interval '14' day")
 
 	for _, variant := range includedVariants {
 		q = q.Where("prow_jobs.variant_combination_id IN (SELECT id FROM variant_combinations WHERE ? = any(variants))", variant)

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -574,6 +574,7 @@ func getQueryCases() []queryCase {
 				res := dbc.DB.Table("prow_job_runs").
 					Joins("JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id").
 					Where("prow_jobs.name = ? AND prow_jobs.release = ?", benchmarkJobName, benchmarkRelease).
+					Where("prow_job_runs.prow_job_release = ?", benchmarkRelease).
 					Order("prow_job_runs.timestamp DESC").
 					Limit(1).
 					Select("prow_job_runs.id, prow_job_runs.timestamp").
@@ -609,7 +610,7 @@ func getQueryCases() []queryCase {
 				}
 				res = dbc.DB.
 					Table("prow_job_run_tests as t").
-					Joins("INNER JOIN prow_job_run_prow_pull_requests as prmap on prmap.prow_job_run_id = t.prow_job_run_id").
+					Joins("INNER JOIN prow_job_run_prow_pull_requests as prmap on prmap.prow_job_run_id = t.prow_job_run_id AND prmap.prow_job_run_release = t.prow_job_run_release").
 					Joins("INNER JOIN prow_pull_requests as prs on prs.id = prmap.prow_pull_request_id").
 					Where("t.test_id = ?", testID).
 					Where("t.prow_job_run_release = ?", benchmarkRelease).

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -519,12 +519,12 @@ func getReportQueryCases() []queryCase {
 		},
 		{
 			name: "ProwJobRunCount",
-			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
+			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
 				var prowJob models.ProwJob
 				if err := dbc.DB.Where("name = ? AND release = ?", benchmarkJobName, benchmarkRelease).First(&prowJob).Error; err != nil {
 					return validationSnapshot{}, err
 				}
-				count, err := query.ProwJobRunCount(dbc, prowJob.ID, benchmarkRelease)
+				count, err := query.ProwJobRunCount(dbc, prowJob.ID, benchmarkRelease, asOf.Add(-14*24*time.Hour))
 				if err != nil {
 					return validationSnapshot{}, err
 				}

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -621,6 +621,7 @@ func getReportQueryCases() []queryCase {
 					Where("t.prow_job_run_release = ?", benchmarkRelease).
 					Where("merged_at is not null").
 					Select("org, repo, number, sha, merged_at").
+					Order("t.prow_job_run_id, prs.id").
 					Limit(1).Scan(&result)
 				if res.Error != nil {
 					return validationSnapshot{}, res.Error

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -62,7 +62,6 @@ func sortedMapKeys[V any](m map[string]V) []string {
 func toBenchmarkCases(cases []queryCase, asOf time.Time) []benchmarkCase {
 	out := make([]benchmarkCase, len(cases))
 	for i, qc := range cases {
-		qc := qc
 		out[i] = benchmarkCase{
 			name: qc.name,
 			fn: func(dbc *db.DB) error {
@@ -77,7 +76,6 @@ func toBenchmarkCases(cases []queryCase, asOf time.Time) []benchmarkCase {
 func toBenchmarkCaseMap(cases map[string]queryCase, asOf time.Time) map[string]benchmarkCase {
 	out := make(map[string]benchmarkCase, len(cases))
 	for name, qc := range cases {
-		qc := qc
 		out[name] = benchmarkCase{
 			name: qc.name,
 			fn: func(dbc *db.DB) error {
@@ -314,11 +312,10 @@ func getQueryCases() []queryCase {
 					CurrentPassPercent float64
 				}
 				var result testResult
-				res := dbc.DB.Raw(query.QueryTestAnalysis, analyzeSince, benchmarkRelease, benchmarkRelease, benchmarkTestName, []string{benchmarkJobName})
+				res := dbc.DB.Raw(query.QueryTestAnalysis, analyzeSince, benchmarkRelease, benchmarkRelease, benchmarkTestName, []string{benchmarkJobName}).Scan(&result)
 				if res.Error != nil {
 					return validationSnapshot{}, res.Error
 				}
-				res.Scan(&result)
 				log.Printf("QueryTestAnalysis: runs=%d successes=%d", result.CurrentRuns, result.CurrentSuccesses)
 				return validationSnapshot{
 					RowCount: result.CurrentRuns,
@@ -416,6 +413,11 @@ func getQueryCases() []queryCase {
 				}, nil
 			},
 		},
+	}
+}
+
+func getReportQueryCases() []queryCase {
+	return []queryCase{
 		{
 			name: "VariantReports",
 			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
@@ -581,6 +583,9 @@ func getQueryCases() []queryCase {
 					Scan(&result)
 				if res.Error != nil {
 					return validationSnapshot{}, res.Error
+				}
+				if result.ID == 0 {
+					return validationSnapshot{}, fmt.Errorf("no job run found for %s/%s", benchmarkRelease, benchmarkJobName)
 				}
 				count, err := query.JobRunTestCount(dbc, result.ID, benchmarkRelease, result.Timestamp)
 				if err != nil {

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -203,6 +203,15 @@ func getIndividualQueryCases() map[string]queryCase {
 	}
 }
 
+func allQueryCases() []queryCase {
+	cases := getQueryCases()
+	cases = append(cases, getReportQueryCases()...)
+	for _, qc := range getIndividualQueryCases() {
+		cases = append(cases, qc)
+	}
+	return cases
+}
+
 func getQueryCases() []queryCase {
 	return []queryCase{
 		{
@@ -413,6 +422,40 @@ func getQueryCases() []queryCase {
 				}, nil
 			},
 		},
+		{
+			name: "FetchJobRunByID",
+			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
+				var jobRunID uint
+				res := dbc.DB.Table("prow_job_runs").
+					Joins("JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id").
+					Where("prow_jobs.name = ? AND prow_jobs.release = ?", benchmarkJobName, benchmarkRelease).
+					Order("prow_job_runs.timestamp DESC").
+					Limit(1).
+					Select("prow_job_runs.id").
+					Scan(&jobRunID)
+				if res.Error != nil {
+					return validationSnapshot{}, res.Error
+				}
+
+				var jobRun models.ProwJobRun
+				res = dbc.DB.Joins("ProwJob").
+					Preload("PullRequests").
+					Order("timestamp DESC").
+					First(&jobRun, jobRunID)
+				if res.Error != nil {
+					return validationSnapshot{}, res.Error
+				}
+				log.Printf("FetchJobRunByID for run %d: release=%s job=%s",
+					jobRun.ID, jobRun.ProwJobRelease, jobRun.ProwJob.Name)
+				return validationSnapshot{
+					RowCount: 1,
+					SpotChecks: map[string]string{
+						"release":  jobRun.ProwJobRelease,
+						"job_name": jobRun.ProwJob.Name,
+					},
+				}, nil
+			},
+		},
 	}
 }
 
@@ -530,40 +573,6 @@ func getReportQueryCases() []queryCase {
 				}
 				log.Printf("ProwJobRunCount for %s: %d", benchmarkJobName, count)
 				return validationSnapshot{RowCount: count}, nil
-			},
-		},
-		{
-			name: "FetchJobRunByID",
-			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
-				var jobRunID uint
-				res := dbc.DB.Table("prow_job_runs").
-					Joins("JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id").
-					Where("prow_jobs.name = ? AND prow_jobs.release = ?", benchmarkJobName, benchmarkRelease).
-					Order("prow_job_runs.timestamp DESC").
-					Limit(1).
-					Select("prow_job_runs.id").
-					Scan(&jobRunID)
-				if res.Error != nil {
-					return validationSnapshot{}, res.Error
-				}
-
-				var jobRun models.ProwJobRun
-				res = dbc.DB.Joins("ProwJob").
-					Preload("PullRequests").
-					Order("timestamp DESC").
-					First(&jobRun, jobRunID)
-				if res.Error != nil {
-					return validationSnapshot{}, res.Error
-				}
-				log.Printf("FetchJobRunByID for run %d: release=%s job=%s",
-					jobRun.ID, jobRun.ProwJobRelease, jobRun.ProwJob.Name)
-				return validationSnapshot{
-					RowCount: 1,
-					SpotChecks: map[string]string{
-						"release":  jobRun.ProwJobRelease,
-						"job_name": jobRun.ProwJob.Name,
-					},
-				}, nil
 			},
 		},
 		{
@@ -738,14 +747,8 @@ func Test_BenchmarkCombined(t *testing.T) {
 	iterations := 3
 
 	var results []benchmarkResult
-	for _, bc := range toBenchmarkCases(getQueryCases(), asOf) {
+	for _, bc := range toBenchmarkCases(allQueryCases(), asOf) {
 		t.Run(bc.name, func(t *testing.T) {
-			r := runBenchmarkCase(t, dbc, bc, iterations)
-			results = append(results, r)
-		})
-	}
-	for name, bc := range toBenchmarkCaseMap(getIndividualQueryCases(), asOf) {
-		t.Run(name, func(t *testing.T) {
 			r := runBenchmarkCase(t, dbc, bc, iterations)
 			results = append(results, r)
 		})

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -425,7 +425,7 @@ func getQueryCases() []queryCase {
 		{
 			name: "FetchJobRunByID",
 			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
-				var jobRunID uint
+				var jobRunID int64
 				res := dbc.DB.Table("prow_job_runs").
 					Joins("JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id").
 					Where("prow_jobs.name = ? AND prow_jobs.release = ?", benchmarkJobName, benchmarkRelease).
@@ -437,11 +437,16 @@ func getQueryCases() []queryCase {
 					return validationSnapshot{}, res.Error
 				}
 
+				partKeys, err := query.LookupProwJobRunPartitionKeys(dbc, jobRunID)
+				if err != nil {
+					return validationSnapshot{}, err
+				}
+
 				var jobRun models.ProwJobRun
 				res = dbc.DB.Joins("ProwJob").
 					Preload("PullRequests").
-					Order("timestamp DESC").
-					First(&jobRun, jobRunID)
+					Where("prow_job_release = ? AND timestamp = ?", partKeys.ProwJobRelease, partKeys.Timestamp).
+					Take(&jobRun, jobRunID)
 				if res.Error != nil {
 					return validationSnapshot{}, res.Error
 				}

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -37,6 +38,55 @@ type benchmarkResult struct {
 	avg        time.Duration
 	min        time.Duration
 	max        time.Duration
+}
+
+type validationSnapshot struct {
+	RowCount   int               `json:"row_count"`
+	SpotChecks map[string]string `json:"spot_checks,omitempty"`
+}
+
+type queryCase struct {
+	name string
+	fn   func(dbc *db.DB, asOf time.Time) (validationSnapshot, error)
+}
+
+func sortedMapKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func toBenchmarkCases(cases []queryCase, asOf time.Time) []benchmarkCase {
+	out := make([]benchmarkCase, len(cases))
+	for i, qc := range cases {
+		qc := qc
+		out[i] = benchmarkCase{
+			name: qc.name,
+			fn: func(dbc *db.DB) error {
+				_, err := qc.fn(dbc, asOf)
+				return err
+			},
+		}
+	}
+	return out
+}
+
+func toBenchmarkCaseMap(cases map[string]queryCase, asOf time.Time) map[string]benchmarkCase {
+	out := make(map[string]benchmarkCase, len(cases))
+	for name, qc := range cases {
+		qc := qc
+		out[name] = benchmarkCase{
+			name: qc.name,
+			fn: func(dbc *db.DB) error {
+				_, err := qc.fn(dbc, asOf)
+				return err
+			},
+		}
+	}
+	return out
 }
 
 func extractConnectionName(dsn string) string {
@@ -117,11 +167,11 @@ func runBenchmarkCase(t *testing.T, dbc *db.DB, bc benchmarkCase, iterations int
 	return result
 }
 
-func getIndividualBenchmarkCases() map[string]benchmarkCase {
-	return map[string]benchmarkCase{
+func getIndividualQueryCases() map[string]queryCase {
+	return map[string]queryCase{
 		"FindTestsByRelease": {
 			name: "FindTestsByRelease",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
 				type testResult struct {
 					ID   uint
 					Name string
@@ -137,108 +187,126 @@ func getIndividualBenchmarkCases() map[string]benchmarkCase {
 					ORDER BY t.name
 					LIMIT 20`, benchmarkRelease, "%events should not repeat%").Scan(&results)
 				if res.Error != nil {
-					return res.Error
+					return validationSnapshot{}, res.Error
 				}
 				log.Printf("Found %d tests matching pattern for release %s", len(results), benchmarkRelease)
 				for _, r := range results {
 					log.Printf("  [%d] %s", r.ID, r.Name)
 				}
-				return nil
+				snap := validationSnapshot{RowCount: len(results)}
+				if len(results) > 0 {
+					snap.SpotChecks = map[string]string{
+						"first_name": results[0].Name,
+					}
+				}
+				return snap, nil
 			},
 		},
 	}
 }
 
-func getBenchmarkCases(asOf time.Time) []benchmarkCase {
-	return []benchmarkCase{
+func getQueryCases() []queryCase {
+	return []queryCase{
 		{
 			name: "TestDurations",
-			fn: func(dbc *db.DB) error {
-				durations, err := query.TestDurations(dbc, benchmarkRelease,
-					benchmarkTestName, nil, nil)
-
-				if err == nil {
-					log.Printf("Found %d test durations", len(durations))
+			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
+				durations, err := query.TestDurations(dbc, benchmarkRelease, benchmarkTestName, nil, nil)
+				if err != nil {
+					return validationSnapshot{}, err
 				}
-
-				return err
+				log.Printf("Found %d test durations", len(durations))
+				snap := validationSnapshot{RowCount: len(durations)}
+				if len(durations) > 0 {
+					snap.SpotChecks = map[string]string{
+						"keys": strings.Join(sortedMapKeys(durations), ","),
+					}
+				}
+				return snap, nil
 			},
 		},
 		{
 			name: "TestOutputs",
-			fn: func(dbc *db.DB) error {
-				testOutputs, err := query.TestOutputs(dbc, benchmarkRelease,
-					benchmarkTestName, nil, nil, 10)
-
-				if err == nil {
-					log.Printf("Found %d test outputs", len(testOutputs))
+			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
+				testOutputs, err := query.TestOutputs(dbc, benchmarkRelease, benchmarkTestName, nil, nil, 10)
+				if err != nil {
+					return validationSnapshot{}, err
 				}
-
-				return err
+				log.Printf("Found %d test outputs", len(testOutputs))
+				return validationSnapshot{RowCount: len(testOutputs)}, nil
 			},
 		},
 		{
 			name: "JobDetails",
-			fn: func(dbc *db.DB) error {
-				jobRuns, err := api.JobDetailsReport(dbc, benchmarkRelease,
-					benchmarkJobName, asOf)
-
-				if err == nil {
-					log.Printf("Found %d job runs", len(jobRuns))
+			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
+				jobRuns, err := api.JobDetailsReport(dbc, benchmarkRelease, benchmarkJobName, asOf)
+				if err != nil {
+					return validationSnapshot{}, err
 				}
-
-				return err
+				log.Printf("Found %d job runs", len(jobRuns))
+				return validationSnapshot{RowCount: len(jobRuns)}, nil
 			},
 		},
 		{
 			name: "TestAnalysisOverall",
-			fn: func(dbc *db.DB) error {
-				results, err := api.GetTestAnalysisOverallFromDB(dbc, nil,
-					benchmarkRelease, benchmarkTestName, asOf)
-
-				if err == nil {
-					for group, rows := range results {
-						log.Printf("TestAnalysisOverall group %s: %d rows", group, len(rows))
+			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
+				results, err := api.GetTestAnalysisOverallFromDB(dbc, nil, benchmarkRelease, benchmarkTestName, asOf)
+				if err != nil {
+					return validationSnapshot{}, err
+				}
+				for group, rows := range results {
+					log.Printf("TestAnalysisOverall group %s: %d rows", group, len(rows))
+				}
+				snap := validationSnapshot{RowCount: len(results)}
+				if len(results) > 0 {
+					snap.SpotChecks = map[string]string{
+						"keys": strings.Join(sortedMapKeys(results), ","),
 					}
 				}
-
-				return err
+				return snap, nil
 			},
 		},
 		{
 			name: "TestAnalysisByJob",
-			fn: func(dbc *db.DB) error {
-				results, err := api.GetTestAnalysisByJobFromDB(dbc, nil,
-					benchmarkRelease, benchmarkTestName, asOf)
-
-				if err == nil {
-					log.Printf("TestAnalysisByJob: %d groups", len(results))
+			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
+				results, err := api.GetTestAnalysisByJobFromDB(dbc, nil, benchmarkRelease, benchmarkTestName, asOf)
+				if err != nil {
+					return validationSnapshot{}, err
 				}
-
-				return err
+				log.Printf("TestAnalysisByJob: %d groups", len(results))
+				snap := validationSnapshot{RowCount: len(results)}
+				if len(results) > 0 {
+					snap.SpotChecks = map[string]string{
+						"keys": strings.Join(sortedMapKeys(results), ","),
+					}
+				}
+				return snap, nil
 			},
 		},
 		{
 			name: "TestAnalysisByJobWithVariantFilter",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
 				f := &filter.Filter{
 					Items: []filter.FilterItem{
 						{Field: "variants", Value: "aws", Not: false},
 					},
 				}
-				results, err := api.GetTestAnalysisByJobFromDB(dbc, f,
-					benchmarkRelease, benchmarkTestName, asOf)
-
-				if err == nil {
-					log.Printf("TestAnalysisByJobWithVariantFilter: %d groups", len(results))
+				results, err := api.GetTestAnalysisByJobFromDB(dbc, f, benchmarkRelease, benchmarkTestName, asOf)
+				if err != nil {
+					return validationSnapshot{}, err
 				}
-
-				return err
+				log.Printf("TestAnalysisByJobWithVariantFilter: %d groups", len(results))
+				snap := validationSnapshot{RowCount: len(results)}
+				if len(results) > 0 {
+					snap.SpotChecks = map[string]string{
+						"keys": strings.Join(sortedMapKeys(results), ","),
+					}
+				}
+				return snap, nil
 			},
 		},
 		{
 			name: "QueryTestAnalysis",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
 				analyzeSince := asOf.Add(-14 * 24 * time.Hour)
 				type testResult struct {
 					CurrentSuccesses   int
@@ -248,42 +316,59 @@ func getBenchmarkCases(asOf time.Time) []benchmarkCase {
 				var result testResult
 				res := dbc.DB.Raw(query.QueryTestAnalysis, analyzeSince, benchmarkRelease, benchmarkRelease, benchmarkTestName, []string{benchmarkJobName})
 				if res.Error != nil {
-					return res.Error
+					return validationSnapshot{}, res.Error
 				}
 				res.Scan(&result)
 				log.Printf("QueryTestAnalysis: runs=%d successes=%d", result.CurrentRuns, result.CurrentSuccesses)
-				return res.Error
+				return validationSnapshot{
+					RowCount: result.CurrentRuns,
+					SpotChecks: map[string]string{
+						"current_successes": strconv.Itoa(result.CurrentSuccesses),
+					},
+				}, nil
 			},
 		},
 		{
 			name: "TestCountsByLookback14",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
 				jobRuns, testIDs, err := api.GetJobRunTestsCountByLookback(dbc, 14)
-				if err == nil {
-					log.Printf("TestCountsByLookback14: %d job runs, %d test IDs", jobRuns, testIDs)
+				if err != nil {
+					return validationSnapshot{}, err
 				}
-				return err
+				log.Printf("TestCountsByLookback14: %d job runs, %d test IDs", jobRuns, testIDs)
+				return validationSnapshot{
+					RowCount: int(jobRuns),
+					SpotChecks: map[string]string{
+						"test_ids_count": strconv.FormatInt(testIDs, 10),
+					},
+				}, nil
 			},
 		},
 		{
 			name: "TestCountsByLookback9",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
 				jobRuns, testIDs, err := api.GetJobRunTestsCountByLookback(dbc, 9)
-				if err == nil {
-					log.Printf("TestCountsByLookback9: %d job runs, %d test IDs", jobRuns, testIDs)
+				if err != nil {
+					return validationSnapshot{}, err
 				}
-				return err
+				log.Printf("TestCountsByLookback9: %d job runs, %d test IDs", jobRuns, testIDs)
+				return validationSnapshot{
+					RowCount: int(jobRuns),
+					SpotChecks: map[string]string{
+						"test_ids_count": strconv.FormatInt(testIDs, 10),
+					},
+				}, nil
 			},
 		},
 		{
 			name: "TestCountsByLookback14ForRelease",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
 				type counts struct {
 					JobRunsCount int64
 					TestIDsCount int64
 				}
 				var result counts
-				truncatedTime := time.Now().UTC().AddDate(0, 0, -14).Truncate(24 * time.Hour)
+				truncatedTime := asOf.AddDate(0, 0, -14).Truncate(24 * time.Hour)
 				res := dbc.DB.Raw(`
 					SELECT count(distinct pjrt.prow_job_run_id) as job_runs_count,
 					       count(distinct pjrt.test_id) as test_ids_count
@@ -291,22 +376,27 @@ func getBenchmarkCases(asOf time.Time) []benchmarkCase {
 					WHERE pjrt.prow_job_run_timestamp > ?
 					  AND pjrt.prow_job_run_release = ?`, truncatedTime, benchmarkRelease).Scan(&result)
 				if res.Error != nil {
-					return res.Error
+					return validationSnapshot{}, res.Error
 				}
 				log.Printf("TestCountsByLookback14ForRelease %s: %d job runs, %d test IDs",
 					benchmarkRelease, result.JobRunsCount, result.TestIDsCount)
-				return nil
+				return validationSnapshot{
+					RowCount: int(result.JobRunsCount),
+					SpotChecks: map[string]string{
+						"test_ids_count": strconv.FormatInt(result.TestIDsCount, 10),
+					},
+				}, nil
 			},
 		},
 		{
 			name: "TestCountsByLookback9ForRelease",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
 				type counts struct {
 					JobRunsCount int64
 					TestIDsCount int64
 				}
 				var result counts
-				truncatedTime := time.Now().UTC().AddDate(0, 0, -9).Truncate(24 * time.Hour)
+				truncatedTime := asOf.AddDate(0, 0, -9).Truncate(24 * time.Hour)
 				res := dbc.DB.Raw(`
 					SELECT count(distinct pjrt.prow_job_run_id) as job_runs_count,
 					       count(distinct pjrt.test_id) as test_ids_count
@@ -314,107 +404,135 @@ func getBenchmarkCases(asOf time.Time) []benchmarkCase {
 					WHERE pjrt.prow_job_run_timestamp > ?
 					  AND pjrt.prow_job_run_release = ?`, truncatedTime, benchmarkRelease).Scan(&result)
 				if res.Error != nil {
-					return res.Error
+					return validationSnapshot{}, res.Error
 				}
 				log.Printf("TestCountsByLookback9ForRelease %s: %d job runs, %d test IDs",
 					benchmarkRelease, result.JobRunsCount, result.TestIDsCount)
-				return nil
+				return validationSnapshot{
+					RowCount: int(result.JobRunsCount),
+					SpotChecks: map[string]string{
+						"test_ids_count": strconv.FormatInt(result.TestIDsCount, 10),
+					},
+				}, nil
 			},
 		},
 		{
 			name: "VariantReports",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
 				start, boundary, end := util.PeriodToDates("default", asOf)
 				results, err := query.VariantReports(dbc, benchmarkRelease, start, boundary, end)
-				if err == nil {
-					log.Printf("VariantReports: %d variants", len(results))
+				if err != nil {
+					return validationSnapshot{}, err
 				}
-				return err
+				log.Printf("VariantReports: %d variants", len(results))
+				return validationSnapshot{RowCount: len(results)}, nil
 			},
 		},
 		{
 			name: "JobReports",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
 				start, boundary, end := util.PeriodToDates("default", asOf)
 				results, err := query.JobReports(dbc, &filter.FilterOptions{Filter: &filter.Filter{}}, benchmarkRelease, start, boundary, end)
-				if err == nil {
-					log.Printf("JobReports: %d jobs", len(results))
+				if err != nil {
+					return validationSnapshot{}, err
 				}
-				return err
+				log.Printf("JobReports: %d jobs", len(results))
+				return validationSnapshot{RowCount: len(results)}, nil
 			},
 		},
 		{
 			name: "BuildClusterHealth",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
 				start, boundary, end := util.PeriodToDates("default", asOf)
 				results, err := query.BuildClusterHealth(dbc, start, boundary, end)
-				if err == nil {
-					log.Printf("BuildClusterHealth: %d clusters", len(results))
+				if err != nil {
+					return validationSnapshot{}, err
 				}
-				return err
+				log.Printf("BuildClusterHealth: %d clusters", len(results))
+				return validationSnapshot{RowCount: len(results)}, nil
 			},
 		},
 		{
 			name: "RecentTestFailures",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
 				period := 7 * 24 * time.Hour
 				previousPeriod := 7 * 24 * time.Hour
 				pagination := &apitype.Pagination{PerPage: 20, Page: 0}
 				result, err := api.GetRecentTestFailures(dbc, benchmarkRelease, period, &previousPeriod, false, &filter.FilterOptions{Filter: &filter.Filter{}}, pagination, asOf)
-				if err == nil {
-					log.Printf("RecentTestFailures: %d rows", result.TotalRows)
+				if err != nil {
+					return validationSnapshot{}, err
 				}
-				return err
+				log.Printf("RecentTestFailures: %d rows", result.TotalRows)
+				return validationSnapshot{RowCount: int(result.TotalRows)}, nil
 			},
 		},
 		{
 			name: "PullRequestReport",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
 				results, err := query.PullRequestReport(dbc, &filter.FilterOptions{Filter: &filter.Filter{}}, benchmarkRelease)
-				if err == nil {
-					log.Printf("PullRequestReport: %d PRs", len(results))
+				if err != nil {
+					return validationSnapshot{}, err
 				}
-				return err
+				log.Printf("PullRequestReport: %d PRs", len(results))
+				return validationSnapshot{RowCount: len(results)}, nil
 			},
 		},
 		{
 			name: "RepositoryReport",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
 				results, err := query.RepositoryReport(dbc, &filter.FilterOptions{Filter: &filter.Filter{}}, benchmarkRelease, asOf)
-				if err == nil {
-					log.Printf("RepositoryReport: %d repos", len(results))
+				if err != nil {
+					return validationSnapshot{}, err
 				}
-				return err
+				log.Printf("RepositoryReport: %d repos", len(results))
+				return validationSnapshot{RowCount: len(results)}, nil
 			},
 		},
 		{
 			name: "JobsRunsReport",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
 				pagination := &apitype.Pagination{PerPage: 20, Page: 0}
 				result, err := api.JobsRunsReportFromDB(dbc, &filter.FilterOptions{Filter: &filter.Filter{}}, benchmarkRelease, pagination, asOf)
-				if err == nil {
-					log.Printf("JobsRunsReport: %d rows", result.TotalRows)
+				if err != nil {
+					return validationSnapshot{}, err
 				}
-				return err
+				log.Printf("JobsRunsReport: %d rows", result.TotalRows)
+				return validationSnapshot{RowCount: int(result.TotalRows)}, nil
 			},
 		},
 		{
 			name: "ProwJobHistoricalTestCounts",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
 				var prowJob models.ProwJob
 				if err := dbc.DB.Where("name = ? AND release = ?", benchmarkJobName, benchmarkRelease).First(&prowJob).Error; err != nil {
-					return err
+					return validationSnapshot{}, err
 				}
 				count, err := query.ProwJobHistoricalTestCounts(dbc, prowJob.ID, benchmarkRelease)
-				if err == nil {
-					log.Printf("ProwJobHistoricalTestCounts for %s: %d", benchmarkJobName, count)
+				if err != nil {
+					return validationSnapshot{}, err
 				}
-				return err
+				log.Printf("ProwJobHistoricalTestCounts for %s: %d", benchmarkJobName, count)
+				return validationSnapshot{RowCount: count}, nil
+			},
+		},
+		{
+			name: "ProwJobRunCount",
+			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
+				var prowJob models.ProwJob
+				if err := dbc.DB.Where("name = ? AND release = ?", benchmarkJobName, benchmarkRelease).First(&prowJob).Error; err != nil {
+					return validationSnapshot{}, err
+				}
+				count, err := query.ProwJobRunCount(dbc, prowJob.ID, benchmarkRelease)
+				if err != nil {
+					return validationSnapshot{}, err
+				}
+				log.Printf("ProwJobRunCount for %s: %d", benchmarkJobName, count)
+				return validationSnapshot{RowCount: count}, nil
 			},
 		},
 		{
 			name: "JobRunTestCount",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
 				var result struct {
 					ID        int64
 					Timestamp time.Time
@@ -427,25 +545,26 @@ func getBenchmarkCases(asOf time.Time) []benchmarkCase {
 					Select("prow_job_runs.id, prow_job_runs.timestamp").
 					Scan(&result)
 				if res.Error != nil {
-					return res.Error
+					return validationSnapshot{}, res.Error
 				}
 				count, err := query.JobRunTestCount(dbc, result.ID, benchmarkRelease, result.Timestamp)
-				if err == nil {
-					log.Printf("JobRunTestCount for run %d: %d tests", result.ID, count)
+				if err != nil {
+					return validationSnapshot{}, err
 				}
-				return err
+				log.Printf("JobRunTestCount for run %d: %d tests", result.ID, count)
+				return validationSnapshot{RowCount: count}, nil
 			},
 		},
 		{
 			name: "IsNewTestQuery",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
 				var testID uint
 				res := dbc.DB.Table("tests").
 					Where("name = ?", benchmarkTestName).
 					Select("id").
 					Scan(&testID)
 				if res.Error != nil {
-					return res.Error
+					return validationSnapshot{}, res.Error
 				}
 				var result struct {
 					Org      string
@@ -464,15 +583,23 @@ func getBenchmarkCases(asOf time.Time) []benchmarkCase {
 					Select("org, repo, number, sha, merged_at").
 					Limit(1).Scan(&result)
 				if res.Error != nil {
-					return res.Error
+					return validationSnapshot{}, res.Error
 				}
 				log.Printf("IsNewTestQuery for test %d: found=%v", testID, result.MergedAt != nil)
-				return nil
+				snap := validationSnapshot{}
+				if result.MergedAt != nil {
+					snap.RowCount = 1
+					snap.SpotChecks = map[string]string{
+						"org":  result.Org,
+						"repo": result.Repo,
+					}
+				}
+				return snap, nil
 			},
 		},
 		{
 			name: "TestAnalysisPassRate",
-			fn: func(dbc *db.DB) error {
+			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
 				type passRate struct {
 					CurrentSuccesses   int
 					CurrentRuns        int
@@ -480,17 +607,22 @@ func getBenchmarkCases(asOf time.Time) []benchmarkCase {
 				}
 				var result passRate
 				res := dbc.DB.Raw(query.QueryTestAnalysis,
-					time.Now().Add(-24*14*time.Hour),
+					asOf.Add(-24*14*time.Hour),
 					benchmarkRelease,
 					benchmarkRelease,
 					benchmarkTestName,
 					[]string{benchmarkJobName}).Scan(&result)
 				if res.Error != nil {
-					return res.Error
+					return validationSnapshot{}, res.Error
 				}
 				log.Printf("TestAnalysisPassRate: %d/%d runs (%.1f%%)",
 					result.CurrentSuccesses, result.CurrentRuns, result.CurrentPassPercent)
-				return nil
+				return validationSnapshot{
+					RowCount: result.CurrentRuns,
+					SpotChecks: map[string]string{
+						"current_successes": strconv.Itoa(result.CurrentSuccesses),
+					},
+				}, nil
 			},
 		},
 	}
@@ -534,7 +666,7 @@ func Test_BenchmarkIndividual(t *testing.T) {
 	dbc, connName := getBenchmarkDBClient(t)
 	asOf := time.Now().UTC()
 	iterations := 3
-	cases := getBenchmarkCases(asOf)
+	cases := toBenchmarkCases(getQueryCases(), asOf)
 
 	var results []benchmarkResult
 	for _, bc := range cases {
@@ -549,7 +681,8 @@ func Test_BenchmarkIndividual(t *testing.T) {
 func Test_BenchmarkFindTestsByRelease(t *testing.T) {
 	dbc, connName := getBenchmarkDBClient(t)
 	iterations := 1
-	bc, ok := getIndividualBenchmarkCases()["FindTestsByRelease"]
+	asOf := time.Now().UTC()
+	bc, ok := toBenchmarkCaseMap(getIndividualQueryCases(), asOf)["FindTestsByRelease"]
 	if !ok {
 		t.Fatal("benchmark case \"FindTestsByRelease\" not found")
 	}
@@ -564,13 +697,13 @@ func Test_BenchmarkCombined(t *testing.T) {
 	iterations := 3
 
 	var results []benchmarkResult
-	for _, bc := range getBenchmarkCases(asOf) {
+	for _, bc := range toBenchmarkCases(getQueryCases(), asOf) {
 		t.Run(bc.name, func(t *testing.T) {
 			r := runBenchmarkCase(t, dbc, bc, iterations)
 			results = append(results, r)
 		})
 	}
-	for name, bc := range getIndividualBenchmarkCases() {
+	for name, bc := range toBenchmarkCaseMap(getIndividualQueryCases(), asOf) {
 		t.Run(name, func(t *testing.T) {
 			r := runBenchmarkCase(t, dbc, bc, iterations)
 			results = append(results, r)
@@ -583,7 +716,7 @@ func Test_BenchmarkGroup(t *testing.T) {
 	dbc, connName := getBenchmarkDBClient(t)
 	asOf := time.Now().UTC()
 	iterations := 1
-	cases := getBenchmarkCases(asOf)
+	cases := toBenchmarkCases(getQueryCases(), asOf)
 
 	group := benchmarkResult{name: "group"}
 	for i := 0; i < iterations; i++ {

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -531,6 +531,40 @@ func getQueryCases() []queryCase {
 			},
 		},
 		{
+			name: "FetchJobRunByID",
+			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
+				var jobRunID uint
+				res := dbc.DB.Table("prow_job_runs").
+					Joins("JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id").
+					Where("prow_jobs.name = ? AND prow_jobs.release = ?", benchmarkJobName, benchmarkRelease).
+					Order("prow_job_runs.timestamp DESC").
+					Limit(1).
+					Select("prow_job_runs.id").
+					Scan(&jobRunID)
+				if res.Error != nil {
+					return validationSnapshot{}, res.Error
+				}
+
+				var jobRun models.ProwJobRun
+				res = dbc.DB.Joins("ProwJob").
+					Preload("PullRequests").
+					Order("timestamp DESC").
+					First(&jobRun, jobRunID)
+				if res.Error != nil {
+					return validationSnapshot{}, res.Error
+				}
+				log.Printf("FetchJobRunByID for run %d: release=%s job=%s",
+					jobRun.ID, jobRun.ProwJobRelease, jobRun.ProwJob.Name)
+				return validationSnapshot{
+					RowCount: 1,
+					SpotChecks: map[string]string{
+						"release":  jobRun.ProwJobRelease,
+						"job_name": jobRun.ProwJob.Name,
+					},
+				}, nil
+			},
+		},
+		{
 			name: "JobRunTestCount",
 			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
 				var result struct {

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -444,7 +444,7 @@ func getQueryCases() []queryCase {
 			name: "BuildClusterHealth",
 			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
 				start, boundary, end := util.PeriodToDates("default", asOf)
-				results, err := query.BuildClusterHealth(dbc, start, boundary, end)
+				results, err := query.BuildClusterHealth(dbc, benchmarkRelease, start, boundary, end)
 				if err != nil {
 					return validationSnapshot{}, err
 				}

--- a/pkg/flags/postgres_validation_test.go
+++ b/pkg/flags/postgres_validation_test.go
@@ -1,0 +1,131 @@
+package flags
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+type goldenFile struct {
+	Metadata struct {
+		AsOf      time.Time `json:"as_of"`
+		Release   string    `json:"release"`
+		Generated time.Time `json:"generated_at"`
+	} `json:"metadata"`
+	Results map[string]validationSnapshot `json:"results"`
+}
+
+func allQueryCases() []queryCase {
+	cases := getQueryCases()
+	for _, qc := range getIndividualQueryCases() {
+		cases = append(cases, qc)
+	}
+	return cases
+}
+
+func Test_GenerateGoldenFile(t *testing.T) {
+	dbc, _ := getBenchmarkDBClient(t)
+	goldenPath := os.Getenv("golden_file_path")
+	if goldenPath == "" {
+		t.Fatal("golden_file_path env var is required")
+	}
+
+	asOf := time.Now().UTC()
+	cases := allQueryCases()
+
+	gf := goldenFile{
+		Results: make(map[string]validationSnapshot),
+	}
+	gf.Metadata.AsOf = asOf
+	gf.Metadata.Release = benchmarkRelease
+	gf.Metadata.Generated = time.Now().UTC()
+
+	for _, vc := range cases {
+		t.Run(vc.name, func(t *testing.T) {
+			snap, err := vc.fn(dbc, asOf)
+			if err != nil {
+				t.Fatalf("%s failed: %v", vc.name, err)
+			}
+			gf.Results[vc.name] = snap
+			t.Logf("%s: row_count=%d", vc.name, snap.RowCount)
+		})
+	}
+
+	data, err := json.MarshalIndent(gf, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal golden file: %v", err)
+	}
+	if err := os.WriteFile(goldenPath, data, 0o600); err != nil {
+		t.Fatalf("failed to write golden file: %v", err)
+	}
+	t.Logf("golden file written to %s with %d cases", goldenPath, len(gf.Results))
+}
+
+func Test_ValidateGoldenFile(t *testing.T) {
+	dbc, _ := getBenchmarkDBClient(t)
+	goldenPath := os.Getenv("golden_file_path")
+	if goldenPath == "" {
+		t.Fatal("golden_file_path env var is required")
+	}
+
+	data, err := os.ReadFile(goldenPath) // #nosec G304
+	if err != nil {
+		t.Fatalf("failed to read golden file: %v", err)
+	}
+
+	var gf goldenFile
+	if err := json.Unmarshal(data, &gf); err != nil {
+		t.Fatalf("failed to unmarshal golden file: %v", err)
+	}
+
+	asOf := gf.Metadata.AsOf
+	t.Logf("validating against golden file (asOf=%s, generated=%s, release=%s)",
+		asOf.Format(time.RFC3339), gf.Metadata.Generated.Format(time.RFC3339), gf.Metadata.Release)
+
+	cases := allQueryCases()
+	var mismatches []string
+
+	for _, vc := range cases {
+		t.Run(vc.name, func(t *testing.T) {
+			expected, ok := gf.Results[vc.name]
+			if !ok {
+				t.Logf("SKIP: case %s not found in golden file", vc.name)
+				return
+			}
+
+			got, err := vc.fn(dbc, asOf)
+			if err != nil {
+				t.Errorf("%s failed: %v", vc.name, err)
+				mismatches = append(mismatches, vc.name)
+				return
+			}
+
+			if got.RowCount != expected.RowCount {
+				t.Errorf("row_count: expected %d, got %d", expected.RowCount, got.RowCount)
+				mismatches = append(mismatches, vc.name)
+			}
+
+			for key, expectedVal := range expected.SpotChecks {
+				gotVal, ok := got.SpotChecks[key]
+				if !ok {
+					t.Errorf("spot_check %q: expected %q, got (missing)", key, expectedVal)
+					mismatches = append(mismatches, fmt.Sprintf("%s.%s", vc.name, key))
+					continue
+				}
+				if gotVal != expectedVal {
+					t.Errorf("spot_check %q: expected %q, got %q", key, expectedVal, gotVal)
+					mismatches = append(mismatches, fmt.Sprintf("%s.%s", vc.name, key))
+				}
+			}
+
+			t.Logf("row_count=%d (expected %d)", got.RowCount, expected.RowCount)
+		})
+	}
+
+	if len(mismatches) > 0 {
+		t.Logf("total mismatches: %d — %s", len(mismatches), strings.Join(mismatches, ", "))
+	}
+}

--- a/pkg/flags/postgres_validation_test.go
+++ b/pkg/flags/postgres_validation_test.go
@@ -66,7 +66,7 @@ func Test_GenerateGoldenFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to marshal golden file: %v", err)
 	}
-	if err := os.WriteFile(goldenPath, data, 0o600); err != nil {
+	if err := os.WriteFile(goldenPath, data, 0o600); err != nil { // #nosec G703
 		t.Fatalf("failed to write golden file: %v", err)
 	}
 	t.Logf("golden file written to %s with %d cases", goldenPath, len(gf.Results))
@@ -79,7 +79,7 @@ func Test_ValidateGoldenFile(t *testing.T) {
 		t.Fatal("golden_file_path env var is required")
 	}
 
-	data, err := os.ReadFile(goldenPath) // #nosec G304
+	data, err := os.ReadFile(goldenPath) // #nosec G304,G703
 	if err != nil {
 		t.Fatalf("failed to read golden file: %v", err)
 	}
@@ -100,7 +100,8 @@ func Test_ValidateGoldenFile(t *testing.T) {
 		t.Run(vc.name, func(t *testing.T) {
 			expected, ok := gf.Results[vc.name]
 			if !ok {
-				t.Logf("SKIP: case %s not found in golden file", vc.name)
+				t.Errorf("case %s not found in golden file", vc.name)
+				mismatches = append(mismatches, vc.name)
 				return
 			}
 

--- a/pkg/flags/postgres_validation_test.go
+++ b/pkg/flags/postgres_validation_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -20,6 +21,7 @@ type goldenFile struct {
 
 func allQueryCases() []queryCase {
 	cases := getQueryCases()
+	cases = append(cases, getReportQueryCases()...)
 	for _, qc := range getIndividualQueryCases() {
 		cases = append(cases, qc)
 	}
@@ -28,8 +30,8 @@ func allQueryCases() []queryCase {
 
 func Test_GenerateGoldenFile(t *testing.T) {
 	dbc, _ := getBenchmarkDBClient(t)
-	goldenPath := os.Getenv("golden_file_path")
-	if goldenPath == "" {
+	goldenPath := filepath.Clean(os.Getenv("golden_file_path"))
+	if goldenPath == "." {
 		t.Fatal("golden_file_path env var is required")
 	}
 
@@ -43,15 +45,21 @@ func Test_GenerateGoldenFile(t *testing.T) {
 	gf.Metadata.Release = benchmarkRelease
 	gf.Metadata.Generated = time.Now().UTC()
 
+	failed := false
 	for _, vc := range cases {
 		t.Run(vc.name, func(t *testing.T) {
 			snap, err := vc.fn(dbc, asOf)
 			if err != nil {
+				failed = true
 				t.Fatalf("%s failed: %v", vc.name, err)
 			}
 			gf.Results[vc.name] = snap
 			t.Logf("%s: row_count=%d", vc.name, snap.RowCount)
 		})
+	}
+
+	if failed {
+		t.Fatalf("%d/%d cases succeeded; refusing to write an incomplete golden file", len(gf.Results), len(cases))
 	}
 
 	data, err := json.MarshalIndent(gf, "", "  ")
@@ -66,8 +74,8 @@ func Test_GenerateGoldenFile(t *testing.T) {
 
 func Test_ValidateGoldenFile(t *testing.T) {
 	dbc, _ := getBenchmarkDBClient(t)
-	goldenPath := os.Getenv("golden_file_path")
-	if goldenPath == "" {
+	goldenPath := filepath.Clean(os.Getenv("golden_file_path"))
+	if goldenPath == "." {
 		t.Fatal("golden_file_path env var is required")
 	}
 

--- a/pkg/flags/postgres_validation_test.go
+++ b/pkg/flags/postgres_validation_test.go
@@ -19,15 +19,6 @@ type goldenFile struct {
 	Results map[string]validationSnapshot `json:"results"`
 }
 
-func allQueryCases() []queryCase {
-	cases := getQueryCases()
-	cases = append(cases, getReportQueryCases()...)
-	for _, qc := range getIndividualQueryCases() {
-		cases = append(cases, qc)
-	}
-	return cases
-}
-
 func Test_GenerateGoldenFile(t *testing.T) {
 	dbc, _ := getBenchmarkDBClient(t)
 	goldenPath := filepath.Clean(os.Getenv("golden_file_path"))

--- a/pkg/mcp/tools/releases.go
+++ b/pkg/mcp/tools/releases.go
@@ -52,13 +52,8 @@ func (rt *ReleasesTool) GetHandler() func(ctx context.Context, request mcp.CallT
 		// Get last updated time from database if available
 		var lastUpdated time.Time
 		if rt.deps.DBClient != nil && rt.deps.DBClient.DB != nil {
-			type LastUpdatedQuery struct {
-				Max time.Time
-			}
-			var result LastUpdatedQuery
-			// Assume our last update is the last time we inserted a prow job run.
-			if err := rt.deps.DBClient.DB.Raw("SELECT MAX(created_at) FROM prow_job_runs").Scan(&result).Error; err == nil {
-				lastUpdated = result.Max
+			if t, err := api.GetLastUpdateTime(rt.deps.DBClient); err == nil {
+				lastUpdated = t
 			}
 		}
 

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -137,7 +137,9 @@ func RefreshMetricsDB(ctx context.Context, dbc *db.DB, bqc *bqclient.Client, crP
 		if err != nil {
 			return errors.Wrapf(err, "could not fetch last updated time")
 		}
-		hoursSinceLastUpdate.WithLabelValues().Set(time.Since(lastUpdated).Hours())
+		if !lastUpdated.IsZero() {
+			hoursSinceLastUpdate.WithLabelValues().Set(time.Since(lastUpdated).Hours())
+		}
 
 		for _, pType := range promReportTypes {
 			// start, boundary and end will just be defaults

--- a/pkg/sippyserver/metrics/metrics.go
+++ b/pkg/sippyserver/metrics/metrics.go
@@ -133,9 +133,9 @@ func RefreshMetricsDB(ctx context.Context, dbc *db.DB, bqc *bqclient.Client, crP
 		promReportTypes := buildPromReportTypes(releases)
 
 		// Get last updated job run
-		var lastUpdated time.Time
-		if r := dbc.DB.Raw("SELECT MAX(created_at) FROM prow_job_runs").Scan(&lastUpdated); r.Error != nil {
-			return errors.Wrapf(r.Error, "could not fetch last updated time")
+		lastUpdated, err := api.GetLastUpdateTime(dbc)
+		if err != nil {
+			return errors.Wrapf(err, "could not fetch last updated time")
 		}
 		hoursSinceLastUpdate.WithLabelValues().Set(time.Since(lastUpdated).Hours())
 
@@ -276,9 +276,13 @@ func updateComponentReadinessMetricsForView(ctx context.Context, provider datapr
 }
 
 func refreshBuildClusterMetrics(dbc *db.DB, reportEnd time.Time) error {
+	release, err := query.CurrentActiveRelease(dbc)
+	if err != nil {
+		return err
+	}
 	for _, period := range []string{"current", "twoDay"} {
 		start, boundary, end := util.PeriodToDates(period, reportEnd)
-		result, err := query.BuildClusterHealth(dbc, start, boundary, end)
+		result, err := query.BuildClusterHealth(dbc, release, start, boundary, end)
 		if err != nil {
 			return err
 		}

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -1572,6 +1572,20 @@ func (s *Server) jsonJobRunPayload(w http.ResponseWriter, req *http.Request) {
 
 func (s *Server) jsonJobRunsReportFromDB(w http.ResponseWriter, req *http.Request) {
 	release := param.SafeRead(req, "release")
+	useCurrentRelease := param.SafeRead(req, "useCurrentRelease") == "true"
+
+	if release != "" && useCurrentRelease {
+		failureResponse(w, http.StatusBadRequest, "release and useCurrentRelease are mutually exclusive")
+		return
+	}
+	if useCurrentRelease {
+		var err error
+		release, err = query.CurrentActiveRelease(s.db)
+		if err != nil {
+			failureResponse(w, http.StatusInternalServerError, "determining current release: "+err.Error())
+			return
+		}
+	}
 
 	filterOpts, err := filter.FilterOptionsFromRequest(req, "timestamp", "desc")
 	if err != nil {

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -445,7 +445,7 @@ func (s *Server) determineCapabilities() {
 		buildClusterRelease, err := query.CurrentActiveRelease(s.db)
 		if err != nil {
 			log.WithError(err).Warningf("could not determine active release for build cluster check")
-		} else if hasBuildCluster, err := query.HasBuildClusterData(s.db, buildClusterRelease); hasBuildCluster {
+		} else if hasBuildCluster, err := query.HasBuildClusterData(s.db, buildClusterRelease, time.Now().Add(-14*24*time.Hour)); hasBuildCluster {
 			capabilities = append(capabilities, BuildClusterCapability)
 		} else if err != nil {
 			log.WithError(err).Warningf("could not fetch build cluster data")

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -442,8 +442,10 @@ func (s *Server) determineCapabilities() {
 	if s.db != nil {
 		capabilities = append(capabilities, LocalDBCapability)
 
-		buildClusterRelease, _ := query.CurrentActiveRelease(s.db)
-		if hasBuildCluster, err := query.HasBuildClusterData(s.db, buildClusterRelease); hasBuildCluster {
+		buildClusterRelease, err := query.CurrentActiveRelease(s.db)
+		if err != nil {
+			log.WithError(err).Warningf("could not determine active release for build cluster check")
+		} else if hasBuildCluster, err := query.HasBuildClusterData(s.db, buildClusterRelease); hasBuildCluster {
 			capabilities = append(capabilities, BuildClusterCapability)
 		} else if err != nil {
 			log.WithError(err).Warningf("could not fetch build cluster data")

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -442,7 +442,8 @@ func (s *Server) determineCapabilities() {
 	if s.db != nil {
 		capabilities = append(capabilities, LocalDBCapability)
 
-		if hasBuildCluster, err := query.HasBuildClusterData(s.db); hasBuildCluster {
+		buildClusterRelease, _ := query.CurrentActiveRelease(s.db)
+		if hasBuildCluster, err := query.HasBuildClusterData(s.db, buildClusterRelease); hasBuildCluster {
 			capabilities = append(capabilities, BuildClusterCapability)
 		} else if err != nil {
 			log.WithError(err).Warningf("could not fetch build cluster data")
@@ -1350,18 +1351,13 @@ func (s *Server) jsonReleasesReportFromDB(w http.ResponseWriter, req *http.Reque
 	// Get last updated time if available
 	var lastUpdated time.Time
 	if s.db != nil {
-		type LastUpdatedQuery struct {
-			Max time.Time
-		}
-		var result LastUpdatedQuery
-		// Assume our last update is the last time we inserted a prow job run.
-		res := s.db.DB.Raw("SELECT MAX(created_at) FROM prow_job_runs").Scan(&result)
-		if res.Error != nil {
-			log.WithError(res.Error).Error("error querying last updated from db")
+		var err error
+		lastUpdated, err = api.GetLastUpdateTime(s.db)
+		if err != nil {
+			log.WithError(err).Error("error querying last updated from db")
 			failureResponse(w, http.StatusInternalServerError, "error querying last updated from db")
 			return
 		}
-		lastUpdated = result.Max
 	}
 
 	// Build response using shared function
@@ -1401,7 +1397,18 @@ func (s *Server) jsonHealthReportFromDB(w http.ResponseWriter, req *http.Request
 func (s *Server) jsonBuildClusterHealth(w http.ResponseWriter, req *http.Request) {
 	start, boundary, end := getPeriodDates("default", req, s.GetReportEnd())
 
-	results, err := api.GetBuildClusterHealthReport(s.db, start, boundary, end)
+	release := param.SafeRead(req, "release")
+	if release == "" {
+		var err error
+		release, err = query.CurrentActiveRelease(s.db)
+		if err != nil {
+			log.WithError(err).Error("error determining release for build cluster health")
+			failureResponse(w, http.StatusInternalServerError, "error determining release: "+err.Error())
+			return
+		}
+	}
+
+	results, err := api.GetBuildClusterHealthReport(s.db, release, start, boundary, end)
 	if err != nil {
 		log.WithError(err).Error("error querying build cluster health from db")
 		failureResponse(w, http.StatusInternalServerError, "error querying build cluster health from db: "+err.Error())
@@ -1414,7 +1421,18 @@ func (s *Server) jsonBuildClusterHealth(w http.ResponseWriter, req *http.Request
 func (s *Server) jsonBuildClusterHealthAnalysis(w http.ResponseWriter, req *http.Request) {
 	period := getPeriod(req, api.PeriodDay)
 
-	results, err := api.GetBuildClusterHealthAnalysis(s.db, period)
+	release := param.SafeRead(req, "release")
+	if release == "" {
+		var err error
+		release, err = query.CurrentActiveRelease(s.db)
+		if err != nil {
+			log.WithError(err).Error("error determining release for build cluster analysis")
+			failureResponse(w, http.StatusInternalServerError, "error determining release: "+err.Error())
+			return
+		}
+	}
+
+	results, err := api.GetBuildClusterHealthAnalysis(s.db, release, period)
 	if err != nil {
 		log.WithError(err).Error("error querying build cluster health from db")
 		failureResponse(w, http.StatusInternalServerError, "error querying build cluster health from db: "+err.Error())

--- a/pkg/sippyserver/server.go
+++ b/pkg/sippyserver/server.go
@@ -442,13 +442,27 @@ func (s *Server) determineCapabilities() {
 	if s.db != nil {
 		capabilities = append(capabilities, LocalDBCapability)
 
-		buildClusterRelease, err := query.CurrentActiveRelease(s.db)
-		if err != nil {
-			log.WithError(err).Warningf("could not determine active release for build cluster check")
-		} else if hasBuildCluster, err := query.HasBuildClusterData(s.db, buildClusterRelease, time.Now().Add(-14*24*time.Hour)); hasBuildCluster {
+		hasBuildCluster := false
+		backoff := 1 * time.Second
+		for attempt := 1; attempt <= 3; attempt++ {
+			buildClusterRelease, err := query.CurrentActiveRelease(s.db)
+			if err != nil {
+				log.WithError(err).WithField("attempt", attempt).Warningf("could not determine active release for build cluster check")
+				time.Sleep(backoff)
+				backoff *= 2
+				continue
+			}
+			hasBuildCluster, err = query.HasBuildClusterData(s.db, buildClusterRelease, time.Now().Add(-14*24*time.Hour))
+			if err != nil {
+				log.WithError(err).WithField("attempt", attempt).Warningf("could not fetch build cluster data")
+				time.Sleep(backoff)
+				backoff *= 2
+				continue
+			}
+			break
+		}
+		if hasBuildCluster {
 			capabilities = append(capabilities, BuildClusterCapability)
-		} else if err != nil {
-			log.WithError(err).Warningf("could not fetch build cluster data")
 		}
 	}
 

--- a/sippy-ng/src/build_clusters/BuildClusterDetails.jsx
+++ b/sippy-ng/src/build_clusters/BuildClusterDetails.jsx
@@ -16,6 +16,7 @@ export default function BuildClusterDetails(props) {
               Periodic Job Runs On {props.cluster}
             </Typography>
             <JobRunsTable
+              useCurrentRelease
               pageSize={10}
               filterModel={{
                 items: [

--- a/sippy-ng/src/jobs/JobRunsTable.jsx
+++ b/sippy-ng/src/jobs/JobRunsTable.jsx
@@ -426,6 +426,8 @@ export default function JobRunsTable(props) {
     let queryString = ''
     if (props.release !== '') {
       queryString += '&release=' + props.release
+    } else if (props.useCurrentRelease) {
+      queryString += '&useCurrentRelease=true'
     }
 
     if (filterModel && filterModel.items.length > 0) {
@@ -479,7 +481,7 @@ export default function JobRunsTable(props) {
 
   useEffect(() => {
     fetchData()
-  }, [filterModel, sort, sortField, page, pageSize, props.release])
+  }, [filterModel, sort, sortField, page, pageSize, props.release, props.useCurrentRelease])
 
   // Fetch label definitions
   useEffect(() => {
@@ -784,6 +786,7 @@ JobRunsTable.defaultProps = {
   hideControls: false,
   pageSize: 25,
   release: '',
+  useCurrentRelease: false,
   filterModel: {
     items: [],
   },
@@ -797,6 +800,7 @@ JobRunsTable.propTypes = {
   limit: PropTypes.number,
   pageSize: PropTypes.number,
   release: PropTypes.string,
+  useCurrentRelease: PropTypes.bool,
   title: PropTypes.string,
   hideControls: PropTypes.bool,
   period: PropTypes.string,

--- a/sippy-ng/src/jobs/JobRunsTable.jsx
+++ b/sippy-ng/src/jobs/JobRunsTable.jsx
@@ -481,7 +481,15 @@ export default function JobRunsTable(props) {
 
   useEffect(() => {
     fetchData()
-  }, [filterModel, sort, sortField, page, pageSize, props.release, props.useCurrentRelease])
+  }, [
+    filterModel,
+    sort,
+    sortField,
+    page,
+    pageSize,
+    props.release,
+    props.useCurrentRelease,
+  ])
 
   // Fetch label definitions
   useEffect(() => {

--- a/sippy-ng/src/jobs/JobTable.jsx
+++ b/sippy-ng/src/jobs/JobTable.jsx
@@ -94,7 +94,7 @@ export const getColumns = (config, _openBugzillaDialog) => {
       renderCell: (params) => {
         if (params.value === undefined || params.value === '') {
           return (
-            <Tooltip title="Job has never passed, or pass predates Sippy's history (typically about 90 days)">
+            <Tooltip title="Job has not passed within the report window">
               <Fragment>-</Fragment>
             </Tooltip>
           )

--- a/test/integration/build_clusters_test.go
+++ b/test/integration/build_clusters_test.go
@@ -40,7 +40,8 @@ func TestHasBuildClusterData(t *testing.T) {
 				cluster:   tt.cluster,
 			})
 
-			has, err := query.HasBuildClusterData(dbc, "4.16")
+			since := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+			has, err := query.HasBuildClusterData(dbc, "4.16", since)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, has)
 		})
@@ -50,7 +51,8 @@ func TestHasBuildClusterData(t *testing.T) {
 func TestHasBuildClusterDataEmpty(t *testing.T) {
 	dbc := intutil.NewTestDB(t, pgContainer)
 
-	has, err := query.HasBuildClusterData(dbc, "4.16")
+	since := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	has, err := query.HasBuildClusterData(dbc, "4.16", since)
 	require.NoError(t, err)
 	assert.False(t, has)
 }

--- a/test/integration/build_clusters_test.go
+++ b/test/integration/build_clusters_test.go
@@ -40,7 +40,7 @@ func TestHasBuildClusterData(t *testing.T) {
 				cluster:   tt.cluster,
 			})
 
-			has, err := query.HasBuildClusterData(dbc)
+			has, err := query.HasBuildClusterData(dbc, "4.16")
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, has)
 		})
@@ -50,7 +50,7 @@ func TestHasBuildClusterData(t *testing.T) {
 func TestHasBuildClusterDataEmpty(t *testing.T) {
 	dbc := intutil.NewTestDB(t, pgContainer)
 
-	has, err := query.HasBuildClusterData(dbc)
+	has, err := query.HasBuildClusterData(dbc, "4.16")
 	require.NoError(t, err)
 	assert.False(t, has)
 }
@@ -81,7 +81,7 @@ func TestBuildClusterHealth(t *testing.T) {
 		{timestamp: end, cluster: "build01"},
 	})
 
-	results, err := query.BuildClusterHealth(dbc, start, boundary, end)
+	results, err := query.BuildClusterHealth(dbc, "4.16", start, boundary, end)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
@@ -118,7 +118,7 @@ func TestBuildClusterHealthMultipleClusters(t *testing.T) {
 		})
 	}
 
-	results, err := query.BuildClusterHealth(dbc, start, boundary, end)
+	results, err := query.BuildClusterHealth(dbc, "4.16", start, boundary, end)
 	require.NoError(t, err)
 	assert.Len(t, results, 2)
 
@@ -146,7 +146,7 @@ func TestBuildClusterHealthZeroRunsInPreviousPeriod(t *testing.T) {
 		{timestamp: boundary.Add(24 * time.Hour), cluster: "build01"},
 	})
 
-	results, err := query.BuildClusterHealth(dbc, start, boundary, end)
+	results, err := query.BuildClusterHealth(dbc, "4.16", start, boundary, end)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
@@ -178,7 +178,7 @@ func TestBuildClusterHealthExcludesNonPeriodic(t *testing.T) {
 		cluster:   "build01",
 	})
 
-	results, err := query.BuildClusterHealth(dbc, start, boundary, end)
+	results, err := query.BuildClusterHealth(dbc, "4.16", start, boundary, end)
 	require.NoError(t, err)
 	assert.Empty(t, results)
 }
@@ -216,7 +216,7 @@ func TestBuildClusterAnalysis(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			results, err := query.BuildClusterAnalysis(dbc, tt.period)
+			results, err := query.BuildClusterAnalysis(dbc, "4.16", tt.period)
 			require.NoError(t, err)
 			assert.Len(t, results, tt.wantRows)
 
@@ -249,7 +249,7 @@ func TestBuildClusterAnalysisByDay(t *testing.T) {
 		{timestamp: yesterday.Add(2 * time.Hour), cluster: "build01"},
 	})
 
-	results, err := query.BuildClusterAnalysis(dbc, "day")
+	results, err := query.BuildClusterAnalysis(dbc, "4.16", "day")
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
@@ -275,7 +275,7 @@ func TestBuildClusterAnalysisExcludesOldData(t *testing.T) {
 		cluster:   "build01",
 	})
 
-	results, err := query.BuildClusterAnalysis(dbc, "day")
+	results, err := query.BuildClusterAnalysis(dbc, "4.16", "day")
 	require.NoError(t, err)
 	assert.Empty(t, results)
 }
@@ -295,7 +295,7 @@ func TestBuildClusterAnalysisExcludesNonPeriodic(t *testing.T) {
 		cluster:   "build01",
 	})
 
-	results, err := query.BuildClusterAnalysis(dbc, "day")
+	results, err := query.BuildClusterAnalysis(dbc, "4.16", "day")
 	require.NoError(t, err)
 	assert.Empty(t, results)
 }

--- a/test/integration/job_runs_report_test.go
+++ b/test/integration/job_runs_report_test.go
@@ -372,6 +372,7 @@ func TestJobRunsReport_NoPagination(t *testing.T) {
 
 func TestJobRunsReport_ReleaseFilter(t *testing.T) {
 	dbc := intutil.NewTestDB(t, pgContainer)
+	intutil.CreateReleaseDefinition(t, dbc, "4.16", 4, 16)
 	td := setupJobRunsTestData(t, dbc)
 
 	t.Run("release 4.16", func(t *testing.T) {
@@ -388,9 +389,12 @@ func TestJobRunsReport_ReleaseFilter(t *testing.T) {
 		assert.Equal(t, idInt(td.runOther.ID), runs[0].ID) //nolint:gosec // DB IDs are well within int range
 	})
 
-	t.Run("empty release returns all", func(t *testing.T) {
+	t.Run("empty release falls back to active release", func(t *testing.T) {
 		result := callJobRunsReport(t, dbc, "", defaultFilterOpts(), defaultPagination(), jrReportEnd)
-		assert.True(t, result.TotalRows >= 5, "empty release should include runs from all releases within window")
+		runs := jobRunsFromResult(t, result)
+		ids := runIDs(runs)
+		assert.NotContains(t, ids, idInt(td.runOther.ID), "4.15 runs should be excluded when falling back to active release") //nolint:gosec // DB IDs are well within int range
+		assert.True(t, result.TotalRows >= 3, "empty release should return runs for the active release")
 	})
 }
 

--- a/test/integration/job_runs_report_test.go
+++ b/test/integration/job_runs_report_test.go
@@ -389,12 +389,10 @@ func TestJobRunsReport_ReleaseFilter(t *testing.T) {
 		assert.Equal(t, idInt(td.runOther.ID), runs[0].ID) //nolint:gosec // DB IDs are well within int range
 	})
 
-	t.Run("empty release falls back to active release", func(t *testing.T) {
-		result := callJobRunsReport(t, dbc, "", defaultFilterOpts(), defaultPagination(), jrReportEnd)
-		runs := jobRunsFromResult(t, result)
-		ids := runIDs(runs)
-		assert.NotContains(t, ids, idInt(td.runOther.ID), "4.15 runs should be excluded when falling back to active release") //nolint:gosec // DB IDs are well within int range
-		assert.True(t, result.TotalRows >= 3, "empty release should return runs for the active release")
+	t.Run("empty release returns error", func(t *testing.T) {
+		_, err := api.JobsRunsReportFromDB(dbc, defaultFilterOpts(), "", defaultPagination(), jrReportEnd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "release is required")
 	})
 }
 

--- a/test/integration/jobs_test.go
+++ b/test/integration/jobs_test.go
@@ -856,20 +856,20 @@ func TestJobRunTestCountNoTests(t *testing.T) {
 	assert.Equal(t, 0, count)
 }
 
-func TestProwJobRunIDs(t *testing.T) {
+func TestProwJobRunCount(t *testing.T) {
 	dbc := intutil.NewTestDB(t, pgContainer)
 
 	job := intutil.CreateProwJob(t, dbc, "periodic-ci-e2e-aws-4.16", "4.16", []string{"aws"})
 	otherJob := intutil.CreateProwJob(t, dbc, "periodic-ci-e2e-gcp-4.16", "4.16", []string{"gcp"})
 
-	run1 := intutil.CreateProwJobRun(t, dbc, job.ID, "4.16", time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC), true, v1.JobSucceeded)
-	run2 := intutil.CreateProwJobRun(t, dbc, job.ID, "4.16", time.Date(2024, 6, 2, 12, 0, 0, 0, time.UTC), false, v1.JobTestFailure)
+	intutil.CreateProwJobRun(t, dbc, job.ID, "4.16", time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC), true, v1.JobSucceeded)
+	intutil.CreateProwJobRun(t, dbc, job.ID, "4.16", time.Date(2024, 6, 2, 12, 0, 0, 0, time.UTC), false, v1.JobTestFailure)
 	// Run for the other job should not appear
 	intutil.CreateProwJobRun(t, dbc, otherJob.ID, "4.16", time.Date(2024, 6, 3, 12, 0, 0, 0, time.UTC), true, v1.JobSucceeded)
 
-	ids, err := query.ProwJobRunIDs(dbc, job.ID)
+	count, err := query.ProwJobRunCount(dbc, job.ID, "4.16")
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []uint{run1.ID, run2.ID}, ids)
+	assert.Equal(t, 2, count)
 }
 
 func TestProwJobHistoricalTestCounts(t *testing.T) {

--- a/test/integration/jobs_test.go
+++ b/test/integration/jobs_test.go
@@ -862,10 +862,11 @@ func TestProwJobRunCount(t *testing.T) {
 	job := intutil.CreateProwJob(t, dbc, "periodic-ci-e2e-aws-4.16", "4.16", []string{"aws"})
 	otherJob := intutil.CreateProwJob(t, dbc, "periodic-ci-e2e-gcp-4.16", "4.16", []string{"gcp"})
 
-	intutil.CreateProwJobRun(t, dbc, job.ID, "4.16", time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC), true, v1.JobSucceeded)
-	intutil.CreateProwJobRun(t, dbc, job.ID, "4.16", time.Date(2024, 6, 2, 12, 0, 0, 0, time.UTC), false, v1.JobTestFailure)
+	now := time.Now().UTC()
+	intutil.CreateProwJobRun(t, dbc, job.ID, "4.16", now.Add(-2*24*time.Hour), true, v1.JobSucceeded)
+	intutil.CreateProwJobRun(t, dbc, job.ID, "4.16", now.Add(-1*24*time.Hour), false, v1.JobTestFailure)
 	// Run for the other job should not appear
-	intutil.CreateProwJobRun(t, dbc, otherJob.ID, "4.16", time.Date(2024, 6, 3, 12, 0, 0, 0, time.UTC), true, v1.JobSucceeded)
+	intutil.CreateProwJobRun(t, dbc, otherJob.ID, "4.16", now.Add(-3*24*time.Hour), true, v1.JobSucceeded)
 
 	count, err := query.ProwJobRunCount(dbc, job.ID, "4.16")
 	require.NoError(t, err)

--- a/test/integration/jobs_test.go
+++ b/test/integration/jobs_test.go
@@ -862,13 +862,13 @@ func TestProwJobRunCount(t *testing.T) {
 	job := intutil.CreateProwJob(t, dbc, "periodic-ci-e2e-aws-4.16", "4.16", []string{"aws"})
 	otherJob := intutil.CreateProwJob(t, dbc, "periodic-ci-e2e-gcp-4.16", "4.16", []string{"gcp"})
 
-	now := time.Now().UTC()
-	intutil.CreateProwJobRun(t, dbc, job.ID, "4.16", now.Add(-2*24*time.Hour), true, v1.JobSucceeded)
-	intutil.CreateProwJobRun(t, dbc, job.ID, "4.16", now.Add(-1*24*time.Hour), false, v1.JobTestFailure)
+	intutil.CreateProwJobRun(t, dbc, job.ID, "4.16", time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC), true, v1.JobSucceeded)
+	intutil.CreateProwJobRun(t, dbc, job.ID, "4.16", time.Date(2024, 6, 2, 12, 0, 0, 0, time.UTC), false, v1.JobTestFailure)
 	// Run for the other job should not appear
-	intutil.CreateProwJobRun(t, dbc, otherJob.ID, "4.16", now.Add(-3*24*time.Hour), true, v1.JobSucceeded)
+	intutil.CreateProwJobRun(t, dbc, otherJob.ID, "4.16", time.Date(2024, 6, 3, 12, 0, 0, 0, time.UTC), true, v1.JobSucceeded)
 
-	count, err := query.ProwJobRunCount(dbc, job.ID, "4.16")
+	since := time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)
+	count, err := query.ProwJobRunCount(dbc, job.ID, "4.16", since)
 	require.NoError(t, err)
 	assert.Equal(t, 2, count)
 }

--- a/test/integration/lookback_count_test.go
+++ b/test/integration/lookback_count_test.go
@@ -52,28 +52,27 @@ func seedLookbackFixtures(t *testing.T, dbc *db.DB) lookbackFixtures {
 	}
 }
 
-func TestLookbackCount_DeduplicatesTestIDsAcrossReleases(t *testing.T) {
+func TestLookbackCount_OnlyCountsActiveRelease(t *testing.T) {
 	dbc := lookbackCountDB(t)
 	f := seedLookbackFixtures(t, dbc)
 
 	today := lookbackDate
 	startMinusOne := today.AddDays(-15)
 
-	// testAlpha appears in both releases with runs in the window.
-	// It should be counted once, not twice.
+	// testAlpha and testBeta in the active release (4.18).
 	intutil.CreateCumulativeSummary(t, dbc, today, "4.18", f.testAlpha, f.jobA, f.suiteA, 100, 90, 5)
 	intutil.CreateCumulativeSummary(t, dbc, startMinusOne, "4.18", f.testAlpha, f.jobA, f.suiteA, 80, 70, 3)
 
-	intutil.CreateCumulativeSummary(t, dbc, today, "4.19", f.testAlpha, f.jobB, f.suiteA, 50, 45, 2)
-	intutil.CreateCumulativeSummary(t, dbc, startMinusOne, "4.19", f.testAlpha, f.jobB, f.suiteA, 30, 25, 1)
-
-	// testBeta only in 4.18.
 	intutil.CreateCumulativeSummary(t, dbc, today, "4.18", f.testBeta, f.jobA, f.suiteA, 60, 55, 3)
 	intutil.CreateCumulativeSummary(t, dbc, startMinusOne, "4.18", f.testBeta, f.jobA, f.suiteA, 40, 35, 2)
 
+	// testGamma only in 4.19 (not the active release, should be ignored).
+	intutil.CreateCumulativeSummary(t, dbc, today, "4.19", f.testGamma, f.jobB, f.suiteA, 50, 45, 2)
+	intutil.CreateCumulativeSummary(t, dbc, startMinusOne, "4.19", f.testGamma, f.jobB, f.suiteA, 30, 25, 1)
+
 	_, testIDsCount, err := api.GetJobRunTestsCountByLookbackAt(dbc, 14, lookbackDate)
 	require.NoError(t, err)
-	assert.Equal(t, int64(2), testIDsCount, "testAlpha should be deduplicated across releases")
+	assert.Equal(t, int64(2), testIDsCount, "should only count tests from the active release")
 }
 
 func TestLookbackCount_ZeroAndNegativeDeltaExcluded(t *testing.T) {

--- a/test/integration/lookback_count_test.go
+++ b/test/integration/lookback_count_test.go
@@ -160,12 +160,12 @@ func TestLookbackCount_MultipleJobsPerTestAggregated(t *testing.T) {
 	assert.Equal(t, int64(1), testIDsCount, "test with positive aggregate delta across jobs should be counted")
 }
 
-func TestLookbackCount_NoReleasesReturnsZeroTests(t *testing.T) {
+func TestLookbackCount_NoReleasesReturnsError(t *testing.T) {
 	dbc := lookbackCountDB(t)
 
-	_, testIDsCount, err := api.GetJobRunTestsCountByLookbackAt(dbc, 14, lookbackDate)
-	require.NoError(t, err)
-	assert.Equal(t, int64(0), testIDsCount)
+	_, _, err := api.GetJobRunTestsCountByLookbackAt(dbc, 14, lookbackDate)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no OCP release found")
 }
 
 func TestLookbackCount_InvalidLookbackDays(t *testing.T) {

--- a/test/integration/util/fixtures.go
+++ b/test/integration/util/fixtures.go
@@ -194,6 +194,7 @@ func CreateReleaseDefinition(t *testing.T, dbc *db.DB, release string, major, mi
 		Release: release,
 		Major:   major,
 		Minor:   minor,
+		Product: "OCP",
 	}
 	require.NoError(t, dbc.DB.Create(&rd).Error, "creating ReleaseDefinition %q", release)
 	return rd

--- a/test/integration/util/testdb.go
+++ b/test/integration/util/testdb.go
@@ -27,12 +27,14 @@ func init() {
 // configurePodmanIfNeeded detects Podman and sets the environment
 // variables that testcontainers-go needs to use it.
 func configurePodmanIfNeeded() {
-	if os.Getenv("DOCKER_HOST") != "" {
+	podmanPath, err := exec.LookPath("podman")
+	if err != nil || podmanPath == "" {
 		return
 	}
 
-	podmanPath, err := exec.LookPath("podman")
-	if err != nil || podmanPath == "" {
+	os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+
+	if os.Getenv("DOCKER_HOST") != "" {
 		return
 	}
 
@@ -45,7 +47,6 @@ func configurePodmanIfNeeded() {
 		socketPath = "unix://" + socketPath
 	}
 	os.Setenv("DOCKER_HOST", socketPath)
-	os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
 }
 
 // podmanSocketPath returns the host-side Podman socket path.


### PR DESCRIPTION
Query optimizations based on partitioning migration for

- prow_job_runs
- prow_job_run_annotations
- prow_job_run_prow_pull_requests

Primary modifications 

- Ensure partition filtering is enabled for relevant queries
  - Queries without release &/| timestamp filtering will get defaults
- jobResultFunction required migration to `LANGUAGE plpgsql` to allow the planner access to the query
- postgres_validation_test added for verification across commits / migration phases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build-cluster health and analysis support selected releases, with automatic fallback to the active release.
  * Cluster autocomplete respects the selected release and recent activity.
  * Added golden-file validation for PostgreSQL query results.

* **Bug Fixes**
  * Improved release and time-range filtering to prevent data from different releases being combined.
  * Improved accuracy of job-run, pull-request, test, repository, and release health reports.
  * Centralized release update timestamp handling for more consistent reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->