### PR TITLE
TRT-2830: add REVIEW.md for agentic review responses

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,3 +1,5 @@
+Extra context for agentic review responses, layered on `/openshift-developer:address-review-pr`.
+
 ## Verify and Push
 
 1. Run `make test` and `make lint`.


### PR DESCRIPTION
## Summary
- Replace `.agentic/followup-config.md` with a root `REVIEW.md` so the agentic review-responder can layer sippy-specific guidance on `/openshift-developer:address-review-pr`.
- Content is unchanged aside from a one-line header describing that overlay.

Companion PRs:
- origin: REVIEW.md migration
- release: review-responder consumes `REVIEW.md`

https://redhat.atlassian.net/browse/TRT-2830

## Test plan
- [ ] Confirm `REVIEW.md` is at repo root and `.agentic/followup-config.md` is gone
- [ ] Confirm `.agentic/solve-config.md` is unchanged
- [ ] Merge before the release review-responder PR so the new file exists when that step starts looking for it


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added additional context for agent-assisted review responses.
  - Updated the review guidance associated with addressing pull request feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->