### PR TITLE
Import the TLSSecurityScan junit suite

### DIFF
--- a/pkg/db/suites.go
+++ b/pkg/db/suites.go
@@ -77,6 +77,7 @@ var testSuites = []string{
 	"ServiceMesh-lp-interop",
 	"OpenshiftPipelines-lp-interop",
 	"tracing-uiplugin",
+	"TLSSecurityScan",
 }
 
 // testSuitePatterns are regular expressions for suite names that should be imported


### PR DESCRIPTION
The tls-scanner periodics (periodic-ci-openshift-tls-scanner-release-*) emit junit results under a testsuite named TLSSecurityScan, with one testcase per workload/port endpoint:

  [sig-security][OCPFeatureGate:TLSAdherence] ns/openshift-apiserver
  deployment/apiserver port/8443 should comply with the cluster TLS profile

The suite is not in the importable list, so the test cases are dropped on import and only job-level pass/fail is visible. Add it so per-endpoint results are tracked.

Release association for these jobs is handled separately by the job-release label (openshift/release#84014).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the TLS security scan suite to the list of explicitly importable test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->