### PR TITLE
Trt 2709 jobrunid mapping csr impl

### DIFF
--- a/docs/plans/trt-2709-job-run-id-mapping.md
+++ b/docs/plans/trt-2709-job-run-id-mapping.md
@@ -1,0 +1,313 @@
+# TRT-2709: Job Run ID Mapping Table Plan
+
+**JIRA:** TRT-2709
+**Branch:** `trt-2709-jobrunid-mapping`
+
+## Problem
+
+APIs, URLs, BigQuery, and triage all identify job runs by **Prow build ID** (`prow_job_runs.id`). Phase 4b will partition `prow_job_runs` by `(prow_job_release, timestamp)` with a composite PK. After that, a lookup by `id` alone cannot partition-prune.
+
+Today, `LookupProwJobRunPartitionKeys` in `pkg/db/query/job_queries.go` scans `prow_job_runs` directly:
+
+```go
+func LookupProwJobRunPartitionKeys(gormDB *gorm.DB, jobRunID int64) (ProwJobRunPartitionKeys, error) {
+	var keys ProwJobRunPartitionKeys
+	err := gormDB.Table("prow_job_runs").
+		Select("prow_job_release, timestamp").
+		Where("id = ?", jobRunID).
+		Take(&keys).Error
+	return keys, err
+}
+```
+
+This works on the current unpartitioned table (~410K rows) but will degrade once `prow_job_runs` is LIST/RANGE partitioned. The comment in that file already calls for a mapping table replacement.
+
+**Callers (5 production paths, no API signature changes needed):**
+
+- `pkg/api/job_runs.go` — `FetchJobRun`
+- `pkg/api/jobartifacts/query.go`
+- `pkg/api/jobrunscan/reevaluate.go`
+- `pkg/db/infrafailure/infrafailure.go`
+- `pkg/flags/postgres_benchmarking_test.go` — validation harness
+
+```mermaid
+flowchart TB
+  subgraph phase1 [Phase 1 - This PR]
+    Migrate[DDL migration]
+    PgWriter[pgwriter writes map rows]
+    LookupUnchanged[Lookup unchanged on prow_job_runs]
+    FindNew[findNewJobRunIDs unchanged]
+  end
+  subgraph phase2 [Phase 2 - External ops backfill]
+    Backfill[External process backfills map]
+    Verify[Verify row counts]
+  end
+  subgraph phase3 [Phase 3 - Post-backfill]
+    SwitchLookup[Lookup switches to map table]
+    FindNewMap[findNewJobRunIDs uses map]
+  end
+  phase1 --> phase2 --> phase3
+```
+
+---
+
+## Design
+
+### Table: `prow_job_run_id_map`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | `BIGINT PRIMARY KEY` | Prow build ID (same as `prow_job_runs.id`) |
+| `prow_job_release` | `TEXT NOT NULL` | Partition key |
+| `timestamp` | `TIMESTAMPTZ NOT NULL` | Partition key |
+
+**Properties:**
+
+- **Not partitioned** — single PK index lookup by `id`
+- **Tiny rows** — ~24 bytes each
+- **No FK to `prow_job_runs`** — application-level integrity (same pattern as phase 4a child tables)
+- **Immutable after insert** — release and timestamp for a build ID never change
+
+---
+
+## Phase 1: Pre-backfill implementation (this PR)
+
+**Goal:** Ship the mapping table infrastructure and start populating it on ingest. All read paths keep using `prow_job_runs` until backfill completes in Phase 2.
+
+### What ships
+
+| Item | File(s) | Notes |
+|------|---------|-------|
+| DDL migration | `pkg/db/migrations/000013_*` | CREATE TABLE only; backfill INSERT commented out |
+| GORM model | `pkg/db/models/prow.go` | `ProwJobRunIDMap` |
+| pgwriter insert | `pkg/dataloader/prowloader/pgwriter/pgwriter.go` | Map rows in same txn as `prow_job_runs` |
+| Test fixture | `test/integration/util/fixtures.go` | `CreateProwJobRun` syncs map row |
+| Tests | `test/integration/pgwriter_test.go` | Verify map row created on pgwriter insert |
+| Docs | `pkg/db/PARTITIONS_README.md` or partitioning prep doc | Document phases; reference example backfill SQL below |
+
+### What does NOT change in Phase 1
+
+| Item | Reason |
+|------|--------|
+| `LookupProwJobRunPartitionKeys` | Map is incomplete until backfill; keep querying `prow_job_runs` |
+| `findNewJobRunIDs` | Still anti-joins `prow_job_runs`; map is incomplete until backfill |
+| External backfill | Managed outside this repo in Phase 2; example SQL documented below |
+| `prow_job_runs` partitioning | Phase 4b, separate effort |
+
+### Phase 1 implementation details
+
+#### Migration `000013_create_prow_job_run_id_map`
+
+```sql
+CREATE TABLE IF NOT EXISTS prow_job_run_id_map (
+    id BIGINT PRIMARY KEY,
+    prow_job_release TEXT NOT NULL,
+    timestamp TIMESTAMPTZ NOT NULL
+);
+
+-- Backfill is intentionally NOT run here. Scanning all of prow_job_runs during
+-- migrate is too slow and timing-sensitive for production deploys. Run the
+-- external backfill process separately in Phase 2 (see example SQL below).
+--
+-- INSERT INTO prow_job_run_id_map (id, prow_job_release, timestamp)
+-- SELECT id, prow_job_release, timestamp
+-- FROM prow_job_runs
+-- WHERE prow_job_release IS NOT NULL AND prow_job_release <> ''
+-- ON CONFLICT (id) DO NOTHING;
+```
+
+**`.down.sql`:** `DROP TABLE IF EXISTS prow_job_run_id_map;`
+
+#### pgwriter
+
+In `pkg/dataloader/prowloader/pgwriter/pgwriter.go`, after populating `tmp_prow_job_runs` and before commit:
+
+```sql
+INSERT INTO prow_job_run_id_map (id, prow_job_release, timestamp)
+SELECT id, prow_job_release, timestamp
+FROM tmp_prow_job_runs
+ON CONFLICT (id) DO NOTHING;
+```
+
+#### Proposed external backfill SQL (example only, not in repo)
+
+Backfill is **not** part of Phase 1 and **no script is added to this repository**. An external ops process owns backfill timing and tooling. The SQL below is a reference example that process may adapt (batching, scheduling, etc.):
+
+```sql
+-- Idempotent; safe to re-run.
+INSERT INTO prow_job_run_id_map (id, prow_job_release, timestamp)
+SELECT id, prow_job_release, timestamp
+FROM prow_job_runs
+WHERE prow_job_release IS NOT NULL AND prow_job_release <> ''
+ON CONFLICT (id) DO NOTHING;
+```
+
+#### Tests
+
+| Test | Verifies |
+|------|----------|
+| pgwriter mapping row | New run via `writeBatch` creates map row |
+
+### Phase 1 verification
+
+```bash
+go run ./cmd/sippy migrate --database-dsn "$SIPPY_SEED_DATABASE_DSN"
+go run ./cmd/sippy migrate --database-dsn "$SIPPY_PRODLIKE_DATABASE_DSN"
+go test ./pkg/db/query/...
+make integration
+make lint
+```
+
+**After Phase 1 deploy (before backfill):**
+
+```sql
+-- Map should have only newly ingested runs (small count)
+SELECT COUNT(*) FROM prow_job_run_id_map;
+
+-- Lookups still use prow_job_runs; no API behavior change
+```
+
+**Do NOT expect map count to match prow_job_runs count yet.**
+
+### Phase 1 risks
+
+| Risk | Mitigation |
+|------|------------|
+| Map unused for reads until Phase 3 | Expected; prow_job_runs lookup unchanged in Phase 1-2 |
+| New run missing from map | pgwriter writes both in same txn |
+| Test inserts bypass pgwriter | `CreateProwJobRun` fixture syncs map row |
+
+---
+
+## Phase 2: External backfill (ops, not in repo)
+
+**Goal:** Populate historical rows into `prow_job_run_id_map` without blocking deploy or migrate.
+
+**Prerequisite:** Phase 1 deployed and pgwriter writing new map rows.
+
+**Owner:** External ops process (not maintained in this repository).
+
+### Steps
+
+1. Run backfill against staging, then production using the external process (may use the example SQL in this plan as a starting point)
+2. Verify completeness:
+
+```sql
+-- Must return 0 before Phase 3
+SELECT COUNT(*) FROM prow_job_runs r
+LEFT JOIN prow_job_run_id_map m ON m.id = r.id
+WHERE m.id IS NULL
+  AND r.prow_job_release IS NOT NULL AND r.prow_job_release <> '';
+```
+
+3. Spot-check counts:
+
+```sql
+SELECT COUNT(*) FROM prow_job_runs;
+SELECT COUNT(*) FROM prow_job_run_id_map;
+-- should match (minus rows with empty prow_job_release)
+```
+
+**No application code changes in Phase 2.** `LookupProwJobRunPartitionKeys` continues querying `prow_job_runs`.
+
+---
+
+## Phase 3: Post-backfill switch (follow-up PR(s))
+
+**Goal:** Move read paths to the map table now that it is complete. Required before phase 4b partitions `prow_job_runs`.
+
+**Prerequisite:** Phase 2 verification query returns 0.
+
+### 3a. Switch `LookupProwJobRunPartitionKeys` (required)
+
+Update `pkg/db/query/job_queries.go` to query `prow_job_run_id_map` only. Remove the "future iteration" TODO comment. No fallback to `prow_job_runs`.
+
+```go
+// Query prow_job_run_id_map by id; return gorm.ErrRecordNotFound if missing
+```
+
+All callers (`FetchJobRun`, job artifacts, re-evaluator, infrafailure) pick up the change automatically via the shared function.
+
+### 3b. Switch `findNewJobRunIDs` (phase 4b)
+
+Replace anti-join target in `pkg/dataloader/prowloader/prow.go`:
+
+```sql
+-- Before (Phase 1-2):
+LEFT JOIN prow_job_runs r ON r.id = t.id WHERE r.id IS NULL
+
+-- After (Phase 3):
+LEFT JOIN prow_job_run_id_map m ON m.id = t.id WHERE m.id IS NULL
+```
+
+Can ship with phase 4b `prow_job_runs` partitioning PR. **Only safe after backfill verified** — map-only before backfill would re-process historical runs.
+
+### Phase 3 also documents
+
+- Retention: when phase 4b drops old `prow_job_runs` partitions, delete corresponding `prow_job_run_id_map` rows in the same operation
+
+---
+
+## Other `prow_job_runs` queries without partition keys (inventory)
+
+Most production queries **already filter on `prow_job_release` and `timestamp`** (job runs report, variant reports, build clusters, autocomplete, test counts, payload queries, etc.). Those are fine for partition pruning once phase 4b lands.
+
+The problem class is **point lookups or writes keyed only by build ID**:
+
+### Already two-step (Phase 3 map fixes step 1)
+
+| Location | Pattern |
+|----------|---------|
+| `pkg/api/job_runs.go` `FetchJobRun` | `LookupProwJobRunPartitionKeys` → `Take` with release + timestamp |
+| `pkg/api/jobartifacts/query.go` `getJobRun` | same |
+| `pkg/api/jobrunscan/reevaluate.go` | same |
+| `pkg/db/infrafailure/infrafailure.go` `subtractFromSummaries` | lookup → child table scan with partition keys |
+
+### ID-only — Phase 3 (after backfill)
+
+| Location | Query | Phase |
+|----------|-------|-------|
+| `pkg/db/query/job_queries.go` | `LookupProwJobRunPartitionKeys` | Phase 3 (map only, no fallback) |
+| `pkg/dataloader/prowloader/prow.go` `findNewJobRunIDs` | `LEFT JOIN prow_job_runs r ON r.id = t.id` | Phase 3 (after backfill) |
+
+### ID-only — NOT in Phase 1; phase 4b follow-up
+
+| Location | Query | Fix |
+|----------|-------|-----|
+| `pkg/db/infrafailure/infrafailure.go` `setInfraFailureLabelSQL` | `UPDATE prow_job_runs ... WHERE id = ?` | Map lookup first; add `AND prow_job_release = ? AND timestamp = ?` |
+| `pkg/db/infrafailure/infrafailure.go` `SubtractNewInfraFailure` | `SELECT 1 ... WHERE id = ? AND labels @> ...` | Same |
+| `pkg/sippyserver/server.go` disruption API | `SELECT MIN/MAX(timestamp) ... WHERE id IN ?` | Query `prow_job_run_id_map` instead |
+
+### JOIN on `id` only, but `WHERE` has partition keys (phase 4b query hardening)
+
+Suboptimal after partitioning; add composite join on release + timestamp (pattern in `pkg/db/query/test_queries.go`):
+
+- `pkg/api/componentreadiness/dataprovider/postgres/provider.go`
+- `pkg/api/recent_test_failures.go`
+- `pkg/db/query/repository_queries.go`
+- `pkg/db/query/pull_request_queries.go`
+- `pkg/db/functions.go`
+
+Not mapping-table problems; separate phase 4b query optimization.
+
+**Phase 1 scope:** DDL + model + pgwriter + pgwriter test + docs. No lookup changes. No backfill script in repo.
+
+---
+
+## Out of scope (all phases)
+
+- Partitioning `prow_job_runs` / annotations / PR join table (phase 4b, separate plan)
+- Golden-file validation (`docs/plans/trt-2709-golden-file-validation.md`)
+- In-migration backfill and repo-maintained backfill scripts (external ops owns backfill; example SQL in this plan only)
+- BigQuery changes (BQ uses build ID strings independently)
+- Infrafailure id-only UPDATE/SELECT, disruption API, composite JOIN hardening (phase 4b; see inventory above)
+
+---
+
+## PR summary
+
+| Phase | Deliverable | When |
+|-------|-------------|------|
+| **1** | This PR: DDL + model + pgwriter + pgwriter test + docs | Now |
+| **2** | External ops backfill + verification | After Phase 1 deploy |
+| **3** | Switch lookup to map + `findNewJobRunIDs` + infrafailure/disruption fixes + composite JOIN hardening | After Phase 2 verified; with phase 4b |

