### PR TITLE
NO-JIRA: avoid globals, inject backoff struct instead

### DIFF
--- a/pkg/api/componentreadiness/component_report.go
+++ b/pkg/api/componentreadiness/component_report.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/sippy/pkg/api"
 	"github.com/openshift/sippy/pkg/api/componentreadiness/dataprovider"
@@ -161,6 +162,7 @@ func NewComponentReportGenerator(provider dataprovider.DataProvider, reqOptions 
 	generator := ComponentReportGenerator{
 		dataProvider:            provider,
 		jobRunTestStatusFetcher: (*ComponentReportGenerator).getJobRunTestStatus,
+		multiTestStatusBackoff:  defaultMultiTestStatusQueryBackoff(),
 		ReqOptions:              reqOptions,
 		dbc:                     dbc,
 		releaseConfigs:          releaseConfigs,
@@ -179,6 +181,7 @@ func NewComponentReportGenerator(provider dataprovider.DataProvider, reqOptions 
 type ComponentReportGenerator struct {
 	dataProvider            dataprovider.DataProvider
 	jobRunTestStatusFetcher func(*ComponentReportGenerator, context.Context) (crstatus.TestJobRunStatuses, []error)
+	multiTestStatusBackoff  wait.Backoff
 	dbc                     *db.DB
 	ReqOptions              reqopts.RequestOptions
 	middlewares             middleware.List

--- a/pkg/api/componentreadiness/test_details.go
+++ b/pkg/api/componentreadiness/test_details.go
@@ -35,11 +35,13 @@ const (
 	multiTestStatusQueryRetries = 4
 )
 
-// multiTestStatusQueryBackoff defines the 1m, 2m, 4m, and 8m waits between five status queries.
-var multiTestStatusQueryBackoff = wait.Backoff{
-	Steps:    multiTestStatusQueryRetries + 1,
-	Duration: time.Minute,
-	Factor:   2,
+// defaultMultiTestStatusQueryBackoff defines the 1m, 2m, 4m, and 8m waits between five status queries.
+func defaultMultiTestStatusQueryBackoff() wait.Backoff {
+	return wait.Backoff{
+		Steps:    multiTestStatusQueryRetries + 1,
+		Duration: time.Minute,
+		Factor:   2,
+	}
 }
 
 func GetTestDetails(ctx context.Context, provider dataprovider.DataProvider, dbc *db.DB, reqOptions reqopts.RequestOptions, releases []v1.Release, baseURL string) (testdetails.Report, []error) {
@@ -171,7 +173,11 @@ func (c *ComponentReportGenerator) getCompleteMultiTestJobRunStatuses(ctx contex
 	if fetchStatuses == nil {
 		fetchStatuses = (*ComponentReportGenerator).getJobRunTestStatus
 	}
-	err := wait.ExponentialBackoffWithContext(ctx, multiTestStatusQueryBackoff, func(ctx context.Context) (bool, error) {
+	backoff := c.multiTestStatusBackoff
+	if backoff.Steps == 0 {
+		backoff = defaultMultiTestStatusQueryBackoff()
+	}
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
 		attempt++
 		before := time.Now()
 		statuses, queryErrs = fetchStatuses(c, ctx)
@@ -188,9 +194,9 @@ func (c *ComponentReportGenerator) getCompleteMultiTestJobRunStatuses(ctx contex
 
 		logrus.WithFields(logrus.Fields{
 			"attempt":     attempt,
-			"maxAttempts": multiTestStatusQueryBackoff.Steps,
+			"maxAttempts": backoff.Steps,
 			"missingKeys": missingKeys,
-			"backoff":     multiTestStatusQueryBackoff,
+			"backoff":     backoff,
 		}).Warn("test details status query was incomplete, retrying")
 		return false, nil
 	})

--- a/pkg/api/componentreadiness/test_details_test.go
+++ b/pkg/api/componentreadiness/test_details_test.go
@@ -35,7 +35,7 @@ func TestMultiTestStatusQueryBackoff(t *testing.T) {
 		Steps:    5,
 		Duration: time.Minute,
 		Factor:   2,
-	}, multiTestStatusQueryBackoff)
+	}, defaultMultiTestStatusQueryBackoff())
 }
 
 func TestGetCompleteMultiTestJobRunStatuses(t *testing.T) {
@@ -61,10 +61,6 @@ func TestGetCompleteMultiTestJobRunStatuses(t *testing.T) {
 			"job": {{TestKeyStr: present.Encode()}, {TestKeyStr: missing.Encode()}},
 		},
 	}
-
-	originalBackoff := multiTestStatusQueryBackoff
-	multiTestStatusQueryBackoff = wait.Backoff{Steps: 5}
-	t.Cleanup(func() { multiTestStatusQueryBackoff = originalBackoff })
 
 	for _, testCase := range []struct {
 		name       string
@@ -122,6 +118,7 @@ func TestGetCompleteMultiTestJobRunStatuses(t *testing.T) {
 					calls++
 					return response.statuses, response.errs
 				},
+				multiTestStatusBackoff: wait.Backoff{Steps: 5},
 			}
 
 			statuses, errs := generator.getCompleteMultiTestJobRunStatuses(context.Background())


### PR DESCRIPTION
Followup to #3973 , address https://github.com/openshift/sippy/pull/3973#discussion_r3934300929