### PR TITLE
TRT-2733: Add CR BigQuery/PostgreSQL parity tooling

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,116 @@
+# Scripts
+
+This directory holds operational and developer scripts for Sippy. Most scripts
+are self-documenting through `--help` or inline comments. This README documents
+the Component Readiness (CR) BigQuery/PostgreSQL parity tooling in detail.
+
+## Component Readiness BQ/PG parity
+
+Component Readiness can be served from two data providers, selected per request
+via the `dataSource` query parameter (`bigquery` or `postgres`). These two
+scripts measure and diagnose differences between the providers so the PostgreSQL
+implementation can reach parity with BigQuery.
+
+The scripts talk to a running Sippy API (staging or prod). They do not require
+direct database access, though `cr-parity-check.py` can optionally probe a
+Postgres DSN for more precise date resolution.
+
+### `cr-parity-check.py`: measure parity
+
+Runs a distributed sample of CR API configurations against both providers and
+reports factual differences without attributing causes:
+
+* grid status-pair mismatches per component/variant cell,
+* `regressed_tests` differences per cell (BQ-only, PG-only, and shared tests
+  with a different regression severity),
+* response times for each provider.
+
+```
+# Compare providers on prod for release 5.0, named views only, JSON output
+python scripts/cr-parity-check.py \
+    --server https://sippy.dptools.openshift.org \
+    --releases 5.0 --scenarios views --json > parity.json
+
+# Human-readable tables with per-cell mismatch detail
+python scripts/cr-parity-check.py --releases 5.0 --scenarios views --verbose
+```
+
+Useful options:
+
+* `--server`: Sippy API base URL (defaults to staging).
+* `--releases`: comma-separated releases (e.g. `5.0,4.22`).
+* `--scenarios`: `views,cross-variant,filtered,date-range,test-details,all`.
+* `--stale-days N`: shift "now" back N days when a database is stale.
+* `--database-dsn`: optional Postgres DSN for precise data-availability probing.
+* `--json`: emit machine-readable output for `cr-parity-analyze.py`.
+
+Force refresh is on by default and should stay on when measuring parity. Cached
+CR results can be up to about 4 hours stale, which produces spurious mismatches;
+`forceRefresh=true` makes both providers compute from the same underlying data.
+Use `--no-force-refresh` only for quick, non-authoritative spot checks.
+
+### `cr-parity-analyze.py`: diagnose mismatches
+
+Takes the `--json` output from `cr-parity-check.py` and drills into the
+`test_details` API for both providers to attribute each mismatch. Grid-level
+cells (component x variant) have no `test_id`, so the script resolves them by
+drilling the grid for both providers, matching tests across them, and picking a
+representative test whose per-test status actually flips (not an arbitrary first
+test).
+
+For each cell it reports every contributing factor (a cell often has more than
+one):
+
+* `job_scope`: BQ-only jobs not in `config/openshift.yaml` (TRT-2861).
+* `ingestion_gap_bq`: job is in config, BQ has runs, PG has none (for example
+  the ROSA HCP release-variant assignment, TRT-2912).
+* `ingestion_gap_pg`: PG has runs, BQ has none.
+* `run_count_divergence`: shared jobs with different run totals, with the net
+  BQ-PG direction (the dedup difference tracked in TRT-2804).
+* `outcome_divergence`: same total runs, different pass/fail/flake counts.
+* `pg_capability_empty`: PG returns no capability/test rows for a component that
+  BQ populates (TRT-2911).
+
+```
+python scripts/cr-parity-analyze.py parity.json \
+    --config config/openshift.yaml --max-mismatches 15 --verbose
+```
+
+Useful options:
+
+* `--config`: path to `config/openshift.yaml` (defaults to the repo path).
+* `--max-mismatches`: cells analyzed per scenario (default 10).
+* `--server`: overrides the server inferred from the input JSON.
+* `--json`: emit machine-readable analysis output.
+
+### Typical workflow
+
+```
+python scripts/cr-parity-check.py \
+    --server https://sippy.dptools.openshift.org \
+    --releases 5.0 --scenarios views --json > parity.json
+
+python scripts/cr-parity-analyze.py parity.json \
+    --config config/openshift.yaml --verbose
+```
+
+The analyzer's grid drill-downs run with force refresh (inherited from the check
+URLs), so a full run can take several minutes per scenario.
+
+### Requirements
+
+Both scripts use only the Python standard library, except that
+`cr-parity-analyze.py` uses PyYAML to parse `config/openshift.yaml`. If PyYAML
+is not installed it falls back to a built-in line parser. Install dependencies
+with:
+
+```
+pip install -r scripts/requirements.txt
+```
+
+### Known parity gaps
+
+Findings from these tools are tracked under epic TRT-2733 (Enable PostgreSQL for
+Component Readiness): TRT-2861 (job scope, verified minor on active releases),
+TRT-2804 (dedup run-count divergence), TRT-2911 (PG component drill-down returns
+no capability/test rows), and TRT-2912 (ROSA HCP release-variant assignment).

