### PR TITLE
Add quay-3.18 component readiness view

### DIFF
--- a/config/views.yaml
+++ b/config/views.yaml
@@ -6395,3 +6395,54 @@ component_readiness:
     enabled: false
   prime_cache:
     enabled: false
+- name: quay-3.18
+  base_release:
+    release: "quay-3.18"
+    relative_start: now-30d
+    relative_end: now-7d
+  sample_release:
+    release: "quay-3.18"
+    relative_start: now-7d
+    relative_end: now
+  variant_options:
+    column_group_by:
+      Platform: { }
+    db_group_by:
+      Architecture: { }
+      Installer: { }
+      Network: { }
+      Platform: { }
+      Suite: { }
+      Topology: { }
+      Upgrade: { }
+    include_variants:
+      Architecture:
+      - amd64
+      Installer:
+      - ipi
+      Network:
+      - ovn
+      Owner:
+      - eng
+      Platform:
+      - aws
+      - gcp
+      Topology:
+      - ha
+      Upgrade:
+      - none
+  advanced_options:
+    minimum_failure: 2
+    confidence: 95
+    pity_factor: 5
+    ignore_missing: false
+    ignore_disruption: true
+    flake_as_failure: false
+    pass_rate_required_new_tests: 95
+    include_multi_release_analysis: false
+  metrics:
+    enabled: true
+  regression_tracking:
+    enabled: true
+  prime_cache:
+    enabled: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `quay-3.18` release view.
  - Added coverage for recent base and sample releases across AWS and GCP environments.
  - Included amd64, IPI, OVN, high-availability, and no-upgrade test variants.
  - Enabled failure analysis, metrics, and regression tracking for this release view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->