--- a/docs/plans/trt-2709-job-run-id-mapping.md
+++ b/docs/plans/trt-2709-job-run-id-mapping.md
@@ -24,11 +24,11 @@ This works on the current unpartitioned table (~410K rows) but will degrade once
 
 **Callers (5 production paths, no API signature changes needed):**
 
-- `pkg/api/job_runs.go` — `FetchJobRun`
+- `pkg/api/job_runs.go` (`FetchJobRun`)
 - `pkg/api/jobartifacts/query.go`
 - `pkg/api/jobrunscan/reevaluate.go`
 - `pkg/db/infrafailure/infrafailure.go`
-- `pkg/flags/postgres_benchmarking_test.go` — validation harness
+- `pkg/flags/postgres_benchmarking_test.go` (validation harness)
 
 ```mermaid
 flowchart TB
@@ -63,10 +63,10 @@ flowchart TB
 
 **Properties:**
 
-- **Not partitioned** — single PK index lookup by `id`
-- **Tiny rows** — ~24 bytes each
-- **No FK to `prow_job_runs`** — application-level integrity (same pattern as phase 4a child tables)
-- **Immutable after insert** — release and timestamp for a build ID never change
+- **Not partitioned**: single PK index lookup by `id`
+- **Tiny rows**: ~24 bytes each
+- **No FK to `prow_job_runs`** (application-level integrity, same pattern as phase 4a child tables)
+- **Immutable after insert**: release and timestamp for a build ID never change
 
 ---
 
@@ -250,7 +250,7 @@ LEFT JOIN prow_job_runs r ON r.id = t.id WHERE r.id IS NULL
 LEFT JOIN prow_job_run_id_map m ON m.id = t.id WHERE m.id IS NULL
 ```
 
