### PR TITLE
TRT-2770: Bump integration/e2e test Postgres image to 18.4

### DIFF
--- a/.devcontainer/init-services.sh
+++ b/.devcontainer/init-services.sh
@@ -13,7 +13,7 @@ podman start sippy-postgres 2>/dev/null || \
         -e POSTGRES_PASSWORD=password \
         -e POSTGRES_HOST_AUTH_METHOD=trust \
         -p 127.0.0.1:5432:5432 \
-        quay.io/enterprisedb/postgresql \
+        docker.io/library/postgres:18.4 \
         -c listen_addresses='*'
 
 podman start sippy-redis 2>/dev/null || \

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -155,7 +155,7 @@ else
 
     # start postgresql in a container:
     echo "Starting new sippy postgresql container: $PSQL_CONTAINER"
-    $DOCKER run --name $PSQL_CONTAINER -e POSTGRES_PASSWORD=password -p $PSQL_PORT:5432 -d quay.io/enterprisedb/postgresql
+    $DOCKER run --name $PSQL_CONTAINER -e POSTGRES_PASSWORD=password -p $PSQL_PORT:5432 -d docker.io/library/postgres:18.4
 
     # start redis in a container:
     echo "Starting new sippy redis container: $REDIS_CONTAINER"

--- a/test/integration/util/testdb.go
+++ b/test/integration/util/testdb.go
@@ -72,7 +72,7 @@ func podmanSocketPath() string {
 }
 
 const (
-	postgresImage    = "docker.io/library/postgres:16"
+	postgresImage    = "docker.io/library/postgres:18.4"
 	postgresUser     = "test"
 	postgresPassword = "test"
 	postgresDB       = "sippy_integration"


### PR DESCRIPTION
## Summary
- Sippy staging is now running PostgreSQL 18.4; bump the Postgres containers used by the integration and e2e test suites to match, so local/CI runs validate against the same major version we run in production/staging.
- `test/integration/util/testdb.go`: testcontainers image `postgres:16` → `postgres:18.4`.
- `scripts/e2e.sh` and `.devcontainer/init-services.sh`: `quay.io/enterprisedb/postgresql` (untagged, resolves to 17.7, no PG18 tag published yet) → `docker.io/library/postgres:18.4`, matching the image already used by the integration tests.

Note: existing devcontainer users won't pick up the new Postgres image until the old `sippy-postgres` container is removed (`podman rm -f sippy-postgres`), since `init-services.sh` reuses an existing container if present.

## Test plan
- [x] `make integration` passes against `postgres:18.4`
- [x] `make e2e` passes against `postgres:18.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL container environments to use the official PostgreSQL 18.4 image.
  * Standardized PostgreSQL versions across development, end-to-end, and integration test setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->