### PR TITLE
trt-2709: bump partition retention

### DIFF
--- a/pkg/dataloader/prowloader/prow.go
+++ b/pkg/dataloader/prowloader/prow.go
@@ -249,7 +249,7 @@ func (pl *ProwLoader) Load() {
 		return
 	}
 
-	// Clean up old partitions (detach partitions older than 100 days, drop detached partitions older than 110 days)
+	// Clean up partitions older than the configured retention period.
 	if detached, dropped, err := pl.dbc.CleanupPartitions(false); err != nil {
 		log.WithError(err).Warning("failed to cleanup old partitions, continuing with load")
 	} else {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -33,6 +33,7 @@ const (
 	partitionedTableProwJobRunTestsOutputs                    = "prow_job_run_test_outputs"
 	partitionedTableTestDailyTotals                           = "test_daily_totals"
 	partitionedTableTestCumulativeSummaries                   = "test_cumulative_summaries"
+	partitionRetentionDays                                    = 365
 )
 
 type DB struct {
@@ -327,23 +328,24 @@ func (d *DB) DetachOldPartitions(retentionDays int, dryRun bool) (int, error) {
 	return totalDetached, nil
 }
 
-// DropDetachedPartitions drops partitions that have been detached for longer than
-// the specified period. This permanently deletes the data.
+// DropDetachedPartitions drops partition tables whose partition date is older than
+// the retention period. Callers should detach matching attached partitions first.
+// This permanently deletes the data.
 //
 // Parameters:
-//   - detachedDays: Minimum age in days since detachment (e.g., 110 means drop partitions detached more than 110 days ago)
+//   - retentionDays: Minimum partition age in days (e.g., 110 removes partitions dated more than 110 days ago)
 //   - dryRun: If true, only preview what would be dropped
 //
 // Returns the total number of partitions dropped across all tables.
-func (d *DB) DropDetachedPartitions(detachedDays int, dryRun bool) (int, error) {
+func (d *DB) DropDetachedPartitions(retentionDays int, dryRun bool) (int, error) {
 	totalDropped := 0
 
 	for _, tableName := range d.PartitionedTables() {
-		log.Infof("Finding detached partitions to drop for %s (detached more than %d days ago)",
-			tableName, detachedDays)
+		log.Infof("Finding detached partitions to drop for %s (older than %d days)",
+			tableName, retentionDays)
 
-		// Get partitions that are detached and older than detached period
-		partitions, err := d.GoparPartitions.GetPartitionsForRemoval(tableName, detachedDays, false)
+		// Include detached partition tables when finding partitions older than the retention period.
+		partitions, err := d.GoparPartitions.GetPartitionsForRemoval(tableName, retentionDays, false)
 		if err != nil {
 			return totalDropped, fmt.Errorf("failed to get detached partitions for removal from %s: %w", tableName, err)
 		}
@@ -368,10 +370,11 @@ func (d *DB) DropDetachedPartitions(detachedDays int, dryRun bool) (int, error) 
 }
 
 // CleanupPartitions performs the full partition lifecycle cleanup:
-// 1. Detaches partitions older than 100 days
-// 2. Drops detached partitions older than 110 days
+// 1. Detaches partitions older than partitionRetentionDays
+// 2. Drops detached partitions older than partitionRetentionDays
 //
-// This provides a 10-day safety window between detachment and permanent deletion.
+// Detached partitions could be held and reattached if needed, but no holding
+// period is configured by default.
 //
 // Parameters:
 //   - dryRun: If true, only preview what would be done
@@ -380,20 +383,15 @@ func (d *DB) DropDetachedPartitions(detachedDays int, dryRun bool) (int, error) 
 func (d *DB) CleanupPartitions(dryRun bool) (detached, dropped int, err error) {
 	log.Info("Starting partition cleanup...")
 
-	// First, detach old attached partitions (100 days)
-	detached, err = d.DetachOldPartitions(100, dryRun)
+	// First, detach old attached partitions.
+	detached, err = d.DetachOldPartitions(partitionRetentionDays, dryRun)
 	if err != nil {
 		return detached, dropped, fmt.Errorf("failed to detach old partitions: %w", err)
 	}
 	log.Infof("Detached %d old partitions", detached)
 
-	// Then, drop old detached partitions (100 days)
-	// We initially held detached partitions for 10 days.
-	// Detaching removes the association with the parent table and leaves them as individual tables
-	// Which clutters the table list
-	// We plan to keep partitions longer and
-	// no longer need the multiphase, detach, wait then drop.
-	dropped, err = d.DropDetachedPartitions(100, dryRun)
+	// Then, drop old detached partitions
+	dropped, err = d.DropDetachedPartitions(partitionRetentionDays, dryRun)
 	if err != nil {
 		return detached, dropped, fmt.Errorf("failed to drop detached partitions: %w", err)
 	}

--- a/test/e2e/db/partitions/partitions_test.go
+++ b/test/e2e/db/partitions/partitions_test.go
@@ -155,9 +155,9 @@ func TestPartitionLifecycle(t *testing.T) {
 
 	t.Run("CleanupPartitions orchestrates detach and drop", func(t *testing.T) {
 		// Create partitions at different ages:
-		// 1. Recent (within 100 days) - should NOT be detached
-		// 2. Old (105 days) - should be detached but NOT dropped
-		// 3. Very old (115 days) - should be dropped
+		// 1. Recent (within 365 days) - should not be detached
+		// 2. Old (370 days) - should be detached, then dropped by cleanup
+		// 3. Very old (380 days) - detached before cleanup, then dropped by cleanup
 		releases := []string{"4.18"}
 
 		// Recent data
@@ -166,20 +166,20 @@ func TestPartitionLifecycle(t *testing.T) {
 		require.NoError(t, err)
 		require.Greater(t, count, 0, "should create recent partitions")
 
-		// Old data (will be detached)
-		oldDate := time.Now().AddDate(0, 0, -105)
+		// Old data (will be detached and dropped by cleanup)
+		oldDate := time.Now().AddDate(0, 0, -370)
 		count, err = dbc.EnsurePartitions(releases, oldDate, oldDate.AddDate(0, 0, 1), false)
 		require.NoError(t, err)
 		require.Greater(t, count, 0, "should create old partitions")
 
-		// Very old data (will be dropped)
-		veryOldDate := time.Now().AddDate(0, 0, -115)
+		// Very old data (will be detached before cleanup and dropped by cleanup)
+		veryOldDate := time.Now().AddDate(0, 0, -380)
 		count, err = dbc.EnsurePartitions(releases, veryOldDate, veryOldDate.AddDate(0, 0, 1), false)
 		require.NoError(t, err)
 		require.Greater(t, count, 0, "should create very old partitions")
 
-		// First detach the very old partitions so they can be dropped
-		_, err = dbc.DetachOldPartitions(110, false)
+		// First detach only the very old partitions so cleanup exercises both paths.
+		_, err = dbc.DetachOldPartitions(375, false)
 		require.NoError(t, err)
 
 		// Diagnostic: Check partition bounds before cleanup
@@ -248,8 +248,20 @@ func TestPartitionLifecycle(t *testing.T) {
 
 		// Verify cleanup occurred
 		t.Logf("Cleanup results: detached=%d, dropped=%d", detached, dropped)
+		assert.Greater(t, detached, 0, "should detach old attached partitions")
 		assert.Greater(t, dropped, 0, "should drop very old detached partitions")
-		assert.GreaterOrEqual(t, detached, 0, "may detach old partitions")
+
+		for _, expiredDate := range []time.Time{oldDate, veryOldDate} {
+			var expiredPartitionCount int64
+			err = dbc.DB.Raw(`
+				SELECT COUNT(*)
+				FROM pg_tables
+				WHERE schemaname = 'public'
+				  AND tablename LIKE ?
+			`, "%"+expiredDate.Format("2006_01_02")+"%").Scan(&expiredPartitionCount).Error
+			require.NoError(t, err)
+			assert.Zero(t, expiredPartitionCount, "expired partitions for %s should be dropped", expiredDate.Format("2006-01-02"))
+		}
 
 		// Check what happened to recent partitions after cleanup
 		var recentAfterCleanup []partitionDiagnostic

--- a/test/e2e/db/partitions/partitions_test.go
+++ b/test/e2e/db/partitions/partitions_test.go
@@ -179,8 +179,9 @@ func TestPartitionLifecycle(t *testing.T) {
 		require.Greater(t, count, 0, "should create very old partitions")
 
 		// First detach only the very old partitions so cleanup exercises both paths.
-		_, err = dbc.DetachOldPartitions(375, false)
+		detachedBeforeCleanup, err := dbc.DetachOldPartitions(375, false)
 		require.NoError(t, err)
+		require.Greater(t, detachedBeforeCleanup, 0, "should detach the very old partitions before cleanup")
 
 		// Diagnostic: Check partition bounds before cleanup
 		type partitionDiagnostic struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated database partition cleanup to use a consistent 365-day retention period.
  * Older partitions are now detached and removed based on their partition date, providing more predictable cleanup behavior.
  * Recent partitions remain preserved during cleanup.
  * Improved cleanup lifecycle validation to confirm that expired partitions are processed while current partitions are retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->