### PR TITLE
trt-2709: update job_runs for partitioning

### DIFF
--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -133,17 +133,17 @@ func JobsRunsReportFromDB(dbc *db.DB, filterOpts *filter.FilterOptions, release 
 		var g errgroup.Group
 
 		g.Go(func() error {
-			return enrichJobRunsWithTestNames(dbc, jobsResult, release)
+			return enrichJobRunsWithTestNames(dbc, jobsResult, release, lookback, reportEnd)
 		})
 
 		if !needs.needsPRJoin() {
 			g.Go(func() error {
-				return enrichJobRunsWithPRData(dbc, jobsResult, release)
+				return enrichJobRunsWithPRData(dbc, jobsResult, release, lookback, reportEnd)
 			})
 		}
 
 		g.Go(func() error {
-			return enrichJobRunsWithAnnotations(dbc, jobsResult, release)
+			return enrichJobRunsWithAnnotations(dbc, jobsResult, release, lookback, reportEnd)
 		})
 
 		if err := g.Wait(); err != nil {
@@ -326,25 +326,30 @@ func testNameFilterSQL(item filter.FilterItem, lookback time.Time) (string, []an
 	return filter.WrapNot(sql, item.Not), args, nil
 }
 
-func jobRunPartitionKeyPredicate(alias string, results []apitype.JobRun, release string) (string, []any) {
+// jobRunPartitionKeyPredicate identifies page rows while giving the planner explicit partition bounds.
+func jobRunPartitionKeyPredicate(alias string, results []apitype.JobRun, release string, lookback, reportEnd time.Time) (string, []any) {
 	placeholders := make([]string, len(results))
-	args := make([]any, 0, len(results)*3)
+	args := make([]any, 0, len(results)*3+3)
 	for i := range results {
 		placeholders[i] = "(?, ?, ?)"
 		args = append(args, results[i].ID, release, results[i].Timestamp)
 	}
-	return fmt.Sprintf("(%s.prow_job_run_id, %s.prow_job_run_release, %s.prow_job_run_timestamp) IN (%s)",
-		alias, alias, alias, strings.Join(placeholders, ", ")), args
+	args = append(args, release, lookback, reportEnd)
+	return fmt.Sprintf(`(%s.prow_job_run_id, %s.prow_job_run_release, %s.prow_job_run_timestamp) IN (%s)
+		AND %s.prow_job_run_release = ?
+		AND %s.prow_job_run_timestamp >= ?
+		AND %s.prow_job_run_timestamp < ?`,
+		alias, alias, alias, strings.Join(placeholders, ", "), alias, alias, alias), args
 }
 
-func enrichJobRunsWithTestNames(dbc *db.DB, results []apitype.JobRun, release string) error {
+func enrichJobRunsWithTestNames(dbc *db.DB, results []apitype.JobRun, release string, lookback, reportEnd time.Time) error {
 	type testNameResult struct {
 		ProwJobRunID    int            `gorm:"column:prow_job_run_id"`
 		FailedTestNames pq.StringArray `gorm:"column:failed_test_names;type:text[]"`
 		FlakedTestNames pq.StringArray `gorm:"column:flaked_test_names;type:text[]"`
 	}
 	var nameResults []testNameResult
-	keyPredicate, keyArgs := jobRunPartitionKeyPredicate("pjrt", results, release)
+	keyPredicate, keyArgs := jobRunPartitionKeyPredicate("pjrt", results, release, lookback, reportEnd)
 	nameSQL := fmt.Sprintf(`SELECT pjrt.prow_job_run_id,
 			array_agg(t.name) FILTER (WHERE pjrt.status = %d) AS failed_test_names,
 			array_agg(t.name) FILTER (WHERE pjrt.status = %d) AS flaked_test_names
@@ -371,7 +376,7 @@ func enrichJobRunsWithTestNames(dbc *db.DB, results []apitype.JobRun, release st
 	return nil
 }
 
-func enrichJobRunsWithPRData(dbc *db.DB, results []apitype.JobRun, release string) error {
+func enrichJobRunsWithPRData(dbc *db.DB, results []apitype.JobRun, release string, lookback, reportEnd time.Time) error {
 	type prResult struct {
 		ID                int    `gorm:"column:id"`
 		PullRequestLink   string `gorm:"column:pull_request_link"`
@@ -381,7 +386,7 @@ func enrichJobRunsWithPRData(dbc *db.DB, results []apitype.JobRun, release strin
 		PullRequestAuthor string `gorm:"column:pull_request_author"`
 	}
 	var prResults []prResult
-	keyPredicate, keyArgs := jobRunPartitionKeyPredicate("jrpp", results, release)
+	keyPredicate, keyArgs := jobRunPartitionKeyPredicate("jrpp", results, release, lookback, reportEnd)
 	q := dbc.DB.Table("prow_job_run_prow_pull_requests jrpp").
 		Select(`DISTINCT ON(jrpp.prow_job_run_id, jrpp.prow_job_run_release, jrpp.prow_job_run_timestamp)
 			jrpp.prow_job_run_id AS id,
@@ -414,9 +419,9 @@ func enrichJobRunsWithPRData(dbc *db.DB, results []apitype.JobRun, release strin
 	return nil
 }
 
-func enrichJobRunsWithAnnotations(dbc *db.DB, results []apitype.JobRun, release string) error {
+func enrichJobRunsWithAnnotations(dbc *db.DB, results []apitype.JobRun, release string, lookback, reportEnd time.Time) error {
 	var annotations []models.ProwJobRunAnnotation
-	keyPredicate, keyArgs := jobRunPartitionKeyPredicate("prow_job_run_annotations", results, release)
+	keyPredicate, keyArgs := jobRunPartitionKeyPredicate("prow_job_run_annotations", results, release, lookback, reportEnd)
 	annotationQuery := dbc.DB.Where(keyPredicate, keyArgs...)
 	if err := annotationQuery.Find(&annotations).Error; err != nil {
 		return err

--- a/pkg/api/job_runs.go
+++ b/pkg/api/job_runs.go
@@ -76,7 +76,15 @@ func JobsRunsReportFromDB(dbc *db.DB, filterOpts *filter.FilterOptions, release 
 
 	addPRJoin := func(q *gorm.DB) *gorm.DB {
 		return q.
-			Joins(`LEFT JOIN (SELECT DISTINCT ON(prow_job_run_id) prow_job_run_id, prow_pull_request_id FROM prow_job_run_prow_pull_requests WHERE prow_job_run_release = ? ORDER BY prow_job_run_id, prow_pull_request_id DESC) jrpp ON jrpp.prow_job_run_id = prow_job_runs.id`, release).
+			Joins(`LEFT JOIN (
+				SELECT DISTINCT ON(prow_job_run_id, prow_job_run_release, prow_job_run_timestamp)
+					prow_job_run_id, prow_job_run_release, prow_job_run_timestamp, prow_pull_request_id
+				FROM prow_job_run_prow_pull_requests
+				WHERE prow_job_run_release = ? AND prow_job_run_timestamp >= ? AND prow_job_run_timestamp < ?
+				ORDER BY prow_job_run_id, prow_job_run_release, prow_job_run_timestamp, prow_pull_request_id DESC
+			) jrpp ON jrpp.prow_job_run_id = prow_job_runs.id
+				AND jrpp.prow_job_run_release = prow_job_runs.prow_job_release
+				AND jrpp.prow_job_run_timestamp = prow_job_runs.timestamp`, release, lookback, reportEnd).
 			Joins("LEFT JOIN prow_pull_requests pp ON pp.id = jrpp.prow_pull_request_id")
 	}
 
@@ -122,25 +130,20 @@ func JobsRunsReportFromDB(dbc *db.DB, filterOpts *filter.FilterOptions, release 
 	// function writes to disjoint fields of jobsResult, so no locking
 	// is needed.
 	if len(jobsResult) > 0 {
-		ids := make([]int, len(jobsResult))
-		for i, jr := range jobsResult {
-			ids[i] = jr.ID
-		}
-
 		var g errgroup.Group
 
 		g.Go(func() error {
-			return enrichJobRunsWithTestNames(dbc, jobsResult, ids, release, lookback)
+			return enrichJobRunsWithTestNames(dbc, jobsResult, release)
 		})
 
 		if !needs.needsPRJoin() {
 			g.Go(func() error {
-				return enrichJobRunsWithPRData(dbc, jobsResult, ids, release)
+				return enrichJobRunsWithPRData(dbc, jobsResult, release)
 			})
 		}
 
 		g.Go(func() error {
-			return enrichJobRunsWithAnnotations(dbc, jobsResult, ids, release)
+			return enrichJobRunsWithAnnotations(dbc, jobsResult, release)
 		})
 
 		if err := g.Wait(); err != nil {
@@ -292,7 +295,7 @@ func testNameFilterSQL(item filter.FilterItem, lookback time.Time) (string, []an
 	}
 
 	existsBase := fmt.Sprintf(
-		"EXISTS (SELECT 1 FROM prow_job_run_tests JOIN tests ON tests.id = prow_job_run_tests.test_id WHERE prow_job_run_tests.prow_job_run_id = prow_job_runs.id AND prow_job_run_tests.prow_job_run_release = prow_jobs.release AND prow_job_run_tests.prow_job_run_timestamp >= ?%s",
+		"EXISTS (SELECT 1 FROM prow_job_run_tests JOIN tests ON tests.id = prow_job_run_tests.test_id WHERE prow_job_run_tests.prow_job_run_id = prow_job_runs.id AND prow_job_run_tests.prow_job_run_release = prow_job_runs.prow_job_release AND prow_job_run_tests.prow_job_run_timestamp = prow_job_runs.timestamp AND prow_job_run_tests.prow_job_run_timestamp >= ?%s",
 		statusClause,
 	)
 
@@ -323,29 +326,36 @@ func testNameFilterSQL(item filter.FilterItem, lookback time.Time) (string, []an
 	return filter.WrapNot(sql, item.Not), args, nil
 }
 
-func enrichJobRunsWithTestNames(dbc *db.DB, results []apitype.JobRun, ids []int, release string, lookback time.Time) error {
+func jobRunPartitionKeyPredicate(alias string, results []apitype.JobRun, release string) (string, []any) {
+	placeholders := make([]string, len(results))
+	args := make([]any, 0, len(results)*3)
+	for i := range results {
+		placeholders[i] = "(?, ?, ?)"
+		args = append(args, results[i].ID, release, results[i].Timestamp)
+	}
+	return fmt.Sprintf("(%s.prow_job_run_id, %s.prow_job_run_release, %s.prow_job_run_timestamp) IN (%s)",
+		alias, alias, alias, strings.Join(placeholders, ", ")), args
+}
+
+func enrichJobRunsWithTestNames(dbc *db.DB, results []apitype.JobRun, release string) error {
 	type testNameResult struct {
 		ProwJobRunID    int            `gorm:"column:prow_job_run_id"`
 		FailedTestNames pq.StringArray `gorm:"column:failed_test_names;type:text[]"`
 		FlakedTestNames pq.StringArray `gorm:"column:flaked_test_names;type:text[]"`
 	}
 	var nameResults []testNameResult
+	keyPredicate, keyArgs := jobRunPartitionKeyPredicate("pjrt", results, release)
 	nameSQL := fmt.Sprintf(`SELECT pjrt.prow_job_run_id,
 			array_agg(t.name) FILTER (WHERE pjrt.status = %d) AS failed_test_names,
 			array_agg(t.name) FILTER (WHERE pjrt.status = %d) AS flaked_test_names
 		FROM prow_job_run_tests pjrt
 			JOIN tests t ON t.id = pjrt.test_id
-		WHERE pjrt.prow_job_run_id IN ?
-			AND pjrt.status IN (%d, %d)
-			AND pjrt.prow_job_run_timestamp >= ?`,
-		sippyprocessingv1.TestStatusFailure, sippyprocessingv1.TestStatusFlake, sippyprocessingv1.TestStatusFailure, sippyprocessingv1.TestStatusFlake)
-	nameArgs := []any{ids, lookback}
-	if len(release) > 0 {
-		nameSQL += ` AND pjrt.prow_job_run_release = ?`
-		nameArgs = append(nameArgs, release)
-	}
+		WHERE %s
+			AND pjrt.status IN (%d, %d)`,
+		sippyprocessingv1.TestStatusFailure, sippyprocessingv1.TestStatusFlake, keyPredicate,
+		sippyprocessingv1.TestStatusFailure, sippyprocessingv1.TestStatusFlake)
 	nameSQL += ` GROUP BY pjrt.prow_job_run_id`
-	if err := dbc.DB.Raw(nameSQL, nameArgs...).Scan(&nameResults).Error; err != nil {
+	if err := dbc.DB.Raw(nameSQL, keyArgs...).Scan(&nameResults).Error; err != nil {
 		return err
 	}
 	nameMap := make(map[int]*testNameResult, len(nameResults))
@@ -361,7 +371,7 @@ func enrichJobRunsWithTestNames(dbc *db.DB, results []apitype.JobRun, ids []int,
 	return nil
 }
 
-func enrichJobRunsWithPRData(dbc *db.DB, results []apitype.JobRun, ids []int, release string) error {
+func enrichJobRunsWithPRData(dbc *db.DB, results []apitype.JobRun, release string) error {
 	type prResult struct {
 		ID                int    `gorm:"column:id"`
 		PullRequestLink   string `gorm:"column:pull_request_link"`
@@ -371,8 +381,9 @@ func enrichJobRunsWithPRData(dbc *db.DB, results []apitype.JobRun, ids []int, re
 		PullRequestAuthor string `gorm:"column:pull_request_author"`
 	}
 	var prResults []prResult
+	keyPredicate, keyArgs := jobRunPartitionKeyPredicate("jrpp", results, release)
 	q := dbc.DB.Table("prow_job_run_prow_pull_requests jrpp").
-		Select(`DISTINCT ON(jrpp.prow_job_run_id)
+		Select(`DISTINCT ON(jrpp.prow_job_run_id, jrpp.prow_job_run_release, jrpp.prow_job_run_timestamp)
 			jrpp.prow_job_run_id AS id,
 			pp.link AS pull_request_link,
 			pp.sha AS pull_request_sha,
@@ -380,11 +391,8 @@ func enrichJobRunsWithPRData(dbc *db.DB, results []apitype.JobRun, ids []int, re
 			pp.author AS pull_request_author,
 			pp.repo AS pull_request_repo`).
 		Joins("INNER JOIN prow_pull_requests pp ON pp.id = jrpp.prow_pull_request_id").
-		Where("jrpp.prow_job_run_id IN ?", ids).
-		Order("jrpp.prow_job_run_id, jrpp.prow_pull_request_id DESC")
-	if len(release) > 0 {
-		q = q.Where("jrpp.prow_job_run_release = ?", release)
-	}
+		Where(keyPredicate, keyArgs...).
+		Order("jrpp.prow_job_run_id, jrpp.prow_job_run_release, jrpp.prow_job_run_timestamp, jrpp.prow_pull_request_id DESC")
 	if err := q.Scan(&prResults).Error; err != nil {
 		return err
 	}
@@ -406,12 +414,10 @@ func enrichJobRunsWithPRData(dbc *db.DB, results []apitype.JobRun, ids []int, re
 	return nil
 }
 
-func enrichJobRunsWithAnnotations(dbc *db.DB, results []apitype.JobRun, ids []int, release string) error {
+func enrichJobRunsWithAnnotations(dbc *db.DB, results []apitype.JobRun, release string) error {
 	var annotations []models.ProwJobRunAnnotation
-	annotationQuery := dbc.DB.Where("prow_job_run_id IN ?", ids)
-	if len(release) > 0 {
-		annotationQuery = annotationQuery.Where("prow_job_run_release = ?", release)
-	}
+	keyPredicate, keyArgs := jobRunPartitionKeyPredicate("prow_job_run_annotations", results, release)
+	annotationQuery := dbc.DB.Where(keyPredicate, keyArgs...)
 	if err := annotationQuery.Find(&annotations).Error; err != nil {
 		return err
 	}
@@ -472,7 +478,7 @@ func FetchJobRun(dbc *db.DB, jobRunID int64, onlyNewTests bool, preloads []strin
 			Where("NOT EXISTS (SELECT 1 FROM test_ownerships tow WHERE tow.test_id = prow_job_run_tests.test_id)").
 			Where(`NOT EXISTS (
 				SELECT 1 FROM prow_job_run_tests t2
-				INNER JOIN prow_job_run_prow_pull_requests prmap ON prmap.prow_job_run_id = t2.prow_job_run_id AND prmap.prow_job_run_release = t2.prow_job_run_release
+				INNER JOIN prow_job_run_prow_pull_requests prmap ON prmap.prow_job_run_id = t2.prow_job_run_id AND prmap.prow_job_run_release = t2.prow_job_run_release AND prmap.prow_job_run_timestamp = t2.prow_job_run_timestamp
 				INNER JOIN prow_pull_requests prs ON prs.id = prmap.prow_pull_request_id
 				WHERE t2.test_id = prow_job_run_tests.test_id
 				  AND t2.prow_job_run_release = prow_job_run_tests.prow_job_run_release

--- a/pkg/api/job_runs_test.go
+++ b/pkg/api/job_runs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	apitype "github.com/openshift/sippy/pkg/apis/api"
 	"github.com/openshift/sippy/pkg/db/models"
@@ -11,6 +12,28 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestJobRunPartitionKeyPredicate(t *testing.T) {
+	lookback := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
+	reportEnd := time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC)
+	firstTimestamp := time.Date(2026, time.August, 30, 12, 0, 0, 0, time.UTC)
+	secondTimestamp := time.Date(2026, time.August, 31, 12, 0, 0, 0, time.UTC)
+
+	predicate, args := jobRunPartitionKeyPredicate("runs", []apitype.JobRun{
+		{ID: 101, Timestamp: firstTimestamp},
+		{ID: 202, Timestamp: secondTimestamp},
+	}, "5.0", lookback, reportEnd)
+
+	assert.Equal(t, `(runs.prow_job_run_id, runs.prow_job_run_release, runs.prow_job_run_timestamp) IN ((?, ?, ?), (?, ?, ?))
+		AND runs.prow_job_run_release = ?
+		AND runs.prow_job_run_timestamp >= ?
+		AND runs.prow_job_run_timestamp < ?`, predicate)
+	assert.Equal(t, []any{
+		101, "5.0", firstTimestamp,
+		202, "5.0", secondTimestamp,
+		"5.0", lookback, reportEnd,
+	}, args)
+}
 
 func TestRunJobAnalysis(t *testing.T) {
 

--- a/pkg/flags/postgres_benchmarking_test.go
+++ b/pkg/flags/postgres_benchmarking_test.go
@@ -24,9 +24,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const benchmarkRelease = "4.22"
+const benchmarkRelease = "5.0"
 const benchmarkTestName = "[Monitor:legacy-test-framework-invariants-pathological][sig-arch] events should not repeat pathologically for ns/kube-system"
-const benchmarkJobName = "periodic-ci-openshift-release-main-ci-4.22-e2e-aws-ovn"
+const benchmarkJobName = "periodic-ci-openshift-release-main-ci-5.0-e2e-aws-ovn"
+const benchmarkVariant = "Platform:aws"
+const benchmarkCluster = "build01"
+const benchmarkPROrg = "openshift"
 
 type benchmarkCase struct {
 	name string
@@ -476,11 +479,38 @@ func getQueryCases() []queryCase {
 				}, nil
 			},
 		},
+		{
+			name: "FetchJobRunOnlyNewTests",
+			fn: func(dbc *db.DB, _ time.Time) (validationSnapshot, error) {
+				var jobRunID int64
+				res := dbc.DB.Table("prow_job_runs").
+					Joins("JOIN prow_jobs ON prow_jobs.id = prow_job_runs.prow_job_id").
+					Where("prow_jobs.name = ? AND prow_jobs.release = ?", benchmarkJobName, benchmarkRelease).
+					Where("prow_job_runs.prow_job_release = ?", benchmarkRelease).
+					Order("prow_job_runs.timestamp DESC").
+					Limit(1).
+					Select("prow_job_runs.id").
+					Scan(&jobRunID)
+				if res.Error != nil {
+					return validationSnapshot{}, res.Error
+				}
+				if jobRunID == 0 {
+					return validationSnapshot{}, fmt.Errorf("no job run found for %s/%s", benchmarkRelease, benchmarkJobName)
+				}
+
+				jobRun, err := api.FetchJobRun(dbc, jobRunID, true, nil, log.WithField("benchmark", "FetchJobRunOnlyNewTests"))
+				if err != nil {
+					return validationSnapshot{}, err
+				}
+				log.Printf("FetchJobRunOnlyNewTests for run %d: %d new tests", jobRunID, len(jobRun.Tests))
+				return validationSnapshot{RowCount: len(jobRun.Tests)}, nil
+			},
+		},
 	}
 }
 
 func getReportQueryCases() []queryCase {
-	return []queryCase{
+	cases := []queryCase{
 		{
 			name: "VariantReports",
 			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
@@ -551,18 +581,6 @@ func getReportQueryCases() []queryCase {
 				}
 				log.Printf("RepositoryReport: %d repos", len(results))
 				return validationSnapshot{RowCount: len(results)}, nil
-			},
-		},
-		{
-			name: "JobsRunsReport",
-			fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
-				pagination := &apitype.Pagination{PerPage: 20, Page: 0}
-				result, err := api.JobsRunsReportFromDB(dbc, &filter.FilterOptions{Filter: &filter.Filter{}}, benchmarkRelease, pagination, asOf)
-				if err != nil {
-					return validationSnapshot{}, err
-				}
-				log.Printf("JobsRunsReport: %d rows", result.TotalRows)
-				return validationSnapshot{RowCount: int(result.TotalRows)}, nil
 			},
 		},
 		{
@@ -696,6 +714,59 @@ func getReportQueryCases() []queryCase {
 			},
 		},
 	}
+	return append(cases, getJobRunsQueryCases()...)
+}
+
+func jobRunsQueryCase(name string, page int, sortField string, sortOrder apitype.Sort, filters func(time.Time) []filter.FilterItem) queryCase {
+	return queryCase{
+		name: name,
+		fn: func(dbc *db.DB, asOf time.Time) (validationSnapshot, error) {
+			filterItems := []filter.FilterItem{}
+			if filters != nil {
+				filterItems = filters(asOf)
+			}
+			result, err := api.JobsRunsReportFromDB(dbc, &filter.FilterOptions{
+				Filter:    &filter.Filter{Items: filterItems},
+				SortField: sortField,
+				Sort:      sortOrder,
+			}, benchmarkRelease, &apitype.Pagination{PerPage: 20, Page: page}, asOf)
+			if err != nil {
+				return validationSnapshot{}, err
+			}
+			log.Printf("%s: %d rows", name, result.TotalRows)
+			return validationSnapshot{RowCount: int(result.TotalRows)}, nil
+		},
+	}
+}
+
+func getJobRunsQueryCases() []queryCase {
+	return []queryCase{
+		jobRunsQueryCase("JobsRunsReport", 0, "", "", nil),
+		jobRunsQueryCase("JobsRunsReportExactJob", 0, "", "", func(_ time.Time) []filter.FilterItem {
+			return []filter.FilterItem{{Field: "job", Operator: filter.OperatorEquals, Value: benchmarkJobName}}
+		}),
+		jobRunsQueryCase("JobsRunsReportVariant", 0, "", "", func(_ time.Time) []filter.FilterItem {
+			return []filter.FilterItem{{Field: "variants", Operator: filter.OperatorHasEntry, Value: benchmarkVariant}}
+		}),
+		jobRunsQueryCase("JobsRunsReportCluster", 0, "", "", func(asOf time.Time) []filter.FilterItem {
+			return []filter.FilterItem{
+				{Field: "cluster", Operator: filter.OperatorEquals, Value: benchmarkCluster},
+				{Field: "name", Operator: filter.OperatorStartsWith, Value: "pull-ci", Not: true},
+				{Field: "timestamp", Operator: filter.OperatorArithmeticGreaterThan, Value: asOf.Add(-14 * 24 * time.Hour).Format(time.RFC3339Nano)},
+			}
+		}),
+		jobRunsQueryCase("JobsRunsReportFailedTest", 0, "", "", func(_ time.Time) []filter.FilterItem {
+			return []filter.FilterItem{{Field: "failed_test_names", Operator: filter.OperatorHasEntry, Value: benchmarkTestName}}
+		}),
+		jobRunsQueryCase("JobsRunsReportFlakedTest", 0, "", "", func(_ time.Time) []filter.FilterItem {
+			return []filter.FilterItem{{Field: "flaked_test_names", Operator: filter.OperatorHasEntry, Value: benchmarkTestName}}
+		}),
+		jobRunsQueryCase("JobsRunsReportPRFilter", 0, "", "", func(_ time.Time) []filter.FilterItem {
+			return []filter.FilterItem{{Field: "pull_request_org", Operator: filter.OperatorEquals, Value: benchmarkPROrg}}
+		}),
+		jobRunsQueryCase("JobsRunsReportPRSort", 0, "pull_request_author", "asc", nil),
+		jobRunsQueryCase("JobsRunsReportSecondPage", 1, "timestamp", "desc", nil),
+	}
 }
 
 func getBenchmarkDBClient(t *testing.T) (*db.DB, string) {
@@ -748,6 +819,22 @@ func Test_BenchmarkIndividual(t *testing.T) {
 	printSummaryTable(t, results, connName)
 }
 
+func Test_BenchmarkJobRuns(t *testing.T) {
+	dbc, connName := getBenchmarkDBClient(t)
+	asOf := time.Now().UTC()
+	iterations := 3
+	cases := toBenchmarkCases(getJobRunsQueryCases(), asOf)
+
+	var results []benchmarkResult
+	for _, bc := range cases {
+		t.Run(bc.name, func(t *testing.T) {
+			r := runBenchmarkCase(t, dbc, bc, iterations)
+			results = append(results, r)
+		})
+	}
+	printSummaryTable(t, results, connName)
+}
+
 func Test_BenchmarkFindTestsByRelease(t *testing.T) {
 	dbc, connName := getBenchmarkDBClient(t)
 	iterations := 1
@@ -758,6 +845,28 @@ func Test_BenchmarkFindTestsByRelease(t *testing.T) {
 	}
 
 	r := runBenchmarkCase(t, dbc, bc, iterations)
+	printSummaryTable(t, []benchmarkResult{r}, connName)
+}
+
+func Test_BenchmarkFetchJobRunOnlyNewTests(t *testing.T) {
+	dbc, connName := getBenchmarkDBClient(t)
+	iterations := 3
+	asOf := time.Now().UTC()
+
+	var benchmark benchmarkCase
+	found := false
+	for _, bc := range toBenchmarkCases(getQueryCases(), asOf) {
+		if bc.name == "FetchJobRunOnlyNewTests" {
+			benchmark = bc
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("benchmark case \"FetchJobRunOnlyNewTests\" not found")
+	}
+
+	r := runBenchmarkCase(t, dbc, benchmark, iterations)
 	printSummaryTable(t, []benchmarkResult{r}, connName)
 }
 
@@ -1085,7 +1194,7 @@ func getAPIBenchmarkCases(asOf time.Time) []benchmarkCase {
 					Filter: &filter.Filter{
 						Items: []filter.FilterItem{
 							{Field: "ran_test_names", Operator: filter.OperatorHasEntry, Value: benchmarkTestName},
-							{Field: "timestamp", Operator: filter.OperatorArithmeticGreaterThan, Value: fmt.Sprintf("%d", asOf.Add(-14*24*time.Hour).UnixMilli())},
+							{Field: "timestamp", Operator: filter.OperatorArithmeticGreaterThan, Value: asOf.Add(-14 * 24 * time.Hour).Format(time.RFC3339Nano)},
 							{Field: "variants", Operator: filter.OperatorHasEntry, Value: "never-stable", Not: true},
 							{Field: "variants", Operator: filter.OperatorHasEntry, Value: "aggregated", Not: true},
 						},
@@ -1107,7 +1216,7 @@ func getAPIBenchmarkCases(asOf time.Time) []benchmarkCase {
 				filterOpts := &filter.FilterOptions{
 					Filter: &filter.Filter{
 						Items: []filter.FilterItem{
-							{Field: "timestamp", Operator: filter.OperatorArithmeticGreaterThan, Value: fmt.Sprintf("%d", asOf.Add(-14*24*time.Hour).UnixMilli())},
+							{Field: "timestamp", Operator: filter.OperatorArithmeticGreaterThan, Value: asOf.Add(-14 * 24 * time.Hour).Format(time.RFC3339Nano)},
 							{Field: "variants", Operator: filter.OperatorHasEntry, Value: "never-stable", Not: true},
 							{Field: "variants", Operator: filter.OperatorHasEntry, Value: "aggregated", Not: true},
 						},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved job-run reports to associate pull requests, tests, and annotations with the correct release and execution time.
  - Prevented results from unrelated job runs or partitions from appearing in reports.
  - Fixed test-result associations for merged pull requests so they correspond to the appropriate job run.
  - Improved report filtering to respect inclusive start and exclusive end timestamp boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->