### PR TITLE
Add quay-3.18 synthetic release to Sippy config

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -128,3 +128,7 @@ releases:
     synthetic: true
     regexp:
       - "^periodic-ci-openshift-hypershift-.*-periodics-hcm-.*"
+  quay-3.18:
+    synthetic: true
+    jobs:
+      periodic-ci-quay-quay-redhat-3.18-aws-ocp422-e2e-install-aws-s3-3-18-nightly-4-22: true


### PR DESCRIPTION
Add a minimal synthetic release configuration for Quay 3.18, tracking the periodic-ci-quay-quay-redhat-3.18-aws-ocp422-e2e-install-aws-s3-3-18-nightly-4-22 e2e job in openshift-customizations.yaml.

Made with chai-bot!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `quay-3.18` release customization.
  - Added a nightly AWS OpenShift 4.22 installation end-to-end test using S3 storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->