### PR TITLE
Fix Component Readiness UI crashes after React 18 upgrade

### DIFF
--- a/sippy-ng/src/component_readiness/AdvancedOptions.jsx
+++ b/sippy-ng/src/component_readiness/AdvancedOptions.jsx
@@ -17,6 +17,26 @@ import Switch from '@mui/material/Switch'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 
+const useStyles = makeStyles((theme) => ({
+  formControl: {
+    margin: theme.spacing(1),
+    minWidth: '20px',
+  },
+  selectEmpty: {
+    marginTop: theme.spacing(2),
+  },
+  headerName: {
+    width: '220px',
+    padding: '0px',
+    margin: '0px',
+  },
+  summary: {
+    backgroundColor: 'rgb(0, 153, 255)',
+    margin: '0px !important',
+    padding: '0px',
+  },
+}))
+
 export default function AdvancedOptions(props) {
   const {
     headerName: _headerName,
@@ -39,26 +59,6 @@ export default function AdvancedOptions(props) {
     setFlakeAsFailure,
     setIncludeMultiReleaseAnalysis,
   } = props
-
-  const useStyles = makeStyles((theme) => ({
-    formControl: {
-      margin: theme.spacing(1),
-      minWidth: '20px',
-    },
-    selectEmpty: {
-      marginTop: theme.spacing(2),
-    },
-    headerName: {
-      width: '220px',
-      padding: '0px',
-      margin: '0px',
-    },
-    summary: {
-      backgroundColor: 'rgb(0, 153, 255)',
-      margin: '0px !important',
-      padding: '0px',
-    },
-  }))
 
   const classes = useStyles()
 
@@ -185,16 +185,18 @@ export default function AdvancedOptions(props) {
               color="primary"
             />
             <Tooltip title="Enable analysis across multiple prior releases">
-              <p>
-                Historical release analysis:{' '}
-                {includeMultiReleaseAnalysis ? 'include' : 'exclude'}
-              </p>
-              <Switch
-                checked={includeMultiReleaseAnalysis}
-                onChange={handleChangeIncludeMultiReleaseAnalysis}
-                name="includeMultiReleaseAnalysis"
-                color="primary"
-              />
+              <div>
+                <p>
+                  Historical release analysis:{' '}
+                  {includeMultiReleaseAnalysis ? 'include' : 'exclude'}
+                </p>
+                <Switch
+                  checked={includeMultiReleaseAnalysis}
+                  onChange={handleChangeIncludeMultiReleaseAnalysis}
+                  name="includeMultiReleaseAnalysis"
+                  color="primary"
+                />
+              </div>
             </Tooltip>
           </FormGroup>
         </AccordionDetails>

--- a/sippy-ng/src/component_readiness/CompCapRow.jsx
+++ b/sippy-ng/src/component_readiness/CompCapRow.jsx
@@ -62,7 +62,7 @@ export default function CompCapRow(props) {
             environment={columnNames[idx]}
             capabilityName={capabilityName}
             filterVals={filterVals}
-            regressedCount={columnVal.regressed_tests}
+            regressedCount={columnVal.regressed_tests?.length || 0}
           />
         ))}
       </TableRow>

--- a/sippy-ng/src/component_readiness/CompReadyRow.jsx
+++ b/sippy-ng/src/component_readiness/CompReadyRow.jsx
@@ -55,7 +55,7 @@ export default function CompReadyRow(props) {
             componentName={componentName}
             filterVals={filterVals}
             grayFactor={grayFactor}
-            regressedCount={columnVal.regressed_tests}
+            regressedCount={columnVal.regressed_tests?.length || 0}
           />
         ))}
       </TableRow>

--- a/sippy-ng/src/component_readiness/CompSeverityIcon.jsx
+++ b/sippy-ng/src/component_readiness/CompSeverityIcon.jsx
@@ -6,6 +6,17 @@ import { withStyles } from '@mui/styles'
 import PropTypes from 'prop-types'
 import React, { useContext } from 'react'
 
