### PR TITLE
NO-ISSUE: feat(sippy-ng): file quay release bugs into PROJQUAY

### DIFF
--- a/sippy-ng/src/bugs/BugButton.jsx
+++ b/sippy-ng/src/bugs/BugButton.jsx
@@ -10,7 +10,7 @@ const useStyles = makeStyles((_theme) => ({
   },
 }))
 
-export default function BugButton(props) {
+export default function BugButton({ jiraProjectID = '10325', ...props }) {
   const classes = useStyles()
   const [_open, _setOpen] = useState(false)
 
@@ -26,7 +26,7 @@ See the [sippy test details|${document.location.href}] for additional context.
 
   const handleClick = () => {
     let message = props.context || text
-    let url = `https://redhat.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10325&issuetype=10016&description=${safeEncodeURIComponent(
+    let url = `https://redhat.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=${jiraProjectID}&issuetype=10016&description=${safeEncodeURIComponent(
       message
     )}`
 
@@ -59,6 +59,7 @@ See the [sippy test details|${document.location.href}] for additional context.
 }
 
 BugButton.propTypes = {
+  jiraProjectID: PropTypes.string,
   jiraComponentID: PropTypes.string,
   component: PropTypes.string,
   capability: PropTypes.string,

--- a/sippy-ng/src/bugs/FileBug.jsx
+++ b/sippy-ng/src/bugs/FileBug.jsx
@@ -54,6 +54,8 @@ export default function FileBug({
   labels = [],
   jiraComponentID,
   jiraComponentName,
+  jiraProject = 'OCPBUGS',
+  jiraProjectID = '10325',
   version,
   setHasBeenTriaged,
   url,
@@ -94,7 +96,11 @@ See the [sippy test details|${url}] for additional context.
     const defaultDescription = context || defaultText
 
     const defaultAffectsVersions = []
-    if (version) defaultAffectsVersions.push(version)
+    // PROJQUAY versions are named quay-v3.18.N, so the release name (e.g.
+    // "quay-3.18") would be rejected by Jira; leave it for the user to fill in.
+    if (version && jiraProject === 'OCPBUGS') {
+      defaultAffectsVersions.push(version)
+    }
 
     setFormData({
       summary: defaultSummary,
@@ -183,6 +189,7 @@ See the [sippy test details|${url}] for additional context.
     }
 
     const bugData = {
+      project: jiraProject,
       summary: formData.summary,
       description: formData.description,
       components: formData.components,
@@ -317,6 +324,7 @@ See the [sippy test details|${url}] for additional context.
                   testName={testName}
                   component={component}
                   capability={capability}
+                  jiraProjectID={jiraProjectID}
                   jiraComponentID={String(jiraComponentID)}
                   labels={formData.labels}
                   context={formData.description}
@@ -591,6 +599,8 @@ FileBug.propTypes = {
   labels: PropTypes.array,
   jiraComponentID: PropTypes.number,
   jiraComponentName: PropTypes.string,
+  jiraProject: PropTypes.string,
+  jiraProjectID: PropTypes.string,
   version: PropTypes.string,
   setHasBeenTriaged: PropTypes.func.isRequired,
   url: PropTypes.string.isRequired,

--- a/sippy-ng/src/component_readiness/TestDetailsReport.jsx
+++ b/sippy-ng/src/component_readiness/TestDetailsReport.jsx
@@ -25,8 +25,11 @@ import {
 } from './CompReadyUtils'
 import { CompReadyVarsContext } from './CompReadyVars'
 import { FileCopy, Help } from '@mui/icons-material'
+import {
+  jiraProjectForRelease,
+  pathForExactTestAnalysisWithFilter,
+} from '../helpers'
 import { Link } from 'react-router-dom'
-import { pathForExactTestAnalysisWithFilter } from '../helpers'
 import { ReleasesContext, SippyCapabilitiesContext } from '../App'
 import BugButton from '../bugs/BugButton'
 import BugTable from '../bugs/BugTable'
@@ -378,6 +381,8 @@ View the [test details report|${document.location.href}] for additional context.
       url: window.location.href,
     }
 
+    const jiraProject = jiraProjectForRelease(sampleRelease)
+
     if (writeEndpointsEnabled) {
       return (
         <FileBug
@@ -386,6 +391,8 @@ View the [test details report|${document.location.href}] for additional context.
           version={sampleRelease}
           jiraComponentID={Number(data.jira_component_id)}
           jiraComponentName={data.jira_component}
+          jiraProject={jiraProject.key}
+          jiraProjectID={jiraProject.pid}
           setHasBeenTriaged={setHasBeenTriaged}
         />
       )
@@ -393,6 +400,7 @@ View the [test details report|${document.location.href}] for additional context.
       return (
         <BugButton
           {...commonProps}
+          jiraProjectID={jiraProject.pid}
           jiraComponentID={String(data.jira_component_id)}
         />
       )

--- a/sippy-ng/src/helpers.jsx
+++ b/sippy-ng/src/helpers.jsx
@@ -439,3 +439,18 @@ export function getTestStatus(stats, flake, fail, success) {
       ? fail
       : success
 }
+
+const JIRA_PROJECTS = {
+  OCPBUGS: { key: 'OCPBUGS', pid: '10325' },
+  PROJQUAY: { key: 'PROJQUAY', pid: '10217' },
+}
+
+// jiraProjectForRelease returns the Jira project (key and redhat.atlassian.net
+// project id) that bugs for the given release should be filed into. The quay-*
+// synthetic releases file into PROJQUAY instead of the default OCPBUGS.
+export function jiraProjectForRelease(release) {
+  if (typeof release === 'string' && release.startsWith('quay-')) {
+    return JIRA_PROJECTS.PROJQUAY
+  }
+  return JIRA_PROJECTS.OCPBUGS
+}

--- a/sippy-ng/src/helpers.test.jsx
+++ b/sippy-ng/src/helpers.test.jsx
@@ -1,0 +1,12 @@
+import { jiraProjectForRelease } from './helpers'
+
+describe('jiraProjectForRelease', () => {
+  test.each([
+    ['quay-3.18', { key: 'PROJQUAY', pid: '10217' }],
+    ['4.22', { key: 'OCPBUGS', pid: '10325' }],
+    ['rosa-4.22', { key: 'OCPBUGS', pid: '10325' }],
+    [undefined, { key: 'OCPBUGS', pid: '10325' }],
+  ])('%s -> %o', (release, expected) => {
+    expect(jiraProjectForRelease(release)).toEqual(expected)
+  })
+})

--- a/sippy-ng/src/tests/TestAnalysis.jsx
+++ b/sippy-ng/src/tests/TestAnalysis.jsx
@@ -22,6 +22,7 @@ import {
 } from '@mui/icons-material'
 import {
   filterFor,
+  jiraProjectForRelease,
   not,
   pathForJobRunsWithTest,
   pathForJobRunsWithTestFailure,
@@ -365,6 +366,7 @@ export function TestAnalysis(props) {
                 }}
               >
                 <BugButton
+                  jiraProjectID={jiraProjectForRelease(props.release).pid}
                   jiraComponentID={test.jira_component_id}
                   testName={testName}
                 />


### PR DESCRIPTION
Add jiraProjectForRelease() in helpers.jsx to route bug filing to the PROJQUAY Jira project for quay-* synthetic releases, keeping OCPBUGS for everything else. Thread jiraProject/jiraProjectID through BugButton and FileBug and wire them up in TestAnalysis and TestDetailsReport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Bug reports now use the appropriate Jira project based on the selected release.
  - Support added for filing issues in both standard and Quay-specific Jira projects.
  - Jira project details are applied consistently when creating reports or using the fallback bug-report option.
  - Affected-version information is automatically populated for standard projects while remaining unset for Quay projects.

- **Tests**
  - Added coverage verifying Jira project selection across standard, Quay, ROSA, and unspecified releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->