### PR TITLE
Add Quay 3.18 GCP e2e job to Sippy config

### DIFF
--- a/config/openshift-customizations.yaml
+++ b/config/openshift-customizations.yaml
@@ -134,3 +134,4 @@ releases:
     synthetic: true
     jobs:
       periodic-ci-quay-quay-redhat-3.18-aws-ocp422-e2e-install-aws-s3-3-18-nightly-4-22: true
+      periodic-ci-quay-quay-redhat-3.18-gcp-ocp422-e2e-install-gcp-gcs-3-18-nightly-4-22: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a scheduled end-to-end installation job for Quay 3.18 on OpenShift 4.22 using Google Cloud Storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->