+const StyledBadge = withStyles((_theme) => ({
+  badge: {
+    height: 12,
+    maxHeight: 12,
+    minHeight: 12,
+    width: 12,
+    maxWidth: 12,
+    minWidth: 12,
+  },
+}))(Badge)
+
 export default function CompSeverityIcon(props) {
   const { accessibilityModeOn } = useContext(AccessibilityModeContext)
   const { explanations, status, grayFactor, count } = props
@@ -21,16 +32,6 @@ export default function CompSeverityIcon(props) {
     toolTip = explanations.join(' ')
   }
 
-  const StyledBadge = withStyles((_theme) => ({
-    badge: {
-      height: 12,
-      maxHeight: 12,
-      minHeight: 12,
-      width: 12,
-      maxWidth: 12,
-      minWidth: 12,
-    },
-  }))(Badge)
   return (
     <div>
       {status < -100 && count > 1 ? (

--- a/sippy-ng/src/component_readiness/GroupByCheckboxList.jsx
+++ b/sippy-ng/src/component_readiness/GroupByCheckboxList.jsx
@@ -16,15 +16,15 @@ import PropTypes from 'prop-types'
 import React, { useContext } from 'react'
 import Typography from '@mui/material/Typography'
 
+const useStyles = makeStyles((theme) => ({
+  formControl: {
+    margin: theme.spacing(1),
+    minWidth: '20px',
+  },
+}))
+
 export default function GroupByCheckboxList(props) {
   const varsContext = useContext(CompReadyVarsContext)
-  const useStyles = makeStyles((theme) => ({
-    formControl: {
-      margin: theme.spacing(1),
-      minWidth: '20px',
-    },
-  }))
-
   const classes = useStyles()
   const handleChange = (event) => {
     const item = event.target.name

--- a/sippy-ng/src/component_readiness/IncludeVariantCheckboxList.jsx
+++ b/sippy-ng/src/component_readiness/IncludeVariantCheckboxList.jsx
@@ -18,6 +18,21 @@ import PropTypes from 'prop-types'
 import React, { useContext, useState } from 'react'
 import Typography from '@mui/material/Typography'
 
+const useIncludeVariantStyles = makeStyles((theme) => ({
+  formControl: {
+    margin: theme.spacing(1),
+    minWidth: '20px',
+  },
+  gridCenter: {
+    marginTop: theme.spacing(1),
+    textAlign: 'center',
+  },
+  gridRight: {
+    justifyContent: 'flex-end',
+    display: 'flex',
+  },
+}))
+
 export default function IncludeVariantCheckBoxList(props) {
   const variantGroupName = props.variantGroupName
   const varsContext = useContext(CompReadyVarsContext)
@@ -79,20 +94,7 @@ export default function IncludeVariantCheckBoxList(props) {
     setIsCompareMode(!isCompareMode)
   }
 
-  const classes = makeStyles((theme) => ({
-    formControl: {
-      margin: theme.spacing(1),
-      minWidth: '20px',
-    },
-    gridCenter: {
-      marginTop: theme.spacing(1),
-      textAlign: 'center',
-    },
-    gridRight: {
-      justifyContent: 'flex-end',
-      display: 'flex',
-    },
-  }))()
+  const classes = useIncludeVariantStyles()
 
   let params = {
     variantGroupName,

--- a/sippy-ng/src/component_readiness/SidebarTestFilters.jsx
+++ b/sippy-ng/src/component_readiness/SidebarTestFilters.jsx
@@ -20,35 +20,34 @@ import PropTypes from 'prop-types'
 import React, { Fragment, useContext } from 'react'
 import Typography from '@mui/material/Typography'
 
+const useStyles = makeStyles((theme) => ({
+  formControl: {
+    margin: theme.spacing(1),
+  },
+  autocomplete: {
+    width: '100%',
+    '& .MuiAutocomplete-inputRoot': {
+      paddingRight: '9px !important',
+    },
+  },
+  chip: {
+    maxWidth: 'none',
+    flex: '1 1 auto',
+  },
+}))
+
 export default function SidebarTestFilters(props) {
+  const varsContext = useContext(CompReadyVarsContext)
+  const testCapabilities = useContext(TestCapabilitiesContext)
+  const testLifecycles = useContext(TestLifecyclesContext)
+  const classes = useStyles()
+
   if (
     !props.controlsOpts?.filterByCapabilities &&
     !props.controlsOpts?.filterByLifecycles
   ) {
-    // if we have no filters to show, omit the whole component
     return <Fragment />
   }
-  const varsContext = useContext(CompReadyVarsContext)
-  const testCapabilities = useContext(TestCapabilitiesContext)
-  const testLifecycles = useContext(TestLifecyclesContext)
-  const useStyles = makeStyles((theme) => ({
-    formControl: {
-      margin: theme.spacing(1),
-    },
-    autocomplete: {
-      width: '100%',
-      // Override Material-UI Autocomplete padding that would make space for the dropdown triangle we disabled
-      '& .MuiAutocomplete-inputRoot': {
-        paddingRight: '9px !important',
-      },
-    },
-    chip: {
-      maxWidth: 'none',
-      flex: '1 1 auto',
-    },
-  }))
-
-  const classes = useStyles()
 
   const handleCapabilitiesChange = (event, newValue) => {
     varsContext.setTestCapabilities(newValue || [])


### PR DESCRIPTION
Two issues caused the regressed tests table to crash:

1. regressedCount passed as array instead of number: commit bfd4f14c7
   removed generateRegressionCount() which converted regressed_tests
   array to .length, but passed the raw array through instead.

2. makeStyles/withStyles called inside component bodies: this pattern
   creates new style sheets on every render, which worked in React 17
   but causes "sheetManager is undefined" crashes during React 18
   error boundary recovery. Moved all makeStyles/withStyles calls to
   module scope in GroupByCheckboxList, IncludeVariantCheckboxList,
   SidebarTestFilters, AdvancedOptions, and CompSeverityIcon.

3. SidebarTestFilters had hooks called after an early return,
   violating React's Rules of Hooks. Moved the early return after
   all hook calls.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Component readiness views now correctly display zero regressed tests when regression data is unavailable.
  - Historical release analysis controls continue to behave consistently within their tooltips.

- **Refactor**
  - Improved rendering consistency and maintainability across readiness filters, options, severity indicators, and variant controls without changing their visible styling or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->