-Can ship with phase 4b `prow_job_runs` partitioning PR. **Only safe after backfill verified** — map-only before backfill would re-process historical runs.
+Can ship with phase 4b `prow_job_runs` partitioning PR. **Only safe after backfill verified**; map-only before backfill would re-process historical runs.
 
 ### Phase 3 also documents
 
@@ -273,14 +273,14 @@ The problem class is **point lookups or writes keyed only by build ID**:
 | `pkg/api/jobrunscan/reevaluate.go` | same |
 | `pkg/db/infrafailure/infrafailure.go` `subtractFromSummaries` | lookup → child table scan with partition keys |
 
-### ID-only — Phase 3 (after backfill)
+### ID-only: Phase 3 (after backfill)
 
 | Location | Query | Phase |
 |----------|-------|-------|
 | `pkg/db/query/job_queries.go` | `LookupProwJobRunPartitionKeys` | Phase 3 (map only, no fallback) |
 | `pkg/dataloader/prowloader/prow.go` `findNewJobRunIDs` | `LEFT JOIN prow_job_runs r ON r.id = t.id` | Phase 3 (after backfill) |
 
-### ID-only — NOT in Phase 1; phase 4b follow-up
+### ID-only: NOT in Phase 1; phase 4b follow-up
 
 | Location | Query | Fix |
 |----------|-------|-----|

