### PR TITLE
TRT-2770: Raise temp_buffers to fix PG18 loader batch write failures

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -91,6 +91,10 @@ func New(dsn string, logLevel gormlogger.LogLevel, opts ...Option) (*DB, error) 
 	// all partitions instead of pruning to the relevant ones.
 	pgxConfig.RuntimeParams["plan_cache_mode"] = "force_custom_plan"
 	pgxConfig.RuntimeParams["work_mem"] = "128MB"
+	// Loaders (e.g. pgwriter) COPY batches into temp tables and then join back
+	// against them; the 8MB default leaves too little headroom and trips
+	// "no empty local buffer available" under normal batch sizes.
+	pgxConfig.RuntimeParams["temp_buffers"] = "128MB"
 	pgxConfig.RuntimeParams["idle_in_transaction_session_timeout"] = "60s"
 	pgxConfig.RuntimeParams["random_page_cost"] = "1.1"
 	pgxConfig.RuntimeParams["timezone"] = "UTC"


### PR DESCRIPTION
## Summary
- As part of PG14→PG18 upgrade validation, the prow loader's batch writer (`pgwriter.Write`) started failing on essentially every batch against the PG18 staging DB with `ERROR: no empty local buffer available (SQLSTATE 53000)` while inserting into `prow_job_run_tests`.
- `pgwriter` COPYs each batch into temp tables and then joins back against them (`tmp_job_run_tests` is scanned twice in one statement in `insertTestResults`). PG18 introduced a new async read-stream prefetch mechanism for local buffers that can race with a concurrent write into the same temp table, exhausting the default 8MB `temp_buffers` even for otherwise-modest batch sizes. `temp_buffers` was confirmed identical (8MB, vanilla default) on both prod (PG14.22) and staging (PG18.4), and this did not reproduce on PG14, so it's a PG18-specific behavior change rather than a config drift.
- Fix: raise `temp_buffers` to 128MB in `pkg/db/db.go`, next to the existing `work_mem` override, applied at connection startup for all pooled connections.

### Blast radius
- `temp_buffers` is a ceiling, not a pre-allocation: Postgres allocates local buffer memory lazily, on demand, only once a session first uses a temp table. Temp-table usage in this codebase is confined to loader code (`pkg/dataloader/*`); the live `sippy serve` API path never creates temp tables, so this change is a no-op for it.
- Unlike `work_mem`, `temp_buffers` has no effect on planner cost estimates, so it cannot change query plans for any other query.

## Test plan
- [x] Reproduced the failure against PG18 staging, applied the fix, confirmed batch writes succeed
- [x] `go vet ./pkg/db/...`, `gofmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * PostgreSQL sessions now use increased temporary buffer capacity, which may improve performance for operations involving temporary data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->