### PR TITLE
TRT-2883: Fix spurious MissingSample/MissingBasis for tests below MinimumFailure

### DIFF
--- a/pkg/api/componentreadiness/dataprovider/postgres/cr_queries.go
+++ b/pkg/api/componentreadiness/dataprovider/postgres/cr_queries.go
@@ -28,7 +28,6 @@ type variantQuerySetup struct {
 	groupMapping    variantGroupMapping
 	filterArgs      []any
 	variantSubquery string
-	minimumFailure  int
 }
 
 const queryPlannerHints = "SET LOCAL max_parallel_workers_per_gather = 4; SET LOCAL parallel_setup_cost = 0; SET LOCAL parallel_tuple_cost = 0; SET LOCAL enable_nestloop = off; SET LOCAL enable_sort = off"
@@ -38,7 +37,6 @@ func prepareVariantQuery(
 	dbc *db.DB,
 	includeVariants map[string][]string,
 	dbGroupBy sets.Set[string],
-	minimumFailure int,
 ) (*variantQuerySetup, error) {
 	vf, err := resolveVariantFilter(ctx, dbc, includeVariants, dbGroupBy)
 	if err != nil {
@@ -52,7 +50,6 @@ func prepareVariantQuery(
 		groupMapping:    buildVariantGroupMapping(vf.lookup),
 		filterArgs:      vf.filterArgs,
 		variantSubquery: vf.variantSubquery,
-		minimumFailure:  minimumFailure,
 	}, nil
 }
 
@@ -182,10 +179,23 @@ func buildStatusCTE(
 	return cteSQL, args
 }
 
+// testBranchTemplate is the UNION ALL branch that selects all tests with runs
+// from a status CTE, regardless of failure count. Used by the standalone path,
+// which has no "other side" to cross-reference (TRT-2883), so the MinimumFailure
+// threshold is left entirely to the Go-side check. The first %s is an optional
+// column prefix, the second %s is the CTE name.
+const testBranchTemplate = `SELECT
+        %spa.unique_id AS test_id, t.name AS test_name,
+        COALESCE(su.name, '') AS test_suite, pa.component, pa.capabilities,
+        pa.variant_group_id, pa.total_count, pa.success_count, pa.flake_count, pa.last_failure
+    FROM %s pa
+    JOIN tests t ON t.id = pa.test_id
+    LEFT JOIN suites su ON su.id = pa.suite_id`
+
 // failureBranchTemplate is the UNION ALL branch that selects tests meeting the
-// minimum failure threshold from a status CTE. The first %s is an optional
-// column prefix (e.g. "'S'::text AS source, " for the combined query, or "" for
-// standalone), and the second %s is the CTE name.
+// minimum failure threshold from a status CTE. The first %s is the column
+// prefix (e.g. "'S'::text AS source, " for the combined query), the second %s
+// is the CTE name.
 const failureBranchTemplate = `SELECT
         %spa.unique_id AS test_id, t.name AS test_name,
         COALESCE(su.name, '') AS test_suite, pa.component, pa.capabilities,
@@ -194,6 +204,55 @@ const failureBranchTemplate = `SELECT
     JOIN tests t ON t.id = pa.test_id
     LEFT JOIN suites su ON su.id = pa.suite_id
     WHERE pa.total_count - pa.success_count - pa.flake_count >= ?`
+
+// keysCTETemplate projects a status CTE down to just the columns needed to
+// answer "does this (unique_id, variant_group_id) exist on this side, and is
+// it above the minimum failure threshold?" The status CTEs (sample_agg /
+// base_agg) are MATERIALIZED and carry every output column (component,
+// capabilities text[], last_failure, etc.) on every row; joining directly
+// against them to answer a yes/no existence question forces Postgres to
+// build a hash table over the full row width. Materializing this narrow
+// projection once lets belowThresholdRescueBranchTemplate join against a
+// 3-column table instead. The first %s is the CTE name to define, the
+// second %s is the source status CTE.
+const keysCTETemplate = `%s AS MATERIALIZED (
+        SELECT unique_id, variant_group_id,
+            total_count - success_count - flake_count AS fail_count
+        FROM %s
+    )`
+
+// belowThresholdRescueBranchTemplate selects tests below the minimum failure
+// threshold that should still be surfaced because the other side doesn't
+// silently absorb them: either (a) the other side has a matching row that's
+// >= threshold (a test crossing the threshold between sample and base,
+// TRT-2883), or (b) the other side has no matching row at all (a test that
+// only ran during this side's window, e.g. newly added or removed) — without
+// this, such a test is silently dropped from both result maps even though
+// BigQuery has no SQL threshold filter and would surface it as
+// MissingBasis/MissingSample.
+//
+// Both conditions are expressed as a single LEFT JOIN against the other
+// side's narrow keys CTE (see keysCTETemplate) rather than two separate
+// correlated EXISTS/NOT EXISTS subqueries against the full status CTE, so
+// the planner only needs to hash/join a small (key, key, fail_count) table
+// once instead of hashing the full-width CTE twice. The first %s is the
+// column prefix, the second %s is this side's CTE, the third %s is the
+// other side's keys CTE.
+const belowThresholdRescueBranchTemplate = `SELECT
+        %spa.unique_id AS test_id, t.name AS test_name,
+        COALESCE(su.name, '') AS test_suite, pa.component, pa.capabilities,
+        pa.variant_group_id, pa.total_count, pa.success_count, pa.flake_count, pa.last_failure
+    FROM %s pa
+    JOIN tests t ON t.id = pa.test_id
+    LEFT JOIN suites su ON su.id = pa.suite_id
+    LEFT JOIN %s other
+      ON other.unique_id = pa.unique_id
+      AND other.variant_group_id = pa.variant_group_id
+    WHERE pa.total_count - pa.success_count - pa.flake_count < ?
+      AND (
+        other.unique_id IS NULL
+        OR other.fail_count >= ?
+      )`
 
 // placeholderBranchTemplate is the UNION ALL branch that produces grid
 // placeholder entries (one per component + col_group_id) from a status CTE.
@@ -207,11 +266,11 @@ const placeholderBranchTemplate = `SELECT
     GROUP BY pa.component, pa.capabilities, pa.col_group_id`
 
 // queryTestStatusCTE builds and executes a single CTE-based query that produces
-// both failure results (tests with >= MinimumFailure failures) and grid
-// placeholder entries (component-level cells confirming data exists).
+// test results and grid placeholder entries (component-level cells confirming
+// data exists).
 //
-// Grid placeholders ensure that cells without failures on one side correctly
-// show MissingSample / MissingBasis instead of NotSignificant.
+// Grid placeholders ensure that cells without any test data on one side
+// correctly show MissingSample / MissingBasis instead of NotSignificant.
 func (p *PostgresProvider) queryTestStatusCTE(
 	ctx context.Context,
 	reqOptions reqopts.RequestOptions,
@@ -222,7 +281,7 @@ func (p *PostgresProvider) queryTestStatusCTE(
 	includeVariants = mergeRequestedVariants(includeVariants, reqOptions)
 	filters := buildDrilldownFilters(reqOptions)
 
-	setup, err := prepareVariantQuery(ctx, p.dbc, includeVariants, reqOptions.VariantOption.DBGroupBy, reqOptions.AdvancedOption.MinimumFailure)
+	setup, err := prepareVariantQuery(ctx, p.dbc, includeVariants, reqOptions.VariantOption.DBGroupBy)
 	if err != nil {
 		return nil, []error{err}
 	}
@@ -240,14 +299,10 @@ func (p *PostgresProvider) queryTestStatusCTE(
 	fullSQL := fmt.Sprintf("WITH vg(vcid, group_id) AS (%s),\ncm(group_id, col_group_id) AS (%s),\n%s\n%s\nUNION ALL\n%s",
 		setup.groupMapping.valuesClause, colMapping.valuesClause,
 		cteSQL,
-		fmt.Sprintf(failureBranchTemplate, "", "status_agg"),
+		fmt.Sprintf(testBranchTemplate, "", "status_agg"),
 		fmt.Sprintf(placeholderBranchTemplate, "", "status_agg"))
 
-	var allArgs []any
-	allArgs = append(allArgs, cteArgs...)
-	allArgs = append(allArgs, setup.minimumFailure)
-
-	return p.scanWithParallelHints(ctx, fullSQL, allArgs, setup.groupMapping)
+	return p.scanWithParallelHints(ctx, fullSQL, cteArgs, setup.groupMapping)
 }
 
 // prefixSumSpec returns a testStatusSpec for querying test_cumulative_summaries
@@ -424,24 +479,36 @@ func (p *PostgresProvider) queryCombinedTestStatus(
 	baseInnerSQL, baseInnerArgs := buildInnerAggregation(baseSpec, baseProwJobJoin, baseVF.filterArgs, filters)
 	baseCTE, baseCTEArgs := buildStatusCTE("base_agg", baseInnerSQL, baseInnerArgs, "cm", filters)
 
+	sampleKeysCTE := fmt.Sprintf(keysCTETemplate, "sample_keys", "sample_agg")
+	baseKeysCTE := fmt.Sprintf(keysCTETemplate, "base_keys", "base_agg")
+
 	// The combined query bakes the source tag into each branch as a typed
 	// literal so the row scanner can split results into sample and base maps.
+	// Each side has three branches: above-threshold tests (failureBranch),
+	// below-threshold tests rescued by a single LEFT JOIN against the other
+	// side's narrow keys CTE (belowThresholdRescueBranch, TRT-2883 + PG/BQ
+	// parity fix), and grid placeholders.
 	sampleSourcePrefix := "'S'::text AS source, "
 	baseSourcePrefix := "'B'::text AS source, "
 
-	fullSQL := fmt.Sprintf("WITH vg(vcid, group_id) AS (%s),\ncm(group_id, col_group_id) AS (%s),\n%s,\n%s\n%s\nUNION ALL\n%s\nUNION ALL\n%s\nUNION ALL\n%s",
+	fullSQL := fmt.Sprintf(
+		"WITH vg(vcid, group_id) AS (%s),\ncm(group_id, col_group_id) AS (%s),\n%s,\n%s,\n%s,\n%s\n%s\nUNION ALL\n%s\nUNION ALL\n%s\nUNION ALL\n%s\nUNION ALL\n%s\nUNION ALL\n%s",
 		groupMapping.valuesClause, colMapping.valuesClause,
-		sampleCTE, baseCTE,
+		sampleCTE, baseCTE, sampleKeysCTE, baseKeysCTE,
 		fmt.Sprintf(failureBranchTemplate, sampleSourcePrefix, "sample_agg"),
+		fmt.Sprintf(belowThresholdRescueBranchTemplate, sampleSourcePrefix, "sample_agg", "base_keys"),
 		fmt.Sprintf(placeholderBranchTemplate, sampleSourcePrefix, "sample_agg"),
 		fmt.Sprintf(failureBranchTemplate, baseSourcePrefix, "base_agg"),
+		fmt.Sprintf(belowThresholdRescueBranchTemplate, baseSourcePrefix, "base_agg", "sample_keys"),
 		fmt.Sprintf(placeholderBranchTemplate, baseSourcePrefix, "base_agg"))
 
 	var allArgs []any
 	allArgs = append(allArgs, sampleCTEArgs...)
 	allArgs = append(allArgs, baseCTEArgs...)
-	allArgs = append(allArgs, minimumFailure) // sample failure branch
-	allArgs = append(allArgs, minimumFailure) // base failure branch
+	allArgs = append(allArgs, minimumFailure)                 // sample failure branch
+	allArgs = append(allArgs, minimumFailure, minimumFailure) // sample below-threshold rescue branch
+	allArgs = append(allArgs, minimumFailure)                 // base failure branch
+	allArgs = append(allArgs, minimumFailure, minimumFailure) // base below-threshold rescue branch
 
 	// Execute with parallel hints
 	var sampleResult, baseResult map[string]crstatus.TestStatus

--- a/test/integration/component_readiness_test.go
+++ b/test/integration/component_readiness_test.go
@@ -414,14 +414,16 @@ func TestQueryTestStatus_SampleResults(t *testing.T) {
 		require.True(t, ok, "test2/gcp with 3 failures should pass MinimumFailure=2")
 		assert.Equal(t, 20, ts.TotalCount)
 
-		// test1/jobAWS has 1 failure (< 2), should NOT appear in failure results
-		// but a placeholder for its component should exist
+		// test1/jobAWS has 1 failure (< 2) and no base-side data at all for this release, so it's a
+		// one-sided test: belowThresholdRescueBranch surfaces it (PG/BQ parity fix) despite being
+		// below MinimumFailure.
 		awsOvnKey := crtest.KeyWithVariants{
 			TestID:   seed.tow1.UniqueID,
 			Variants: map[string]string{"Platform": "aws", "Network": "ovn"},
 		}
-		_, hasDirect := result[awsOvnKey.Encode()]
-		assert.False(t, hasDirect, "test1/aws-ovn with 1 failure should not pass MinimumFailure=2 filter")
+		directTS, hasDirect := result[awsOvnKey.Encode()]
+		require.True(t, hasDirect, "test1/aws-ovn with no base-side data should be rescued as a one-sided test")
+		assert.Equal(t, 10, directTS.TotalCount)
 	})
 
 	t.Run("no data for release", func(t *testing.T) {
@@ -1058,6 +1060,44 @@ func TestQueryBaseTestStatus_PrefixSum(t *testing.T) {
 	assert.Equal(t, 2, ts.FlakeCount)
 }
 
+// TestQueryBaseTestStatus_BelowMinimumFailure covers the standalone query path
+// (queryTestStatusCTE, used only by release-fallback). Unlike the combined query, this path has
+// no "other side" to cross-reference, so TRT-2883 is fixed by dropping the SQL-level
+// MinimumFailure filter entirely rather than adding a cross-branch. This test confirms a base
+// test with failures below MinimumFailure is still returned instead of being filtered out.
+func TestQueryBaseTestStatus_BelowMinimumFailure(t *testing.T) {
+	dbc := crTestDB(t)
+	release := "4.16"
+	seed := seedCRData(t, dbc)
+
+	baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+	baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+
+	// base: 100 runs, 99 successes -> 1 failure, well below MinimumFailure=3
+	createCumulativeSummary(t, dbc, baseLookupStart, release, seed.test1.ID, seed.jobAWS.ID, seed.suite.ID, 0, 0, 0)
+	createCumulativeSummary(t, dbc, baseLookupEnd, release, seed.test1.ID, seed.jobAWS.ID, seed.suite.ID, 100, 99, 0)
+
+	provider := postgres.NewPostgresProvider(dbc, nil)
+	opts := defaultReqOptions(release)
+	opts.AdvancedOption.MinimumFailure = 3
+	opts.VariantOption.IncludeVariants = map[string][]string{
+		"Platform": {"aws"},
+		"Network":  {"ovn"},
+	}
+
+	result, errs := provider.QueryBaseTestStatus(context.Background(), opts)
+	require.Empty(t, errs)
+
+	awsOvnKey := crtest.KeyWithVariants{
+		TestID:   seed.tow1.UniqueID,
+		Variants: map[string]string{"Platform": "aws", "Network": "ovn"},
+	}
+	ts, ok := result[awsOvnKey.Encode()]
+	require.True(t, ok, "base test with 1 failure (< MinimumFailure=3) should still be returned")
+	assert.Equal(t, 100, ts.TotalCount)
+	assert.Equal(t, 99, ts.SuccessCount)
+}
+
 func TestQueryTestStatus_DifferentBaseAndSampleReleases(t *testing.T) {
 	dbc := crTestDB(t)
 	baseRelease := "4.16"
@@ -1127,6 +1167,122 @@ func TestQueryTestStatus_DifferentBaseAndSampleReleases(t *testing.T) {
 	require.True(t, ok, "expected sample result")
 	assert.Equal(t, 10, sampleTS.TotalCount, "sample should reflect sampleRelease data only")
 	assert.Equal(t, 8, sampleTS.SuccessCount)
+}
+
+// TestQueryTestStatus_BelowThresholdBothSides confirms that when a test's failure count is
+// below MinimumFailure on both the sample and base side, belowThresholdRescueBranchTemplate's
+// LEFT JOIN finds a matching row on the other side but it's also below threshold (not NULL,
+// not >= threshold), so neither side's rescue condition is met and the test is cleanly
+// excluded from both result maps.
+func TestQueryTestStatus_BelowThresholdBothSides(t *testing.T) {
+	dbc := crTestDB(t)
+	release := "4.16"
+
+	vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+	job := createProwJobWithVC(t, dbc, "periodic-e2e-aws-both-below", release, vc)
+
+	test := intutil.CreateTest(t, dbc, "openshift-tests:[sig-etcd] both below threshold test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests-both-below")
+	tow := createTestOwnership(t, dbc, test.ID, &suite.ID, "openshift-tests:both-below", "Etcd", []string{"Quorum"})
+
+	baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+	baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+	sampleLookupStart := civil.Date{Year: 2024, Month: 5, Day: 31}
+	sampleLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 14}
+
+	// base: 100 runs/99 success -> 1 failure < MinimumFailure=3
+	createCumulativeSummary(t, dbc, baseLookupStart, release, test.ID, job.ID, suite.ID, 0, 0, 0)
+	createCumulativeSummary(t, dbc, baseLookupEnd, release, test.ID, job.ID, suite.ID, 100, 99, 0)
+	// sample: 100 runs/98 success -> 2 failures < MinimumFailure=3
+	createCumulativeSummary(t, dbc, sampleLookupStart, release, test.ID, job.ID, suite.ID, 100, 99, 0)
+	createCumulativeSummary(t, dbc, sampleLookupEnd, release, test.ID, job.ID, suite.ID, 200, 197, 0)
+
+	provider := postgres.NewPostgresProvider(dbc, nil)
+	opts := defaultReqOptions(release)
+	opts.AdvancedOption.MinimumFailure = 3
+	opts.VariantOption.IncludeVariants = map[string][]string{
+		"Platform": {"aws"},
+		"Network":  {"ovn"},
+	}
+
+	baseStatus, sampleStatus, errs := provider.QueryTestStatus(context.Background(), opts)
+	require.Empty(t, errs)
+
+	key := crtest.KeyWithVariants{
+		TestID:   tow.UniqueID,
+		Variants: map[string]string{"Platform": "aws", "Network": "ovn"},
+	}
+
+	_, inSample := sampleStatus[key.Encode()]
+	assert.False(t, inSample, "test below MinimumFailure on both sides should not appear in sample results")
+	_, inBase := baseStatus[key.Encode()]
+	assert.False(t, inBase, "test below MinimumFailure on both sides should not appear in base results")
+}
+
+// TestQueryTestStatus_OneSidedBelowThreshold confirms the PG/BigQuery parity fix: a test that
+// only ran during one side's window (no counterpart row at all on the other side) is surfaced
+// even when it's below MinimumFailure on the side it did run on. BigQuery has no SQL-level
+// MinimumFailure filter, so such a test always reaches Go and is classified as
+// MissingBasis/MissingSample there; without belowThresholdRescueBranch's "other side has no row"
+// case, PostgreSQL would silently drop the row from both result maps instead.
+func TestQueryTestStatus_OneSidedBelowThreshold(t *testing.T) {
+	dbc := crTestDB(t)
+	release := "4.16"
+
+	vc := createVariantCombination(t, dbc, []string{"Platform:aws", "Network:ovn"})
+	job := createProwJobWithVC(t, dbc, "periodic-e2e-aws-onesided", release, vc)
+
+	sampleOnlyTest := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] sample-only below threshold test")
+	baseOnlyTest := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] base-only below threshold test")
+	suite := intutil.CreateSuite(t, dbc, "openshift-tests-onesided")
+	sampleOnlyTow := createTestOwnership(t, dbc, sampleOnlyTest.ID, &suite.ID, "openshift-tests:sample-only-below", "Storage", []string{"PVC"})
+	baseOnlyTow := createTestOwnership(t, dbc, baseOnlyTest.ID, &suite.ID, "openshift-tests:base-only-below", "Storage", []string{"PVC"})
+
+	baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
+	baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
+	sampleLookupStart := civil.Date{Year: 2024, Month: 5, Day: 31}
+	sampleLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 14}
+
+	// sampleOnlyTest: no base-side data at all; sample: 100 runs/98 success -> 2 failures < MinimumFailure=3
+	createCumulativeSummary(t, dbc, sampleLookupStart, release, sampleOnlyTest.ID, job.ID, suite.ID, 100, 99, 0)
+	createCumulativeSummary(t, dbc, sampleLookupEnd, release, sampleOnlyTest.ID, job.ID, suite.ID, 200, 197, 0)
+
+	// baseOnlyTest: no sample-side data at all; base: 100 runs/99 success -> 1 failure < MinimumFailure=3
+	createCumulativeSummary(t, dbc, baseLookupStart, release, baseOnlyTest.ID, job.ID, suite.ID, 0, 0, 0)
+	createCumulativeSummary(t, dbc, baseLookupEnd, release, baseOnlyTest.ID, job.ID, suite.ID, 100, 99, 0)
+
+	provider := postgres.NewPostgresProvider(dbc, nil)
+	opts := defaultReqOptions(release)
+	opts.AdvancedOption.MinimumFailure = 3
+	opts.VariantOption.IncludeVariants = map[string][]string{
+		"Platform": {"aws"},
+		"Network":  {"ovn"},
+	}
+
+	baseStatus, sampleStatus, errs := provider.QueryTestStatus(context.Background(), opts)
+	require.Empty(t, errs)
+
+	sampleOnlyKey := crtest.KeyWithVariants{
+		TestID:   sampleOnlyTow.UniqueID,
+		Variants: map[string]string{"Platform": "aws", "Network": "ovn"},
+	}
+	sampleOnlyTS, ok := sampleStatus[sampleOnlyKey.Encode()]
+	require.True(t, ok, "sample-only test below MinimumFailure with no base counterpart should be rescued")
+	assert.Equal(t, 100, sampleOnlyTS.TotalCount)
+	assert.Equal(t, 98, sampleOnlyTS.SuccessCount)
+	_, inBase := baseStatus[sampleOnlyKey.Encode()]
+	assert.False(t, inBase, "sample-only test should not appear in base results")
+
+	baseOnlyKey := crtest.KeyWithVariants{
+		TestID:   baseOnlyTow.UniqueID,
+		Variants: map[string]string{"Platform": "aws", "Network": "ovn"},
+	}
+	baseOnlyTS, ok := baseStatus[baseOnlyKey.Encode()]
+	require.True(t, ok, "base-only test below MinimumFailure with no sample counterpart should be rescued")
+	assert.Equal(t, 100, baseOnlyTS.TotalCount)
+	assert.Equal(t, 99, baseOnlyTS.SuccessCount)
+	_, inSample := sampleStatus[baseOnlyKey.Encode()]
+	assert.False(t, inSample, "base-only test should not appear in sample results")
 }
 
 func TestQueryBaseTestStatus_GA(t *testing.T) {
@@ -2821,14 +2977,19 @@ func TestMinimumFailureWithCapabilityFilter(t *testing.T) {
 
 	nonPlaceholders := filterPlaceholders(result)
 	// testHigh has PVC capability and 5 failures >= 3: should appear
-	// testLow has PVC capability but 1 failure < 3: should NOT appear
+	// testLow has PVC capability, 1 failure < 3, and no base-side data at all: it's a one-sided
+	// test, so belowThresholdRescueBranch surfaces it (PG/BQ parity fix) despite being below
+	// MinimumFailure
 	// testOther has 5 failures >= 3 but Services capability, not PVC: should NOT appear
+	var sawLow bool
 	for _, ts := range nonPlaceholders {
-		assert.NotEqual(t, towLow.UniqueID, ts.TestID,
-			"low-failure PVC test should not pass MinimumFailure=3")
+		if ts.TestID == towLow.UniqueID {
+			sawLow = true
+		}
 		assert.NotEqual(t, "openshift-tests:high-net", ts.TestID,
 			"non-PVC test should not appear with PVC capability filter")
 	}
+	assert.True(t, sawLow, "low-failure PVC test with no base-side data should be rescued as a one-sided test")
 }
 
 func TestDrillDownBySecondaryCapability(t *testing.T) {
@@ -4178,10 +4339,14 @@ func TestGenerateReport_MinimumFailureThreshold(t *testing.T) {
 
 	testHigh := intutil.CreateTest(t, dbc, "openshift-tests:[sig-storage] high failure report test")
 	testLow := intutil.CreateTest(t, dbc, "openshift-tests:[sig-network] low failure report test")
+	testReverse := intutil.CreateTest(t, dbc, "openshift-tests:[sig-compute] reverse-direction report test")
+	testBothBelow := intutil.CreateTest(t, dbc, "openshift-tests:[sig-etcd] both-below-threshold report test")
 	suite := intutil.CreateSuite(t, dbc, "openshift-tests-mf-report")
 
 	createTestOwnership(t, dbc, testHigh.ID, &suite.ID, "openshift-tests:high-fail", "Storage", []string{"PVC"})
 	createTestOwnership(t, dbc, testLow.ID, &suite.ID, "openshift-tests:low-fail", "Networking", []string{"Services"})
+	createTestOwnership(t, dbc, testReverse.ID, &suite.ID, "openshift-tests:reverse-fail", "Compute", []string{"Nodes"})
+	createTestOwnership(t, dbc, testBothBelow.ID, &suite.ID, "openshift-tests:both-below-fail", "Etcd", []string{"Quorum"})
 
 	baseLookupStart := civil.Date{Year: 2024, Month: 5, Day: 14}
 	baseLookupEnd := civil.Date{Year: 2024, Month: 6, Day: 1}
@@ -4199,6 +4364,24 @@ func TestGenerateReport_MinimumFailureThreshold(t *testing.T) {
 	createCumulativeSummary(t, dbc, baseLookupEnd, release, testLow.ID, job.ID, suite.ID, 100, 95, 0)
 	createCumulativeSummary(t, dbc, sampleLookupStart, release, testLow.ID, job.ID, suite.ID, 100, 95, 0)
 	createCumulativeSummary(t, dbc, sampleLookupEnd, release, testLow.ID, job.ID, suite.ID, 200, 193, 0)
+
+	// testReverse: base 100 runs/98 success → 2 failures < MinimumFailure=3 (below threshold),
+	// sample 100 runs/40 success → 60 failures >= MinimumFailure=3 (above threshold). This is the
+	// mirror image of testLow: it exercises belowThresholdRescueBranchTemplate's LEFT JOIN on
+	// the base side, rescuing the below-threshold base row because sample is at/above threshold.
+	createCumulativeSummary(t, dbc, baseLookupStart, release, testReverse.ID, job.ID, suite.ID, 0, 0, 0)
+	createCumulativeSummary(t, dbc, baseLookupEnd, release, testReverse.ID, job.ID, suite.ID, 100, 98, 0)
+	createCumulativeSummary(t, dbc, sampleLookupStart, release, testReverse.ID, job.ID, suite.ID, 100, 98, 0)
+	createCumulativeSummary(t, dbc, sampleLookupEnd, release, testReverse.ID, job.ID, suite.ID, 200, 138, 0)
+
+	// testBothBelow: base 100 runs/99 success → 1 failure < MinimumFailure=3, sample 100 runs/98
+	// success → 2 failures < MinimumFailure=3. Both sides are below threshold, so
+	// failureBranch doesn't match and belowThresholdRescueBranchTemplate's LEFT JOIN finds a
+	// matching row that's also below threshold, so neither branch matches on either side.
+	createCumulativeSummary(t, dbc, baseLookupStart, release, testBothBelow.ID, job.ID, suite.ID, 0, 0, 0)
+	createCumulativeSummary(t, dbc, baseLookupEnd, release, testBothBelow.ID, job.ID, suite.ID, 100, 99, 0)
+	createCumulativeSummary(t, dbc, sampleLookupStart, release, testBothBelow.ID, job.ID, suite.ID, 100, 99, 0)
+	createCumulativeSummary(t, dbc, sampleLookupEnd, release, testBothBelow.ID, job.ID, suite.ID, 200, 197, 0)
 
 	provider := postgres.NewPostgresProvider(dbc, nil)
 	opts := defaultReqOptions(release)
@@ -4219,10 +4402,31 @@ func TestGenerateReport_MinimumFailureThreshold(t *testing.T) {
 	assert.Equal(t, crtest.ExtremeRegression, storageCol.Status, "test with 60 failures should be extreme regression")
 	require.NotEmpty(t, storageCol.RegressedTests)
 
-	// testLow: 2 failures < MinimumFailure=3, should not be flagged as a regression
+	// testLow: 2 failures < MinimumFailure=3, should be NotSignificant (not MissingSample).
+	// TRT-2883: the Go-side MinimumFailure check handles this; SQL must not drop the row.
 	networkRow := findReportRow(t, report, "Networking")
 	networkCol := findReportColumn(t, networkRow, map[string]string{"Platform": "aws"})
 	assert.Empty(t, networkCol.RegressedTests, "test below MinimumFailure should not appear as regression")
+	assert.Equal(t, crtest.NotSignificant, networkCol.Status,
+		"test with failures below MinimumFailure should be NotSignificant, not MissingSample")
+
+	// testReverse: base below MinimumFailure, sample above it. Go's MinimumFailure check only
+	// looks at the sample side, so this should proceed to full Fisher exact analysis using the
+	// real (non-placeholder) base stats brought in by belowThresholdRescueBranchTemplate's
+	// LEFT JOIN on the base side.
+	computeRow := findReportRow(t, report, "Compute")
+	computeCol := findReportColumn(t, computeRow, map[string]string{"Platform": "aws"})
+	assert.Equal(t, crtest.ExtremeRegression, computeCol.Status,
+		"sample above MinimumFailure with a below-threshold base should still be analyzed as a regression")
+	require.NotEmpty(t, computeCol.RegressedTests)
+
+	// testBothBelow: below MinimumFailure on both sides. belowThresholdRescueBranchTemplate's
+	// LEFT JOIN finds a matching row on the other side but it's also below threshold, so
+	// neither branch matches on either side and the test must not surface as a regression
+	// anywhere in the report.
+	etcdRow := findReportRow(t, report, "Etcd")
+	etcdCol := findReportColumn(t, etcdRow, map[string]string{"Platform": "aws"})
+	assert.Empty(t, etcdCol.RegressedTests, "test below MinimumFailure on both sides should not appear as a regression")
 }
 
 // --- Report helpers ---


### PR DESCRIPTION
## Summary
- The PostgreSQL component-readiness `MinimumFailure` SQL filter dropped below-threshold rows from the combined query (`queryCombinedTestStatus`) in two cases, both of which BigQuery (which has no SQL-level `MinimumFailure` filter, and does all classification in Go) handles correctly:
  1. A test below threshold on one side but at/above it on the other side was dropped from the side it was below threshold on, causing the Go-side merge to report `MissingSample`/`MissingBasis` instead of `NotSignificant`.
  2. A test that only ran during one side's window (no counterpart row at all on the other side) and is below threshold on the side it did run on was dropped from **both** result maps entirely, so it never appeared in the report at all, instead of the `MissingBasis`/`MissingSample` BigQuery would surface.
- `belowThresholdRescueBranchTemplate` (a single UNION ALL branch, replacing the earlier cross-only branch) now handles both cases with one `LEFT JOIN` against a narrow per-side `keys` CTE (`unique_id`, `variant_group_id`, `fail_count`): a below-threshold row is rescued when the other side has a matching row that's `>= threshold`, or when the other side has no matching row at all. Joining the narrow keys projection instead of the full status CTE avoids building a hash table over every column (including a `capabilities text[]` array) just to answer a yes/no threshold question — validated against production data on the real `5.0-main` view to keep the added latency to ~+16% versus ~+27-30% for less targeted approaches (e.g. two separate `EXISTS`/`NOT EXISTS` subqueries, or joining the full-width CTEs directly).
- For the standalone query path (`queryTestStatusCTE`, used only by release-fallback via `QueryBaseTestStatus`), drops the SQL-level `MinimumFailure` filter entirely since there's no "other side" to cross-reference; the existing Go-side `MinimumFailure` check in `component_report.go` already handles it correctly.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./pkg/api/componentreadiness/...`
- [x] `test/integration` full suite (453 tests)
- [x] Updated `TestGenerateReport_MinimumFailureThreshold` to assert `NotSignificant` (not just empty `RegressedTests`) for a test whose failures fall below `MinimumFailure`
- [x] Added `TestQueryTestStatus_OneSidedBelowThreshold` covering both directions (sample-only and base-only below-threshold tests with no counterpart)
- [x] Updated `TestQueryTestStatus_SampleResults` and `TestMinimumFailureWithCapabilityFilter`, which had unintentionally been asserting the old (buggy) silent-drop behavior for one-sided tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved component readiness results for tests with low failure counts.
  - Ensured below-threshold tests remain visible and are correctly marked **Not Significant**.
  - Improved handling of tests that ran on only one side, including accurate **Missing Sample** or **Missing Base** statuses.
  - Correctly identifies regressions when one side has qualifying results despite the other being below threshold.
  - Excludes results only when both sides fall below the configured threshold and contain data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