--- a/docs/plans/trt-2709-job-run-id-mapping.md
+++ b/docs/plans/trt-2709-job-run-id-mapping.md
@@ -33,7 +33,7 @@ This works on the current unpartitioned table (~410K rows) but will degrade once
 ```mermaid
 flowchart TB
   subgraph phase1 [Phase 1 - This PR]
-    Migrate[DDL migration]
+    AutoMigrate[GORM AutoMigrate]
     PgWriter[pgwriter writes map rows]
     LookupUnchanged[Lookup unchanged on prow_job_runs]
     FindNew[findNewJobRunIDs unchanged]
@@ -78,8 +78,7 @@ flowchart TB
 
 | Item | File(s) | Notes |
 |------|---------|-------|
-| DDL migration | `pkg/db/migrations/000013_*` | CREATE TABLE only; backfill INSERT commented out |
-| GORM model | `pkg/db/models/prow.go` | `ProwJobRunIDMap` |
+| GORM model + AutoMigrate | `pkg/db/models/prow.go`, `pkg/db/db.go` | `ProwJobRunIDMap` registered in `UpdateSchema` |
 | pgwriter insert | `pkg/dataloader/prowloader/pgwriter/pgwriter.go` | Map rows in same txn as `prow_job_runs` |
 | Test fixture | `test/integration/util/fixtures.go` | `CreateProwJobRun` syncs map row |
 | Tests | `test/integration/pgwriter_test.go` | Verify map row created on pgwriter insert |
@@ -96,27 +95,19 @@ flowchart TB
 
 ### Phase 1 implementation details
 
-#### Migration `000013_create_prow_job_run_id_map`
+#### Schema (`ProwJobRunIDMap`)
+
+The table is created by GORM `AutoMigrate` in `UpdateSchema` (no golang-migrate file). Equivalent DDL:
 
 ```sql
