### PR TITLE
config: add CAPA e2e jobs to rosa-stage Sippy release

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -89,6 +89,8 @@ releases:
       - "^periodic-ci-openshift-rosa-master-e2e-rosa-.*"
       # Terraform provider RHCS e2e tests
       - "^periodic-ci-terraform-redhat-terraform-provider-rhcs-main-e2e-rosa-.*"
+      # CAPA e2e tests (uses underscore separator: rosa-e2e-main_capa-e2e)
+      - "^periodic-ci-openshift-online-rosa-e2e-main_capa-e2e-.*"
   rosa-integration:
     synthetic: true
     regexp:


### PR DESCRIPTION
The CAPA e2e periodic jobs use an underscore separator in their Prow job names (`rosa-e2e-main_capa-e2e`) rather than the hyphen used by all other rosa-e2e jobs. None of the existing `rosa-stage` regexps match this pattern, so CAPA jobs have never appeared in the rosa-stage Sippy view.

## Change

Add a new regexp to `rosa-stage`:

```yaml
# CAPA e2e tests (uses underscore separator: rosa-e2e-main_capa-e2e)
- "^periodic-ci-openshift-online-rosa-e2e-main_capa-e2e-.*"
```

Affected jobs:
- `periodic-ci-openshift-online-rosa-e2e-main_capa-e2e-capa-e2e`
- `periodic-ci-openshift-online-rosa-e2e-main_capa-e2e-capa-e2e-full`

## Context

ROSA CI has a daily health report bot (chai-bot) that reads job categories from `openshift-online/rosa-e2e` `configs/ci-status-jobs.yaml` and queries Sippy for pass rate data. Because CAPA jobs are absent from the `rosa-stage` Sippy release, the bot reports this category as "no runs" every day even though the jobs run regularly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing CAPA end-to-end test jobs that use the underscore-separated `main_capa-e2e` naming format in the `rosa-stage` environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->