### PR TITLE
NO-JIRA: Fix lifecycle filtering in test detail queries

### DIFF
--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -38,7 +38,7 @@ import (
 const (
 	explanationNoRegression         = "No significant regressions found"
 	ComponentReportCacheKeyPrefix   = "ComponentReport~"
-	TestDetailsReportCacheKeyPrefix = "TestDetailsReport~"
+	TestDetailsReportCacheKeyPrefix = "TestDetailsReportV2~"
 )
 
 type GeneratorType string

--- a/pkg/api/componentreadiness/dataprovider/bigquery/provider.go
+++ b/pkg/api/componentreadiness/dataprovider/bigquery/provider.go
@@ -140,7 +140,7 @@ func (p *BigQueryProvider) QuerySampleJobRunTestStatus(ctx context.Context, reqO
 	generator := NewSampleTestDetailsQueryGenerator(p.client, reqOptions, allJobVariants, includeVariants, start, end)
 	result, errs := apiPkg.GetDataFromCacheOrGenerate[crstatus.TestJobRunStatuses](
 		ctx, p.client.Cache, reqOptions.CacheOption,
-		apiPkg.NewCacheSpec(generator, "SampleJobRunTestStatusV3~", &end),
+		apiPkg.NewCacheSpec(generator, "SampleJobRunTestStatusV4~", &end),
 		generator.QueryTestStatus, crstatus.TestJobRunStatuses{})
 	if len(errs) > 0 {
 		return nil, errs

--- a/pkg/api/componentreadiness/dataprovider/bigquery/querygenerators.go
+++ b/pkg/api/componentreadiness/dataprovider/bigquery/querygenerators.go
@@ -653,6 +653,13 @@ func buildTestDetailsQuery(
 
 	if isSample {
 		queryString += filterByCrossCompareVariants(c.VariantOption.VariantCrossCompare, c.VariantOption.CompareVariants, &commonParams)
+		if len(c.Lifecycles) > 0 {
+			queryString += ` AND COALESCE(NULLIF(junit.lifecycle, ''), 'blocking') IN UNNEST(@Lifecycles)`
+			commonParams = append(commonParams, bigquery.QueryParameter{
+				Name:  "Lifecycles",
+				Value: c.Lifecycles,
+			})
+		}
 		// Only set sample release when PR and payload options are not set
 		if c.SampleRelease.PayloadOptions == nil && c.SampleRelease.PullRequestOptions == nil {
 			queryString += ` AND jv_Release.variant_value = @SampleRelease`

--- a/pkg/api/componentreadiness/dataprovider/bigquery/querygenerators_test.go
+++ b/pkg/api/componentreadiness/dataprovider/bigquery/querygenerators_test.go
@@ -169,6 +169,74 @@ func TestBuildComponentReportQuery_ExclusiveTestFiltering(t *testing.T) {
 	}
 }
 
+func TestBuildTestDetailsQuery_LifecycleFiltering(t *testing.T) {
+	client := &bqcachedclient.Client{Dataset: "test_dataset"}
+	reqOptions := reqopts.RequestOptions{
+		TestFilters: reqopts.TestFilters{Lifecycles: []string{"blocking"}},
+		SampleRelease: reqopts.Release{
+			Name: "4.20",
+		},
+	}
+	testIDOptions := []reqopts.TestIdentification{{TestID: "test-id"}}
+	allJobVariants := crtest.JobVariants{
+		Variants: map[string][]string{"Release": {"4.20"}},
+	}
+
+	tests := []struct {
+		name             string
+		isSample         bool
+		lifecycles       []string
+		wantFilter       bool
+		wantLifecycleArg bool
+	}{
+		{
+			name:             "sample details use lifecycle filter",
+			isSample:         true,
+			lifecycles:       []string{"blocking"},
+			wantFilter:       true,
+			wantLifecycleArg: true,
+		},
+		{
+			name:       "base details remain unfiltered",
+			isSample:   false,
+			lifecycles: []string{"blocking"},
+		},
+		{
+			name:     "sample details without configured lifecycles remain unfiltered",
+			isSample: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := reqOptions
+			options.Lifecycles = tt.lifecycles
+			query, _, params := buildTestDetailsQuery(
+				client,
+				testIDOptions,
+				options,
+				allJobVariants,
+				nil,
+				DefaultJunitTable,
+				tt.isSample,
+				options.SampleRelease.Name,
+			)
+
+			assert.Equal(t, tt.wantFilter,
+				strings.Contains(query, "COALESCE(NULLIF(junit.lifecycle, ''), 'blocking') IN UNNEST(@Lifecycles)"))
+
+			var lifecycleParamFound bool
+			for _, queryParam := range params {
+				if queryParam.Name == "Lifecycles" {
+					lifecycleParamFound = true
+					assert.Equal(t, tt.lifecycles, queryParam.Value)
+				}
+			}
+			assert.Equal(t, tt.wantLifecycleArg, lifecycleParamFound)
+		})
+	}
+}
+
 func TestBuildComponentReportQuery_ExclusiveTestLogic(t *testing.T) {
 	// This test verifies the specific logic: we only exclude OTHER tests from jobs
 	// where key tests FAILED (not just present)

--- a/pkg/api/componentreadiness/dataprovider/postgres/provider.go
+++ b/pkg/api/componentreadiness/dataprovider/postgres/provider.go
@@ -350,7 +350,8 @@ type testDetailRow struct {
 
 func (p *PostgresProvider) queryTestDetails(ctx context.Context, release string, start, end time.Time,
 	reqOptions reqopts.RequestOptions,
-	includeVariants map[string][]string) (map[string][]crstatus.TestDetailsSummary, []error) {
+	includeVariants map[string][]string,
+	lifecycles []string) (map[string][]crstatus.TestDetailsSummary, []error) {
 
 	if includeVariants == nil {
 		includeVariants = map[string][]string{}
@@ -408,6 +409,7 @@ WHERE pj.release = ?
     AND (pjr.labels IS NULL OR NOT pjr.labels @> ARRAY['InfraFailure'])`
 
 	args = append(args, release, start, end, release, release, start, end)
+	sqlQuery, args = appendTestDetailsLifecycleFilter(sqlQuery, args, lifecycles)
 
 	if len(includeVariants) > 0 {
 		filterClause, filterArgs := buildVariantFilterClause(includeVariants)
@@ -485,12 +487,22 @@ WHERE pj.release = ?
 	return crstatus.SummarizeTestJobRuns(result), nil
 }
 
+// appendTestDetailsLifecycleFilter keeps sample test details aligned with the
+// lifecycle-filtered component report that selected the tests for analysis.
+func appendTestDetailsLifecycleFilter(sqlQuery string, args []any, lifecycles []string) (string, []any) {
+	if len(lifecycles) == 0 {
+		return sqlQuery, args
+	}
+
+	return sqlQuery + " AND pjrt.lifecycle = ANY(?)", append(args, pq.Array(lifecycles))
+}
+
 func (p *PostgresProvider) QueryBaseJobRunTestStatus(ctx context.Context, reqOptions reqopts.RequestOptions) (map[string][]crstatus.TestDetailsSummary, []error) {
 	result, errs := p.queryTestDetails(
 		ctx,
 		reqOptions.BaseRelease.Name,
 		reqOptions.BaseRelease.Start, reqOptions.BaseRelease.End,
-		reqOptions, reqOptions.VariantOption.IncludeVariants,
+		reqOptions, reqOptions.VariantOption.IncludeVariants, nil,
 	)
 	if len(errs) > 0 {
 		return result, errs
@@ -714,7 +726,7 @@ func (p *PostgresProvider) QuerySampleJobRunTestStatus(ctx context.Context, reqO
 		ctx,
 		reqOptions.SampleRelease.Name,
 		start, end,
-		reqOptions, mergeCompareVariants(reqOptions, includeVariants),
+		reqOptions, mergeCompareVariants(reqOptions, includeVariants), reqOptions.Lifecycles,
 	)
 }
 

--- a/pkg/api/componentreadiness/dataprovider/postgres/provider_test.go
+++ b/pkg/api/componentreadiness/dataprovider/postgres/provider_test.go
@@ -1,11 +1,55 @@
 package postgres
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/lib/pq"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
+
+func TestAppendTestDetailsLifecycleFilter(t *testing.T) {
+	tests := []struct {
+		name           string
+		lifecycles     []string
+		wantFilter     bool
+		wantAdditional int
+	}{
+		{
+			name:           "configured lifecycle is filtered",
+			lifecycles:     []string{"blocking"},
+			wantFilter:     true,
+			wantAdditional: 1,
+		},
+		{
+			name:       "empty lifecycle is unfiltered",
+			lifecycles: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalArgs := []any{"existing"}
+			query, args := appendTestDetailsLifecycleFilter("SELECT 1 WHERE true", originalArgs, tt.lifecycles)
+
+			if got := strings.Contains(query, "pjrt.lifecycle = ANY(?)"); got != tt.wantFilter {
+				t.Fatalf("lifecycle filter present = %t, want %t", got, tt.wantFilter)
+			}
+			if got, want := len(args), len(originalArgs)+tt.wantAdditional; got != want {
+				t.Fatalf("argument count = %d, want %d", got, want)
+			}
+			if tt.wantAdditional == 1 {
+				got, ok := args[len(args)-1].(*pq.StringArray)
+				if !ok {
+					t.Fatalf("lifecycle argument has type %T, want *pq.StringArray", args[len(args)-1])
+				}
+				if strings.Join(*got, ",") != strings.Join(tt.lifecycles, ",") {
+					t.Fatalf("lifecycle argument = %v, want %v", got, tt.lifecycles)
+				}
+			}
+		})
+	}
+}
 
 func TestParseVariants(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Problem statement:
Cache priming selects regressions from a component report that applies the view's sample lifecycle filter, then regenerates per-run test details. The BigQuery and PostgreSQL detail queries did not apply that filter. If informing results changed significance, GenerateTestDetailsReportMultiTest rejected the formerly regressed test and the cache-primer Job failed with fewer reports than requests.

Observation:
On dpcr in namespace sippy, both attempts of cache-primer-1788514252695 failed deterministically. View 5.1-main produced 81 reports for 82 requests and 5.1-main-mass-failure produced 53 for 54. For test openshift-tests:23bc4605b41f62ad23a24ce8911365f4, the blocking-only summary used 40 sample passes and 3 failures. The detail report used 65 passes and 3 failures. A separate informing-only query returned exactly the extra 25 passes and no failures. PostgreSQL reproduced the same 65/3 detail result despite its summary using 40/3, which rules out a transient cache miss and identifies provider query parity as the cause.

Proposed fix:
Apply Lifecycles to sample test-detail rows in both providers while intentionally leaving base rows unfiltered, matching component-summary semantics. Version the BigQuery sample-status and final test-details cache keys so results generated under the old query cannot be reused. Add tests proving sample queries include the lifecycle predicate and base or unfiltered requests do not.

Independent validation:
Query GET /api/component_readiness with view=5.1-main and dataSource=bigquery, locate the test ID above, and follow its generated test_details link. Before this change the summary sample counts are 40/3 while GET /api/component_readiness/test_details reports 65/3. After deployment both must report 40/3 and the detail analysis must remain regressed. Repeat with dataSource=postgres to validate provider parity. Finally run the cache primer and verify it returns one detail report per request for both affected views rather than 81/82 and 53/54.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Sample test-detail results now respect configured lifecycle filters across supported data providers.
  - Tests with empty or missing lifecycle values are treated as `blocking` when applying these filters.
  - Base-release test details remain unfiltered, while sample-release details use the selected lifecycle criteria.

- **Bug Fixes**
  - Updated report and sample status caching to prevent stale results from being returned after these filtering changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->