### PR TITLE
NO-JIRA: add useCurrentRelease param to param.go

### DIFF
--- a/pkg/util/param/param.go
+++ b/pkg/util/param/param.go
@@ -31,31 +31,32 @@ var nonEmptyRegex = regexp.MustCompile(`^.+$`)
 var boolRegexp = regexp.MustCompile(`^(true|false)$`)
 var paramRegexp = map[string]*regexp.Regexp{
 	// sippy classic params
-	"release":          regexp.MustCompile(`^[\w.-]+$`), // usually 4.x or Presubmit, but allow any "word"
-	"period":           wordRegexp,
-	"stream":           wordRegexp,
-	"arch":             wordRegexp,
-	"payload":          nameRegexp,
-	"fromPayload":      nameRegexp,
-	"toPayload":        nameRegexp,
-	"job":              nameRegexp,
-	"job_name":         nameRegexp,
-	"test":             regexp.MustCompile(`^.+$`),        // tests can be anything, so always parameterize in sql
-	"test_id":          regexp.MustCompile(`^[\w:. -]+$`), // test IDs like "openshift-tests-upgrade:af8a62c596e5c2b5448a5d308f4989a6" or "cluster install:0cb1bb27e418491b1ffdacab58c5c8c0"
-	"prow_job_run_id":  uintRegexp,
-	"prow_job_run_ids": regexp.MustCompile(`^\d+(,\d+)*$`), // comma-separated integers
-	"org":              nameRegexp,
-	"repo":             nameRegexp,
-	"pr_number":        uintRegexp,
-	"feature_gate":     nameRegexp,
-	"file":             nameRegexp,
-	"repo_info":        nameRegexp,
-	"pull_number":      uintRegexp,
-	"sort":             wordRegexp,
-	"sortField":        wordRegexp,
-	"start_date":       dateRegexp, // YYYY-MM-DD format
-	"end_date":         dateRegexp, // YYYY-MM-DD format
-	"include_success":  boolRegexp, // true or false
+	"release":           regexp.MustCompile(`^[\w.-]+$`), // usually 4.x or Presubmit, but allow any "word"
+	"period":            wordRegexp,
+	"stream":            wordRegexp,
+	"arch":              wordRegexp,
+	"payload":           nameRegexp,
+	"fromPayload":       nameRegexp,
+	"toPayload":         nameRegexp,
+	"job":               nameRegexp,
+	"job_name":          nameRegexp,
+	"test":              regexp.MustCompile(`^.+$`),        // tests can be anything, so always parameterize in sql
+	"test_id":           regexp.MustCompile(`^[\w:. -]+$`), // test IDs like "openshift-tests-upgrade:af8a62c596e5c2b5448a5d308f4989a6" or "cluster install:0cb1bb27e418491b1ffdacab58c5c8c0"
+	"prow_job_run_id":   uintRegexp,
+	"prow_job_run_ids":  regexp.MustCompile(`^\d+(,\d+)*$`), // comma-separated integers
+	"org":               nameRegexp,
+	"repo":              nameRegexp,
+	"pr_number":         uintRegexp,
+	"feature_gate":      nameRegexp,
+	"file":              nameRegexp,
+	"repo_info":         nameRegexp,
+	"pull_number":       uintRegexp,
+	"sort":              wordRegexp,
+	"sortField":         wordRegexp,
+	"start_date":        dateRegexp, // YYYY-MM-DD format
+	"end_date":          dateRegexp, // YYYY-MM-DD format
+	"include_success":   boolRegexp, // true or false
+	"useCurrentRelease": boolRegexp, // true or false
 	// component readiness params
 	"baseRelease":      releaseRegexp,
 	"sampleRelease":    releaseRegexp,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `useCurrentRelease` query parameter.
  * The parameter accepts case-sensitive boolean values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->