### PR TITLE
TRT-2931: pull postgres and redis sidecars from QCI

### DIFF
--- a/.devcontainer/init-services.sh
+++ b/.devcontainer/init-services.sh
@@ -7,20 +7,36 @@ mkdir -p "${HOME}/.config/gcloud" "${HOME}/.config/gh" "${HOME}/.claude"
 
 podman network create sippy-net 2>/dev/null || true
 
+POSTGRES_IMAGE=quay.io/openshift/ci:ci_postgresql_postgresql-18-c9s
+REDIS_IMAGE=quay.io/openshift/ci:ci_redis_redis-7-c9s
+
+warn_if_wrong_image() {
+    name=$1
+    expected=$2
+    current=$(podman inspect -f '{{.Config.Image}}' "$name" 2>/dev/null || true)
+    if [ -n "$current" ] && [ "$current" != "$expected" ]; then
+        echo "WARNING: $name is using $current (expected $expected). Remove it to pick up the new image: podman rm -f $name" >&2
+    fi
+}
+
 podman start sippy-postgres 2>/dev/null || \
     podman run -d --name sippy-postgres \
+        --platform linux/amd64 \
         --network sippy-net \
         -e POSTGRESQL_ADMIN_PASSWORD=password \
         -p 127.0.0.1:5432:5432 \
-        quay.io/openshift/ci:ci_postgresql_postgresql-18-c9s
+        "$POSTGRES_IMAGE"
+warn_if_wrong_image sippy-postgres "$POSTGRES_IMAGE"
 
 podman start sippy-redis 2>/dev/null || \
     podman run -d --name sippy-redis \
+        --platform linux/amd64 \
         --network sippy-net \
         --restart=always \
         --memory=4g \
         -p 127.0.0.1:6379:6379 \
-        quay.io/openshift/ci:ci_redis_redis-7-c9s
+        "$REDIS_IMAGE"
+warn_if_wrong_image sippy-redis "$REDIS_IMAGE"
 
 echo "Waiting for PostgreSQL..."
 pg_ready=false

--- a/.devcontainer/init-services.sh
+++ b/.devcontainer/init-services.sh
@@ -10,11 +10,12 @@ podman network create sippy-net 2>/dev/null || true
 podman start sippy-postgres 2>/dev/null || \
     podman run -d --name sippy-postgres \
         --network sippy-net \
-        -e POSTGRES_PASSWORD=password \
-        -e POSTGRES_HOST_AUTH_METHOD=trust \
+        -e POSTGRESQL_USER=sippy \
+        -e POSTGRESQL_PASSWORD=password \
+        -e POSTGRESQL_DATABASE=prodlike \
+        -e POSTGRESQL_ADMIN_PASSWORD=password \
         -p 127.0.0.1:5432:5432 \
-        docker.io/library/postgres:18.4 \
-        -c listen_addresses='*'
+        quay.io/openshift/ci:ci_postgresql_postgresql-18-c9s
 
 podman start sippy-redis 2>/dev/null || \
     podman run -d --name sippy-redis \
@@ -22,12 +23,11 @@ podman start sippy-redis 2>/dev/null || \
         --restart=always \
         --memory=4g \
         -p 127.0.0.1:6379:6379 \
-        docker.io/redis:7-alpine \
-        redis-server --maxmemory 3800mb --maxmemory-policy allkeys-lru
+        quay.io/openshift/ci:ci_redis_redis-7-c9s
 
 echo "Waiting for PostgreSQL..."
 pg_ready=false
-for i in $(seq 1 30); do
+for i in $(seq 1 60); do
     if podman exec sippy-postgres pg_isready -U postgres >/dev/null 2>&1; then
         pg_ready=true
         break
@@ -35,15 +35,15 @@ for i in $(seq 1 30); do
     sleep 1
 done
 if [ "$pg_ready" = false ]; then
-    echo "ERROR: PostgreSQL did not become ready within 30 seconds."
+    echo "ERROR: PostgreSQL did not become ready within 60 seconds."
     exit 1
 fi
 
 echo "Creating prod-like database (prodlike)..."
-podman exec sippy-postgres psql -U postgres -tc \
+podman exec -e PGPASSWORD=password sippy-postgres psql -U postgres -tc \
     "SELECT 1 FROM pg_database WHERE datname = 'prodlike'" \
     | grep -q 1 \
-    || podman exec sippy-postgres psql -U postgres -c "CREATE DATABASE prodlike"
+    || podman exec -e PGPASSWORD=password sippy-postgres psql -U postgres -c "CREATE DATABASE prodlike"
 
 echo "Waiting for Redis..."
 redis_ready=false

--- a/.devcontainer/init-services.sh
+++ b/.devcontainer/init-services.sh
@@ -10,9 +10,6 @@ podman network create sippy-net 2>/dev/null || true
 podman start sippy-postgres 2>/dev/null || \
     podman run -d --name sippy-postgres \
         --network sippy-net \
-        -e POSTGRESQL_USER=sippy \
-        -e POSTGRESQL_PASSWORD=password \
-        -e POSTGRESQL_DATABASE=prodlike \
         -e POSTGRESQL_ADMIN_PASSWORD=password \
         -p 127.0.0.1:5432:5432 \
         quay.io/openshift/ci:ci_postgresql_postgresql-18-c9s

--- a/hack/agentic_setup.sh
+++ b/hack/agentic_setup.sh
@@ -6,9 +6,9 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-export SIPPY_DATABASE_DSN="postgresql://postgres@localhost:5432/postgres?sslmode=disable"
+export SIPPY_DATABASE_DSN="postgresql://postgres:password@localhost:5432/postgres?sslmode=disable"
 export SIPPY_SEED_DATABASE_DSN="${SIPPY_DATABASE_DSN}"
-export SIPPY_PRODLIKE_DATABASE_DSN="postgresql://postgres@localhost:5432/prodlike?sslmode=disable"
+export SIPPY_PRODLIKE_DATABASE_DSN="postgresql://postgres:password@localhost:5432/prodlike?sslmode=disable"
 export REDIS_URL="redis://localhost:6379"
 export SIPPY_E2E_REDIS_URL="redis://localhost:6379/1"
 


### PR DESCRIPTION
/hold for https://github.com/openshift/release/pull/84869

## Summary
- Pull postgres/redis sidecars from QCI instead of docker.io (`quay.io/openshift/ci:ci_postgresql_postgresql-18-c9s`, `quay.io/openshift/ci:ci_redis_redis-7-c9s`).
- Use sclorg env vars (`POSTGRESQL_*`) and include the postgres password in agentic DSNs.

## Test plan
- [ ] Wait until https://github.com/openshift/release/pull/84869 is merged and the QCI tags exist
- [ ] `/hold cancel` after those images are pullable
- [ ] Recreate local sidecars (`podman rm -f sippy-postgres sippy-redis`) and run `hack/agentic_setup.sh` (or the devcontainer init path)
- [ ] Confirm postgres and redis become ready and `prodlike` is created


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated local development services to use standardized PostgreSQL and Redis images.
  - Improved PostgreSQL startup reliability with expanded readiness checks and configured database credentials.
  - Updated local database connection settings to consistently authenticate with the configured password.
  - No end-user-facing product behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->