### PR TITLE
TRT-2886: treat zero-count summary rows as equivalent to absent in verify

### DIFF
--- a/pkg/db/verify/comparison.go
+++ b/pkg/db/verify/comparison.go
@@ -18,6 +18,13 @@ func compareCounts(check Check, release string, date civil.Date, expectedRows, a
 		expectedCounts, hasExpected := expected[key]
 		actualCounts, hasActual := actual[key]
 		if !hasExpected {
+			if actualCounts.IsZero() {
+				// A row can be left behind with all-zero counts once its only
+				// contributing run is subtracted out (e.g. an InfraFailure
+				// exclusion applied after the row was first written). That is
+				// indistinguishable from the row never having existed.
+				continue
+			}
 			discrepancies = append(discrepancies, Discrepancy{
 				Check: check, Release: release, Date: date, Kind: "unexpected-row", Key: key.String(),
 				Expected: "missing", Actual: "present",

--- a/pkg/db/verify/types.go
+++ b/pkg/db/verify/types.go
@@ -207,6 +207,14 @@ type Counts struct {
 	Runs      int64
 }
 
+// IsZero reports whether every counter is zero. A stored summary row can be
+// left with all-zero counts after its only contributing run is subtracted out
+// (see pkg/db/infrafailure), so such a row is equivalent to the row being
+// absent altogether.
+func (c Counts) IsZero() bool {
+	return c.Successes == 0 && c.Failures == 0 && c.Flakes == 0 && c.Runs == 0
+}
+
 func (c Counts) Add(other Counts) Counts {
 	return Counts{
 		Successes: c.Successes + other.Successes,

--- a/pkg/db/verify/verify_test.go
+++ b/pkg/db/verify/verify_test.go
@@ -93,6 +93,7 @@ func TestCompareDaily(t *testing.T) {
 		{name: "equal", expected: []DailyRow{base}, actual: []DailyRow{base}},
 		{name: "raw only", expected: []DailyRow{base}, wantKind: "missing-row"},
 		{name: "summary only", actual: []DailyRow{base}, wantKind: "unexpected-row"},
+		{name: "zero-count summary only is not a discrepancy", actual: []DailyRow{{Key: key, Counts: Counts{}}}},
 		{name: "success mismatch", expected: []DailyRow{base}, actual: []DailyRow{{Key: key, Counts: Counts{Successes: 4, Failures: 2, Flakes: 1, Runs: 7}}}, wantKind: "count-mismatch", wantField: "successes"},
 		{name: "failure mismatch", expected: []DailyRow{base}, actual: []DailyRow{{Key: key, Counts: Counts{Successes: 3, Failures: 3, Flakes: 1, Runs: 7}}}, wantKind: "count-mismatch", wantField: "failures"},
 		{name: "flake mismatch", expected: []DailyRow{base}, actual: []DailyRow{{Key: key, Counts: Counts{Successes: 3, Failures: 2, Flakes: 2, Runs: 7}}}, wantKind: "count-mismatch", wantField: "flakes"},
@@ -113,6 +114,14 @@ func TestCompareDaily(t *testing.T) {
 			assert.Equal(t, tt.wantField, discrepancies[0].Field)
 		})
 	}
+}
+
+func TestCountsIsZero(t *testing.T) {
+	assert.True(t, Counts{}.IsZero())
+	assert.False(t, Counts{Successes: 1}.IsZero())
+	assert.False(t, Counts{Failures: 1}.IsZero())
+	assert.False(t, Counts{Flakes: 1}.IsZero())
+	assert.False(t, Counts{Runs: 1}.IsZero())
 }
 
 func TestCompareCumulative(t *testing.T) {


### PR DESCRIPTION
## Summary
- `sippy verify --check daily-totals` was reporting false-positive `unexpected-row` discrepancies for job runs later labeled `InfraFailure` ([TRT-2884](https://redhat.atlassian.net/browse/TRT-2884)). `infrafailure.RecordInfraFailure`/`SubtractNewInfraFailure` subtract a run's contribution from `test_daily_totals`/`test_cumulative_summaries` via `UPDATE`, which can leave an all-zero-count row behind rather than deleting it.
- The daily-totals check's "expected" side is a live recomputation that excludes `InfraFailure`-labeled runs entirely, so a key whose only contribution came from such a run never appears in "expected" — even though the stored (zeroed) row is functionally equivalent to the row not existing.
- Root-caused against production data: `prow_job_id=16286` job run `2094274293461422080` on 2026-08-31 was labeled `InfraFailure` (`GoDownloadTimeout` symptom) after its 12 `test_daily_totals` rows were written; those rows still exist with all counts at 0, which the check flagged as unexpected.
- Fix: `compareCounts` in `pkg/db/verify/comparison.go` now skips the `unexpected-row` discrepancy when the actual-only row's counts are all zero (`Counts.IsZero()`, added in `pkg/db/verify/types.go`). Applies to both `daily-totals` and `cumulative-summaries` since they share this comparison function.

## Test plan
- [x] `go test ./pkg/db/verify/...` — added `TestCompareDaily/zero-count_summary_only_is_not_a_discrepancy` regression test and `TestCountsIsZero`
- [x] `go vet ./pkg/db/verify/...`
- [x] `gofmt -l` clean on changed files

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Verification no longer reports unexpected summary rows when all their recorded counts are zero.
  - Unexpected rows with nonzero counts continue to be reported as discrepancies.

- **Tests**
  - Added coverage for zero-count summary rows and validation of count handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->