-CREATE TABLE IF NOT EXISTS prow_job_run_id_map (
+CREATE TABLE prow_job_run_id_map (
     id BIGINT PRIMARY KEY,
     prow_job_release TEXT NOT NULL,
     timestamp TIMESTAMPTZ NOT NULL
 );
-
--- Backfill is intentionally NOT run here. Scanning all of prow_job_runs during
--- migrate is too slow and timing-sensitive for production deploys. Run the
--- external backfill process separately in Phase 2 (see example SQL below).
---
--- INSERT INTO prow_job_run_id_map (id, prow_job_release, timestamp)
--- SELECT id, prow_job_release, timestamp
--- FROM prow_job_runs
--- WHERE prow_job_release IS NOT NULL AND prow_job_release <> ''
--- ON CONFLICT (id) DO NOTHING;
 ```
 
-**`.down.sql`:** `DROP TABLE IF EXISTS prow_job_run_id_map;`
+Historical backfill is **not** run during schema setup. An external ops process handles backfill separately in Phase 2 (see example SQL below).
 
 #### pgwriter
 
@@ -149,6 +140,8 @@ ON CONFLICT (id) DO NOTHING;
 | pgwriter mapping row | New run via `writeBatch` creates map row |
 
 ### Phase 1 verification
+
+`prow_job_run_id_map` is created by GORM `AutoMigrate` in `UpdateSchema` (invoked by `migrate`, `serve`, and integration test setup), not by a golang-migrate SQL file.
 
 ```bash
 go run ./cmd/sippy migrate --database-dsn "$SIPPY_SEED_DATABASE_DSN"
@@ -290,7 +283,7 @@ Suboptimal after partitioning; add composite join on release + timestamp (patter
 
 Not mapping-table problems; separate phase 4b query optimization.
 
-**Phase 1 scope:** DDL + model + pgwriter + pgwriter test + docs. No lookup changes. No backfill script in repo.
+**Phase 1 scope:** GORM AutoMigrate + model + pgwriter + pgwriter test + docs. No lookup changes. No backfill script in repo.
 
 ---
 
@@ -298,7 +291,7 @@ Not mapping-table problems; separate phase 4b query optimization.
 
 - Partitioning `prow_job_runs` / annotations / PR join table (phase 4b, separate plan)
 - Golden-file validation (`docs/plans/trt-2709-golden-file-validation.md`)
-- In-migration backfill and repo-maintained backfill scripts (external ops owns backfill; example SQL in this plan only)
+- In-migrate backfill and repo-maintained backfill scripts (external ops owns backfill; example SQL in this plan only)
 - BigQuery changes (BQ uses build ID strings independently)
 - Infrafailure id-only UPDATE/SELECT, disruption API, composite JOIN hardening (phase 4b; see inventory above)
 
@@ -308,6 +301,6 @@ Not mapping-table problems; separate phase 4b query optimization.
 
 | Phase | Deliverable | When |
 |-------|-------------|------|
-| **1** | This PR: DDL + model + pgwriter + pgwriter test + docs | Now |
+| **1** | This PR: AutoMigrate + model + pgwriter + pgwriter test + docs | Now |
 | **2** | External ops backfill + verification | After Phase 1 deploy |
 | **3** | Switch lookup to map + `findNewJobRunIDs` + infrafailure/disruption fixes + composite JOIN hardening | After Phase 2 verified; with phase 4b |

--- a/docs/plans/trt-2709-job-run-id-mapping.md
+++ b/docs/plans/trt-2709-job-run-id-mapping.md
@@ -38,8 +38,8 @@ flowchart TB
     LookupUnchanged[Lookup unchanged on prow_job_runs]
     FindNew[findNewJobRunIDs unchanged]
   end
-  subgraph phase2 [Phase 2 - External ops backfill]
-    Backfill[External process backfills map]
+  subgraph phase2 [Phase 2 - Premigration backfill]
+    Backfill[gopar premigration backfills map]
     Verify[Verify row counts]
   end
   subgraph phase3 [Phase 3 - Post-backfill]
@@ -82,7 +82,8 @@ flowchart TB
 | pgwriter insert | `pkg/dataloader/prowloader/pgwriter/pgwriter.go` | Map rows in same txn as `prow_job_runs` |
 | Test fixture | `test/integration/util/fixtures.go` | `CreateProwJobRun` syncs map row |
 | Tests | `test/integration/pgwriter_test.go` | Verify map row created on pgwriter insert |
-| Docs | `pkg/db/PARTITIONS_README.md` or partitioning prep doc | Document phases; reference example backfill SQL below |
+| Premigration backfill | `config/specs/premigration/003_prow_job_run_id_map_backfill.json` (gopar) | Batched INSERT from `prow_job_runs`; run in Phase 2 |
+| Docs | `pkg/db/PARTITIONS_README.md` or partitioning prep doc | Document phases |
 
 ### What does NOT change in Phase 1
 
@@ -90,7 +91,7 @@ flowchart TB
 |------|--------|
 | `LookupProwJobRunPartitionKeys` | Map is incomplete until backfill; keep querying `prow_job_runs` |
 | `findNewJobRunIDs` | Still anti-joins `prow_job_runs`; map is incomplete until backfill |
-| External backfill | Managed outside this repo in Phase 2; example SQL documented below |
+| Running the backfill | Spec ships in Phase 1; execution is Phase 2 after deploy |
 | `prow_job_runs` partitioning | Phase 4b, separate effort |
 
 ### Phase 1 implementation details
@@ -107,7 +108,7 @@ CREATE TABLE prow_job_run_id_map (
 );
 ```
 
-Historical backfill is **not** run during schema setup. An external ops process handles backfill separately in Phase 2 (see example SQL below).
+Historical backfill is **not** run during schema setup. Backfill is handled separately in Phase 2 via a gopar premigration spec (see below).
 
 #### pgwriter
 
@@ -120,17 +121,29 @@ FROM tmp_prow_job_runs
 ON CONFLICT (id) DO NOTHING;
 ```
 
-#### Proposed external backfill SQL (example only, not in repo)
+#### Premigration backfill spec (gopar)
 
-Backfill is **not** part of Phase 1 and **no script is added to this repository**. An external ops process owns backfill timing and tooling. The SQL below is a reference example that process may adapt (batching, scheduling, etc.):
+Backfill is handled in Phase 2 via the gopar premigration spec at `config/specs/premigration/003_prow_job_run_id_map_backfill.json`. The spec uses the same batched CTE pattern as the existing premigration backfills (batch size 500K, `LEFT JOIN` to find missing rows, `ON CONFLICT DO NOTHING` for idempotency):
 
 ```sql
--- Idempotent; safe to re-run.
-INSERT INTO prow_job_run_id_map (id, prow_job_release, timestamp)
-SELECT id, prow_job_release, timestamp
-FROM prow_job_runs
-WHERE prow_job_release IS NOT NULL AND prow_job_release <> ''
-ON CONFLICT (id) DO NOTHING;
+WITH batch AS (
+    SELECT r.id, r.prow_job_release, r."timestamp"
+    FROM prow_job_runs r
+    LEFT JOIN prow_job_run_id_map m ON m.id = r.id
+    WHERE m.id IS NULL
+    AND r.prow_job_release IS NOT NULL AND r.prow_job_release <> ''
+    LIMIT $1
+)
+INSERT INTO prow_job_run_id_map (id, prow_job_release, "timestamp")
+SELECT id, prow_job_release, "timestamp"
+FROM batch
+ON CONFLICT (id) DO NOTHING
+```
+
+Run via:
+
+```bash
+gopar sql --dsn "$DSN" --spec-file config/specs/premigration/003_prow_job_run_id_map_backfill.json
 ```
 
 #### Tests
@@ -172,17 +185,21 @@ SELECT COUNT(*) FROM prow_job_run_id_map;
 
 ---
 
-## Phase 2: External backfill (ops, not in repo)
+## Phase 2: Premigration backfill (gopar)
 
 **Goal:** Populate historical rows into `prow_job_run_id_map` without blocking deploy or migrate.
 
 **Prerequisite:** Phase 1 deployed and pgwriter writing new map rows.
 
-**Owner:** External ops process (not maintained in this repository).
+**Owner:** gopar premigration spec (`config/specs/premigration/003_prow_job_run_id_map_backfill.json`).
 
 ### Steps
 
-1. Run backfill against staging, then production using the external process (may use the example SQL in this plan as a starting point)
+1. Run backfill against staging, then production via gopar:
+
+```bash
+gopar sql --dsn "$DSN" --spec-file config/specs/premigration/003_prow_job_run_id_map_backfill.json
+```
 2. Verify completeness:
 
 ```sql
@@ -201,7 +218,7 @@ SELECT COUNT(*) FROM prow_job_run_id_map;
 -- should match (minus rows with empty prow_job_release)
 ```
 
-**No application code changes in Phase 2.** `LookupProwJobRunPartitionKeys` continues querying `prow_job_runs`.
+**No application code changes in Phase 2.** `LookupProwJobRunPartitionKeys` continues querying `prow_job_runs`. The backfill is idempotent and safe to re-run.
 
 ---
 
@@ -283,7 +300,7 @@ Suboptimal after partitioning; add composite join on release + timestamp (patter
 
 Not mapping-table problems; separate phase 4b query optimization.
 
-**Phase 1 scope:** GORM AutoMigrate + model + pgwriter + pgwriter test + docs. No lookup changes. No backfill script in repo.
+**Phase 1 scope:** GORM AutoMigrate + model + pgwriter + pgwriter test + docs. No lookup changes. Backfill script ships as gopar premigration spec (run in Phase 2).
 
 ---
 
@@ -291,7 +308,7 @@ Not mapping-table problems; separate phase 4b query optimization.
 
 - Partitioning `prow_job_runs` / annotations / PR join table (phase 4b, separate plan)
 - Golden-file validation (`docs/plans/trt-2709-golden-file-validation.md`)
-- In-migrate backfill and repo-maintained backfill scripts (external ops owns backfill; example SQL in this plan only)
+- In-migrate backfill (backfill runs via gopar premigration spec, not during GORM AutoMigrate)
 - BigQuery changes (BQ uses build ID strings independently)
 - Infrafailure id-only UPDATE/SELECT, disruption API, composite JOIN hardening (phase 4b; see inventory above)
 
@@ -301,6 +318,6 @@ Not mapping-table problems; separate phase 4b query optimization.
 
 | Phase | Deliverable | When |
 |-------|-------------|------|
-| **1** | This PR: AutoMigrate + model + pgwriter + pgwriter test + docs | Now |
-| **2** | External ops backfill + verification | After Phase 1 deploy |
+| **1** | This PR: AutoMigrate + model + pgwriter + pgwriter test + docs + gopar premigration backfill spec | Now |
+| **2** | Run gopar premigration backfill + verification | After Phase 1 deploy |
 | **3** | Switch lookup to map + `findNewJobRunIDs` + infrafailure/disruption fixes + composite JOIN hardening | After Phase 2 verified; with phase 4b |

--- a/pkg/dataloader/prowloader/pgwriter/pgwriter.go
+++ b/pkg/dataloader/prowloader/pgwriter/pgwriter.go
@@ -222,6 +222,9 @@ func Write(ctx context.Context, dbc *db.DB, currentDate civil.Date, batch []JobR
 	if err := insertJobRuns(ctx, tx); err != nil {
 		return err
 	}
+	if err := insertJobRunIDMap(ctx, tx); err != nil {
+		return err
+	}
 	if err := insertAnnotations(ctx, tx, len(anns)); err != nil {
 		return err
 	}
@@ -268,6 +271,20 @@ func insertJobRuns(ctx context.Context, tx pgx.Tx) error {
 		return fmt.Errorf("inserting prow_job_runs: %w", err)
 	}
 	log.WithField("elapsed", time.Since(stepStart)).Debug("inserted prow_job_runs")
+	return nil
+}
+
+func insertJobRunIDMap(ctx context.Context, tx pgx.Tx) error {
+	stepStart := time.Now()
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO prow_job_run_id_map (id, prow_job_release, timestamp)
+		SELECT id, prow_job_release, timestamp
+		FROM tmp_prow_job_runs
+		ON CONFLICT (id) DO NOTHING
+	`); err != nil {
+		return fmt.Errorf("inserting prow_job_run_id_map: %w", err)
+	}
+	log.WithField("elapsed", time.Since(stepStart)).Debug("inserted prow_job_run_id_map")
 	return nil
 }
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -155,6 +155,7 @@ func (d *DB) UpdateSchema(reportEnd *time.Time) error {
 		&models.VariantCombination{},
 		&models.ProwJob{},
 		&models.ProwJobRun{},
+		&models.ProwJobRunIDMap{},
 		&models.ProwJobRunAnnotation{},
 		&models.Test{},
 		&models.Suite{},

--- a/pkg/db/models/prow.go
+++ b/pkg/db/models/prow.go
@@ -45,6 +45,18 @@ type IDName struct {
 	Name string `gorm:"unique"`
 }
 
+// ProwJobRunIDMap maps a Prow build ID to the partition keys for prow_job_runs.
+// Populated on ingest via pgwriter; used for partition-pruned lookups after
+// prow_job_runs is partitioned (see docs/plans/trt-2709-job-run-id-mapping.md).
+type ProwJobRunIDMap struct {
+	ID             uint      `gorm:"primaryKey"`
+	ProwJobRelease string    `gorm:"not null"`
+	Timestamp      time.Time `gorm:"not null"`
+}
+
+// TableName overrides GORM's default pluralization, which would use prow_job_run_id_maps.
+func (ProwJobRunIDMap) TableName() string { return "prow_job_run_id_map" }
+
 type ProwJobRun struct {
 	gorm.Model
 

--- a/test/integration/pgwriter_test.go
+++ b/test/integration/pgwriter_test.go
@@ -60,6 +60,12 @@ func TestJobRunsPersisted(t *testing.T) {
 	assert.Equal(t, "S", string(run.OverallResult))
 	assert.Equal(t, 2, run.TestFailures)
 	assert.True(t, run.Succeeded)
+
+	var idMap models.ProwJobRunIDMap
+	require.NoError(t, dbc.DB.First(&idMap, 1001).Error)
+	assert.Equal(t, uint(1001), idMap.ID)
+	assert.Equal(t, "4.18", idMap.ProwJobRelease)
+	assert.True(t, ts.Equal(idMap.Timestamp))
 }
 
 func TestAnnotationsStored(t *testing.T) {

--- a/test/integration/util/fixtures.go
+++ b/test/integration/util/fixtures.go
@@ -95,6 +95,11 @@ func CreateProwJobRun(t *testing.T, dbc *db.DB, prowJobID uint, release string, 
 		opt(&run)
 	}
 	require.NoError(t, dbc.DB.Create(&run).Error, "creating ProwJobRun")
+	require.NoError(t, dbc.DB.Create(&models.ProwJobRunIDMap{
+		ID:             run.ID,
+		ProwJobRelease: run.ProwJobRelease,
+		Timestamp:      run.Timestamp,
+	}).Error, "creating ProwJobRunIDMap for run %d", run.ID)
 	return run
 }
 

--- a/test/integration/util/schema.go
+++ b/test/integration/util/schema.go
@@ -29,6 +29,7 @@ func SetupIntegrationSchema(dbc *db.DB) error {
 		&models.VariantCombination{},
 		&models.ProwJob{},
 		&models.ProwJobRun{},
+		&models.ProwJobRunIDMap{},
 		&models.ProwJobRunAnnotation{},
 		&models.Test{},
 		&models.Suite{},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic mapping records for job runs, including release and timestamp details.
  * Job-run mappings are created during data ingestion and supported by database schema migration.

* **Bug Fixes**
  * Prevented duplicate mapping records during repeated writes.

* **Tests**
  * Expanded integration coverage to verify mapping records and their expected values.
  * Updated test fixtures and schemas to include job-run mappings.

* **Documentation**
  * Added a rollout plan for future job-run data partitioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->