### PR TITLE
Add regexp match for tls-scanner 5.0/5.1 periodics

### DIFF
--- a/config/openshift.yaml
+++ b/config/openshift.yaml
@@ -16746,6 +16746,8 @@ releases:
             periodic-ci-stolostron-policy-collection-main-ocp5.0-interop-opp-aws: true
             periodic-ci-stolostron-policy-collection-main-ocp5.0-interop-opp-vsphere: true
             periodic-ci-stolostron-policy-collection-main-ocp5.0-upgrade-interop-opp-upgrade-aws: true
+        regexp:
+            - ^periodic-ci-openshift-tls-scanner-release-5\.0-periodics-.*
         blockingJobs:
             - periodic-ci-openshift-hypershift-release-5.0-periodics-e2e-aks
             - periodic-ci-openshift-hypershift-release-5.0-periodics-e2e-aks-multi-x-ax
@@ -18701,6 +18703,8 @@ releases:
             periodic-ci-stolostron-policy-collection-main-ocp5.1-interop-opp-vsphere: true
             periodic-ci-stolostron-policy-collection-main-ocp5.1-upgrade-interop-opp-upgrade-aws: true
             release-openshift-origin-installer-e2e-aws-upgrade-4.19-to-4.20-to-4.21-to-5.1-ci: true
+        regexp:
+            - ^periodic-ci-openshift-tls-scanner-release-5\.1-periodics-.*
         blockingJobs:
             - periodic-ci-openshift-hypershift-release-5.1-periodics-e2e-aks
             - periodic-ci-openshift-hypershift-release-5.1-periodics-e2e-aks-multi-x-ax


### PR DESCRIPTION
The periodic-tls13-adherence-* jobs (added via openshift/release#83621) were never being ingested by Sippy because neither the 5.0 nor the 5.1 release config listed them under jobs so matchRelease() dropped every run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added job selectors for OpenShift 5.0 and 5.1 periodic TLS scanner release jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->