### PR TITLE
docs: remove dead resources/ link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ Sippy also exposes REST APIs for programmatic access to its data and reports.
 See [DEVELOPMENT.md](DEVELOPMENT.md) for information about standing up a
 local environment.
 
-See [resources](resources/) for example deployment manifests in
-Kubernetes.
-
 ## API
 
 See [the API documentation](pkg/api/README.md)


### PR DESCRIPTION
The resources/ directory was removed. The README link was never updated.

Remove the resources section from the README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the README link to the example Kubernetes deployment manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->