### PR TITLE
NO-JIRA: Pin Go IDE tools so @latest cannot break Go 1.25 setups

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -59,7 +59,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 
 
 USER vscode
 
-RUN go install gotest.tools/gotestsum@latest
+RUN go install gotest.tools/gotestsum@v1.13.0
 
 # Cursor's install script calls base64 -D (macOS flag) but GNU coreutils uses -d
 RUN sudo cp /usr/bin/base64 /usr/bin/base64.gnu && \

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,8 +3,8 @@ set -eu
 
 echo "==> Installing Go IDE tools..."
 go install golang.org/x/tools/gopls@v0.21.1
-go install github.com/go-delve/delve/cmd/dlv@latest
-go install honnef.co/go/tools/cmd/staticcheck@latest
+go install github.com/go-delve/delve/cmd/dlv@v1.27.1
+go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
 
 echo "==> Downloading Go module dependencies..."
 go mod download


### PR DESCRIPTION
staticcheck v0.8.0 now requires Go 1.26; pin it to v0.7.0 and pin dlv and gotestsum as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned development tooling to specific versions for more consistent development environments.
  * Standardized versions for test reporting, debugging, and static analysis tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->