--- a/scripts/cr-parity-analyze.py
+++ b/scripts/cr-parity-analyze.py
@@ -1,0 +1,944 @@
+#!/usr/bin/env python3
+"""
+CR Parity Analyze: Investigate the root cause of BQ/PG parity mismatches.
+
+Takes JSON output from cr-parity-check.py and drills into the test_details
+API to compare per-job run lists between providers. Cross-references job
+names against config/openshift.yaml and reports every contributing factor
+per cell (a cell often has more than one):
+  - job_scope           BQ-only jobs not in config (TRT-2861)
+  - ingestion_gap_bq    job in config, BQ has runs, PG none (e.g. ROSA, TRT-2912)
+  - ingestion_gap_pg    PG has runs, BQ none
+  - run_count_divergence shared jobs, different totals (dedup, TRT-2804);
+                        net direction (BQ-PG) is reported
+  - outcome_divergence  same total runs, different pass/fail/flake
+  - pg_capability_empty PG returns no capability/test rows for a component
+                        that BQ populates (TRT-2911)
+
+Grid-level mismatches (component x variant cells) have no test_id. This
+script resolves test_ids by drilling into the CR grid for BOTH providers,
+matching tests across them, and picking a representative test that actually
+reflects the cell's status flip (rather than an arbitrary first test).
+
+Usage:
+    python scripts/cr-parity-check.py --json 2>/dev/null > parity.json
+    python scripts/cr-parity-analyze.py parity.json
+
+Examples:
+    # Analyze up to 5 mismatches per scenario
+    python scripts/cr-parity-analyze.py parity.json --max-mismatches 5
+
+    # Use a different config file
+    python scripts/cr-parity-analyze.py parity.json --config path/to/openshift.yaml
+
+    # Verbose: show individual job run details
+    python scripts/cr-parity-analyze.py parity.json --verbose
+
+    # JSON output
+    python scripts/cr-parity-analyze.py parity.json --json
+"""
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+
+DEFAULT_SERVER = "https://sippy-staging.dptools.openshift.org"
+DEFAULT_CONFIG = "config/openshift.yaml"
+DEFAULT_TIMEOUT = 120
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Analyze root causes of BQ/PG parity mismatches"
+    )
+    p.add_argument(
+        "input_file",
+        help="JSON output from cr-parity-check.py --json",
+    )
+    p.add_argument(
+        "--server",
+        help="Sippy server URL (default: inferred from input JSON)",
+    )
+    p.add_argument(
+        "--config",
+        default=DEFAULT_CONFIG,
+        help=f"Path to config/openshift.yaml (default: {DEFAULT_CONFIG})",
+    )
+    p.add_argument(
+        "--max-mismatches",
+        type=int,
+        default=10,
+        help="Max mismatches to analyze per scenario (default: 10)",
+    )
+    p.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help=f"HTTP request timeout in seconds (default: {DEFAULT_TIMEOUT})",
+    )
+    p.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show per-job run details for each mismatch",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Output results as JSON",
+    )
+    return p.parse_args()
+
+
+def log(msg, args, **kwargs):
+    dest = sys.stderr if args.json else sys.stdout
+    print(msg, file=dest, **kwargs)
+
+
+def load_config_jobs(config_path):
+    """Parse config/openshift.yaml and extract the job set per release.
+
+    Uses a simple line-by-line parser that handles the flat
+    'job-name: true' structure under each release's jobs: block.
+    """
+    jobs_by_release = {}
+    try:
+        import yaml
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+        for release, rdata in config.get("releases", {}).items():
+            jobs_by_release[str(release)] = set(rdata.get("jobs", {}).keys())
+        return jobs_by_release
+    except ImportError:
+        pass
+
+    # Fallback: minimal line parser for the flat jobs map
+    jobs_by_release = {}
+    current_release = None
+    in_jobs = False
+
+    try:
+        with open(config_path) as f:
+            for line in f:
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+
+                indent = len(line) - len(line.lstrip())
+
+                if indent == 4 and stripped.startswith('"') and stripped.endswith('":'):
+                    current_release = stripped.strip('"').rstrip(":")
+                    in_jobs = False
+                    if current_release not in jobs_by_release:
+                        jobs_by_release[current_release] = set()
+                elif indent == 8 and stripped == "jobs:":
+                    in_jobs = True
+                elif indent == 8 and stripped != "jobs:" and not stripped.endswith(": true"):
+                    in_jobs = False
+                elif indent == 12 and in_jobs and current_release:
+                    job_name = stripped.split(":")[0].strip()
+                    jobs_by_release[current_release].add(job_name)
+    except FileNotFoundError:
+        print(f"Warning: config file not found: {config_path}", file=sys.stderr)
+
+    return jobs_by_release
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def fetch_json(url, timeout):
+    """Fetch JSON from a full URL. Returns (data, elapsed, error)."""
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/json")
+    start = time.monotonic()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            elapsed = time.monotonic() - start
+            body = resp.read().decode("utf-8")
+            return json.loads(body), elapsed, None
+    except urllib.error.HTTPError as e:
+        elapsed = time.monotonic() - start
+        body = ""
+        try:
+            body = e.read().decode("utf-8", errors="replace")[:200]
+        except Exception:
+            pass
+        return None, elapsed, f"HTTP {e.code}: {body}"
+    except urllib.error.URLError as e:
+        return None, time.monotonic() - start, f"URL error: {e.reason}"
+    except TimeoutError:
+        return None, time.monotonic() - start, f"Timeout after {timeout}s"
+
+
+def api_get(server, path, params, timeout):
+    """Make a GET request and return (json, elapsed, url, error)."""
+    query_parts = []
+    for key, value in params:
+        encoded_val = urllib.parse.quote(str(value), safe="")
+        query_parts.append(f"{key}={encoded_val}")
+    query_string = "&".join(query_parts)
+
+    url = f"{server.rstrip('/')}{path}"
+    if query_string:
+        url += f"?{query_string}"
+
+    data, elapsed, err = fetch_json(url, timeout)
+    return data, elapsed, url, err
+
+
+# ---------------------------------------------------------------------------
+# URL and variant helpers
+# ---------------------------------------------------------------------------
+
+def add_url_param(url, key, value):
+    """Append a query parameter to a URL."""
+    separator = "&" if "?" in url else "?"
+    encoded_value = urllib.parse.quote(str(value), safe="")
+    return f"{url}{separator}{key}={encoded_value}"
+
+
+def make_variant_key(variants):
+    """Create a hashable key from a variant dict, filtering empty values."""
+    filtered = {k: v for k, v in variants.items() if v != ""}
+    return tuple(sorted(filtered.items()))
+
+
+def extract_view_from_url(url):
+    """Extract the view parameter from a parity check URL."""
+    parsed = urllib.parse.urlparse(url)
+    params = urllib.parse.parse_qs(parsed.query)
+    views = params.get("view", [])
+    return views[0] if views else None
+
+
+def extract_release_from_view(view_name):
+    """Extract the release version from a view name like '5.0-main'."""
+    if not view_name:
+        return None
+    parts = view_name.split("-", 1)
+    return parts[0] if parts else None
+
+
+# ---------------------------------------------------------------------------
+# Test ID resolution for grid-level mismatches
+# ---------------------------------------------------------------------------
+
+def index_cell_tests(data):
+    """Index a component-drilled grid response as vkey -> {test_id: test_info}.
+
+    Each test_info carries the full variant set and per-test status so callers
+    can match tests across providers and pick the one driving a cell's flip.
+    """
+    cols = defaultdict(dict)
+    if not data:
+        return cols
+    for row in data.get("rows", []):
+        for col in row.get("columns", []):
+            vkey = make_variant_key(col.get("variants", {}))
+            for t in col.get("all_tests", []) + col.get("regressed_tests", []):
+                tid = t.get("test_id", "")
+                full_variants = t.get("variants", {})
+                if tid and full_variants:
+                    cols[vkey][tid] = {
+                        "test_id": tid,
+                        "test_name": t.get("test_name", ""),
+                        "capability": t.get("capability", ""),
+                        "full_variants": full_variants,
+                        "status": t.get("status", 0),
+                    }
+    return cols
+
+
+def choose_representative(bq_tests, pg_tests, mismatch):
+    """Pick the test that best explains a cell-level status mismatch.
+
+    Prefers a test present in BOTH providers whose per-test status flip matches
+    the cell's flip; then any shared test whose status differs; then any shared
+    test; then a BQ test matching the cell's BQ status; then any available test.
+    Picking the first test (the old behavior) frequently landed on a test with
+    no sample data, mis-attributing the cause.
+    """
+    cell_bq = mismatch.get("bq_status")
+    cell_pg = mismatch.get("pg_status")
+    shared = set(bq_tests) & set(pg_tests)
+
+    for tid in shared:
+        if bq_tests[tid]["status"] == cell_bq and pg_tests[tid]["status"] == cell_pg:
+            return bq_tests[tid]
+    for tid in shared:
+        if bq_tests[tid]["status"] != pg_tests[tid]["status"]:
+            return bq_tests[tid]
+    if shared:
+        return bq_tests[next(iter(shared))]
+    for t in bq_tests.values():
+        if t["status"] == cell_bq:
+            return t
+    if bq_tests:
+        return next(iter(bq_tests.values()))
+    if pg_tests:
+        return next(iter(pg_tests.values()))
+    return None
+
+
+def resolve_test_ids(scenario_result, mismatches, timeout, args):
+    """Drill into the CR grid (BOTH providers) to find test_ids for cell mismatches.
+
+    Grid-level mismatches have empty test_id because they represent aggregated
+    component x variant cells. This drills each component in BQ and PG, matches
+    tests across providers, and picks a representative test that actually
+    reflects the cell's status flip. When PG returns no capability/test rows for
+    a component that BQ populates, the cell is flagged pg_drill_empty (TRT-2911).
+    """
+    bq_url = scenario_result.get("bq_url", "")
+    pg_url = scenario_result.get("pg_url", "")
+    if not bq_url:
+        return
+
+    by_component = defaultdict(list)
+    for m in mismatches:
+        if not m.get("test_id"):
+            by_component[m["component"]].append(m)
+
+    if not by_component:
+        return
+
+    for component, comp_mismatches in by_component.items():
+        bq_drill = add_url_param(add_url_param(bq_url, "component", component), "includeAllTests", "true")
+        pg_drill = ""
+        if pg_url:
+            pg_drill = add_url_param(add_url_param(pg_url, "component", component), "includeAllTests", "true")
+
+        short_name = component.split(" / ")[-1] if " / " in component else component
+        log(f"    Resolving tests for {short_name}...", args, end="", flush=True)
+
+        bq_data, elapsed, err = fetch_json(bq_drill, timeout)
+        if err or not bq_data:
+            log(f" error: {err}", args)
+            continue
+
+        pg_data = None
+        if pg_drill:
+            pg_data, _, _ = fetch_json(pg_drill, timeout)
+
+        bq_cols = index_cell_tests(bq_data)
+        pg_cols = index_cell_tests(pg_data) if pg_data is not None else {}
+
+        resolved = 0
+        pg_empty = 0
+        for m in comp_mismatches:
+            vkey = make_variant_key(m.get("variants", {}))
+            bq_tests = bq_cols.get(vkey, {})
+            pg_tests = pg_cols.get(vkey, {})
+
+            # PG returns no capability/test rows where BQ does (TRT-2911)
+            if pg_data is not None and bq_tests and not pg_tests:
+                m["pg_drill_empty"] = True
+                pg_empty += 1
+
+            chosen = choose_representative(bq_tests, pg_tests, m)
+            if chosen:
+                m["resolved_test_id"] = chosen["test_id"]
+                m["resolved_test_name"] = chosen["test_name"]
+                m["resolved_variants"] = chosen["full_variants"]
+                if chosen.get("capability"):
+                    m["resolved_capability"] = chosen["capability"]
+                resolved += 1
+
+        suffix = f" [{pg_empty} PG-empty]" if pg_empty else ""
+        log(f" {resolved}/{len(comp_mismatches)} resolved{suffix} ({elapsed:.1f}s)", args)
+
+
+# ---------------------------------------------------------------------------
+# Test details analysis
+# ---------------------------------------------------------------------------
+
+def build_test_details_params(mismatch, view_name):
+    """Build query params for a test_details request from a mismatch entry.
+
+    The test_details endpoint requires ALL dbGroupBy variant dimensions
+    as query params (e.g., Architecture, FeatureSet, Installer, etc.).
+    Uses resolved_variants (full set from grid drill-down) when available,
+    falling back to the mismatch's column-level variants.
+    """
+    params = []
+    if view_name:
+        params.append(("view", view_name))
+
+    params.append(("testId", mismatch["test_id"]))
+    params.append(("component", mismatch["component"]))
+    capability = mismatch.get("resolved_capability") or mismatch.get("capability")
+    if capability:
+        params.append(("capability", capability))
+
+    variants = mismatch.get("resolved_variants") or mismatch.get("variants", {})
+    for key, value in sorted(variants.items()):
+        if value:
+            params.append((key, value))
+
+    return params
+
+
+def extract_job_stats(test_details_data):
+    """Extract per-job sample and base run info from a test_details response."""
+    if not test_details_data:
+        return {}, {}
+
+    analyses = test_details_data.get("analyses", [])
+    if not analyses:
+        return {}, {}
+
+    analysis = analyses[0]
+    sample_jobs = {}
+    base_jobs = {}
+
+    for js in analysis.get("job_stats", []):
+        sample_name = js.get("sample_job_name", "")
+        base_name = js.get("base_job_name", "")
+        sample_stats = js.get("sample_stats", {})
+        base_stats = js.get("base_stats", {})
+
+        sample_runs = (
+            sample_stats.get("success_count", 0)
+            + sample_stats.get("failure_count", 0)
+            + sample_stats.get("flake_count", 0)
+        )
+        base_runs = (
+            base_stats.get("success_count", 0)
+            + base_stats.get("failure_count", 0)
+            + base_stats.get("flake_count", 0)
+        )
+
+        if sample_name and sample_runs > 0:
+            sample_jobs[sample_name] = {
+                "runs": sample_runs,
+                "success": sample_stats.get("success_count", 0),
+                "failure": sample_stats.get("failure_count", 0),
+                "flake": sample_stats.get("flake_count", 0),
+            }
+        if base_name and base_runs > 0:
+            base_jobs[base_name] = {
+                "runs": base_runs,
+                "success": base_stats.get("success_count", 0),
+                "failure": base_stats.get("failure_count", 0),
+                "flake": base_stats.get("flake_count", 0),
+            }
+
+    return sample_jobs, base_jobs
+
+
+def analyze_mismatch(server, mismatch, view_name, config_jobs, release, timeout):
+    """Analyze a single mismatch by comparing test_details job lists."""
+    params = build_test_details_params(mismatch, view_name)
+
+    bq_params = params + [("dataSource", "bigquery")]
+    bq_data, bq_time, _, bq_err = api_get(
+        server, "/api/component_readiness/test_details", bq_params, timeout
+    )
+
+    pg_params = params + [("dataSource", "postgres")]
+    pg_data, pg_time, _, pg_err = api_get(
+        server, "/api/component_readiness/test_details", pg_params, timeout
+    )
+
+    result = {
+        "test_id": mismatch["test_id"],
+        "component": mismatch["component"],
+        "capability": mismatch.get("capability", ""),
+        "variants": mismatch.get("variants", {}),
+        "bq_status": mismatch["bq_status"],
+        "pg_status": mismatch["pg_status"],
+        "bq_status_name": mismatch["bq_status_name"],
+        "pg_status_name": mismatch["pg_status_name"],
+        "bq_time_s": round(bq_time, 2),
+        "pg_time_s": round(pg_time, 2),
+    }
+
+    if mismatch.get("resolved_test_name"):
+        result["resolved_test_name"] = mismatch["resolved_test_name"]
+
+    if bq_err or pg_err:
+        result["error"] = bq_err or pg_err
+        result["cause"] = "error"
+        return result
+
+    bq_sample, bq_base = extract_job_stats(bq_data)
+    pg_sample, pg_base = extract_job_stats(pg_data)
+
+    release_jobs = config_jobs.get(release, set())
+
+    # Analyze sample period job differences
+    sample_analysis = analyze_job_diff(bq_sample, pg_sample, release_jobs)
+    base_analysis = analyze_job_diff(bq_base, pg_base, release_jobs)
+
+    result["sample"] = sample_analysis
+    result["base"] = base_analysis
+
+    # A cell can have several contributing factors at once. Report all of them
+    # (result["causes"]) and pick a primary in priority order for summaries.
+    bq_only_not_in_config = (
+        sample_analysis["bq_only_not_in_config_runs"]
+        + base_analysis["bq_only_not_in_config_runs"]
+    )
+    bq_only_in_config = (
+        sample_analysis["bq_only_in_config_runs"]
+        + base_analysis["bq_only_in_config_runs"]
+    )
+    pg_only_runs = sample_analysis["pg_only_runs"] + base_analysis["pg_only_runs"]
+    shared_diff_runs = (
+        sample_analysis["shared_run_diff"] + base_analysis["shared_run_diff"]
+    )
+    content_diff = (
+        len(sample_analysis["shared_content_divergent"])
+        + len(base_analysis["shared_content_divergent"])
+    )
+    net_diff = sample_analysis["net_run_diff"] + base_analysis["net_run_diff"]
+
+    result["net_run_diff"] = net_diff
+    result["run_diff_direction"] = (
+        "BQ>PG" if net_diff > 0 else ("PG>BQ" if net_diff < 0 else "even")
+    )
+
+    causes = []
+    if mismatch.get("pg_drill_empty"):
+        # PG has no capability/test rows for this component; the representative
+        # test is BQ-only by construction, so job-diff factors would be noise.
+        causes = ["pg_capability_empty"]
+    else:
+        if bq_only_not_in_config > 0:
+            causes.append("job_scope")
+        if bq_only_in_config > 0:
+            causes.append("ingestion_gap_bq")
+        if pg_only_runs > 0:
+            causes.append("ingestion_gap_pg")
+        if shared_diff_runs > 0:
+            causes.append("run_count_divergence")
+        if content_diff > 0:
+            causes.append("outcome_divergence")
+        if not causes:
+            if not bq_sample and not pg_sample and not bq_base and not pg_base:
+                causes.append("no_job_stats")
+            else:
+                causes.append("unknown")
+
+    result["causes"] = causes
+    result["cause"] = causes[0]
+
+    return result
+
+
+def analyze_job_diff(bq_jobs, pg_jobs, config_jobs):
+    """Compare job sets between BQ and PG, cross-reference against config."""
+    bq_names = set(bq_jobs.keys())
+    pg_names = set(pg_jobs.keys())
+
+    bq_only = bq_names - pg_names
+    pg_only = pg_names - bq_names
+    shared = bq_names & pg_names
+
+    bq_only_in_config = []
+    bq_only_not_in_config = []
+    for name in sorted(bq_only):
+        entry = {"name": name, **bq_jobs[name]}
+        if name in config_jobs:
+            entry["in_config"] = True
+            bq_only_in_config.append(entry)
+        else:
+            entry["in_config"] = False
+            bq_only_not_in_config.append(entry)
+
+    pg_only_list = [{"name": name, **pg_jobs[name]} for name in sorted(pg_only)]
+
+    shared_divergent = []          # total run count differs
+    shared_content_divergent = []  # same total, different success/failure/flake
+    shared_run_diff = 0            # absolute magnitude
+    net_run_diff = 0              # signed (BQ - PG): direction of the divergence
+    for name in sorted(shared):
+        b = bq_jobs[name]
+        p = pg_jobs[name]
+        bq_runs = b["runs"]
+        pg_runs = p["runs"]
+        if bq_runs != pg_runs:
+            shared_divergent.append({
+                "name": name,
+                "bq_runs": bq_runs,
+                "pg_runs": pg_runs,
+                "diff": bq_runs - pg_runs,
+                "bq_success": b["success"], "pg_success": p["success"],
+                "bq_failure": b["failure"], "pg_failure": p["failure"],
+                "bq_flake": b["flake"], "pg_flake": p["flake"],
+            })
+            shared_run_diff += abs(bq_runs - pg_runs)
+            net_run_diff += bq_runs - pg_runs
+        elif (b["success"], b["failure"], b["flake"]) != (p["success"], p["failure"], p["flake"]):
+            shared_content_divergent.append({
+                "name": name,
+                "runs": bq_runs,
+                "bq_success": b["success"], "pg_success": p["success"],
+                "bq_failure": b["failure"], "pg_failure": p["failure"],
+                "bq_flake": b["flake"], "pg_flake": p["flake"],
+            })
+
+    return {
+        "bq_only_not_in_config": bq_only_not_in_config,
+        "bq_only_not_in_config_runs": sum(j["runs"] for j in bq_only_not_in_config),
+        "bq_only_in_config": bq_only_in_config,
+        "bq_only_in_config_runs": sum(j["runs"] for j in bq_only_in_config),
+        "pg_only": pg_only_list,
+        "pg_only_runs": sum(j["runs"] for j in pg_only_list),
+        "shared_divergent": shared_divergent,
+        "shared_run_diff": shared_run_diff,
+        "net_run_diff": net_run_diff,
+        "shared_content_divergent": shared_content_divergent,
+        "bq_job_count": len(bq_names),
+        "pg_job_count": len(pg_names),
+        "shared_job_count": len(shared),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+CAUSE_LABELS = {
+    "pg_capability_empty": "PG drill-down empty (no capability/test rows in PG)",
+    "job_scope": "Job scope (BQ-only jobs not in config)",
+    "job_scope_primary": "Job scope (primary) + other factors",
+    "ingestion_gap": "Ingestion gap (job in config but missing from one provider)",
+    "ingestion_gap_bq": "Ingestion gap (job in config, BQ has runs, PG none)",
+    "ingestion_gap_pg": "Ingestion gap (PG has runs, BQ none)",
+    "run_count_divergence": "Run count divergence (shared jobs, different counts)",
+    "outcome_divergence": "Outcome divergence (same runs, different pass/fail/flake)",
+    "no_job_stats": "No job stats available",
+    "no_test_id": "Could not resolve test ID from grid",
+    "unknown": "Unknown",
+    "error": "API error",
+}
+
+
+def print_table_results(scenario_analyses, verbose):
+    """Print analysis results as formatted tables."""
+    line_width = 100
+
+    print(f"\n{'=' * line_width}")
+    print("CR PARITY GAP ANALYSIS")
+    print(f"{'=' * line_width}")
+    print()
+
+    overall_causes = defaultdict(int)
+    overall_factors = defaultdict(int)
+    net_direction = {"BQ>PG": 0, "PG>BQ": 0, "even": 0}
+    overall_bq_only_not_in_config_jobs = defaultdict(lambda: {"mismatches": 0, "runs": 0})
+
+    for scenario in scenario_analyses:
+        name = scenario["scenario_name"]
+        analyses = scenario["analyses"]
+        total = scenario["total_mismatches"]
+        analyzed = len(analyses)
+
+        print(f"ANALYSIS: {name} ({total} mismatches, {analyzed} analyzed)")
+        print(f"{'─' * line_width}")
+
+        cause_counts = defaultdict(int)
+        for a in analyses:
+            cause = a.get("cause", "unknown")
+            cause_counts[cause] += 1
+            overall_causes[cause] += 1
+            for factor in a.get("causes", [cause]):
+                overall_factors[factor] += 1
+            direction = a.get("run_diff_direction")
+            if direction in net_direction:
+                net_direction[direction] += 1
+
+            # Collect BQ-only jobs across all analyses
+            for period in ("sample", "base"):
+                period_data = a.get(period, {})
+                for job in period_data.get("bq_only_not_in_config", []):
+                    key = job["name"]
+                    overall_bq_only_not_in_config_jobs[key]["mismatches"] += 1
+                    overall_bq_only_not_in_config_jobs[key]["runs"] += job["runs"]
+
+        header = f"  {'Cause':<55} {'Count':>6}"
+        print(header)
+        print(f"  {'─' * 62}")
+        for cause, count in sorted(cause_counts.items(), key=lambda x: -x[1]):
+            label = CAUSE_LABELS.get(cause, cause)
+            print(f"  {label:<55} {count:>6}")
+        print()
+
+        if verbose:
+            for a in analyses:
+                comp_cap = a["component"]
+                if a.get("capability"):
+                    comp_cap += f"/{a['capability']}"
+                print(f"  {comp_cap}")
+
+                if a.get("resolved_test_name"):
+                    print(f"    Representative test: {a['resolved_test_name']}")
+
+                variants_str = ", ".join(
+                    f"{k}={v}" for k, v in sorted(a.get("variants", {}).items())
+                )
+                if variants_str:
+                    print(f"    Variants: {variants_str}")
+                factors = a.get("causes", [a.get("cause", "unknown")])
+                factor_str = ", ".join(CAUSE_LABELS.get(f, f) for f in factors)
+                print(
+                    f"    Status: BQ={a['bq_status_name']} PG={a['pg_status_name']}  "
+                    f"Factors: {factor_str}"
+                )
+                if a.get("net_run_diff"):
+                    print(
+                        f"    Run-count net (BQ-PG): {a['net_run_diff']:+d} "
+                        f"({a.get('run_diff_direction', '')})"
+                    )
+
+                for period in ("sample", "base"):
+                    pd = a.get(period, {})
+                    if not pd:
+                        continue
+                    bq_only_nc = pd.get("bq_only_not_in_config", [])
+                    bq_only_ic = pd.get("bq_only_in_config", [])
+                    pg_only = pd.get("pg_only", [])
+                    shared_div = pd.get("shared_divergent", [])
+                    content_div = pd.get("shared_content_divergent", [])
+
+                    if bq_only_nc or bq_only_ic or pg_only or shared_div or content_div:
+                        print(f"    {period.title()} period:")
+                        print(
+                            f"      Jobs: BQ={pd['bq_job_count']} PG={pd['pg_job_count']} "
+                            f"shared={pd['shared_job_count']}"
+                        )
+                    for j in bq_only_nc:
+                        print(
+                            f"      BQ-only (NOT in config): {j['name']} "
+                            f"({j['runs']} runs)"
+                        )
+                    for j in bq_only_ic:
+                        print(
+                            f"      BQ-only (IN config): {j['name']} "
+                            f"({j['runs']} runs)"
+                        )
+                    for j in pg_only:
+                        print(
+                            f"      PG-only: {j['name']} ({j['runs']} runs)"
+                        )
+                    for j in shared_div:
+                        print(
+                            f"      Shared divergent: {j['name']} "
+                            f"(BQ={j['bq_runs']} PG={j['pg_runs']} diff={j['diff']:+d})"
+                        )
+                    for j in content_div:
+                        print(
+                            f"      Same runs, diff outcome: {j['name']} "
+                            f"(runs={j['runs']} BQ s/f/fl={j['bq_success']}/{j['bq_failure']}/{j['bq_flake']} "
+                            f"PG s/f/fl={j['pg_success']}/{j['pg_failure']}/{j['pg_flake']})"
+                        )
+                print()
+
+    # Overall summary
+    total_analyzed = sum(overall_causes.values())
+    if total_analyzed > 0:
+        print(f"{'=' * line_width}")
+        print("OVERALL SUMMARY")
+        print(f"{'─' * line_width}")
+        header = f"  {'Cause':<55} {'Count':>6} {'%':>6}"
+        print(header)
+        print(f"  {'─' * 68}")
+        for cause, count in sorted(overall_causes.items(), key=lambda x: -x[1]):
+            label = CAUSE_LABELS.get(cause, cause)
+            pct = count / total_analyzed * 100
+            print(f"  {label:<55} {count:>6} {pct:>5.0f}%")
+        print(f"  {'─' * 68}")
+        print(f"  {'Total analyzed (by primary cause)':<55} {total_analyzed:>6}")
+        print()
+
+        # A cell often has more than one contributing factor; the primary-cause
+        # table above counts each cell once, so it can understate factors that
+        # co-occur (e.g. run-count divergence alongside an ingestion gap).
+        print("CONTRIBUTING FACTORS (co-occurring; a cell may count in several)")
+        print(f"{'─' * line_width}")
+        for factor, count in sorted(overall_factors.items(), key=lambda x: -x[1]):
+            label = CAUSE_LABELS.get(factor, factor)
+            pct = count / total_analyzed * 100
+            print(f"  {label:<55} {count:>6} {pct:>5.0f}%")
+        print()
+
+        directional = sum(net_direction.values())
+        if directional:
+            print("RUN-COUNT DIVERGENCE DIRECTION (net BQ-PG per cell)")
+            print(f"{'─' * line_width}")
+            print(f"  {'BQ has more runs':<55} {net_direction['BQ>PG']:>6}")
+            print(f"  {'PG has more runs':<55} {net_direction['PG>BQ']:>6}")
+            print(f"  {'even':<55} {net_direction['even']:>6}")
+            print()
+
+    # Top BQ-only jobs not in config
+    if overall_bq_only_not_in_config_jobs:
+        print("BQ-ONLY JOBS (not in config/openshift.yaml)")
+        print(f"{'─' * line_width}")
+        header = f"  {'Job Name':<65} {'Mismatches':>10} {'Runs':>8}"
+        print(header)
+        print(f"  {'─' * 84}")
+        for name, data in sorted(
+            overall_bq_only_not_in_config_jobs.items(),
+            key=lambda x: -x[1]["mismatches"],
+        )[:20]:
+            display_name = name if len(name) <= 64 else name[:61] + "..."
+            print(f"  {display_name:<65} {data['mismatches']:>10} {data['runs']:>8}")
+        if len(overall_bq_only_not_in_config_jobs) > 20:
+            print(f"  ... and {len(overall_bq_only_not_in_config_jobs) - 20} more")
+        print()
+
+
+def print_json_output(scenario_analyses):
+    output = {
+        "scenario_analyses": scenario_analyses,
+    }
+    print(json.dumps(output, indent=2, default=str))
+
+
+def main():
+    args = parse_args()
+
+    with open(args.input_file) as f:
+        parity_data = json.load(f)
+
+    results = parity_data.get("results", [])
+    if not results:
+        log("No results found in input file.", args)
+        sys.exit(1)
+
+    # Infer server from input data
+    server = args.server
+    if not server:
+        for r in results:
+            url = r.get("bq_url", "")
+            if url:
+                parsed = urllib.parse.urlparse(url)
+                server = f"{parsed.scheme}://{parsed.netloc}"
+                break
+    if not server:
+        server = DEFAULT_SERVER
+
+    log(f"CR Parity Gap Analysis", args)
+    log(f"Input: {args.input_file}", args)
+    log(f"Server: {server}", args)
+    log(f"Config: {args.config}", args)
+    log(f"Max mismatches per scenario: {args.max_mismatches}", args)
+    log("", args)
+
+    # Load config jobs
+    config_jobs = load_config_jobs(args.config)
+    total_config_jobs = sum(len(v) for v in config_jobs.values())
+    log(f"Loaded {total_config_jobs} jobs across {len(config_jobs)} releases from config", args)
+    log("", args)
+
+    # Find scenarios with mismatches
+    cr_results = [
+        r for r in results
+        if r["endpoint"] == "/api/component_readiness"
+        and r.get("comparison")
+        and r["comparison"].get("mismatch_details")
+    ]
+
+    if not cr_results:
+        log("No mismatches found to analyze.", args)
+        sys.exit(0)
+
+    total_mismatches = sum(
+        len(r["comparison"]["mismatch_details"]) for r in cr_results
+    )
+    log(f"Found {len(cr_results)} scenarios with {total_mismatches} total mismatches", args)
+    log("", args)
+
+    scenario_analyses = []
+
+    for r in cr_results:
+        name = r["name"]
+        mismatches = r["comparison"]["mismatch_details"]
+        view_name = extract_view_from_url(r.get("bq_url", ""))
+        release = extract_release_from_view(view_name)
+
+        to_analyze = mismatches[: args.max_mismatches]
+
+        log(f"Analyzing {name} ({len(to_analyze)}/{len(mismatches)} mismatches)...", args)
+
+        # Resolve test_ids for grid-level mismatches (empty test_id)
+        grid_level = [m for m in to_analyze if not m.get("test_id")]
+        if grid_level:
+            log(f"  Resolving test IDs for {len(grid_level)} grid-level mismatches...", args)
+            resolve_test_ids(r, grid_level, args.timeout, args)
+
+        log(f"  Fetching test details...", args)
+        analyses = []
+        for i, mismatch in enumerate(to_analyze):
+            test_id = mismatch.get("resolved_test_id") or mismatch.get("test_id")
+
+            label = mismatch["component"]
+            if mismatch.get("capability"):
+                label += f"/{mismatch['capability']}"
+            log(
+                f"    [{i + 1}/{len(to_analyze)}] {label}...",
+                args,
+                end="",
+                flush=True,
+            )
+
+            if not test_id:
+                log(f" could not resolve test ID", args)
+                analyses.append({
+                    "component": mismatch["component"],
+                    "capability": mismatch.get("capability", ""),
+                    "variants": mismatch.get("variants", {}),
+                    "bq_status": mismatch["bq_status"],
+                    "pg_status": mismatch["pg_status"],
+                    "bq_status_name": mismatch["bq_status_name"],
+                    "pg_status_name": mismatch["pg_status_name"],
+                    "cause": "no_test_id",
+                })
+                continue
+
+            mismatch_for_analysis = dict(mismatch)
+            mismatch_for_analysis["test_id"] = test_id
+            if mismatch.get("resolved_variants"):
+                mismatch_for_analysis["resolved_variants"] = mismatch["resolved_variants"]
+            if mismatch.get("resolved_capability"):
+                mismatch_for_analysis["resolved_capability"] = mismatch["resolved_capability"]
+
+            analysis = analyze_mismatch(
+                server, mismatch_for_analysis, view_name, config_jobs, release, args.timeout
+            )
+
+            if mismatch.get("resolved_test_id"):
+                analysis["resolved_test_id"] = mismatch["resolved_test_id"]
+            if mismatch.get("resolved_test_name"):
+                analysis["resolved_test_name"] = mismatch["resolved_test_name"]
+
+            analyses.append(analysis)
+
+            cause = analysis.get("cause", "unknown")
+            log(f" {CAUSE_LABELS.get(cause, cause)}", args)
+
+        scenario_analyses.append({
+            "scenario_name": name,
+            "total_mismatches": len(mismatches),
+            "analyzed_count": len(analyses),
+            "analyses": analyses,
+        })
+
+    log("", args)
+
+    if args.json:
+        print_json_output(scenario_analyses)
+    else:
+        print_table_results(scenario_analyses, args.verbose)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cr-parity-check.py
+++ b/scripts/cr-parity-check.py
@@ -1,0 +1,1209 @@
+#!/usr/bin/env python3
+"""
+CR Parity Check: Compare BigQuery and Postgres providers for Component Readiness reports.
+
+Runs a well-distributed sampling of CR API configurations against both data sources,
+comparing response times and result parity. Reports factual status-pair mismatches
+without attributing causes. Use cr-parity-analyze.py on the JSON output to investigate
+the root cause of mismatches against the actual data.
+
+Usage:
+    python scripts/cr-parity-check.py [options]
+
+Examples:
+    # Run against staging with default settings
+    python scripts/cr-parity-check.py --stale-days 5
+
+    # Run with DB probing for accurate date detection
+    python scripts/cr-parity-check.py --database-dsn "$(cat ~/Documents/sippy-postgres/staging.dsn)"
+
+    # Run against a local server, specific scenarios only
+    python scripts/cr-parity-check.py --server http://localhost:9090 --scenarios views,cross-variant
+
+    # JSON output for downstream analysis
+    python scripts/cr-parity-check.py --json 2>/dev/null > parity.json
+    python scripts/cr-parity-analyze.py parity.json
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+DEFAULT_SERVER = "https://sippy-staging.dptools.openshift.org"
+DEFAULT_RELEASES = "5.0,4.22"
+DEFAULT_TIMEOUT = 120
+
+STATUS_NAMES = {
+    -1000: "FailedFixedRegression",
+    -500: "ExtremeRegression",
+    -400: "SignificantRegression",
+    -300: "ExtremeTriagedRegression",
+    -200: "SignificantTriagedRegression",
+    -150: "FixedRegression",
+    -100: "MissingSample",
+    0: "NotSignificant",
+    100: "MissingBasis",
+    200: "MissingBasisAndSample",
+    300: "SignificantImprovement",
+}
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Compare BQ and PG providers for Component Readiness reports"
+    )
+    p.add_argument(
+        "--server",
+        default=DEFAULT_SERVER,
+        help=f"Sippy server URL (default: {DEFAULT_SERVER})",
+    )
+    p.add_argument(
+        "--database-dsn",
+        help="Optional PG DSN for data availability probing",
+    )
+    p.add_argument(
+        "--releases",
+        default=DEFAULT_RELEASES,
+        help=f"Comma-separated releases to test (default: {DEFAULT_RELEASES})",
+    )
+    p.add_argument(
+        "--stale-days",
+        type=int,
+        default=0,
+        help="Shift 'now' back N days for date calculations on stale DBs (default: 0)",
+    )
+    p.add_argument(
+        "--no-force-refresh",
+        action="store_true",
+        help="Disable forceRefresh (default: forceRefresh=true)",
+    )
+    p.add_argument(
+        "--scenarios",
+        default="all",
+        help="Comma-separated: views,cross-variant,filtered,date-range,test-details,all (default: all)",
+    )
+    p.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show per-row comparison details for mismatches",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Output results as JSON",
+    )
+    p.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help=f"HTTP request timeout in seconds (default: {DEFAULT_TIMEOUT})",
+    )
+    return p.parse_args()
+
+
+def api_get(server, path, params, timeout):
+    """Make a GET request to the Sippy API and return (response_json, elapsed_seconds)."""
+    query_parts = []
+    for key, value in params:
+        encoded_val = urllib.request.quote(str(value), safe="")
+        query_parts.append(f"{key}={encoded_val}")
+    query_string = "&".join(query_parts)
+
+    url = f"{server.rstrip('/')}{path}"
+    if query_string:
+        url += f"?{query_string}"
+
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/json")
+
+    start = time.monotonic()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            elapsed = time.monotonic() - start
+            body = resp.read().decode("utf-8")
+            return json.loads(body), elapsed, url, None
+    except urllib.error.HTTPError as e:
+        elapsed = time.monotonic() - start
+        body = ""
+        try:
+            body = e.read().decode("utf-8", errors="replace")
+        except Exception:
+            pass
+        return None, elapsed, url, f"HTTP {e.code}: {body[:200]}"
+    except urllib.error.URLError as e:
+        elapsed = time.monotonic() - start
+        return None, elapsed, url, f"URL error: {e.reason}"
+    except TimeoutError:
+        elapsed = time.monotonic() - start
+        return None, elapsed, url, f"Timeout after {timeout}s"
+
+
+def probe_date_with_db(dsn, release, date_str):
+    """Check if data exists for a specific release and date using psql."""
+    sql = f"SELECT EXISTS(SELECT 1 FROM test_cumulative_summaries WHERE release = '{release}' AND date = '{date_str}')"
+    try:
+        result = subprocess.run(
+            ["psql", dsn, "-t", "-A", "-c", sql],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.stdout.strip() == "t"
+    except (subprocess.TimeoutExpired, FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+
+def find_latest_date_with_db(dsn, release, max_days_back=90):
+    """Binary search for the most recent date with data for a release."""
+    today = datetime.now(timezone.utc).date()
+
+    lo, hi = 1, max_days_back
+    latest_found = None
+
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        probe_date = today - timedelta(days=mid)
+        exists = probe_date_with_db(dsn, release, probe_date.isoformat())
+        if exists is None:
+            return None
+        if exists:
+            latest_found = probe_date
+            hi = mid - 1
+        else:
+            lo = mid + 1
+
+    if latest_found is None:
+        for days_back in range(1, max_days_back + 1):
+            probe_date = today - timedelta(days=days_back)
+            exists = probe_date_with_db(dsn, release, probe_date.isoformat())
+            if exists is None:
+                return None
+            if exists:
+                return probe_date
+
+    return latest_found
+
+
+def find_latest_date_with_api(server, timeout, stale_days):
+    """Use the views API to get resolved dates and infer data availability."""
+    data, _, _, err = api_get(server, "/api/component_readiness/views", [], timeout)
+    if err or not data:
+        return {}
+
+    available_dates = {}
+    for view in data:
+        sample = view.get("sample_release", {})
+        release = sample.get("release", "")
+        end_str = sample.get("end", "")
+        if release and end_str:
+            try:
+                end_dt = datetime.fromisoformat(end_str.replace("Z", "+00:00"))
+                effective = end_dt.date() - timedelta(days=stale_days)
+                if release not in available_dates or effective > available_dates[release]:
+                    available_dates[release] = effective
+            except (ValueError, TypeError):
+                continue
+    return available_dates
+
+
+def probe_data_availability(args):
+    """Determine the latest date with data for each release."""
+    releases = [r.strip() for r in args.releases.split(",")]
+    available = {}
+
+    if args.database_dsn:
+        log("Probing data availability via database...", args)
+        for release in releases:
+            latest = find_latest_date_with_db(args.database_dsn, release)
+            if latest:
+                available[release] = latest
+                log(f"  {release}: data available through {latest}", args)
+            else:
+                log(f"  {release}: no data found (or psql unavailable)", args)
+    else:
+        if args.stale_days > 0:
+            log(f"Using API views endpoint with --stale-days={args.stale_days} offset...", args)
+        else:
+            log("Using API views endpoint for date resolution (use --database-dsn for precise probing)...", args)
+        available = find_latest_date_with_api(args.server, args.timeout, args.stale_days)
+        for release in releases:
+            if release in available:
+                log(f"  {release}: estimated data through {available[release]}", args)
+            else:
+                log(f"  {release}: not found in views (will use relative dates)", args)
+
+    return available
+
+
+def build_base_params(view_name, force_refresh):
+    """Build the common query parameters for a scenario."""
+    params = [("view", view_name)]
+    if force_refresh:
+        params.append(("forceRefresh", "true"))
+    return params
+
+
+def build_view_scenarios(releases, force_refresh):
+    """Category 1: Named views (standard cross-release)."""
+    scenarios = []
+
+    view_map = {
+        "5.0": [
+            ("5.0-main", "Main grid (5.0)"),
+            ("5.0-rosa", "ROSA filtered (5.0)"),
+            ("5.0-hypershift-candidates", "Hypershift candidates (5.0)"),
+        ],
+        "4.22": [
+            ("4.22-main", "Main grid (4.22)"),
+            ("4.22-rosa", "ROSA filtered (4.22)"),
+            ("4.22-hypershift-candidates", "Hypershift candidates (4.22)"),
+        ],
+    }
+
+    for release in releases:
+        for view_name, label in view_map.get(release, []):
+            params = build_base_params(view_name, force_refresh)
+            scenarios.append({
+                "name": label,
+                "category": "views",
+                "endpoint": "/api/component_readiness",
+                "params": params,
+                "view": view_name,
+            })
+
+    return scenarios
+
+
+def build_cross_variant_scenarios(releases, force_refresh):
+    """Category 2: Cross-variant views."""
+    scenarios = []
+
+    cross_variant_map = {
+        "5.0": [
+            ("5.0-ha-vs-single", "HA vs Single (5.0)", "Topology"),
+            ("5.0-x86-vs-multi-arm", "x86 vs ARM (5.0)", "Architecture"),
+            ("5.0-rhcos10-vs-rhcos9", "RHCOS10 vs RHCOS9 (5.0)", "OS"),
+            ("5.0-ha-vs-two-node-arbiter", "HA vs Two-Node Arbiter (5.0)", "Topology"),
+        ],
+        "4.22": [
+            ("4.22-ha-vs-single", "HA vs Single (4.22)", "Topology"),
+            ("4.22-x86-vs-multi-arm", "x86 vs ARM (4.22)", "Architecture"),
+            ("4.22-ha-vs-two-node-arbiter", "HA vs Two-Node Arbiter (4.22)", "Topology"),
+        ],
+    }
+
+    for release in releases:
+        for view_name, label, cross_key in cross_variant_map.get(release, []):
+            params = build_base_params(view_name, force_refresh)
+            scenarios.append({
+                "name": label,
+                "category": "cross-variant",
+                "endpoint": "/api/component_readiness",
+                "params": params,
+                "view": view_name,
+                "cross_compare_key": cross_key,
+            })
+
+    return scenarios
+
+
+def build_filtered_scenarios(releases, force_refresh):
+    """Category 3: Custom filtered queries using a base view with overrides."""
+    scenarios = []
+
+    base_views = {"5.0": "5.0-main", "4.22": "4.22-main"}
+
+    for release in releases:
+        base_view = base_views.get(release)
+        if not base_view:
+            continue
+
+        # Component filter
+        params = build_base_params(base_view, force_refresh)
+        params.append(("component", "Etcd"))
+        scenarios.append({
+            "name": f"Component:Etcd ({release})",
+            "category": "filtered",
+            "endpoint": "/api/component_readiness",
+            "params": params,
+            "view": base_view,
+        })
+
+        # Single variant filter
+        params = build_base_params(base_view, force_refresh)
+        params.append(("includeVariant", "Platform:aws"))
+        scenarios.append({
+            "name": f"Platform:aws ({release})",
+            "category": "filtered",
+            "endpoint": "/api/component_readiness",
+            "params": params,
+            "view": base_view,
+        })
+
+        # Multi variant filter
+        params = build_base_params(base_view, force_refresh)
+        params.append(("includeVariant", "Platform:aws"))
+        params.append(("includeVariant", "Architecture:amd64"))
+        scenarios.append({
+            "name": f"Platform:aws+Arch:amd64 ({release})",
+            "category": "filtered",
+            "endpoint": "/api/component_readiness",
+            "params": params,
+            "view": base_view,
+        })
+
+        # Column group by Topology
+        params = build_base_params(base_view, force_refresh)
+        params.append(("columnGroupBy", "Topology"))
+        scenarios.append({
+            "name": f"ColGroupBy:Topology ({release})",
+            "category": "filtered",
+            "endpoint": "/api/component_readiness",
+            "params": params,
+            "view": base_view,
+        })
+
+        # Column group by Architecture
+        params = build_base_params(base_view, force_refresh)
+        params.append(("columnGroupBy", "Architecture"))
+        scenarios.append({
+            "name": f"ColGroupBy:Architecture ({release})",
+            "category": "filtered",
+            "endpoint": "/api/component_readiness",
+            "params": params,
+            "view": base_view,
+        })
+
+    return scenarios
+
+
+def build_date_range_scenarios(releases, available_dates, force_refresh):
+    """Category 4: Custom date ranges with different sample window sizes."""
+    scenarios = []
+
+    release_bases = {"5.0": "4.22", "4.22": "4.21"}
+    db_group_by = "Platform,Architecture,Network,Topology,FeatureSet,Upgrade,Suite,Installer,LayeredProduct"
+    column_group_by = "Platform,Architecture,Network"
+
+    for release in releases:
+        latest = available_dates.get(release)
+        base_release = release_bases.get(release)
+        if not latest or not base_release:
+            continue
+
+        for window_days, label in [(7, "7d"), (14, "14d"), (30, "30d")]:
+            sample_end = latest
+            sample_start = sample_end - timedelta(days=window_days)
+
+            params = [
+                ("baseRelease", base_release),
+                ("sampleRelease", release),
+                ("sampleStartTime", datetime.combine(sample_start, datetime.min.time(), tzinfo=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")),
+                ("sampleEndTime", datetime.combine(sample_end, datetime.max.time().replace(microsecond=0), tzinfo=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")),
+                ("dbGroupBy", db_group_by),
+                ("columnGroupBy", column_group_by),
+                ("confidence", "95"),
+                ("pity", "5"),
+                ("minFail", "3"),
+                ("ignoreDisruption", "true"),
+            ]
+            if force_refresh:
+                params.append(("forceRefresh", "true"))
+
+            scenarios.append({
+                "name": f"{release} {label} window ({sample_start} to {sample_end})",
+                "category": "date-range",
+                "endpoint": "/api/component_readiness",
+                "params": params,
+            })
+
+    return scenarios
+
+
+def extract_test_detail_targets(cr_response, view_name, max_targets=3):
+    """Pick test targets from a CR response for test_details drilldown.
+
+    The main CR grid has rows at the component level (no test_id). Individual tests
+    with their full variant sets are found in regressed_tests/all_tests within columns.
+    """
+    if not cr_response or "rows" not in cr_response:
+        return []
+
+    targets = []
+    seen_components = set()
+
+    for row in cr_response.get("rows", []):
+        component = row.get("component", "")
+        if component in seen_components:
+            continue
+
+        for col in row.get("columns", []):
+            # Look in regressed_tests first, then all_tests
+            test_lists = col.get("regressed_tests", []) + col.get("all_tests", [])
+            for test in test_lists:
+                test_id = test.get("test_id", "")
+                if not test_id:
+                    continue
+
+                test_component = test.get("component", component)
+                test_capability = test.get("capability", "")
+                variants = test.get("variants", {})
+                status = test.get("status", col.get("status", 0))
+
+                if not variants:
+                    continue
+
+                targets.append({
+                    "test_id": test_id,
+                    "component": test_component,
+                    "capability": test_capability,
+                    "variants": variants,
+                    "status": status,
+                })
+                seen_components.add(component)
+                break
+
+            if component in seen_components:
+                break
+
+        if len(targets) >= max_targets:
+            break
+
+    return targets
+
+
+def build_test_detail_scenarios(targets, view_name, force_refresh):
+    """Category 5: Test details drilldown from extracted targets."""
+    scenarios = []
+
+    for i, target in enumerate(targets):
+        params = [("view", view_name)]
+        params.append(("testId", target["test_id"]))
+        params.append(("component", target["component"]))
+        if target["capability"]:
+            params.append(("capability", target["capability"]))
+
+        for key, value in sorted(target["variants"].items()):
+            params.append((key, value))
+
+        if force_refresh:
+            params.append(("forceRefresh", "true"))
+
+        status_name = STATUS_NAMES.get(target["status"], str(target["status"]))
+        scenarios.append({
+            "name": f"TestDetails: {target['component']}/{target['capability']} ({status_name})",
+            "category": "test-details",
+            "endpoint": "/api/component_readiness/test_details",
+            "params": params,
+            "view": view_name,
+        })
+
+    return scenarios
+
+
+def make_row_key(row):
+    """Create a hashable key for matching rows across BQ and PG."""
+    return (
+        row.get("component", ""),
+        row.get("capability", ""),
+        row.get("test_name", ""),
+        row.get("test_id", ""),
+    )
+
+
+def make_column_key(col):
+    """Create a hashable key for matching columns within a row."""
+    variants = col.get("variants", {})
+    return tuple(sorted(variants.items()))
+
+
+def normalize_variant_key(col):
+    """Normalize variant maps to handle empty-string vs missing key differences (TRT-2863)."""
+    variants = col.get("variants", {})
+    return {k: v for k, v in variants.items() if v != ""}
+
+
+
+def check_last_failure_match(bq_data, pg_data):
+    """Check whether last_failure timestamps match between BQ and PG test_details."""
+    bq_analyses = bq_data.get("analyses", []) if bq_data else []
+    pg_analyses = pg_data.get("analyses", []) if pg_data else []
+
+    for bq_a, pg_a in zip(bq_analyses, pg_analyses):
+        bq_lf = bq_a.get("last_failure")
+        pg_lf = pg_a.get("last_failure")
+        if bq_lf != pg_lf:
+            return False
+    return True
+
+
+def compare_regressed_tests(bq_col, pg_col):
+    """Compare regressed_tests arrays between BQ and PG for a single cell.
+
+    Returns None if neither provider has regressed tests, otherwise returns
+    a dict with bq_only_tests, pg_only_tests, and status_mismatches.
+    """
+    bq_tests = bq_col.get("regressed_tests") or []
+    pg_tests = pg_col.get("regressed_tests") or []
+
+    if not bq_tests and not pg_tests:
+        return None
+
+    bq_by_id = {}
+    for t in bq_tests:
+        key = t.get("test_id") or t.get("test_name", "")
+        if key:
+            bq_by_id[key] = t
+
+    pg_by_id = {}
+    for t in pg_tests:
+        key = t.get("test_id") or t.get("test_name", "")
+        if key:
+            pg_by_id[key] = t
+
+    bq_only_keys = set(bq_by_id.keys()) - set(pg_by_id.keys())
+    pg_only_keys = set(pg_by_id.keys()) - set(bq_by_id.keys())
+    shared_keys = set(bq_by_id.keys()) & set(pg_by_id.keys())
+
+    bq_only_tests = []
+    for key in sorted(bq_only_keys):
+        t = bq_by_id[key]
+        status = t.get("status", 0)
+        bq_only_tests.append({
+            "test_id": t.get("test_id", ""),
+            "test_name": t.get("test_name", ""),
+            "status": status,
+            "status_name": STATUS_NAMES.get(status, str(status)),
+        })
+
+    pg_only_tests = []
+    for key in sorted(pg_only_keys):
+        t = pg_by_id[key]
+        status = t.get("status", 0)
+        pg_only_tests.append({
+            "test_id": t.get("test_id", ""),
+            "test_name": t.get("test_name", ""),
+            "status": status,
+            "status_name": STATUS_NAMES.get(status, str(status)),
+        })
+
+    status_mismatches = []
+    for key in sorted(shared_keys):
+        bq_t = bq_by_id[key]
+        pg_t = pg_by_id[key]
+        bq_status = bq_t.get("status", 0)
+        pg_status = pg_t.get("status", 0)
+        if bq_status != pg_status:
+            status_mismatches.append({
+                "test_id": bq_t.get("test_id", ""),
+                "test_name": bq_t.get("test_name", ""),
+                "bq_status": bq_status,
+                "pg_status": pg_status,
+                "bq_status_name": STATUS_NAMES.get(bq_status, str(bq_status)),
+                "pg_status_name": STATUS_NAMES.get(pg_status, str(pg_status)),
+            })
+
+    if not bq_only_tests and not pg_only_tests and not status_mismatches:
+        return {"match": True}
+
+    return {
+        "match": False,
+        "bq_count": len(bq_tests),
+        "pg_count": len(pg_tests),
+        "bq_only_tests": bq_only_tests,
+        "pg_only_tests": pg_only_tests,
+        "status_mismatches": status_mismatches,
+    }
+
+
+def compare_cr_responses(bq_data, pg_data):
+    """Compare two component readiness responses and return parity metrics."""
+    if not bq_data or not pg_data:
+        return {
+            "bq_rows": len(bq_data.get("rows", [])) if bq_data else 0,
+            "pg_rows": len(pg_data.get("rows", [])) if pg_data else 0,
+            "matched_rows": 0,
+            "bq_only_rows": 0,
+            "pg_only_rows": 0,
+            "status_matches": 0,
+            "status_mismatches": 0,
+            "status_match_pct": 0.0,
+            "mismatch_details": [],
+            "regressed_tests_total_cells": 0,
+            "regressed_tests_match_cells": 0,
+            "regressed_tests_mismatch_cells": 0,
+            "regressed_tests_mismatches": [],
+        }
+
+    bq_rows = bq_data.get("rows", [])
+    pg_rows = pg_data.get("rows", [])
+
+    bq_by_key = {}
+    for row in bq_rows:
+        key = make_row_key(row)
+        bq_by_key[key] = row
+
+    pg_by_key = {}
+    for row in pg_rows:
+        key = make_row_key(row)
+        pg_by_key[key] = row
+
+    matched_keys = set(bq_by_key.keys()) & set(pg_by_key.keys())
+    bq_only = set(bq_by_key.keys()) - set(pg_by_key.keys())
+    pg_only = set(pg_by_key.keys()) - set(bq_by_key.keys())
+
+    status_matches = 0
+    status_mismatches = 0
+    total_comparisons = 0
+    mismatch_details = []
+    status_pair_counts = defaultdict(int)
+    rt_total_cells = 0
+    rt_match_cells = 0
+    rt_mismatch_cells = 0
+    rt_mismatches = []
+
+    for key in matched_keys:
+        bq_row = bq_by_key[key]
+        pg_row = pg_by_key[key]
+
+        bq_cols = {make_column_key(c): c for c in bq_row.get("columns", [])}
+        pg_cols = {make_column_key(c): c for c in pg_row.get("columns", [])}
+
+        matched_col_keys = set(bq_cols.keys()) & set(pg_cols.keys())
+
+        # Try normalized matching for unmatched columns (TRT-2863)
+        bq_unmatched = set(bq_cols.keys()) - matched_col_keys
+        pg_unmatched = set(pg_cols.keys()) - matched_col_keys
+
+        if bq_unmatched or pg_unmatched:
+            bq_norm = {}
+            for ck in bq_unmatched:
+                norm = tuple(sorted(normalize_variant_key(bq_cols[ck]).items()))
+                bq_norm[norm] = ck
+
+            for pck in list(pg_unmatched):
+                norm = tuple(sorted(normalize_variant_key(pg_cols[pck]).items()))
+                if norm in bq_norm:
+                    bck = bq_norm[norm]
+                    matched_col_keys.add(bck)
+                    bq_unmatched.discard(bck)
+                    pg_unmatched.discard(pck)
+
+        for col_key in matched_col_keys:
+            bq_col = bq_cols.get(col_key)
+            pg_col = pg_cols.get(col_key)
+            if not bq_col or not pg_col:
+                for c in bq_row.get("columns", []):
+                    if make_column_key(c) == col_key:
+                        bq_col = c
+                        break
+                for c in pg_row.get("columns", []):
+                    if make_column_key(c) == col_key:
+                        pg_col = c
+                        break
+            if not bq_col or not pg_col:
+                continue
+
+            total_comparisons += 1
+            bq_status = bq_col.get("status", 0)
+            pg_status = pg_col.get("status", 0)
+
+            if bq_status == pg_status:
+                status_matches += 1
+            else:
+                status_mismatches += 1
+                bq_name = STATUS_NAMES.get(bq_status, str(bq_status))
+                pg_name = STATUS_NAMES.get(pg_status, str(pg_status))
+                status_pair_counts[(bq_name, pg_name)] += 1
+                mismatch_details.append({
+                    "component": key[0],
+                    "capability": key[1],
+                    "test_name": key[2],
+                    "test_id": key[3],
+                    "variants": dict(col_key) if isinstance(col_key, tuple) else {},
+                    "bq_status": bq_status,
+                    "pg_status": pg_status,
+                    "bq_status_name": bq_name,
+                    "pg_status_name": pg_name,
+                })
+
+            rt_result = compare_regressed_tests(bq_col, pg_col)
+            if rt_result is not None:
+                rt_total_cells += 1
+                if rt_result.get("match"):
+                    rt_match_cells += 1
+                else:
+                    rt_mismatch_cells += 1
+                    cell_variants = dict(col_key) if isinstance(col_key, tuple) else {}
+                    rt_mismatches.append({
+                        "component": key[0],
+                        "capability": key[1],
+                        "variants": cell_variants,
+                        "cell_status_match": bq_status == pg_status,
+                        "bq_count": rt_result["bq_count"],
+                        "pg_count": rt_result["pg_count"],
+                        "bq_only_tests": rt_result["bq_only_tests"],
+                        "pg_only_tests": rt_result["pg_only_tests"],
+                        "status_mismatches": rt_result["status_mismatches"],
+                    })
+
+    match_pct = (status_matches / total_comparisons * 100) if total_comparisons > 0 else 0.0
+
+    return {
+        "bq_rows": len(bq_rows),
+        "pg_rows": len(pg_rows),
+        "matched_rows": len(matched_keys),
+        "bq_only_rows": len(bq_only),
+        "pg_only_rows": len(pg_only),
+        "status_matches": status_matches,
+        "status_mismatches": status_mismatches,
+        "total_comparisons": total_comparisons,
+        "status_match_pct": match_pct,
+        "mismatch_details": mismatch_details,
+        "status_pair_counts": {f"BQ={k[0]}, PG={k[1]}": v for k, v in status_pair_counts.items()},
+        "regressed_tests_total_cells": rt_total_cells,
+        "regressed_tests_match_cells": rt_match_cells,
+        "regressed_tests_mismatch_cells": rt_mismatch_cells,
+        "regressed_tests_mismatches": rt_mismatches,
+    }
+
+
+def compare_test_detail_responses(bq_data, pg_data):
+    """Compare two test_details responses."""
+    if not bq_data or not pg_data:
+        return {
+            "has_data": False,
+            "status_match": None,
+            "count_match": None,
+            "last_failure_match": None,
+            "details": [],
+        }
+
+    bq_analyses = bq_data.get("analyses", [])
+    pg_analyses = pg_data.get("analyses", [])
+
+    if not bq_analyses or not pg_analyses:
+        return {
+            "has_data": bool(bq_analyses or pg_analyses),
+            "status_match": None,
+            "count_match": None,
+            "last_failure_match": None,
+            "details": [],
+        }
+
+    bq_a = bq_analyses[0]
+    pg_a = pg_analyses[0]
+
+    bq_status = bq_a.get("status", 0)
+    pg_status = pg_a.get("status", 0)
+
+    bq_sample = bq_a.get("sample_stats", {})
+    pg_sample = pg_a.get("sample_stats", {})
+    bq_base = bq_a.get("base_stats") or {}
+    pg_base = pg_a.get("base_stats") or {}
+
+    details = {
+        "bq_status": bq_status,
+        "pg_status": pg_status,
+        "bq_sample_success": bq_sample.get("success_count", 0),
+        "pg_sample_success": pg_sample.get("success_count", 0),
+        "bq_sample_failure": bq_sample.get("failure_count", 0),
+        "pg_sample_failure": pg_sample.get("failure_count", 0),
+        "bq_base_success": bq_base.get("success_count", 0),
+        "pg_base_success": pg_base.get("success_count", 0),
+        "bq_base_failure": bq_base.get("failure_count", 0),
+        "pg_base_failure": pg_base.get("failure_count", 0),
+    }
+
+    status_match = bq_status == pg_status
+    sample_match = (
+        bq_sample.get("success_count", 0) == pg_sample.get("success_count", 0)
+        and bq_sample.get("failure_count", 0) == pg_sample.get("failure_count", 0)
+        and bq_sample.get("flake_count", 0) == pg_sample.get("flake_count", 0)
+    )
+    base_match = (
+        bq_base.get("success_count", 0) == pg_base.get("success_count", 0)
+        and bq_base.get("failure_count", 0) == pg_base.get("failure_count", 0)
+        and bq_base.get("flake_count", 0) == pg_base.get("flake_count", 0)
+    )
+
+    lf_match = check_last_failure_match(bq_data, pg_data)
+
+    return {
+        "has_data": True,
+        "status_match": status_match,
+        "count_match": sample_match and base_match,
+        "last_failure_match": lf_match,
+        "details": details,
+    }
+
+
+def run_scenario(server, scenario, timeout):
+    """Run a single scenario against both BQ and PG, return results."""
+    endpoint = scenario["endpoint"]
+    params = list(scenario["params"])
+
+    bq_params = params + [("dataSource", "bigquery")]
+    bq_data, bq_time, bq_url, bq_err = api_get(server, endpoint, bq_params, timeout)
+
+    pg_params = params + [("dataSource", "postgres")]
+    pg_data, pg_time, pg_url, pg_err = api_get(server, endpoint, pg_params, timeout)
+
+    result = {
+        "name": scenario["name"],
+        "category": scenario["category"],
+        "endpoint": endpoint,
+        "bq_time_s": round(bq_time, 2),
+        "pg_time_s": round(pg_time, 2),
+        "bq_error": bq_err,
+        "pg_error": pg_err,
+        "bq_url": bq_url,
+        "pg_url": pg_url,
+    }
+
+    if bq_err or pg_err:
+        result["comparison"] = None
+        return result, bq_data, pg_data
+
+    if endpoint == "/api/component_readiness/test_details":
+        result["comparison"] = compare_test_detail_responses(bq_data, pg_data)
+    else:
+        result["comparison"] = compare_cr_responses(bq_data, pg_data)
+
+    return result, bq_data, pg_data
+
+
+def format_time(seconds):
+    if seconds >= 60:
+        return f"{seconds / 60:.1f}m"
+    return f"{seconds:.1f}s"
+
+
+def format_ratio(bq_time, pg_time):
+    if pg_time == 0 or bq_time == 0:
+        return "N/A"
+    if pg_time < bq_time:
+        return f"PG {bq_time / pg_time:.1f}x"
+    return f"BQ {pg_time / bq_time:.1f}x"
+
+
+def print_table_results(results, verbose):
+    """Print results as formatted tables."""
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"\n{'=' * 120}")
+    print("CR PARITY CHECK RESULTS")
+    print(f"{'=' * 120}")
+    print(f"Date: {now}")
+    print()
+
+    name_width = 50
+    line_width = 120
+
+    # Performance comparison
+    print("PERFORMANCE COMPARISON")
+    print(f"{'─' * line_width}")
+    header = f"{'Scenario':<{name_width}} {'BQ Time':>9} {'PG Time':>9} {'Faster':>12} {'Status':>10}"
+    print(header)
+    print(f"{'─' * line_width}")
+
+    for r in results:
+        if r.get("bq_error") or r.get("pg_error"):
+            status = "ERROR"
+            bq_t = r.get("bq_error", "OK")[:8] if r.get("bq_error") else format_time(r["bq_time_s"])
+            pg_t = r.get("pg_error", "OK")[:8] if r.get("pg_error") else format_time(r["pg_time_s"])
+            ratio = "N/A"
+        else:
+            bq_t = format_time(r["bq_time_s"])
+            pg_t = format_time(r["pg_time_s"])
+            ratio = format_ratio(r["bq_time_s"], r["pg_time_s"])
+            status = "OK"
+
+        name = r["name"][:name_width - 1]
+        print(f"{name:<{name_width}} {bq_t:>9} {pg_t:>9} {ratio:>12} {status:>10}")
+
+    print()
+
+    # Parity comparison (only for CR reports, not test_details)
+    cr_results = [r for r in results if r["endpoint"] == "/api/component_readiness" and r.get("comparison")]
+    if cr_results:
+        print("PARITY COMPARISON")
+        print(f"{'─' * line_width}")
+        header = f"{'Scenario':<{name_width}} {'BQ Rows':>8} {'PG Rows':>8} {'Matched':>8} {'Parity%':>8} {'Status':>10}"
+        print(header)
+        print(f"{'─' * line_width}")
+
+        for r in cr_results:
+            c = r["comparison"]
+            name = r["name"][:name_width - 1]
+            pct = f"{c['status_match_pct']:.0f}%"
+            status = "MATCH" if c["status_match_pct"] == 100.0 else "MISMATCH"
+            print(f"{name:<{name_width}} {c['bq_rows']:>8} {c['pg_rows']:>8} {c['matched_rows']:>8} {pct:>8} {status:>10}")
+
+        print()
+
+    # Regressed tests parity (only for CR reports with regressed test data)
+    rt_results = [
+        r for r in cr_results
+        if r.get("comparison", {}).get("regressed_tests_total_cells", 0) > 0
+    ]
+    if rt_results:
+        print("REGRESSED TESTS PARITY")
+        print(f"{'─' * line_width}")
+        header = f"{'Scenario':<{name_width}} {'Cells w/RT':>10} {'Match':>8} {'Mismatch':>10} {'Status':>10}"
+        print(header)
+        print(f"{'─' * line_width}")
+
+        for r in rt_results:
+            c = r["comparison"]
+            name = r["name"][:name_width - 1]
+            total = c["regressed_tests_total_cells"]
+            match = c["regressed_tests_match_cells"]
+            mismatch = c["regressed_tests_mismatch_cells"]
+            status = "MATCH" if mismatch == 0 else "MISMATCH"
+            print(f"{name:<{name_width}} {total:>10} {match:>8} {mismatch:>10} {status:>10}")
+
+        print()
+
+    # Test details comparison
+    td_results = [r for r in results if r["endpoint"] == "/api/component_readiness/test_details" and r.get("comparison")]
+    if td_results:
+        print("TEST DETAILS COMPARISON")
+        print(f"{'─' * line_width}")
+        header = f"{'Scenario':<{name_width}} {'Status':>7} {'Counts':>7} {'LastFail':>9}"
+        print(header)
+        print(f"{'─' * line_width}")
+
+        for r in td_results:
+            c = r["comparison"]
+            name = r["name"][:name_width - 1]
+            if not c.get("has_data"):
+                print(f"{name:<{name_width}} {'N/A':>7} {'N/A':>7} {'N/A':>9}")
+                continue
+            sm = "Match" if c["status_match"] else "Differ"
+            cm = "Match" if c["count_match"] else "Differ"
+            lf = "Match" if c.get("last_failure_match") else "Differ"
+            print(f"{name:<{name_width}} {sm:>7} {cm:>7} {lf:>9}")
+
+        print()
+
+    # Overall mismatch summary by status pair
+    total_pair_counts = defaultdict(int)
+    for r in results:
+        if r.get("comparison") and isinstance(r["comparison"].get("status_pair_counts"), dict):
+            for pair, count in r["comparison"]["status_pair_counts"].items():
+                total_pair_counts[pair] += count
+
+    if total_pair_counts:
+        total_mismatches = sum(total_pair_counts.values())
+        print("MISMATCH SUMMARY")
+        print(f"{'─' * line_width}")
+        for pair, count in sorted(total_pair_counts.items(), key=lambda x: -x[1]):
+            print(f"  {pair:<60} {count:>5}")
+        print(f"  {'─' * 66}")
+        print(f"  {'Total mismatches':<60} {total_mismatches:>5}")
+        print()
+        print("  Use cr-parity-analyze.py on --json output to investigate root causes.")
+        print()
+
+    # Regressed tests mismatch summary
+    total_bq_only = 0
+    total_pg_only = 0
+    total_rt_status_mismatches = 0
+    for r in results:
+        for rt_m in r.get("comparison", {}).get("regressed_tests_mismatches", []):
+            total_bq_only += len(rt_m.get("bq_only_tests", []))
+            total_pg_only += len(rt_m.get("pg_only_tests", []))
+            total_rt_status_mismatches += len(rt_m.get("status_mismatches", []))
+
+    total_rt_discrepancies = total_bq_only + total_pg_only + total_rt_status_mismatches
+    if total_rt_discrepancies > 0:
+        print("REGRESSED TESTS MISMATCH SUMMARY")
+        print(f"{'─' * line_width}")
+        print(f"  {'BQ-only regressed tests (not regressed in PG)':<60} {total_bq_only:>5}")
+        print(f"  {'PG-only regressed tests (not regressed in BQ)':<60} {total_pg_only:>5}")
+        print(f"  {'Shared tests with different regression severity':<60} {total_rt_status_mismatches:>5}")
+        print(f"  {'─' * 66}")
+        print(f"  {'Total regressed test discrepancies':<60} {total_rt_discrepancies:>5}")
+        print()
+
+    # Verbose: per-row mismatch details
+    if verbose:
+        for r in results:
+            if not r.get("comparison"):
+                continue
+            mismatches = r["comparison"].get("mismatch_details", [])
+            if not mismatches:
+                continue
+
+            print(f"MISMATCH DETAILS: {r['name']}")
+            print(f"{'─' * line_width}")
+            for m in mismatches[:20]:
+                variants_str = ", ".join(f"{k}={v}" for k, v in sorted(m.get("variants", {}).items()))
+                print(f"  {m['component']}/{m['capability']}")
+                if variants_str:
+                    print(f"    Variants: {variants_str}")
+                print(f"    BQ: {m['bq_status_name']} ({m['bq_status']})  PG: {m['pg_status_name']} ({m['pg_status']})")
+            if len(mismatches) > 20:
+                print(f"  ... and {len(mismatches) - 20} more")
+            print()
+
+    if verbose:
+        for r in results:
+            if not r.get("comparison"):
+                continue
+            rt_mismatches = r["comparison"].get("regressed_tests_mismatches", [])
+            if not rt_mismatches:
+                continue
+
+            print(f"REGRESSED TESTS DETAILS: {r['name']}")
+            print(f"{'─' * line_width}")
+            for rt_m in rt_mismatches[:20]:
+                variants_str = ", ".join(f"{k}={v}" for k, v in sorted(rt_m.get("variants", {}).items()))
+                comp_cap = rt_m["component"]
+                if rt_m.get("capability"):
+                    comp_cap += f" / {rt_m['capability']}"
+                print(f"  {comp_cap} ({variants_str})")
+                status_label = "MATCH" if rt_m["cell_status_match"] else "MISMATCH"
+                print(f"    Cell status: {status_label}  BQ regressed: {rt_m['bq_count']}  PG regressed: {rt_m['pg_count']}")
+
+                for t in rt_m.get("bq_only_tests", []):
+                    name = t["test_name"][:80] if t["test_name"] else t["test_id"][:40]
+                    print(f"    BQ-only: {name} ({t['status_name']})")
+                for t in rt_m.get("pg_only_tests", []):
+                    name = t["test_name"][:80] if t["test_name"] else t["test_id"][:40]
+                    print(f"    PG-only: {name} ({t['status_name']})")
+                for t in rt_m.get("status_mismatches", []):
+                    name = t["test_name"][:80] if t["test_name"] else t["test_id"][:40]
+                    print(f"    Status diff: {name} (BQ={t['bq_status_name']} PG={t['pg_status_name']})")
+            if len(rt_mismatches) > 20:
+                print(f"  ... and {len(rt_mismatches) - 20} more")
+            print()
+
+
+def print_json_results(results):
+    """Print results as JSON."""
+    output = {
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "results": results,
+    }
+    print(json.dumps(output, indent=2, default=str))
+
+
+def log(msg, args, **kwargs):
+    """Print progress to stderr when in JSON mode, stdout otherwise."""
+    dest = sys.stderr if args.json else sys.stdout
+    print(msg, file=dest, **kwargs)
+
+
+def main():
+    args = parse_args()
+    server = args.server.rstrip("/")
+    force_refresh = not args.no_force_refresh
+    releases = [r.strip() for r in args.releases.split(",")]
+    scenario_types = set(args.scenarios.split(","))
+    run_all = "all" in scenario_types
+
+    log("CR Parity Check", args)
+    log(f"Server: {server}", args)
+    log(f"Releases: {', '.join(releases)}", args)
+    log(f"Force refresh: {force_refresh}", args)
+    log("", args)
+
+    # Probe data availability
+    available_dates = probe_data_availability(args)
+    log("", args)
+
+    # Build scenario list
+    scenarios = []
+
+    if run_all or "views" in scenario_types:
+        scenarios.extend(build_view_scenarios(releases, force_refresh))
+
+    if run_all or "cross-variant" in scenario_types:
+        scenarios.extend(build_cross_variant_scenarios(releases, force_refresh))
+
+    if run_all or "filtered" in scenario_types:
+        scenarios.extend(build_filtered_scenarios(releases, force_refresh))
+
+    if run_all or "date-range" in scenario_types:
+        scenarios.extend(build_date_range_scenarios(releases, available_dates, force_refresh))
+
+    if not scenarios:
+        log("No scenarios to run (check --scenarios and --releases)", args)
+        sys.exit(1)
+
+    log(f"Running {len(scenarios)} scenarios...", args)
+    log("", args)
+
+    # Execute scenarios
+    results = []
+    test_detail_sources = {}
+
+    for i, scenario in enumerate(scenarios):
+        progress = f"[{i + 1}/{len(scenarios)}]"
+        log(f"{progress} {scenario['name']}...", args, end="", flush=True)
+
+        result, bq_data, pg_data = run_scenario(server, scenario, args.timeout)
+        results.append(result)
+
+        if result.get("bq_error") or result.get("pg_error"):
+            errors = []
+            if result.get("bq_error"):
+                errors.append(f"BQ: {result['bq_error'][:50]}")
+            if result.get("pg_error"):
+                errors.append(f"PG: {result['pg_error'][:50]}")
+            log(f" ERROR ({'; '.join(errors)})", args)
+        else:
+            comp = result.get("comparison", {})
+            if scenario["endpoint"] == "/api/component_readiness":
+                pct = comp.get("status_match_pct", 0)
+                log(f" BQ={format_time(result['bq_time_s'])} PG={format_time(result['pg_time_s'])} parity={pct:.0f}%", args)
+
+                # Save BQ response for test_details extraction
+                if scenario["category"] == "views" and bq_data and scenario.get("view"):
+                    test_detail_sources[scenario["view"]] = bq_data
+            else:
+                sm = "match" if comp.get("status_match") else "mismatch"
+                log(f" BQ={format_time(result['bq_time_s'])} PG={format_time(result['pg_time_s'])} status={sm}", args)
+
+    # Test details scenarios (built from collected CR responses)
+    if run_all or "test-details" in scenario_types:
+        td_scenarios = []
+        for view_name in ["5.0-main", "4.22-main"]:
+            cr_data = test_detail_sources.get(view_name)
+            if cr_data:
+                targets = extract_test_detail_targets(cr_data, view_name)
+                td_scenarios.extend(build_test_detail_scenarios(targets, view_name, force_refresh))
+
+        if td_scenarios:
+            log(f"\nRunning {len(td_scenarios)} test_details scenarios...", args)
+            for i, scenario in enumerate(td_scenarios):
+                progress = f"[{i + 1}/{len(td_scenarios)}]"
+                log(f"{progress} {scenario['name']}...", args, end="", flush=True)
+
+                result, _, _ = run_scenario(server, scenario, args.timeout)
+                results.append(result)
+
+                if result.get("bq_error") or result.get("pg_error"):
+                    log(" ERROR", args)
+                else:
+                    comp = result.get("comparison", {})
+                    sm = "match" if comp.get("status_match") else "mismatch"
+                    log(f" BQ={format_time(result['bq_time_s'])} PG={format_time(result['pg_time_s'])} status={sm}", args)
+
+    # Output results
+    log("", args)
+    if args.json:
+        print_json_results(results)
+    else:
+        print_table_results(results, args.verbose)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,4 @@
 argparse
 sqlalchemy
 psycopg2
+pyyaml


### PR DESCRIPTION
## Summary

Adds two scripts for measuring and diagnosing Component Readiness (CR) parity between the BigQuery and PostgreSQL providers (selected per request via the `dataSource` query parameter). These support the ongoing work to bring the PostgreSQL CR implementation to parity with BigQuery under epic [TRT-2733](https://redhat.atlassian.net/browse/TRT-2733).

- **`scripts/cr-parity-check.py`**: samples CR API configurations against both providers and reports factual differences without attributing causes: grid status-pair mismatches, `regressed_tests` differences per cell, and per-provider response times. Supports `--json` for downstream analysis.
- **`scripts/cr-parity-analyze.py`**: consumes the `--json` output and drills into `test_details` for both providers to attribute each mismatch. Resolves grid-level cells to a representative test whose per-test status actually flips (drilling both providers), and reports every contributing factor per cell:
  - `job_scope` ([TRT-2861](https://redhat.atlassian.net/browse/TRT-2861))
  - `ingestion_gap_bq` / `ingestion_gap_pg` (e.g. ROSA HCP release-variant assignment, [TRT-2912](https://redhat.atlassian.net/browse/TRT-2912))
  - `run_count_divergence` with net BQ-PG direction (dedup, [TRT-2804](https://redhat.atlassian.net/browse/TRT-2804))
  - `outcome_divergence` (same runs, different pass/fail/flake)
  - `pg_capability_empty` (PG component drill-down returns no capability/test rows, [TRT-2911](https://redhat.atlassian.net/browse/TRT-2911))

## Documentation

- `scripts/README.md` documents purpose, both scripts with options and examples, the typical workflow, and links to the tracked parity gaps.
- `scripts/requirements.txt` adds `pyyaml` (used by the analyzer to parse `config/openshift.yaml`; falls back to a built-in parser if absent).

## Notes

These are read-only diagnostic tools that talk to a running Sippy API (staging or prod); they do not require direct database access. Force refresh is kept on by default when measuring parity, since cached CR results can be up to about 4 hours stale and produce spurious mismatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)